### PR TITLE
#723 Pitometer enhancement for service-indicators/objectives files

### DIFF
--- a/pitometer-service/examples/remediation.yaml
+++ b/pitometer-service/examples/remediation.yaml
@@ -1,0 +1,5 @@
+remediations:
+- name: cpu_usage_p95_sockshop_carts_production
+  actions:
+  - action: scaling
+    value: +1

--- a/pitometer-service/examples/service-indicators.yaml
+++ b/pitometer-service/examples/service-indicators.yaml
@@ -2,3 +2,6 @@ indicators:
 - metric: cpu_usage_p95_sockshop_carts_production
   source: Prometheus
   query: avg(rate(container_cpu_usage_seconds_total{namespace="sockshop-production",pod_name=~"carts-blue-.*|carts-green-.*"}[$DURATION_MINUTES]))
+- metric: request_latency_seconds
+  source: Prometheus
+  query: rate(requests_latency_seconds_sum{job='carts-$ENVIRONMENT'}[$DURATION_MINUTESm])/rate(requests_latency_seconds_count{job='carts-$ENVIRONMENT'}[$DURATION_MINUTESm])

--- a/pitometer-service/examples/service-indicators.yaml
+++ b/pitometer-service/examples/service-indicators.yaml
@@ -1,0 +1,4 @@
+indicators:
+- metric: cpu_usage_p95_sockshop_carts_production
+  source: Prometheus
+  query: avg(rate(container_cpu_usage_seconds_total{namespace="sockshop-production",pod_name=~"carts-blue-.*|carts-green-.*"}[$DURATION_MINUTES]))

--- a/pitometer-service/examples/service-objectives.yaml
+++ b/pitometer-service/examples/service-objectives.yaml
@@ -1,4 +1,7 @@
+pass: 90
+warning: 75
 objectives:
 - metric: cpu_usage_p95_sockshop_carts_production
   threshold: 90
   timeframe: 5m
+  score: 100

--- a/pitometer-service/examples/service-objectives.yaml
+++ b/pitometer-service/examples/service-objectives.yaml
@@ -1,0 +1,4 @@
+objectives:
+- metric: cpu_usage_p95_sockshop_carts_production
+  threshold: 90
+  timeframe: 5m

--- a/pitometer-service/examples/service-objectives.yaml
+++ b/pitometer-service/examples/service-objectives.yaml
@@ -1,7 +1,7 @@
 pass: 90
 warning: 75
 objectives:
-- metric: cpu_usage_p95_sockshop_carts_production
-  threshold: 90
+- metric: request_latency_seconds
+  threshold: 0.8
   timeframe: 5m
   score: 100

--- a/pitometer-service/package-lock.json
+++ b/pitometer-service/package-lock.json
@@ -72,6 +72,14 @@
       "integrity": "sha512-9fJTDipQFvlfSVdD/JBtkiY0br9BtfvW2R8wo6CX/Ej2eMuV0gWPk1M67Mt3eggQvBqYW1FCEk8BN7WvGm/g5g==",
       "dev": true
     },
+    "@babel/runtime": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+      "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+      "requires": {
+        "regenerator-runtime": "^0.13.2"
+      }
+    },
     "@babel/template": {
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
@@ -5584,6 +5592,11 @@
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
       "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
     },
