### PR TITLE
Enhance error message for authentication failures

### DIFF
--- a/cli/cmd/auth.go
+++ b/cli/cmd/auth.go
@@ -44,7 +44,8 @@ Example:
 		if !mocking {
 			_, err := authHandler.Authenticate()
 			if err != nil {
-				logging.PrintLog("Authentication was unsuccessful", logging.QuietLevel)
+				errMsg := fmt.Sprintf("Authentication was unsuccessful. %s", *err.Message)
+				logging.PrintLog(errMsg, logging.QuietLevel)
 				return fmt.Errorf("Authentication was unsuccessful. %s", *err.Message)
 			}
 

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -136,7 +136,7 @@ Please see https://kubernetes.io/docs/tasks/tools/install-kubectl/`)
 			}
 			return doInstallation()
 		}
-		fmt.Println("Skipping intallation due to mocking flag")
+		fmt.Println("Skipping installation due to mocking flag")
 		return nil
 	},
 }


### PR DESCRIPTION
I just came across a problem with authentication, which I can not properly debug as the error message does not contain the actual error.
This PR adds a proper error message (and a typo)