### PR TITLE
Patch for testing return value of curl

### DIFF
--- a/install/scripts/applyAutoTaggingRules.sh
+++ b/install/scripts/applyAutoTaggingRules.sh
@@ -37,7 +37,7 @@ curl -X POST \
   ]
 }'
 
-if [[ $1 != '0' ]]; then
+if [[ $? != '0' ]]; then
   echo ""
   print_error "Tagging rule for service could not be created in tenant $DT_TENANT_ID."
   exit 1
@@ -75,7 +75,7 @@ curl -X POST \
   ]
 }'
 
-if [[ $1 != '0' ]]; then
+if [[ $? != '0' ]]; then
   echo ""
   print_error "Tagging rule for environment could not be created in tenant $DT_TENANT_ID."
   exit 1


### PR DESCRIPTION
The return value of two curls for creating tagging rules in Dynatrace are not verified correctly. Instead of verifying $?, $1 was checked.