+    "regenerator-runtime": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+    },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -6874,6 +6887,14 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
+    },
+    "yaml": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.6.0.tgz",
+      "integrity": "sha512-iZfse3lwrJRoSlfs/9KQ9iIXxs9++RvBFVzAqbbBiFT+giYtyanevreF9r61ZTbGMgWQBxAua3FzJiniiJXWWw==",
+      "requires": {
+        "@babel/runtime": "^7.4.5"
+      }
     },
     "yargs": {
       "version": "13.2.2",

--- a/pitometer-service/package.json
+++ b/pitometer-service/package.json
@@ -55,7 +55,8 @@
     "reflect-metadata": "^0.1.13",
     "swagger-express-ts": "^1.0.1",
     "swagger-ui-dist": "^3.22.2",
-    "uuid": "^3.3.2"
+    "uuid": "^3.3.2",
+    "yaml": "^1.6.0"
   },
   "nyc": {
     "include": [

--- a/pitometer-service/src/svc/Service.ts
+++ b/pitometer-service/src/svc/Service.ts
@@ -61,7 +61,7 @@ export class Service {
       let perfspecString;
 
       try {
-        perfspecString = this.getPerfspecString(event);
+        perfspecString = await this.getPerfspecString(event);
       } catch (e) {
         this.handleEvaluationResult(
           {
@@ -406,11 +406,11 @@ export class Service {
     try {
       const indicators = await this.getServiceIndicators(event);
       if (indicators === null) {
-        return this.getServiceResourceContent(event, 'perfspec.json');
+        return await this.getServiceResourceContent(event, 'perfspec.json');
       }
       const objectives = await this.getServiceObjectives(event);
       if (objectives === null) {
-        return this.getServiceResourceContent(event, 'perfspec.json');
+        return await this.getServiceResourceContent(event, 'perfspec.json');
       }
       const perfspecObject = this.createPerfspecObject(indicators, objectives);
       return JSON.stringify(perfspecObject);
@@ -471,7 +471,6 @@ export class Service {
 
     try {
       response = await axios.get(url, {});
-      console.log(response);
     } catch (e) {
       Logger.log(
         event.shkeptncontext, event.id,

--- a/pitometer-service/src/svc/Service.ts
+++ b/pitometer-service/src/svc/Service.ts
@@ -466,11 +466,12 @@ export class Service {
 
   async getServiceResourceContent(event: RequestModel, resourceUri: string): Promise<string> {
     // tslint:disable-next-line: max-line-length
-    const url = `http://configuration-service.keptn.svc.cluster.local:8080/v1/project/${event.data.project}/stage/${event.data.stage}/service/${event.data.service}/${resourceUri}`;
+    const url = `http://configuration-service.keptn.svc.cluster.local:8080/v1/project/${event.data.project}/stage/${event.data.stage}/service/${event.data.service}/resource/${resourceUri}`;
     let response;
 
     try {
       response = await axios.get(url, {});
+      console.log(response);
     } catch (e) {
       Logger.log(
         event.shkeptncontext, event.id,

--- a/pitometer-service/src/svc/Service.ts
+++ b/pitometer-service/src/svc/Service.ts
@@ -406,15 +406,15 @@ export class Service {
     try {
       const indicators = await this.getServiceIndicators(event);
       if (indicators === null
-        && indicators.indicators !== undefined
-        && indicators.indicators.length > 0
+        || indicators.indicators === undefined
+        || indicators.indicators.length === 0
       ) {
         return await this.getServiceResourceContent(event, 'perfspec.json');
       }
       const objectives = await this.getServiceObjectives(event);
       if (objectives === null
-        && objectives.objectives !== undefined
-        && objectives.objectives.length > 0
+        || objectives.objectives === undefined
+        || objectives.objectives.length === 0
       ) {
         return await this.getServiceResourceContent(event, 'perfspec.json');
       }

--- a/pitometer-service/src/svc/Service.ts
+++ b/pitometer-service/src/svc/Service.ts
@@ -405,11 +405,17 @@ export class Service {
   async getPerfspecString(event: RequestModel): Promise<string> {
     try {
       const indicators = await this.getServiceIndicators(event);
-      if (indicators === null) {
+      if (indicators === null
+        && indicators.indicators !== undefined
+        && indicators.indicators.length > 0
+      ) {
         return await this.getServiceResourceContent(event, 'perfspec.json');
       }
       const objectives = await this.getServiceObjectives(event);
-      if (objectives === null) {
+      if (objectives === null
+        && objectives.objectives !== undefined
+        && objectives.objectives.length > 0
+      ) {
         return await this.getServiceResourceContent(event, 'perfspec.json');
       }
       const perfspecObject = this.createPerfspecObject(indicators, objectives);
@@ -490,7 +496,11 @@ export class Service {
       evaluationResult.result !== undefined &&
       (evaluationResult.result === 'pass' || evaluationResult.result === 'warning');
 
-    Logger.log(sourceEvent.shkeptncontext, sourceEvent.id, `Evaluation passed: ${evaluationPassed}`);
+    Logger.log(
+      sourceEvent.shkeptncontext,
+      sourceEvent.id,
+      `Evaluation passed: ${evaluationPassed}`,
+    );
     try {
       Logger.log(
         sourceEvent.shkeptncontext, sourceEvent.id,

--- a/pitometer-service/src/svc/Service.ts
+++ b/pitometer-service/src/svc/Service.ts
@@ -2,6 +2,7 @@ import 'reflect-metadata';
 import { injectable, inject } from 'inversify';
 import { RequestModel } from './RequestModel';
 import axios, { AxiosRequestConfig, AxiosPromise, AxiosError } from 'axios';
+import YAML from 'yaml'
 const { base64encode, base64decode } = require('nodejs-base64');
 
 const Pitometer = require('@keptn/pitometer').Pitometer;
@@ -18,6 +19,10 @@ import { Logger } from '../lib/Logger';
 import { Keptn } from '../lib/Keptn';
 import { Credentials } from '../lib/Credentials';
 import { DynatraceCredentialsModel } from '../lib/DynatraceCredentialsModel';
+import { ServiceIndicators, Indicator } from './ServiceIndicators';
+import { ServiceObjectives, Objective } from './ServiceObjectives';
+import { create } from 'domain';
+import { json } from 'body-parser';
 
 @injectable()
 export class Service {
@@ -53,15 +58,21 @@ export class Service {
 
       pitometer.addGrader('Threshold', new ThresholdGrader());
 
-      // tslint:disable-next-line: max-line-length
-      // const perfspecUrl = `https://raw.githubusercontent.com/${event.data.githuborg}/${event.data.service}/master/perfspec/perfspec.json`;
-      const perfspecUrl = `http://configuration-service.keptn.svc.cluster.local:8080/v1/project/${event.data.project}/stage/${event.data.stage}/service/${event.data.service}/resource/perfspec.json`
-      let perfspecResponse;
+      let perfspecString;
 
       try {
-        perfspecResponse = await axios.get(perfspecUrl, {
-        });
+        perfspecString = this.getPerfspecString(event);
       } catch (e) {
+        this.handleEvaluationResult(
+          {
+            result: 'failed',
+            error: 'Error while retrieving perfspec content.',
+          },
+          event,
+        );
+        return false;
+      }
+      if (perfspecString === '') {
         Logger.log(
           event.shkeptncontext, event.id,
           `No perfspec file defined for `
@@ -70,136 +81,131 @@ export class Service {
         return true;
       }
 
-      if (perfspecResponse.data !== undefined && perfspecResponse.data.resourceContent !== undefined) {
-        let perfspecString;
-        let perfspec;
-        // decode the base64 encoded string
-        perfspecString = base64decode(perfspecResponse.data.resourceContent)
+      let perfspec;
 
-        Logger.log(
-          event.shkeptncontext, event.id,
-          perfspecString,
-        );
+      Logger.log(
+        event.shkeptncontext, event.id,
+        perfspecString,
+      );
 
-        try {
-          perfspec = JSON.parse(perfspecString);
-        } catch (e) {
-          this.handleEvaluationResult(
-            {
-              result: 'failed',
-              error: 'Bad perfspec format.',
-            },
-            event,
-          );
-          return false;
-        }
-
-        const envPlaceHolderRegex = new RegExp('\\$ENVIRONMENT', 'g');
-
-        /*
-        /* TODO: going forward, setting the duration via the $DURATION_MINUTES
-        /* placeholder will become obsolete, since this is handled by pitometer now.
-        /* For backwards compatibility reasons we have to keep this for now.
-        */
-        const durationRegex = new RegExp('\\$DURATION_MINUTES', 'g');
-        perfspecString =
-          perfspecString.replace(envPlaceHolderRegex, `${event.data.project}-${event.data.stage}`);
-        if (testRunDurationMinutes > 0) {
-          perfspecString = perfspecString.replace(durationRegex, `${testRunDurationMinutes}`);
-        } else {
-          perfspecString = perfspecString.replace(durationRegex, `3`);
-        }
-
+      try {
         perfspec = JSON.parse(perfspecString);
-        Logger.log(
-          event.shkeptncontext, event.id,
-          `Perfspec file content: ${JSON.stringify(perfspec)}`,
+      } catch (e) {
+        this.handleEvaluationResult(
+          {
+            result: 'failed',
+            error: 'Bad perfspec format.',
+          },
+          event,
         );
+        return false;
+      }
 
-        const indicators = [];
-        if (perfspec === undefined || perfspec.indicators === undefined) {
-          this.handleEvaluationResult(
-            {
-              result: 'failed',
-              error: 'Bad perfspec format.',
-            },
-            event,
-          );
-          return false;
-        }
+      const envPlaceHolderRegex = new RegExp('\\$ENVIRONMENT', 'g');
 
-        if (perfspec.indicators
-          .find(indicator => indicator.source.toLowerCase() === 'prometheus') !== undefined) {
-          this.addPrometheusSource(event, pitometer, prometheusUrl);
-        }
-        // get dynatrace service entity ID if Dynatrace source is defined in perfspec
-        let serviceEntityId = '';
-        if (perfspec.indicators
-          .find(indicator => indicator.source.toLowerCase() === 'dynatrace') !== undefined) {
-          try {
-            const dynatraceCredentials = await this.addDynatraceSource(event, pitometer);
-            serviceEntityId = await this.getDTServiceEntityId(event, dynatraceCredentials);
+      /*
+      /* TODO: going forward, setting the duration via the $DURATION_MINUTES
+      /* placeholder will become obsolete, since this is handled by pitometer now.
+      /* For backwards compatibility reasons we have to keep this for now.
+      */
+      const durationRegex = new RegExp('\\$DURATION_MINUTES', 'g');
+      perfspecString =
+        perfspecString.replace(envPlaceHolderRegex, `${event.data.project}-${event.data.stage}`);
+      if (testRunDurationMinutes > 0) {
+        perfspecString = perfspecString.replace(durationRegex, `${testRunDurationMinutes}`);
+      } else {
+        perfspecString = perfspecString.replace(durationRegex, `3`);
+      }
 
-            if (serviceEntityId === undefined || serviceEntityId === '') {
-              this.handleEvaluationResult(
-                {
-                  result: 'failed',
-                  error: 'No Dynatrace Service Entity found.',
-                },
-                event,
-              );
-              return false;
-            }
-          } catch (e) {
+      perfspec = JSON.parse(perfspecString);
+      Logger.log(
+        event.shkeptncontext, event.id,
+        `Perfspec file content: ${JSON.stringify(perfspec)}`,
+      );
+
+      const indicators = [];
+      if (perfspec === undefined || perfspec.indicators === undefined) {
+        this.handleEvaluationResult(
+          {
+            result: 'failed',
+            error: 'Bad perfspec format.',
+          },
+          event,
+        );
+        return false;
+      }
+
+      if (perfspec.indicators
+        .find(indicator => indicator.source.toLowerCase() === 'prometheus') !== undefined) {
+        this.addPrometheusSource(event, pitometer, prometheusUrl);
+      }
+      // get dynatrace service entity ID if Dynatrace source is defined in perfspec
+      let serviceEntityId = '';
+      if (perfspec.indicators
+        .find(indicator => indicator.source.toLowerCase() === 'dynatrace') !== undefined) {
+        try {
+          const dynatraceCredentials = await this.addDynatraceSource(event, pitometer);
+          serviceEntityId = await this.getDTServiceEntityId(event, dynatraceCredentials);
+
+          if (serviceEntityId === undefined || serviceEntityId === '') {
             this.handleEvaluationResult(
               {
                 result: 'failed',
-                error: `Error while fetching Dynatrace data: ${e}`,
+                error: 'No Dynatrace Service Entity found.',
               },
               event,
             );
             return false;
           }
-        }
-
-        for (let i = 0; i < perfspec.indicators.length; i += 1) {
-          const indicator = perfspec.indicators[i];
-          if (indicator.source.toLowerCase() === 'dynatrace' && indicator.query !== undefined) {
-            if (serviceEntityId !== undefined && serviceEntityId !== '') {
-              indicator.query.entityIds = [serviceEntityId];
-            }
-          }
-          indicators.push(indicator);
-        }
-        perfspec.indicators = indicators;
-        try {
-          const evaluationResult = await pitometer.run(
-            perfspec,
-            {
-              timeStart: moment(event.data.startedat).unix(),
-              timeEnd: moment(event.time).unix(),
-            },
-          );
-          Logger.log(
-            event.shkeptncontext, event.id,
-            evaluationResult,
-          );
-
-          this.handleEvaluationResult(evaluationResult, event);
         } catch (e) {
-          Logger.log(
-            event.shkeptncontext,
-            JSON.stringify(e.config.data),
-            'ERROR',
-          );
           this.handleEvaluationResult(
             {
               result: 'failed',
-              error: `${e}`,
+              error: `Error while fetching Dynatrace data: ${e}`,
             },
             event,
           );
+          return false;
         }
+      }
+
+      for (let i = 0; i < perfspec.indicators.length; i += 1) {
+        const indicator = perfspec.indicators[i];
+        if (indicator.source.toLowerCase() === 'dynatrace' && indicator.query !== undefined) {
+          if (serviceEntityId !== undefined && serviceEntityId !== '') {
+            indicator.query.entityIds = [serviceEntityId];
+          }
+        }
+        indicators.push(indicator);
+      }
+      perfspec.indicators = indicators;
+      try {
+        const evaluationResult = await pitometer.run(
+          perfspec,
+          {
+            timeStart: moment(event.data.startedat).unix(),
+            timeEnd: moment(event.time).unix(),
+          },
+        );
+        Logger.log(
+          event.shkeptncontext, event.id,
+          evaluationResult,
+        );
+
+        this.handleEvaluationResult(evaluationResult, event);
+      } catch (e) {
+        Logger.log(
+          event.shkeptncontext,
+          JSON.stringify(e.config.data),
+          'ERROR',
+        );
+        this.handleEvaluationResult(
+          {
+            result: 'failed',
+            error: `${e}`,
+          },
+          event,
+        );
       }
       return true;
     } catch (e) {
@@ -335,6 +341,148 @@ export class Service {
       );
     }
     return entityId;
+  }
+
+  async getServiceIndicators(event: RequestModel): Promise<ServiceIndicators> {
+
+    const indicatorString =
+      await this.getServiceResourceContent(event, 'service-indicators.yaml');
+
+    if (indicatorString === '') {
+      Logger.log(
+        event.shkeptncontext, event.id,
+        `No service-indicators file defined for `
+        + `${event.data.project}:${event.data.service}:${event.data.stage}`);
+      return null;
+    }
+
+    Logger.log(
+      event.shkeptncontext, event.id,
+      `Service Indicator file content: ${indicatorString}`,
+    );
+
+    try {
+      const indicators = <ServiceIndicators>YAML.parse(indicatorString);
+      return indicators;
+    } catch (e) {
+      Logger.log(
+        event.shkeptncontext, event.id,
+        `Invalid Service indicators format: `
+        + `${event.data.project}:${event.data.service}:${event.data.stage}`);
+      throw e;
+    }
+  }
+
+  async getServiceObjectives(event: RequestModel): Promise<ServiceObjectives> {
+    const objectivesString =
+      await this.getServiceResourceContent(event, 'service-objectives.yaml');
+
+    if (objectivesString === '') {
+      Logger.log(
+        event.shkeptncontext, event.id,
+        `No service-objectives file defined for `
+        + `${event.data.project}:${event.data.service}:${event.data.stage}`);
+      return null;
+    }
+
+    Logger.log(
+      event.shkeptncontext, event.id,
+      `Service Objectives file content: ${objectivesString}`,
+    );
+
+    try {
+      const objectives = <ServiceObjectives>YAML.parse(objectivesString);
+      return objectives;
+    } catch (e) {
+      Logger.log(
+        event.shkeptncontext, event.id,
+        `Invalid Service objectives format: `
+        + `${event.data.project}:${event.data.service}:${event.data.stage}`);
+      throw e;
+    }
+  }
+
+  async getPerfspecString(event: RequestModel): Promise<string> {
+    try {
+      const indicators = await this.getServiceIndicators(event);
+      if (indicators === null) {
+        return this.getServiceResourceContent(event, 'perfspec.json');
+      }
+      const objectives = await this.getServiceObjectives(event);
+      if (objectives === null) {
+        return this.getServiceResourceContent(event, 'perfspec.json');
+      }
+      const perfspecObject = this.createPerfspecObject(indicators, objectives);
+      return JSON.stringify(perfspecObject);
+    } catch (e) {
+      throw e;
+    }
+  }
+
+  createPerfspecObject(indicators: ServiceIndicators, objectives: ServiceObjectives): any {
+    const perfspecObject = {
+      spec_version: '1.0',
+      indicators: [],
+      objectives: {
+        pass: objectives.pass,
+        warning: objectives.warning,
+      },
+    };
+
+    const getIndicator = (name: string): Indicator => {
+      for (let i = 0; i < indicators.indicators.length; i += 1) {
+        if (indicators.indicators[i].name === name) {
+          return indicators.indicators[i];
+        }
+      }
+      return null;
+    };
+
+    for (let i = 0; i < objectives.objectives.length; i += 1) {
+      const objective = objectives.objectives[i];
+      const indicator = getIndicator(objective.name);
+      if (indicator !== null) {
+        const newPerfspecIndicator = {
+          id: indicator.name,
+          source: indicator.source,
+          query: indicator.query,
+          grading: {
+            type: 'Threshold',
+            thresholds: {
+              upperSevere: objective.threshold,
+            },
+            metricScore: objective.score,
+          },
+        };
+        const durationRegex = new RegExp('\\$DURATION_MINUTES', 'g');
+        newPerfspecIndicator.query =
+          newPerfspecIndicator.query.replace(durationRegex, objective.timeframe);
+        perfspecObject.indicators.push(newPerfspecIndicator);
+      }
+    }
+
+    return perfspecObject;
+  }
+
+  async getServiceResourceContent(event: RequestModel, resourceUri: string): Promise<string> {
+    // tslint:disable-next-line: max-line-length
+    const url = `http://configuration-service.keptn.svc.cluster.local:8080/v1/project/${event.data.project}/stage/${event.data.stage}/service/${event.data.service}/${resourceUri}`;
+    let response;
+
+    try {
+      response = await axios.get(url, {});
+    } catch (e) {
+      Logger.log(
+        event.shkeptncontext, event.id,
+        `Resource ${resourceUri} not found in`
+        + `${event.data.project}:${event.data.service}:${event.data.stage}`);
+      return '';
+    }
+    if (response.data !== undefined && response.data.resourceContent !== undefined) {
+      // decode the base64 encoded string
+      return base64decode(response.data.resourceContent);
+    }
+    return '';
   }
 
   async handleEvaluationResult(evaluationResult: any, sourceEvent: RequestModel): Promise<void> {

--- a/pitometer-service/src/svc/ServiceIndicators.ts
+++ b/pitometer-service/src/svc/ServiceIndicators.ts
@@ -1,0 +1,9 @@
+export interface ServiceIndicators {
+  indicators: Indicator[];
+}
+
+export interface Indicator {
+  name: string;
+  source: string;
+  query: string;
+}

--- a/pitometer-service/src/svc/ServiceObjectives.ts
+++ b/pitometer-service/src/svc/ServiceObjectives.ts
@@ -1,0 +1,12 @@
+export interface ServiceObjectives {
+  pass: number;
+  warning: number;
+  objectives: Objective[];
+}
+
+export interface Objective {
+  name: string;
+  threshold: number;
+  timeframe: string;
+  score: number;
+}


### PR DESCRIPTION
The service now checks if both a `service-indicators.yaml` and `service-objectives.yaml` file are located in the service's directory in the config repo. If they are present and both valid, the service will internally recreate a perfspec.json file that will be passed to pitometer. If those files are not present, the service checks if there is a `perfspec.json` file in the service directory and try to use that for the evaluation