### PR TITLE
use kubectl apply instead of create

### DIFF
--- a/install/scripts/deployDynatrace.sh
+++ b/install/scripts/deployDynatrace.sh
@@ -10,7 +10,7 @@ kubectl create namespace dynatrace
 kubectl label namespace dynatrace istio-injection=disabled
 export LATEST_RELEASE=$(curl -s https://api.github.com/repos/dynatrace/dynatrace-oneagent-operator/releases/latest | grep tag_name | cut -d '"' -f 4)
 echo "Installing Dynatrace Operator $LATEST_RELEASE"
-kubectl create -f https://raw.githubusercontent.com/Dynatrace/dynatrace-oneagent-operator/$LATEST_RELEASE/deploy/kubernetes.yaml
+kubectl apply -f https://raw.githubusercontent.com/Dynatrace/dynatrace-oneagent-operator/$LATEST_RELEASE/deploy/kubernetes.yaml
 sleep 60
 kubectl -n dynatrace create secret generic oneagent --from-literal="apiToken=$DT_API_TOKEN" --from-literal="paasToken=$DT_PAAS_TOKEN"
 
@@ -19,7 +19,7 @@ rm -f ../manifests/gen/cr.yml
 curl -o ../manifests/dynatrace/cr.yml https://raw.githubusercontent.com/Dynatrace/dynatrace-oneagent-operator/$LATEST_RELEASE/deploy/cr.yaml
 cat ../manifests/dynatrace/cr.yml | sed 's/ENVIRONMENTID/'"$DT_TENANT_ID"'/' >> ../manifests/gen/cr.yml
 
-kubectl create -f ../manifests/gen/cr.yml
+kubectl apply -f ../manifests/gen/cr.yml
 
 # Apply auto tagging rules in Dynatrace
 echo "--------------------------"
@@ -33,3 +33,5 @@ echo "End applying auto tagging rules in Dynatrace "
 echo "--------------------------"
 
 ./createServiceEntry.sh $DT_TENANT_ID $DT_PAAS_TOKEN
+
+./redeployJenkins.sh

--- a/install/scripts/setupInfrastructure.sh
+++ b/install/scripts/setupInfrastructure.sh
@@ -27,17 +27,17 @@ set +e
 
 # Grant cluster admin rights to gcloud user
 export GCLOUD_USER=$(gcloud config get-value account)
-kubectl create clusterrolebinding dynatrace-cluster-admin-binding --clusterrole=cluster-admin --user=$GCLOUD_USER
+kubectl apply clusterrolebinding dynatrace-cluster-admin-binding --clusterrole=cluster-admin --user=$GCLOUD_USER
 
 # Create K8s namespaces
-kubectl create -f ../manifests/k8s-namespaces.yml 
+kubectl apply -f ../manifests/k8s-namespaces.yml 
 
 # Create container registry
-kubectl create -f ../manifests/container-registry/k8s-docker-registry-configmap.yml
-kubectl create -f ../manifests/container-registry/k8s-docker-registry-pvc.yml
-kubectl create -f ../manifests/container-registry/k8s-docker-registry-configmap.yml
-kubectl create -f ../manifests/container-registry/k8s-docker-registry-deployment.yml
-kubectl create -f ../manifests/container-registry/k8s-docker-registry-service.yml
+kubectl apply -f ../manifests/container-registry/k8s-docker-registry-configmap.yml
+kubectl apply -f ../manifests/container-registry/k8s-docker-registry-pvc.yml
+kubectl apply -f ../manifests/container-registry/k8s-docker-registry-configmap.yml
+kubectl apply -f ../manifests/container-registry/k8s-docker-registry-deployment.yml
+kubectl apply -f ../manifests/container-registry/k8s-docker-registry-service.yml
 
 echo "Wait 100s for docker service to get public ip..."
 sleep 100

--- a/install/scripts/setupKnative.sh
+++ b/install/scripts/setupKnative.sh
@@ -4,14 +4,14 @@ CLUSTER_NAME=$2
 CLUSTER_ZONE=$3
 SHOW_API_TOKEN=$4
 
-kubectl create namespace keptn
+kubectl create namespace keptn 2> /dev/null
 
 # Create container registry
-kubectl create -f ../manifests/container-registry/k8s-docker-registry-configmap.yml
-kubectl create -f ../manifests/container-registry/k8s-docker-registry-pvc.yml
-kubectl create -f ../manifests/container-registry/k8s-docker-registry-configmap.yml
-kubectl create -f ../manifests/container-registry/k8s-docker-registry-deployment.yml
-kubectl create -f ../manifests/container-registry/k8s-docker-registry-service.yml
+kubectl apply -f ../manifests/container-registry/k8s-docker-registry-configmap.yml
+kubectl apply -f ../manifests/container-registry/k8s-docker-registry-pvc.yml
+kubectl apply -f ../manifests/container-registry/k8s-docker-registry-configmap.yml
+kubectl apply -f ../manifests/container-registry/k8s-docker-registry-deployment.yml
+kubectl apply -f ../manifests/container-registry/k8s-docker-registry-service.yml
 
 kubectl label namespace keptn istio-injection=enabled
 
@@ -70,7 +70,7 @@ kubectl apply -f ../../core/eventbroker/config/problem-channel.yaml
 export KEPTN_CHANNEL_URI=$(kubectl describe channel keptn-channel -n keptn | grep "Hostname:" | sed 's~[ \t]*Hostname:[ \t]*~~')
 
 export KEPTN_API_TOKEN=$(head -c 16 /dev/urandom | base64)
-kubectl create secret generic -n keptn keptn-api-token --from-literal=keptn-api-token="$KEPTN_API_TOKEN"
+kubectl apply secret generic -n keptn keptn-api-token --from-literal=keptn-api-token="$KEPTN_API_TOKEN"
 
 # Deploy event broker
 cd ../../core/eventbroker
@@ -97,7 +97,7 @@ fi
 # Set up SSL
 openssl req -nodes -newkey rsa:2048 -keyout key.pem -out certificate.pem  -x509 -days 365 -subj "/CN=$ISTIO_INGRESS_IP.xip.io"
 
-kubectl create --namespace istio-system secret tls istio-ingressgateway-certs --key key.pem --cert certificate.pem
+kubectl apply --namespace istio-system secret tls istio-ingressgateway-certs --key key.pem --cert certificate.pem
 
 kubectl get gateway knative-ingress-gateway --namespace knative-serving -o=yaml | yq w - spec.servers[1].tls.mode SIMPLE | yq w - spec.servers[1].tls.privateKey /etc/istio/ingressgateway-certs/tls.key | yq w - spec.servers[1].tls.serverCertificate /etc/istio/ingressgateway-certs/tls.crt | kubectl apply -f -
 


### PR DESCRIPTION
This prevents those kinds of errors:

Error from server (AlreadyExists): error when creating “../manifests/container-registry/k8s-docker-registry-service.yml”: services “docker-registry” already exists