### PR TITLE
Reuse master branch to deploy control

### DIFF
--- a/core/control/config/control.yaml
+++ b/core/control/config/control.yaml
@@ -17,7 +17,7 @@ spec:
           source:
             git:
               url: https://github.com/keptn/keptn.git
-              revision: cloudevents-sdk
+              revision: master
           template:
             name: kaniko
             arguments:


### PR DESCRIPTION
Temporary it was necessary to use the branch cloudevents-sdk