### PR TITLE
#627 use passthrough termination for keptn route in openshift

### DIFF
--- a/installer/scripts/openshift/setupKeptn.sh
+++ b/installer/scripts/openshift/setupKeptn.sh
@@ -28,9 +28,7 @@ oc project istio-system
 
 BASE_URL=$(oc get route -n istio-system istio-ingressgateway -oyaml | yq r - spec.host | sed 's~istio-ingressgateway-istio-system.~~')
 
-oc create route edge istio-wildcard-ingress --service=istio-ingressgateway --hostname="www.ingress-gateway.$BASE_URL" --port=http2 --wildcard-policy=Subdomain --insecure-policy='Allow'
-#verify_kubectl $? "Creation of ingress route failed."
-oc create route edge istio-wildcard-ingress-secure-keptn --service=istio-ingressgateway --hostname="www.keptn.ingress-gateway.$BASE_URL" --port=http2 --wildcard-policy=Subdomain --insecure-policy='Allow'
+oc create route passthrough istio-wildcard-ingress-secure-keptn --service=istio-ingressgateway --hostname="www.keptn.ingress-gateway.$BASE_URL" --port=https --wildcard-policy=Subdomain --insecure-policy='None' -n istio-system
 #verify_kubectl $? "Creation of keptn ingress route failed."
 
 oc adm policy  add-cluster-role-to-user cluster-admin system:serviceaccount:keptn:default


### PR DESCRIPTION
We previously used edge-termination which resulted in requests being redirected to port 80 of the ingress gateway, which is not exposed anymore.
additionally, insecure traffic is now disallowed for this route.