### PR TITLE
Fixing #929 - git clone and secret fixes

### DIFF
--- a/configuration-service/common/git.go
+++ b/configuration-service/common/git.go
@@ -3,6 +3,7 @@ package common
 import (
 	"encoding/json"
 	"errors"
+	"net/url"
 	"os"
 	"strings"
 
@@ -38,6 +39,11 @@ func CloneRepo(project string, user string, token string, uri string) error {
 }
 
 func getRepoURI(uri string, user string, token string) string {
+	if strings.Contains(user, "@") {
+		// username contains an @, probably an e-mail; need to encode it
+		// see https://stackoverflow.com/a/29356143
+		user = url.QueryEscape(user)
+	}
 
 	if strings.Contains(uri, user+"@") {
 		uri = strings.Replace(uri, "https://"+user+"@", "https://"+user+":"+token+"@", 1)


### PR DESCRIPTION
This fixes the issues that occured in #929 with `keptn create project`
Work in progress - don't merge yet

* When git clone fails, a secret for git credentials was created -> secret is now cleaned up
* The order of cloning a repo and creating a secret was wrong
* Git usernames that contain an `@` (e.g., e-mail address) lead to problems when using `git clone`
