### PR TITLE
Build the develop branch when not a cron job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -130,7 +130,7 @@ jobs:
       fi
 
   - stage: develop
-    if: branch = develop AND NOT type = pull_request
+    if: branch = develop AND NOT type = cron
     script: 
     - echo $TRAVIS_BUILD_STAGE_NAME
     - |


### PR DESCRIPTION
Since we have a cron job that creates a keptn installation every day based on the develop branch, it is required to exclude this cron job for building artifacts.