### PR TITLE
#957 basic tests fail on linux, revert back to osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,10 +104,11 @@ jobs:
 
   # all commits (including external pull requests) should run basic tests for the CLI (if anything has changed)
   - stage: CLI tests
+    os: osx # ToDo: cli tests fail for os: linux 
     script:
     - | 
       if [[ $CHANGED_FILES == *"${CLI_FOLDER}"*  ]]; then
-        echo "Testing keptn CLI on linux"
+        echo "Testing keptn CLI on osx"
         cd ./cli
         dep ensure
         go test ./...


### PR DESCRIPTION
The following tests seem to fail with os: linux on travis-ci:

```bash
      if [[ $CHANGED_FILES == *"${CLI_FOLDER}"*  ]]; then
        echo "Testing keptn CLI on osx"
        cd ./cli
        dep ensure
        go test ./...
      fi
```

The tests run fine with `os: osx` though, see this build as an example:
https://travis-ci.org/keptn/keptn/builds/598183032

While we need to investigate this for sure, this PR sets the stage for CLI test to osx for now.