### PR TITLE
#462 Allow NodePort for istio-ingressgateway

### DIFF
--- a/cli/Gopkg.lock
+++ b/cli/Gopkg.lock
@@ -472,7 +472,7 @@
 
 [[projects]]
   branch = "develop"
-  digest = "1:7598ad5e8a2a636615ba8f7212b8e6b672d1b32b241e2d226e6ef3d84051b827"
+  digest = "1:066d93a90c0be408a79f0e2cb4f1fca996a36ceac97082223041273c3213ab61"
   name = "github.com/keptn/go-utils"
   packages = [
     "pkg/api/models",
@@ -482,7 +482,7 @@
     "pkg/utils",
   ]
   pruneopts = ""
-  revision = "e97a5e95ea3ccb6bff87cda5049a780a89d1fc35"
+  revision = "9eefe99dfb20b6d13dbbf30d193e0e54aba6a94c"
 
 [[projects]]
   digest = "1:91317956b340c9e61a4287fd94c870bfad3f1922280c3e0a65db91c29017e8de"
@@ -1125,7 +1125,7 @@
   version = "kubernetes-1.12.0"
 
 [[projects]]
-  digest = "1:ccdf880a2361789a52b2a7076c05e77dd608d13a7207004f3b9518e99c12676c"
+  digest = "1:c35e91a5a3af23a68b1440fc1a9c5a713853b5447bf4e0606def69cbc84148ef"
   name = "k8s.io/helm"
   packages = [
     "pkg/chartutil",

--- a/cli/cmd/auth.go
+++ b/cli/cmd/auth.go
@@ -97,11 +97,11 @@ To manually set up your keptn CLI, please follow the instructions at https://kep
 
 func getEndpointUsingKube() (string, error) {
 	ops := options{"get",
-		"virtualservice",
-		"api",
+		"cm",
+		"keptn-domain",
 		"-n",
 		"keptn",
-		"-ojsonpath={.spec.hosts[0]}"}
+		"-ojsonpath={.data.app_domain}"}
 	ops.appendIfNotEmpty(kubectlOptions)
 	return keptnutils.ExecuteCommand("kubectl", ops)
 }

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -187,6 +187,7 @@ func init() {
 		"The platform to run keptn on [aks,eks,gke,pks,openshift,kubernetes]")
 	installParams.GatewayType = installCmd.Flags().StringP("gateway", "g", "LoadBalancer",
 		"The ingress-loadbalancer type [LoadBalancer,NodePort]")
+	installCmd.Flags().MarkHidden("gateway")
 	installCmd.PersistentFlags().BoolVarP(&insecureSkipTLSVerify, "insecure-skip-tls-verify", "s",
 		false, "Skip tls verification for kubectl commands")
 }

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -34,9 +34,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var configFilePath *string
-var installerVersion *string
-var platformIdentifier *string
+type installCmdParams struct {
+	ConfigFilePath     *string
+	InstallerVersion   *string
+	PlatformIdentifier *string
+	GatewayType        *string
+}
+
+var installParams *installCmdParams
 
 const gke = "gke"
 const aks = "aks"
@@ -79,6 +84,10 @@ Example:
 			return err
 		}
 
