### PR TITLE
#255 Dynatrace-managed support

### DIFF
--- a/install/manifests/dynatrace/cr.yml
+++ b/install/manifests/dynatrace/cr.yml
@@ -7,7 +7,7 @@ metadata:
   namespace: dynatrace
 spec:
   # dynatrace api url including `/api` path at the end
-  apiUrl: https://ENVIRONMENTID.live.dynatrace.com/api
+  apiUrl: https://DT_TENANT/api
   # disable certificate validation checks for installer download and API communication
   skipCertCheck: false
   # name of secret holding `apiToken` and `paasToken`

--- a/install/manifests/dynatrace/cr.yml
+++ b/install/manifests/dynatrace/cr.yml
@@ -7,7 +7,7 @@ metadata:
   namespace: dynatrace
 spec:
   # dynatrace api url including `/api` path at the end
-  apiUrl: https://DT_TENANT/api
+  apiUrl: https://ENVIRONMENTID.live.dynatrace.com/api
   # disable certificate validation checks for installer download and API communication
   skipCertCheck: false
   # name of secret holding `apiToken` and `paasToken`

--- a/install/scripts/applyAutoTaggingRules.sh
+++ b/install/scripts/applyAutoTaggingRules.sh
@@ -2,11 +2,11 @@
 
 source ./utils.sh
 
-DT_TENANT_ID=$1
+DT_TENANT=$1
 DT_API_TOKEN=$2
 
 curl -X POST \
-  "https://$DT_TENANT_ID.live.dynatrace.com/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache' \
   -d '{
@@ -39,12 +39,12 @@ curl -X POST \
 
 if [[ $1 != '0' ]]; then
   echo ""
-  print_error "Tagging rule for service could not be created in tenant $DT_TENANT_ID."
+  print_error "Tagging rule for service could not be created in tenant $DT_TENANT."
   exit 1
 fi
 
 curl -X POST \
-  "https://$DT_TENANT_ID.live.dynatrace.com/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache' \
   -d '{
@@ -77,6 +77,6 @@ curl -X POST \
 
 if [[ $1 != '0' ]]; then
   echo ""
-  print_error "Tagging rule for environment could not be created in tenant $DT_TENANT_ID."
+  print_error "Tagging rule for environment could not be created in tenant $DT_TENANT."
   exit 1
 fi

--- a/install/scripts/applyAutoTaggingRules.sh
+++ b/install/scripts/applyAutoTaggingRules.sh
@@ -6,7 +6,7 @@ DT_TENANT=$1
 DT_API_TOKEN=$2
 
 curl -X POST \
-  "https://$DT_TENANT/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT/api/config/v1/autoTags?api-token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache' \
   -d '{
@@ -37,14 +37,14 @@ curl -X POST \
   ]
 }'
 
-if [[ $1 != '0' ]]; then
+if [[ $? != '0' ]]; then
   echo ""
   print_error "Tagging rule for service could not be created in tenant $DT_TENANT."
   exit 1
 fi
 
 curl -X POST \
-  "https://$DT_TENANT/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT/api/config/v1/autoTags?api-token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache' \
   -d '{
@@ -75,7 +75,7 @@ curl -X POST \
   ]
 }'
 
-if [[ $1 != '0' ]]; then
+if [[ $? != '0' ]]; then
   echo ""
   print_error "Tagging rule for environment could not be created in tenant $DT_TENANT."
   exit 1

--- a/install/scripts/createServiceEntry.sh
+++ b/install/scripts/createServiceEntry.sh
@@ -3,9 +3,9 @@
 source ./utils.sh
 
 DT_TENANT=$1
-DT_API_TOKEN=$2
+DT_TOKEN=$2
 
