### PR TITLE
Set tag of core components to latest for develop branch

### DIFF
--- a/core/auth/config/authenticator.yaml
+++ b/core/auth/config/authenticator.yaml
@@ -13,7 +13,7 @@ spec:
             autoscaling.knative.dev/minScale: "1"
         spec:
           container:
-            image: keptn/keptn-authenticator:0.2.1
+            image: keptn/keptn-authenticator:latest
             imagePullPolicy: Always
             env:
             - name: SECRET_TOKEN

--- a/core/control/config/control.yaml
+++ b/core/control/config/control.yaml
@@ -13,7 +13,7 @@ spec:
             autoscaling.knative.dev/minScale: "1"
         spec:
           container:
-            image: keptn/keptn-control:0.2.1
+            image: keptn/keptn-control:latest
             imagePullPolicy: Always
             env:
             - name: CHANNEL_URI

--- a/core/eventbroker-ext/config/event-broker-ext.yaml
+++ b/core/eventbroker-ext/config/event-broker-ext.yaml
@@ -15,5 +15,5 @@ spec:
             autoscaling.knative.dev/minScale: "1"
         spec:
           container:
-            image: keptn/keptn-event-broker-ext:0.2.1
+            image: keptn/keptn-event-broker-ext:latest
             imagePullPolicy: Always

--- a/core/eventbroker/config/event-broker.yaml
+++ b/core/eventbroker/config/event-broker.yaml
@@ -15,5 +15,5 @@ spec:
             autoscaling.knative.dev/minScale: "1"
         spec:
           container:
-            image: keptn/keptn-event-broker:0.2.1
+            image: keptn/keptn-event-broker:latest
             imagePullPolicy: Always


### PR DESCRIPTION
To use the latest image version of each core component when using the develop branch, it is necessary to set the tag in the manifest to 'latest'.