### PR TITLE
Bug/helm error message

### DIFF
--- a/helm-service/controller/configuration_changer.go
+++ b/helm-service/controller/configuration_changer.go
@@ -7,10 +7,11 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"log"
 	"os"
 	"strings"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/helm/pkg/proto/hapi/chart"
 
@@ -66,7 +67,7 @@ func (c *ConfigurationChanger) ChangeAndApplyConfiguration(ce cloudevents.Event,
 	if os.Getenv("PRE_WORKFLOW_ENGINE") == "true" && e.Stage == "" {
 		stage, err := getFirstStage(e.Project)
 		if err != nil {
-			c.logger.Error(fmt.Sprintf("Error when reading shipyard: %s" + err.Error()))
+			c.logger.Error(fmt.Sprintf("Error when reading shipyard: %s", err.Error()))
 			return err
 		}
 		e.Stage = stage


### PR DESCRIPTION
I came across this error while debugging.

```go
			c.logger.Error(fmt.Sprintf("Error when reading shipyard: %s" + err.Error()))
```
should really be
```go
			c.logger.Error(fmt.Sprintf("Error when reading shipyard: %s", err.Error()))
```

It results in the following log output:

```
{"timestamp":"2019-10-16T14:29:38.149407636Z","logLevel":"ERROR","message":"Error when reading shipyard: %!s(MISSING)resource not found"}
{"timestamp":"2019-10-16T14:29:38.544697765Z","logLevel":"ERROR","message":"Error when reading shipyard: %!s(MISSING)resource not found"}
```