-entries=$(curl https://$DT_TENANT/api/v1/deployment/installer/agent/connectioninfo?Api-Token=$DT_API_TOKEN | jq -r '.communicationEndpoints[]')
+entries=$(curl https://$DT_TENANT/api/v1/deployment/installer/agent/connectioninfo?api-token=$DT_TOKEN | jq -r '.communicationEndpoints[]')
 
 rm -f ../manifests/gen/service_entries_oneagent.yml
 rm -f ../manifests/gen/hosts

--- a/install/scripts/createServiceEntry.sh
+++ b/install/scripts/createServiceEntry.sh
@@ -2,7 +2,10 @@
 
 source ./utils.sh
 
-entries=$(curl https://$1.live.dynatrace.com/api/v1/deployment/installer/agent/connectioninfo?Api-Token=$2 | jq -r '.communicationEndpoints[]')
+DT_TENANT=$1
+DT_API_TOKEN=$2
+
+entries=$(curl https://$DT_TENANT/api/v1/deployment/installer/agent/connectioninfo?Api-Token=$DT_API_TOKEN | jq -r '.communicationEndpoints[]')
 
 rm -f ../manifests/gen/service_entries_oneagent.yml
 rm -f ../manifests/gen/hosts
@@ -10,8 +13,8 @@ rm -f ../manifests/gen/service_entries
 
 cat ../manifests/istio/service_entries_tpl/header_tmpl >> ../manifests/gen/service_entries_oneagent.yml
 
-echo -e "  - $1.live.dynatrace.com" >> ../manifests/gen/hosts
-cat ../manifests/istio/service_entries_tpl/service_entry_tmpl | sed 's~ENDPOINT_PLACEHOLDER~'"$1"'.live.dynatrace.com~' >> ../manifests/gen/service_entries
+echo -e "  - $DT_TENANT" >> ../manifests/gen/hosts
+cat ../manifests/istio/service_entries_tpl/service_entry_tmpl | sed 's~ENDPOINT_PLACEHOLDER~'"$DT_TENANT"'~' >> ../manifests/gen/service_entries
 
 for row in $entries; do
     row=$(echo $row | sed 's~https://~~')

--- a/install/scripts/defineDynatraceCredentials.sh
+++ b/install/scripts/defineDynatraceCredentials.sh
@@ -7,7 +7,7 @@ CREDS=./creds_dt.json
 rm $CREDS 2> /dev/null
 
 echo -e "${YLW}Please enter the credentials as requested below: ${NC}"
-read -p "Dynatrace Tenant ID (8-digits) (default=$DTENV): " DTENVC
+read -p "Dynatrace Tenant {your-domain}/e/{your-environment-id} for managed or {your-environment-id}.live.dynatrace.com for SaaS (default=$DTENV): " DTENVC
 read -p "Dynatrace API Token (default=$DTAPI): " DTAPIC
 read -p "Dynatrace PaaS Token (default=$DTAPI): " DTPAAST
 echo ""

--- a/install/scripts/deployDynatrace.sh
+++ b/install/scripts/deployDynatrace.sh
@@ -6,7 +6,7 @@ DT_TENANT=$(cat creds_dt.json | jq -r '.dynatraceTenant')
 DT_API_TOKEN=$(cat creds_dt.json | jq -r '.dynatraceApiToken')
 DT_PAAS_TOKEN=$(cat creds_dt.json | jq -r '.dynatracePaaSToken')
 
-# # Deploy Dynatrace operator
+# Deploy Dynatrace operator
 LATEST_RELEASE=$(curl -s https://api.github.com/repos/dynatrace/dynatrace-oneagent-operator/releases/latest | grep tag_name | cut -d '"' -f 4)
 print_info "Installing Dynatrace Operator $LATEST_RELEASE"
 

--- a/install/scripts/deployDynatrace.sh
+++ b/install/scripts/deployDynatrace.sh
@@ -2,7 +2,7 @@
 
 source ./utils.sh
 
-DT_TENANT_ID=$(cat creds_dt.json | jq -r '.dynatraceTenant')
+DT_TENANT=$(cat creds_dt.json | jq -r '.dynatraceTenant')
 DT_API_TOKEN=$(cat creds_dt.json | jq -r '.dynatraceApiToken')
 DT_PAAS_TOKEN=$(cat creds_dt.json | jq -r '.dynatracePaaSToken')
 
@@ -27,22 +27,22 @@ verify_kubectl $? "Creating secret for Dynatrace OneAgent failed."
 rm -f ../manifests/gen/cr.yml
 
 curl -o ../manifests/dynatrace/cr.yml https://raw.githubusercontent.com/Dynatrace/dynatrace-oneagent-operator/$LATEST_RELEASE/deploy/cr.yaml
-cat ../manifests/dynatrace/cr.yml | sed 's/ENVIRONMENTID/'"$DT_TENANT_ID"'/' >> ../manifests/gen/cr.yml
+cat ../manifests/dynatrace/cr.yml | sed 's/ENVIRONMENTID/'"$DT_TENANT"'/' >> ../manifests/gen/cr.yml
 
 kubectl apply -f ../manifests/gen/cr.yml
 verify_kubectl $? "Creating Dynatrace OneAgent failed."
 
 # Apply auto tagging rules in Dynatrace
 print_info "Applying auto tagging rules in Dynatrace."
-./applyAutoTaggingRules.sh $DT_TENANT_ID $DT_API_TOKEN
+./applyAutoTaggingRules.sh $DT_TENANT $DT_API_TOKEN
 verify_install_step $? "Applying auto tagging rules in Dynatrace failed."
 print_info "Applying auto tagging rules in Dynatrace done."
 
 print_info "Creating service entries for Dynatrace OneAgent."
-./createServiceEntry.sh $DT_TENANT_ID $DT_PAAS_TOKEN
+./createServiceEntry.sh $DT_TENANT $DT_PAAS_TOKEN
 verify_install_step $? "Creating service entries for Dynatrace OneAgent failed."
 print_info "Creating service entries for Dynatrace OneAgent done."
 
 # Create secrets to be used by keptn services
-kubectl -n keptn create secret generic dynatrace --from-literal="DT_API_TOKEN=$DT_API_TOKEN" --from-literal="DT_TENANT_ID=$DT_TENANT_ID"
+kubectl -n keptn create secret generic dynatrace --from-literal="DT_API_TOKEN=$DT_API_TOKEN" --from-literal="DT_TENANT=$DT_TENANT"
 verify_kubectl $? "Creating dynatrace secret for keptn services failed."

--- a/install/scripts/deployDynatrace.sh
+++ b/install/scripts/deployDynatrace.sh
@@ -27,7 +27,7 @@ verify_kubectl $? "Creating secret for Dynatrace OneAgent failed."
 rm -f ../manifests/gen/cr.yml
 
 curl -o ../manifests/dynatrace/cr.yml https://raw.githubusercontent.com/Dynatrace/dynatrace-oneagent-operator/$LATEST_RELEASE/deploy/cr.yaml
-cat ../manifests/dynatrace/cr.yml | sed 's/ENVIRONMENTID/'"$DT_TENANT"'/' >> ../manifests/gen/cr.yml
+cat ../manifests/dynatrace/cr.yml | sed 's/DT_TENANT/'"$DT_TENANT"'/' >> ../manifests/gen/cr.yml
 
 kubectl apply -f ../manifests/gen/cr.yml
 verify_kubectl $? "Creating Dynatrace OneAgent failed."

--- a/install/scripts/deployDynatrace.sh
+++ b/install/scripts/deployDynatrace.sh
@@ -6,7 +6,7 @@ DT_TENANT=$(cat creds_dt.json | jq -r '.dynatraceTenant')
 DT_API_TOKEN=$(cat creds_dt.json | jq -r '.dynatraceApiToken')
 DT_PAAS_TOKEN=$(cat creds_dt.json | jq -r '.dynatracePaaSToken')
 
-# Deploy Dynatrace operator
+# # Deploy Dynatrace operator
 LATEST_RELEASE=$(curl -s https://api.github.com/repos/dynatrace/dynatrace-oneagent-operator/releases/latest | grep tag_name | cut -d '"' -f 4)
 print_info "Installing Dynatrace Operator $LATEST_RELEASE"
 
@@ -27,7 +27,7 @@ verify_kubectl $? "Creating secret for Dynatrace OneAgent failed."
 rm -f ../manifests/gen/cr.yml
 
 curl -o ../manifests/dynatrace/cr.yml https://raw.githubusercontent.com/Dynatrace/dynatrace-oneagent-operator/$LATEST_RELEASE/deploy/cr.yaml
-cat ../manifests/dynatrace/cr.yml | sed 's/DT_TENANT/'"$DT_TENANT"'/' >> ../manifests/gen/cr.yml
+cat ../manifests/dynatrace/cr.yml | sed 's~ENVIRONMENTID.live.dynatrace.com~'"$DT_TENANT"'~' >> ../manifests/gen/cr.yml
 
 kubectl apply -f ../manifests/gen/cr.yml
 verify_kubectl $? "Creating Dynatrace OneAgent failed."

--- a/install/scripts/deployDynatrace.sh
+++ b/install/scripts/deployDynatrace.sh
@@ -38,10 +38,13 @@ print_info "Applying auto tagging rules in Dynatrace."
 verify_install_step $? "Applying auto tagging rules in Dynatrace failed."
 print_info "Applying auto tagging rules in Dynatrace done."
 
-print_info "Creating service entries for Dynatrace OneAgent."
-./createServiceEntry.sh $DT_TENANT $DT_PAAS_TOKEN
-verify_install_step $? "Creating service entries for Dynatrace OneAgent failed."
-print_info "Creating service entries for Dynatrace OneAgent done."
+# Create service entries for Dynatrace
+if [[ $DT_TENANT == *"live.dynatrace"*  ]]; then
+  print_info "Creating service entries for Dynatrace OneAgent."
+  ./createServiceEntry.sh $DT_TENANT $DT_PAAS_TOKEN
+  verify_install_step $? "Creating service entries for Dynatrace OneAgent failed."
+  print_info "Creating service entries for Dynatrace OneAgent done."
+fi
 
 # Create secrets to be used by keptn services
 kubectl -n keptn create secret generic dynatrace --from-literal="DT_API_TOKEN=$DT_API_TOKEN" --from-literal="DT_TENANT=$DT_TENANT"

--- a/install/scripts/uninstallKeptn.sh
+++ b/install/scripts/uninstallKeptn.sh
@@ -1,6 +1,7 @@
 # Clean up dynatrace namespace
 kubectl delete services,deployments,pods --all -n dynatrace --ignore-not-found
 kubectl delete namespace dynatrace --ignore-not-found
+kubectl delete secret dynatrace -n keptn --ignore-not-found
 
 # Clean up keptn namespace
 kubectl delete services,deployments,pods,secrets --all -n keptn --ignore-not-found

--- a/install/scripts/wearUniform.sh
+++ b/install/scripts/wearUniform.sh
@@ -48,28 +48,28 @@ mkdir keptn-services
 cd keptn-services
 
 # Install services
-git clone --branch 0.2.0 https://github.com/keptn/jenkins-service.git --single-branch
+git clone --branch develop https://github.com/keptn/jenkins-service.git --single-branch
 cd jenkins-service
 chmod +x deploy.sh
 ./deploy.sh $REGISTRY_URL $JENKINS_USER $JENKINS_PASSWORD $GITHUB_USER_NAME $GITHUB_USER_EMAIL $GITHUB_ORGANIZATION $GITHUB_PERSONAL_ACCESS_TOKEN
 verify_install_step $? "Deploying jenkins-service failed."
 cd ..
 
-git clone --branch 0.1.1 https://github.com/keptn/github-service.git --single-branch
+git clone --branch develop https://github.com/keptn/github-service.git --single-branch
 cd github-service
 chmod +x deploy.sh
 ./deploy.sh
 verify_install_step $? "Deploying github-service failed."
 cd ..
 
-git clone --branch 0.1.0 https://github.com/keptn/servicenow-service.git --single-branch
+git clone --branch develop https://github.com/keptn/servicenow-service.git --single-branch
 cd servicenow-service
 chmod +x deploy.sh
 ./deploy.sh
 verify_install_step $? "Deploying servicenow-service failed."
 cd ..
 
-git clone --branch 0.1.1 https://github.com/keptn/pitometer-service.git --single-branch
+git clone --branch develop https://github.com/keptn/pitometer-service.git --single-branch
 cd pitometer-service
 chmod +x deploy.sh
 ./deploy.sh


### PR DESCRIPTION
Removed hard-coded URLs (live.dynatrace.com), which were used for Dynatrace SaaS tenants, to support the use of Dynatrace-managed tenants. 