### PR TITLE
#946 fix nightly crons

### DIFF
--- a/travis-scripts/cronjob_main.sh
+++ b/travis-scripts/cronjob_main.sh
@@ -4,10 +4,12 @@ gcloud --quiet config set project $PROJECT_NAME
 gcloud --quiet config set container/cluster $CLUSTER_NAME_NIGHTLY
 gcloud --quiet config set compute/zone ${CLOUDSDK_COMPUTE_ZONE}
 
+# clean up any nightly clusters
 clusters=$(gcloud container clusters list --zone $CLOUDSDK_COMPUTE_ZONE --project $PROJECT_NAME)
 if echo "$clusters" | grep $CLUSTER_NAME_NIGHTLY; then 
     echo "First delete old keptn installation"
     cd ./installer/scripts
+    echo "WARNING: Uninstallation is currently broken..."
     ./common/uninstallKeptn.sh
     cd ../..
 
@@ -15,18 +17,19 @@ if echo "$clusters" | grep $CLUSTER_NAME_NIGHTLY; then
     gcloud container clusters delete $CLUSTER_NAME_NIGHTLY --zone $CLOUDSDK_COMPUTE_ZONE --project $PROJECT_NAME --quiet
     echo "Finished deleting nigtly cluster"
 else 
-    echo "No nightly cluster available"
+    echo "No nightly cluster need to be deleted"
 fi
 
-gcloud container --project $PROJECT_NAME clusters create $CLUSTER_NAME_NIGHTLY --zone $CLOUDSDK_COMPUTE_ZONE --username "admin" --cluster-version "1.12.8-gke.10" --machine-type "n1-standard-4" --image-type "UBUNTU" --disk-type "pd-standard" --disk-size "100" --scopes "https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" --num-nodes "1" --enable-cloud-logging --enable-cloud-monitoring --no-enable-ip-alias --network "projects/sai-research/global/networks/default" --subnetwork "projects/sai-research/regions/$CLOUDSDK_REGION/subnetworks/default" --addons HorizontalPodAutoscaling,HttpLoadBalancing --no-enable-autoupgrade --no-enable-autorepair
+# create a new cluster
+gcloud container --project $PROJECT_NAME clusters create $CLUSTER_NAME_NIGHTLY --zone $CLOUDSDK_COMPUTE_ZONE --username "admin" --cluster-version $GKE_VERSION --machine-type "n1-standard-4" --image-type "UBUNTU" --disk-type "pd-standard" --disk-size "100" --scopes "https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" --num-nodes "1" --enable-cloud-logging --enable-cloud-monitoring --no-enable-ip-alias --network "projects/sai-research/global/networks/default" --subnetwork "projects/sai-research/regions/$CLOUDSDK_REGION/subnetworks/default" --addons HorizontalPodAutoscaling,HttpLoadBalancing --no-enable-autoupgrade --no-enable-autorepair
 if [[ $? != '0' ]]; then
-    print_error "gcloud cluster create failed."
+    echo "gcloud cluster create failed."
     exit 1
 fi
 
 gcloud container clusters get-credentials $CLUSTER_NAME_NIGHTLY --zone $CLOUDSDK_COMPUTE_ZONE --project $PROJECT_NAME
 if [[ $? != '0' ]]; then
-    print_error "gcloud get credentials failed."
+    echo "gcloud get credentials failed."
     exit 1
 fi
 

--- a/travis-scripts/setup_functions.sh
+++ b/travis-scripts/setup_functions.sh
@@ -49,7 +49,7 @@ function setup_knative {
 
 function uninstall_keptn {
     cd ./installer/scripts
-    ./uninstallKeptn.sh
+    ./uninstallKeptn.sh # uninstallKeptn.sh is no longer available - this will fail
     cd ../..
 }
 


### PR DESCRIPTION
Nightly cron jobs currently fail on travis as the provided GKE version is no longer available.

I've introduced a new variable in travis-ci called `GKE_VERSION`, and I've set it to `1.12.8` at the moment (which should allow `gcloud` to automatically pick the latest 1.12.8-* version).

Also, `print_error` should not be called within the cronjob, as it is not available in there. Using `echo` instead.