+		if !checkIfGatewayTypeIsSupported() {
+			return errors.New(`Keptn currently supports 'LoadBalancer' and 'NodePort'`)
+		}
+
 		isInstallerAvailable, err := checkInstallerAvailability()
 		if err != nil || !isInstallerAvailable {
 			return errors.New("Installers not found under:\n" +
@@ -92,13 +101,13 @@ Example:
 		// Check whether kubectl is installed
 		isKubAvailable, err := utils.IsKubectlAvailable()
 		if err != nil || !isKubAvailable {
-			return errors.New(`keptn requires 'kubectl' but it is not available.
+			return errors.New(`Keptn requires 'kubectl' but it is not available.
 Please see https://kubernetes.io/docs/tasks/tools/install-kubectl/`)
 		}
 
-		if configFilePath != nil && *configFilePath != "" {
+		if installParams.ConfigFilePath != nil && *installParams.ConfigFilePath != "" {
 			// Config was provided in form of a file
-			err = parseConfig(*configFilePath)
+			err = parseConfig(*installParams.ConfigFilePath)
 			if err != nil {
 				return err
 			}
@@ -119,7 +128,7 @@ Please see https://kubernetes.io/docs/tasks/tools/install-kubectl/`)
 
 		var err error
 		if !mocking {
-			if configFilePath == nil || *configFilePath == "" {
+			if installParams.ConfigFilePath == nil || *installParams.ConfigFilePath == "" {
 				err = readCreds()
 				if err != nil {
 					return err
@@ -132,11 +141,15 @@ Please see https://kubernetes.io/docs/tasks/tools/install-kubectl/`)
 	},
 }
 
+func checkIfGatewayTypeIsSupported() bool {
+	return *installParams.GatewayType == "NodePort" || *installParams.GatewayType == "LoadBalancer"
+}
+
 func setPlatform() error {
 
-	*platformIdentifier = strings.ToLower(*platformIdentifier)
+	*installParams.PlatformIdentifier = strings.ToLower(*installParams.PlatformIdentifier)
 
-	switch *platformIdentifier {
+	switch *installParams.PlatformIdentifier {
 	case gke:
 		p = newGKEPlatform()
 		return nil
@@ -156,18 +169,26 @@ func setPlatform() error {
 		p = newKubernetesPlatform()
 		return nil
 	default:
-		return errors.New("Unsupported platform '" + *platformIdentifier + "'. The following platforms are supported: aks, eks, gke, pks, openshift, and kubernetes")
+		return errors.New("Unsupported platform '" + *installParams.PlatformIdentifier +
+			"'. The following platforms are supported: aks, eks, gke, pks, openshift, and kubernetes")
 	}
 }
 
 func init() {
 	rootCmd.AddCommand(installCmd)
-	configFilePath = installCmd.Flags().StringP("creds", "c", "", "The name of the creds file")
+	installParams = &installCmdParams{}
+	installParams.ConfigFilePath = installCmd.Flags().StringP("creds", "c", "",
+		"The name of the creds file")
 	installCmd.Flags().MarkHidden("creds")
-	installerVersion = installCmd.Flags().StringP("keptn-version", "k", "master", "The branch or tag of the version which is installed")
+	installParams.InstallerVersion = installCmd.Flags().StringP("keptn-version", "k",
+		"master", "The branch or tag of the version which is installed")
 	installCmd.Flags().MarkHidden("keptn-version")
-	platformIdentifier = installCmd.Flags().StringP("platform", "p", "gke", "The platform to run keptn on [aks,eks,gke,pks,openshift,kubernetes]")
-	installCmd.PersistentFlags().BoolVarP(&insecureSkipTLSVerify, "insecure-skip-tls-verify", "s", false, "Skip tls verification for kubectl commands")
+	installParams.PlatformIdentifier = installCmd.Flags().StringP("platform", "p", "gke",
+		"The platform to run keptn on [aks,eks,gke,pks,openshift,kubernetes]")
+	installParams.GatewayType = installCmd.Flags().StringP("gateway", "g", "LoadBalancer",
+		"The ingress-loadbalancer type [LoadBalancer,NodePort]")
+	installCmd.PersistentFlags().BoolVarP(&insecureSkipTLSVerify, "insecure-skip-tls-verify", "s",
+		false, "Skip tls verification for kubectl commands")
 }
 
 func checkInstallerAvailability() (bool, error) {
@@ -191,11 +212,11 @@ func checkInstallerAvailability() (bool, error) {
 }
 
 func getInstallerURL() string {
-	return installerPrefixURL + *installerVersion + installerSuffixPath
+	return installerPrefixURL + *installParams.InstallerVersion + installerSuffixPath
 }
 
 func getRbacURL() string {
-	return installerPrefixURL + *installerVersion + rbacSuffixPath
+	return installerPrefixURL + *installParams.InstallerVersion + rbacSuffixPath
 }
 
 // Preconditions: 1. Already authenticated against the cluster;
@@ -213,7 +234,13 @@ func doInstallation() error {
 	}
 
 	if err := utils.Replace(installerPath,
-		utils.PlaceholderReplacement{PlaceholderValue: "PLATFORM_PLACEHOLDER", DesiredValue: *platformIdentifier}); err != nil {
+		utils.PlaceholderReplacement{PlaceholderValue: "PLATFORM_PLACEHOLDER",
+			DesiredValue: *installParams.PlatformIdentifier}); err != nil {
+		return err
+	}
+	if err := utils.Replace(installerPath,
+		utils.PlaceholderReplacement{PlaceholderValue: "GATEWAY_TYPE_PLACEHOLDER",
+			DesiredValue: *installParams.GatewayType}); err != nil {
 		return err
 	}
 

--- a/cli/utils/websockethelper/websocketHelper.go
+++ b/cli/utils/websockethelper/websocketHelper.go
@@ -36,7 +36,7 @@ func PrintWSContentCEResponse(responseCE *cloudevents.Event, apiEndPoint url.URL
 // PrintWSContentChannelInfo opens a websocket using the passed
 // connection data and prints status data
 func PrintWSContentChannelInfo(channelInfo *apimodels.ChannelInfo, apiEndPoint url.URL) error {
-	connectionData := &keptnutils.ConnectionData{ChannelInfo:*channelInfo}
+	connectionData := &keptnutils.ConnectionData{ChannelInfo: *channelInfo}
 	return printWSContent(*connectionData, apiEndPoint)
 }
 
@@ -85,6 +85,7 @@ func openWS(connData keptnutils.ConnectionData, apiEndPoint url.URL) (*websocket
 	header := http.Header{}
 	header.Add("Token", *connData.ChannelInfo.Token)
 	header.Add("Keptn-Ws-Channel-Id", *connData.ChannelInfo.ChannelID)
+	header.Add("Host", "api.keptn")
 	dialer := websocket.DefaultDialer
 	dialer.NetDial = utils.ResolveXipIo
 	dialer.TLSClientConfig = &tls.Config{

--- a/installer/manifests/installer/installer.yaml
+++ b/installer/manifests/installer/installer.yaml
@@ -18,4 +18,6 @@ spec:
         env:       
         - name: PLATFORM
           value: PLATFORM_PLACEHOLDER
+        - name: GATEWAY_TYPE
+          value: GATEWAY_TYPE_PLACEHOLDER
       restartPolicy: OnFailure

--- a/installer/manifests/installer/installer.yaml
+++ b/installer/manifests/installer/installer.yaml
@@ -14,7 +14,7 @@ spec:
         emptyDir: {}
       containers:
       - name: keptn-installer
-        image: keptn/installer:6895470
+        image: keptn/installer:latest
         env:       
         - name: PLATFORM
           value: PLATFORM_PLACEHOLDER

--- a/installer/manifests/installer/installer.yaml
+++ b/installer/manifests/installer/installer.yaml
@@ -14,7 +14,7 @@ spec:
         emptyDir: {}
       containers:
       - name: keptn-installer
-        image: keptn/installer:latest
+        image: keptn/installer:6895470
         env:       
         - name: PLATFORM
           value: PLATFORM_PLACEHOLDER

--- a/installer/manifests/keptn/keptn-api-virtualservice.yaml
+++ b/installer/manifests/keptn/keptn-api-virtualservice.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   hosts:
   - "api.keptn.DOMAIN_PLACEHOLDER"
+  - "api.keptn"
   gateways:
   - keptn-gateway
   http:

--- a/installer/scripts/common/setupIstio.sh
+++ b/installer/scripts/common/setupIstio.sh
@@ -6,6 +6,11 @@ kubectl create namespace istio-system
 helm template ../manifests/istio/helm/istio-init --name istio-init --namespace istio-system | kubectl apply -f -
 verify_kubectl $? "Creating Istio resources failed"
 wait_for_crds "adapters.config.istio.io,attributemanifests.config.istio.io,authorizationpolicies.rbac.istio.io,clusterrbacconfigs.rbac.istio.io,destinationrules.networking.istio.io,envoyfilters.networking.istio.io,gateways.networking.istio.io,handlers.config.istio.io,httpapispecbindings.config.istio.io,httpapispecs.config.istio.io,instances.config.istio.io,meshpolicies.authentication.istio.io,policies.authentication.istio.io,quotaspecbindings.config.istio.io,quotaspecs.config.istio.io,rbacconfigs.rbac.istio.io,rules.config.istio.io,serviceentries.networking.istio.io,servicerolebindings.rbac.istio.io,serviceroles.rbac.istio.io,sidecars.networking.istio.io,templates.config.istio.io,virtualservices.networking.istio.io"
+
+# We tested it with helm --set according to the descriptions provided in https://istio.io/docs/setup/install/helm/
+# However, it did not work out. Therefore, we are using sed
+sed 's/LoadBalancer #change to NodePort, ClusterIP or LoadBalancer if need be/'$GATEWAY_TYPE'/g' ../manifests/istio/helm/istio/charts/gateways/values.yaml  > ../manifests/istio/helm/istio/charts/gateways/values_tmp.yaml
+mv ../manifests/istio/helm/istio/charts/gateways/values_tmp.yaml ../manifests/istio/helm/istio/charts/gateways/values.yaml
 helm template ../manifests/istio/helm/istio --name istio --namespace istio-system --values ../manifests/istio/helm/istio/values-istio-minimal.yaml | kubectl apply -f -
 verify_kubectl $? "Installing Istio failed."
 wait_for_deployment_in_namespace "istio-ingressgateway" "istio-system"

--- a/releasenotes/releasenotes_develop.md
+++ b/releasenotes/releasenotes_develop.md
@@ -1,6 +1,7 @@
 # Release Notes develop
 
 ## New Features
+- Allow installation using a NodePort for the istio-ingressgateway [#462](https://github.com/keptn/keptn/issues/462)
 
 ## CLI Enhancements
 


### PR DESCRIPTION
- Add `gateway` flag in `keptn install` in order to allow to select if a LoadBalancer or a NodePort is used for the istio-ingressgateway
- Set Host in API requests and WS communication
