### PR TITLE
Feature/943 Github Release + Travis Status Badge, ignore .idea files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ configuration-service/cmd/configuration-service-server/__debug_bin
 
 # IDE files
 .vscode/
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 ![keptn](./assets/keptn.png)
 
 # Keptn
+![GitHub release (latest by date)](https://img.shields.io/github/v/release/keptn/keptn)
+[![Build Status](https://travis-ci.org/keptn/keptn.svg?branch=master)](https://travis-ci.org/keptn/keptn)
+
 Keptn is a fabric for cloud-native lifecycle automation at enterprise scale. In the current version it provides an automated setup of the Keptn core components as well as a demo application. Also included are three pre-configured use cases for the demo application: automated quality gates, runbook automation, and automated evaluation of blue/green deployments.
 
 ## Usage


### PR DESCRIPTION
Re-opened* and combined PRs

* Added github release + travis build status badges (from #937)
* ignore jetbrains .idea files (from #935)

\* as travis-ci build pipeline requires us to have proper branch naming.