### PR TITLE
Changed travis condition for develop branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -130,7 +130,7 @@ jobs:
       fi
 
   - stage: develop
-    if: branch = develop AND NOT type = cron
+    if: branch = develop AND type = push
     script: 
     - echo $TRAVIS_BUILD_STAGE_NAME
     - |


### PR DESCRIPTION
In order to avoid duplicate travis builds for the same code base of the develop branch, it is required to specify 'AND type = push' instead of 'AND NOT type = cron'.