### PR TITLE
Update issue/bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,10 +7,41 @@ assignees: ''
 
 ---
 
+Your issue may already be reported! Please search on the [issue tracker](https://github.com/keptn/keptn/issues) before creating a new one.
+
+
+**Environment**
+<!-- Please tell us about the environment in which this bug can be reproduced in -->
+
+* Client OS (e.g., Linux, OSX, Windows):
+* Keptn Version (`keptn version`):
+* Kubernetes Cloud Provider (e.g., GKE, AKS):
+* Kubernetes version (`kubectl version`):
+
+<!-- Please also let us know about other components and their version if you believe that this issue is related to them (e.g., Istio, Web Browser Version). -->
+
+**Affected Component**
+<!-- Please tell us which component of Keptn is affected (leave empty if you are unsure). -->
+
+* [ ] Docs
+* [ ] CLI
+* [ ] Kubernetes Integration
+* [ ] Openshift Integration
+* [ ] Helm
+* [ ] Istio
+* [ ] Bridge
+* [ ] Gatekeeper
+* [ ] Datastore
+* [ ] REST API
+* [ ] eventbroker / distributor
+* [ ] jmeter
+
 **Describe the bug**
-A clear and concise description of what the bug is.
+<!-- Please provide a clear and concise description of what the bug is. Code samples should be put in the **To Reproduce** section. -->
 
 **To Reproduce**
+<!-- Please provide detailed instructions of how to reproduce the behaviour, including code samples if applicable. -->
+
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
@@ -18,13 +49,13 @@ Steps to reproduce the behavior:
 4. See error
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+<!--- Please provide a clear and concise description of what you expected to happen -->
+
+**Current behavior**
+<!--- Please tell us what happens instead of the expected behavior -->
 
 **Screenshots**
-If applicable, add screenshots to help explain your problem.
-
-**Environment**
-Kubernetes version, Istio version, Knative version, ...
+<!-- If applicable, add screenshots to help explain your problem. -->
 
 **Additional context**
-Add any other context about the problem here.
+<!-- Add any other context about the problem here. -->


### PR DESCRIPTION
Our current template does not provide all the information we need to look into issues.

The new template asks the user to specify the environment and which component they believe is affected right away.

**This PR is set to master on purpose. If you believe that we should go the full cycle with the development branch, let me know.**

FYI: I created a new issue to display how this would look like: https://github.com/keptn/keptn/issues/1003