### PR TITLE
#387 Fixed typo: Changed artefact to artifact

### DIFF
--- a/cli/cmd/send_event_newArtifact.go
+++ b/cli/cmd/send_event_newArtifact.go
@@ -72,7 +72,7 @@ Example:
 		event := cloudevents.Event{
 			Context: cloudevents.EventContextV02{
 				ID:          uuid.New().String(),
-				Type:        "sh.keptn.events.new-artefact",
+				Type:        "sh.keptn.events.new-artifact",
 				Source:      types.URLRef{URL: *source},
 				ContentType: &contentType,
 			}.AsV02(),

--- a/cli/cmd/send_event_test.go
+++ b/cli/cmd/send_event_test.go
@@ -27,7 +27,7 @@ func TestSend(t *testing.T) {
 "specversion":"0.2",
 "time":"` + time.String() + `",
 "datacontenttype":"application/json",
-"type":"sh.keptn.events.new-artefact",
+"type":"sh.keptn.events.new-artifact",
 "data":{
 	"project":"sockshop",
 	"service":"carts",

--- a/releasenotes/releasenotes_develop.md
+++ b/releasenotes/releasenotes_develop.md
@@ -1,8 +1,9 @@
 # Release Notes x.x.x
 
-
 ## New Features
 
 ## Fixed Issues
+
+- keptn CLI: Fixed typo - Changed _art**e**fact_ to _art**i**fact_ [#387](https://github.com/keptn/keptn/issues/387)
 
 ## Known Limitations


### PR DESCRIPTION
This PR ensures a consistent use of the word artifact instead of artefact across all keptn repositories.