### PR TITLE
#1011 Use latest version of go-utils for mongodb-datastore

### DIFF
--- a/mongodb-datastore/Gopkg.lock
+++ b/mongodb-datastore/Gopkg.lock
@@ -2,12 +2,12 @@
 
 
 [[projects]]
-  digest = "1:80004fcc5cf64e591486b3e11b406f1e0d17bf85d475d64203c8494f5da4fcd1"
+  digest = "1:26ee1e365ea8f312ee11e170fc6675bac0dd3d4adf2406e753d0a43527e1afb8"
   name = "cloud.google.com/go"
   packages = ["compute/metadata"]
   pruneopts = "UT"
-  revision = "cdaaf98f9226c39dc162b8e55083b2fbc67b4674"
-  version = "v0.43.0"
+  revision = "cfe8f6d1fe6976d03af790d7a8b9bf6aa73287bd"
+  version = "v0.47.0"
 
 [[projects]]
   digest = "1:7e11a0a4c2d7792a108629e27c83ff4397b950dede4ccce23f99639bfa84846b"
@@ -21,6 +21,38 @@
   ]
   pruneopts = "UT"
   revision = "bca49d5b51a50dc5bb17bbf6204c711c6dbded06"
+
+[[projects]]
+  digest = "1:9f3b30d9f8e0d7040f729b82dcbc8f0dead820a133b3147ce355fc451f32d761"
+  name = "github.com/BurntSushi/toml"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005"
+  version = "v0.3.1"
+
+[[projects]]
+  digest = "1:3b10c6fd33854dc41de2cf78b7bae105da94c2789b6fa5b9ac9e593ea43484ac"
+  name = "github.com/Masterminds/goutils"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "41ac8693c5c10a92ea1ff5ac3a7f95646f6123b0"
+  version = "v1.1.0"
+
+[[projects]]
+  digest = "1:d37f34e1e231ee4b8657d1b6153e2696b1d7341850f648f5d78151d3bc1f677b"
+  name = "github.com/Masterminds/semver"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "fe7c21038085e01e67044ec1efe3afb1eaa59f75"
+  version = "v3.0.1"
+
+[[projects]]
+  digest = "1:b565deb585c50ab8e94fe5d6c9903f1495970b97814803e4ab0e70c0a9c87a30"
+  name = "github.com/Masterminds/sprig"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "e4c0945838d570720d876a6ad9b4568ed32317b4"
+  version = "v2.22.0"
 
 [[projects]]
   digest = "1:a2682518d905d662d984ef9959984ef87cecb777d379bfa9d9fe40e78069b3e4"
@@ -45,6 +77,29 @@
   pruneopts = "UT"
   revision = "ccb8e960c48f04d6935e72476ae4a51028f9e22f"
   version = "v9"
+
+[[projects]]
+  digest = "1:c3e52bee89f586d4fc5e4594d645b892ee3f7a195c3f977e4f669f17bf67bee1"
+  name = "github.com/cloudevents/sdk-go"
+  packages = [
+    "pkg/cloudevents",
+    "pkg/cloudevents/datacodec",
+    "pkg/cloudevents/datacodec/json",
+    "pkg/cloudevents/datacodec/xml",
+    "pkg/cloudevents/observability",
+    "pkg/cloudevents/types",
+  ]
+  pruneopts = "UT"
+  revision = "56931988abe3adf6792b5c6e575ee5f573e9ccbc"
+  version = "0.7.0"
+
+[[projects]]
+  digest = "1:ec66ad050342a3573ed2f5a4337d51b4c6d5d2a717cc6c9ecf86b081235a5759"
+  name = "github.com/cyphar/filepath-securejoin"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "a261ee33d7a517f054effbf451841abaafe3e0fd"
+  version = "v0.2.2"
 
 [[projects]]
   digest = "1:76dc72490af7174349349838f2fe118996381b31ea83243812a97e5a0fd5ed55"
@@ -86,15 +141,15 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:87082ea822adf4db51d1bec2a92c9fe0a38b56729bbcd7d036a36848a9bb2b97"
+  digest = "1:adbc24353f685b2045b5881bb15f48cec5267fc70a5ecaf2cf60b1241a43c83a"
   name = "github.com/go-openapi/analysis"
   packages = [
     ".",
     "internal",
   ]
   pruneopts = "UT"
-  revision = "48f4521ad6c3df9d6192efb04287c4a411e1f806"
-  version = "v0.19.4"
+  revision = "9864a87593df5ab83eac00921906932d1d77fae2"
+  version = "v0.19.5"
 
 [[projects]]
   digest = "1:3bca1e4623bc7e1f9849a14fe730c093953727991f0592be3dad0168cb67758e"
@@ -105,31 +160,31 @@
   version = "v0.19.2"
 
 [[projects]]
-  digest = "1:3199d542cd80a8505e4cd90bb6c7d0bca8a67948834239053c78f9e20b8caa5f"
+  digest = "1:ed15647db08b6d63666bf9755d337725960c302bbfa5e23754b4b915a4797e42"
   name = "github.com/go-openapi/jsonpointer"
   packages = ["."]
   pruneopts = "UT"
-  revision = "a105a905c5e6ad147f08504784917f3e178e0ba5"
-  version = "v0.19.2"
+  revision = "ed123515f087412cd7ef02e49b0b0a5e6a79a360"
+  version = "v0.19.3"
 
 [[projects]]
-  digest = "1:8b54a5c13b78b966644a9887433794034c14993a89ac93d532c587fc22d7f6bf"
+  digest = "1:451fe53c19443c6941be5d4295edc973a3eb16baccb940efee94284024be03b0"
   name = "github.com/go-openapi/jsonreference"
   packages = ["."]
   pruneopts = "UT"
-  revision = "2903bfd4bfbaf188694f1edf731f2725a8fa344f"
-  version = "v0.19.2"
+  revision = "82f31475a8f7a12bc26962f6e26ceade8ea6f66a"
+  version = "v0.19.3"
 
 [[projects]]
-  digest = "1:cdace6771905e7cd0656263b5132f012a668c5bf937a6bdabf4c37bc8ed3addf"
+  digest = "1:9dbde8fb0423931f1c23610428cbdd351a0cd066891b4d43c620e0669ca2c3a9"
   name = "github.com/go-openapi/loads"
   packages = ["."]
   pruneopts = "UT"
-  revision = "8548893a17237be4a5b2f74773f23002f4179bbe"
-  version = "v0.19.2"
+  revision = "bda4742c39071f7804171d847fb6e9bca84f9f57"
+  version = "v0.19.4"
 
 [[projects]]
-  digest = "1:94179a6c9293851a32d8d1ba38dfac8091ee0702f0ae849d4ea74c605b5e8aec"
+  digest = "1:3649061b5d5486ec5f90bb16e219c096c7c84ea9859396da0191f17a6631d75a"
   name = "github.com/go-openapi/runtime"
   packages = [
     ".",
@@ -142,40 +197,40 @@
     "security",
   ]
   pruneopts = "UT"
-  revision = "58872d9a7ca5f28beff9effa19ac4c17d3e42cd3"
-  version = "v0.19.3"
+  revision = "553c9d1fb273d9550562d9f76949a413af265138"
+  version = "v0.19.7"
 
 [[projects]]
-  digest = "1:b1f97d0d316f90c2059f7bfee14855c314d65834a3b93f02856e01c1fb8fbebe"
+  digest = "1:55d1c09fc8b3320b6842565249a9e4d0f363bead6f9b8be05c3b47f2c4264eda"
   name = "github.com/go-openapi/spec"
   packages = ["."]
   pruneopts = "UT"
-  revision = "bdfd7e07daecc404d77868a88b2364d0aed0ee5a"
-  version = "v0.19.2"
-
-[[projects]]
-  digest = "1:60e14b70fbc3b2814e48562179462d7f633fc8733b6ee8e57f576801cd863f57"
-  name = "github.com/go-openapi/strfmt"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "432db8fbcb18bf11f72ca9538e07943e45be4d9f"
-  version = "v0.19.2"
-
-[[projects]]
-  digest = "1:2de91ae845491f7158c1644a1183d2bbcc5a7bd668768b60a91519f848603dad"
-  name = "github.com/go-openapi/swag"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "de649ffb9e02183a414820c5b1b4582f7b009792"
+  revision = "8557d72e4f077c2dbe1e48df09e596b6fb9b7991"
   version = "v0.19.4"
 
 [[projects]]
-  digest = "1:9d2bd059a75e4ac3983cc93fe013dbc7f789fccb996171094279458b15329842"
+  digest = "1:787b399bfeddd801aca6144bd9928f4fe1d40eadcb09c59fcbd421cc528ea11c"
+  name = "github.com/go-openapi/strfmt"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "6faa644e1cdafc07f7b38eb06c1af5f92128f289"
+  version = "v0.19.3"
+
+[[projects]]
+  digest = "1:43d0f99f53acce97119181dcd592321084690c2d462c57680ccb4472ae084949"
+  name = "github.com/go-openapi/swag"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "c3d0f7896d589f3babb99eea24bbc7de98108e72"
+  version = "v0.19.5"
+
+[[projects]]
+  digest = "1:683e8ed8f90886b6338ab90d12aa8f4111383506313173ef02ad0724608512b5"
   name = "github.com/go-openapi/validate"
   packages = ["."]
   pruneopts = "UT"
-  revision = "6405b9095e4c96aabb45856da08a9323d50d9336"
-  version = "v0.19.2"
+  revision = "80d596e2af47cef147b636dfd76abce249d2b847"
+  version = "v0.19.4"
 
 [[projects]]
   digest = "1:586ea76dbd0374d6fb649a91d70d652b7fe0ccffb8910a77468e7702e7901f3d"
@@ -186,15 +241,32 @@
   version = "v1.8.0"
 
 [[projects]]
-  digest = "1:4d02824a56d268f74a6b6fdd944b20b58a77c3d70e81008b3ee0c4f1a6777340"
+  digest = "1:9ae31ce33b4bab257668963e844d98765b44160be4ee98cafc44637a213e530d"
+  name = "github.com/gobwas/glob"
+  packages = [
+    ".",
+    "compiler",
+    "match",
+    "syntax",
+    "syntax/ast",
+    "syntax/lexer",
+    "util/runes",
+    "util/strings",
+  ]
+  pruneopts = "UT"
+  revision = "5ccd90ef52e1e632236f7326478d4faa74f99438"
+  version = "v0.2.3"
+
+[[projects]]
+  digest = "1:582e25eccee928dc12416ea4c23b6dae8f3b5687730632aa1473ebebe80a2359"
   name = "github.com/gogo/protobuf"
   packages = [
     "proto",
     "sortkeys",
   ]
   pruneopts = "UT"
-  revision = "ba06b47c162d49f2af050fb4c75bcbc86a159d5c"
-  version = "v1.2.1"
+  revision = "5628607bb4c51c3157aacc3a50f0ab707582b805"
+  version = "v1.3.1"
 
 [[projects]]
   branch = "master"
@@ -203,6 +275,14 @@
   packages = ["."]
   pruneopts = "UT"
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
+
+[[projects]]
+  branch = "master"
+  digest = "1:b7cb6054d3dff43b38ad2e92492f220f57ae6087ee797dca298139776749ace8"
+  name = "github.com/golang/groupcache"
+  packages = ["lru"]
+  pruneopts = "UT"
+  revision = "404acd9df4cc9859d64fb9eed42e5c026187287a"
 
 [[projects]]
   digest = "1:f5ce1529abc1204444ec73779f44f94e2fa8fcdb7aca3c355b0c95947e4005c6"
@@ -220,11 +300,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:e4f5819333ac698d294fe04dbf640f84719658d5c7ce195b10060cc37292ce79"
+  digest = "1:700b1e527116332847452edf9febc0c252c026785a8c3cfa3f68a8eeffb09ee8"
   name = "github.com/golang/snappy"
   packages = ["."]
   pruneopts = "UT"
-  revision = "2a8bb927dd31d8daada140a5d09578521ce5c36a"
+  revision = "ff6b7dc882cf4cfba7ee0b9f7dcc1ac096c554aa"
 
 [[projects]]
   digest = "1:0bfbe13936953a98ae3cfe8ed6670d396ad81edf069a806d2f6515d7bb6950df"
@@ -243,7 +323,15 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:d1a3774c1f8336a21669d6da87a7bafb4d6171a84752268b7011e767d6722c2b"
+  digest = "1:582b704bebaa06b48c29b0cec224a6058a09c86883aaddabde889cd1a5f73e1b"
+  name = "github.com/google/uuid"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "0cd6bf5da1e1c83f8b45653022c74f71af0538a4"
+  version = "v1.1.1"
+
+[[projects]]
+  digest = "1:ca4524b4855ded427c7003ec903a5c854f37e7b1e8e2a93277243462c5b753a8"
   name = "github.com/googleapis/gnostic"
   packages = [
     "OpenAPIv2",
@@ -251,11 +339,11 @@
     "extensions",
   ]
   pruneopts = "UT"
-  revision = "e73c7ec21d36ddb0711cb36d1502d18363b5c2c9"
-  version = "v0.3.0"
+  revision = "ab0dd09aa10e2952b28e12ecd35681b20463ebab"
+  version = "v0.3.1"
 
 [[projects]]
-  digest = "1:54ef28a48fa2d032b67da95b11f864bf40af351b778db76f15591ca7382c1553"
+  digest = "1:a10e92469ba0d1776fbceb287feefe5f69d3c579254ca4e14863f5f8c2712870"
   name = "github.com/gophercloud/gophercloud"
   packages = [
     ".",
@@ -267,8 +355,16 @@
     "pagination",
   ]
   pruneopts = "UT"
-  revision = "0398b0cd16bfffade0883973c745180adbbe8918"
-  version = "v0.3.0"
+  revision = "a8bdb516e71d7c586306501b30b80f06f53c013e"
+  version = "v0.6.0"
+
+[[projects]]
+  digest = "1:e62657cca9badaa308d86e7716083e4c5933bb78e30a17743fc67f50be26f6f4"
+  name = "github.com/gorilla/websocket"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "c3e18be99d19e6b3e8f1559eea2c161a665c4b6b"
+  version = "v1.4.1"
 
 [[projects]]
   branch = "master"
@@ -282,12 +378,20 @@
   revision = "901d90724c7919163f472a9812253fb26761123d"
 
 [[projects]]
-  digest = "1:a0cefd27d12712af4b5018dc7046f245e1e3b5760e2e848c30b171b570708f9b"
+  digest = "1:f9a5e090336881be43cfc1cf468330c1bdd60abdc9dd194e0b1ab69f4b94dd7c"
+  name = "github.com/huandu/xstrings"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "f02667b379e2fb5916c3cda2cf31e0eb885d79f8"
+  version = "v1.2.0"
+
+[[projects]]
+  digest = "1:78d28d5b84a26159c67ea51996a230da4bc07cac648adaae1dfb5fc0ec8e40d3"
   name = "github.com/imdario/mergo"
   packages = ["."]
   pruneopts = "UT"
-  revision = "7c29201646fa3de8506f701213473dd407f19646"
-  version = "v0.3.7"
+  revision = "1afb36080aec31e0d1528973ebe6721b191b0369"
+  version = "v0.3.8"
 
 [[projects]]
   branch = "master"
@@ -298,12 +402,12 @@
   revision = "d14ea06fba99483203c19d92cfcd13ebe73135f4"
 
 [[projects]]
-  branch = "master"
-  digest = "1:288453580cfb900f3aa91faf60a5ba879e08f6cdb48eb0238258a939f9ca51e9"
+  digest = "1:86aed07a7a7adac9ad94cd5670afb6b399ab4b3aecf68919c6aa8345fa28fd36"
   name = "github.com/jeremywohl/flatten"
   packages = ["."]
   pruneopts = "UT"
-  revision = "588fe0d4c603f5dc8b3854ff3f7f16e570618ef7"
+  revision = "d936035e55cf57138fe3218d7647cc7054bb7a8e"
+  version = "v1.0"
 
 [[projects]]
   digest = "1:a2cff208d4759f6ba1b1cd228587b0a1869f95f22542ec9cd17fff64430113c7"
@@ -314,20 +418,26 @@
   version = "v1.4.0"
 
 [[projects]]
-  digest = "1:709cd2a2c29cc9b89732f6c24846bbb9d6270f28ef5ef2128cc73bd0d6d7bff9"
+  digest = "1:beb5b4f42a25056f0aa291b5eadd21e2f2903a05d15dfe7caf7eaee7e12fa972"
   name = "github.com/json-iterator/go"
   packages = ["."]
   pruneopts = "UT"
-  revision = "27518f6661eba504be5a7a9a9f6d9460d892ade3"
-  version = "v1.1.7"
+  revision = "03217c3e97663914aec3faafde50d081f197a0a2"
+  version = "1.1.8"
 
 [[projects]]
-  digest = "1:88f017a0f027ac3019f1000c1b62e84750c78a40743e57c49f114f2cb154fa5c"
+  branch = "develop"
+  digest = "1:2bcd6d68efe6debdc548b39c811521ed78e9441a3b4d6a553b2838992ce8473e"
   name = "github.com/keptn/go-utils"
-  packages = ["pkg/utils"]
+  packages = [
+    "pkg/api/models",
+    "pkg/configuration-service/models",
+    "pkg/configuration-service/utils",
+    "pkg/models",
+    "pkg/utils",
+  ]
   pruneopts = "UT"
-  revision = "9f13e220173a73b4bc0e04dc56e8edc2c7cbe126"
-  version = "0.1.1"
+  revision = "aa38fada9f5dfdf61cf5283c61dd3c66711043e5"
 
 [[projects]]
   digest = "1:fd7f169f32c221b096c74e756bda16fe22d3bb448bbf74042fd0700407a1f92f"
@@ -338,7 +448,6 @@
   version = "1.0"
 
 [[projects]]
-  branch = "master"
   digest = "1:927762c6729b4e72957ba3310e485ed09cf8451c5a637a52fd016a9fe09e7936"
   name = "github.com/mailru/easyjson"
   packages = [
@@ -347,7 +456,16 @@
     "jwriter",
   ]
   pruneopts = "UT"
-  revision = "b2ccc519800e761ac8000b95e5d57c80a897ff9e"
+  revision = "1b2b06f5f209fea48ff5922d8bfb2b9ed5d8f00b"
+  version = "v0.7.0"
+
+[[projects]]
+  digest = "1:09ca328575f38b80969ccf857f6d7302f2ce09d53778ea7aaba526cfd2cec739"
+  name = "github.com/mitchellh/copystructure"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "9a1b6f44e8da0e0e374624fb0a825a231b00c537"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:5d231480e1c64a726869bc4142d270184c419749d34f167646baa21008eb0a79"
@@ -364,6 +482,14 @@
   pruneopts = "UT"
   revision = "3536a929edddb9a5b34bd6861dc4a9647cb459fe"
   version = "v1.1.2"
+
+[[projects]]
+  digest = "1:2a7e6f8bebdca6bd8bc359c37f01ae1c4ea4f8481eaabf93b1ae4863f15b72c7"
+  name = "github.com/mitchellh/reflectwalk"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "3e2c75dfad4fbf904b58782a80fd595c760ad185"
+  version = "v1.0.1"
 
 [[projects]]
   digest = "1:33422d238f147d247752996a26574ac48dcf472976eda7f5134015f06bf16563"
@@ -398,6 +524,14 @@
   version = "v3.0.0"
 
 [[projects]]
+  digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
+  version = "v0.8.1"
+
+[[projects]]
   digest = "1:d917313f309bda80d27274d53985bc65651f81a5b66b820749ac7f8ef061fd04"
   name = "github.com/sergi/go-diff"
   packages = ["diffmatchpatch"]
@@ -406,12 +540,12 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:c1b1102241e7f645bc8e0c22ae352e8f0dc6484b6cb4d132fa9f24174e0119e2"
+  digest = "1:524b71991fc7d9246cc7dc2d9e0886ccb97648091c63e30eef619e6862c955dd"
   name = "github.com/spf13/pflag"
   packages = ["."]
   pruneopts = "UT"
-  revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
-  version = "v1.0.3"
+  revision = "2e9d26c8c37aae03e3f9d4e90b7116f5accb7cab"
+  version = "v1.0.5"
 
 [[projects]]
   digest = "1:e4ed0afd67bf7be353921665cdac50834c867ff1bba153efc0745b755a7f5905"
@@ -490,8 +624,30 @@
   version = "v1.0.4"
 
 [[projects]]
+  digest = "1:74accd9945e4e51580cbe9b9428c228c1a7d37180cf2647ac33a1dff7197546a"
+  name = "go.opencensus.io"
+  packages = [
+    ".",
+    "internal",
+    "internal/tagencoding",
+    "metric/metricdata",
+    "metric/metricproducer",
+    "resource",
+    "stats",
+    "stats/internal",
+    "stats/view",
+    "tag",
+    "trace",
+    "trace/internal",
+    "trace/tracestate",
+  ]
+  pruneopts = "UT"
+  revision = "59d1ce35d30f3c25ba762169da2a37eab6ffa041"
+  version = "v0.22.1"
+
+[[projects]]
   branch = "master"
-  digest = "1:ee2c5135eeb44e749c8fc586b2a9c339901cc40333f3f813fba06c3fdd76bd1b"
+  digest = "1:306fbbddc88a1a1d0447006c3f6486fd4ae3e568f22494527b56fec97d609af9"
   name = "golang.org/x/crypto"
   packages = [
     "cast5",
@@ -508,17 +664,18 @@
     "openpgp/s2k",
     "pbkdf2",
     "poly1305",
+    "scrypt",
     "ssh",
     "ssh/agent",
     "ssh/knownhosts",
     "ssh/terminal",
   ]
   pruneopts = "UT"
-  revision = "4def268fd1a49955bfb3dda92fe3db4f924f2285"
+  revision = "87dc89f01550277dc22b74ffcf4cd89fa2f40f4c"
 
 [[projects]]
   branch = "master"
-  digest = "1:80b910fed4f53858a3120cc2a021cd813fc4ca4c73753173247647ebdfbb2f82"
+  digest = "1:0a171d45ece4a27c08f102c2b7ca0453a5707330482b7c60980371a575d7f66d"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -532,7 +689,7 @@
     "proxy",
   ]
   pruneopts = "UT"
-  revision = "ca1201d0de80cfde86cb01aea620983605dfe99b"
+  revision = "ec77196f6094c3492a8b61f2c11cf937f78992ae"
 
 [[projects]]
   branch = "master"
@@ -554,11 +711,11 @@
   name = "golang.org/x/sync"
   packages = ["semaphore"]
   pruneopts = "UT"
-  revision = "112230192c580c3556b8cee6403af37a4fc5f28c"
+  revision = "cd5d95a43a6e21273425c7ae415d3df9ea832eeb"
 
 [[projects]]
   branch = "master"
-  digest = "1:afce8593ac5918df05a46499b04b8c4e46a91e99566055e4a8ba829a8f389a09"
+  digest = "1:9a7e33a18b6fb80e9815211b7e9dfc8ac60bb167f84d7793589498feb21a1c8d"
   name = "golang.org/x/sys"
   packages = [
     "cpu",
@@ -566,7 +723,7 @@
     "windows",
   ]
   pruneopts = "UT"
-  revision = "51ab0e2deafac1f46c46ad59cf0921be2f180c3d"
+  revision = "e66fe6eb8e0cbfacade8b490cf55cd2494f4db62"
 
 [[projects]]
   digest = "1:66a2f252a58b4fbbad0e4e180e1d85a83c222b6bce09c3dcdef3dc87c72eda7c"
@@ -596,14 +753,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:9fdc2b55e8e0fafe4b41884091e51e77344f7dc511c5acedcfd98200003bff90"
+  digest = "1:a2f668c709f9078828e99cb1768cb02e876cb81030545046a32b54b2ac2a9ea8"
   name = "golang.org/x/time"
   packages = ["rate"]
   pruneopts = "UT"
-  revision = "9d24e82272b4f38b78bc8cff74fa936d31ccd8ef"
+  revision = "555d28b269f0569763d25dbe1a237ae74c6bcc82"
 
 [[projects]]
-  digest = "1:498b722d33dde4471e7d6e5d88a5e7132d2a8306fea5ff5ee82d1f418b4f41ed"
+  digest = "1:3c03b58f57452764a4499c55c582346c0ee78c8a5033affe5bdfd9efd3da5bd1"
   name = "google.golang.org/appengine"
   packages = [
     ".",
@@ -618,8 +775,8 @@
     "urlfetch",
   ]
   pruneopts = "UT"
-  revision = "b2f4a3cf3c67576a2ee09e1fe62656a5086ce880"
-  version = "v1.6.1"
+  revision = "971852bfffca25b069c31162ae8f247a3dba083b"
+  version = "v1.6.5"
 
 [[projects]]
   digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
@@ -702,12 +859,12 @@
   version = "v0.1.2"
 
 [[projects]]
-  digest = "1:4d2e5a73dc1500038e504a8d78b986630e3626dc027bc030ba5c75da257cdb96"
+  digest = "1:59f10c1537d2199d9115d946927fe31165959a95190849c82ff11e05803528b0"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
   pruneopts = "UT"
-  revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
-  version = "v2.2.2"
+  revision = "f221b8435cfb71e54062f6c6e99e9ade30b124d5"
+  version = "v2.2.4"
 
 [[projects]]
   digest = "1:910ec974550174f4ca48b9f4a3caec16b693e584c3762dc726dc0dcf28f8e318"
@@ -750,7 +907,7 @@
   version = "kubernetes-1.12.0"
 
 [[projects]]
-  digest = "1:18f352651d6e8578fdbaf29c68334b042439b288b8ae4112c2b2ba9a6e35ced0"
+  digest = "1:0ac15d4614bef5c0639daeb593775c0080cd7ac0e312f43c5cdde936d8790a57"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
@@ -784,6 +941,7 @@
     "pkg/util/sets",
     "pkg/util/validation",
     "pkg/util/validation/field",
+    "pkg/util/wait",
     "pkg/util/yaml",
     "pkg/version",
     "pkg/watch",
@@ -794,7 +952,7 @@
   version = "kubernetes-1.12.0"
 
 [[projects]]
-  digest = "1:63f1dd4b853d891b2459875cd38c86a99bc11d839e5c2dbb703cdeb6f0bcaf6c"
+  digest = "1:685233f7e59ae3ddaa21b8f3685fa94983aabce6e3849b0d21b457136fb10532"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -858,10 +1016,29 @@
     "util/homedir",
     "util/integer",
     "util/jsonpath",
+    "util/retry",
   ]
   pruneopts = "UT"
   revision = "1638f8970cefaa404ff3a62950f88b08292b2696"
   version = "kubernetes-1.12.0"
+
+[[projects]]
+  digest = "1:8ee4da6e9e8d15816e7a7376b55b7738bb1b0fe434217d7975541fc1cb151058"
+  name = "k8s.io/helm"
+  packages = [
+    "pkg/chartutil",
+    "pkg/engine",
+    "pkg/ignore",
+    "pkg/proto/hapi/chart",
+    "pkg/proto/hapi/version",
+    "pkg/renderutil",
+    "pkg/sympath",
+    "pkg/timeconv",
+    "pkg/version",
+  ]
+  pruneopts = "UT"
+  revision = "cf1de4f8ba70eded310918a8af3a96bfe8e7683b"
+  version = "v2.15.1"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/mongodb-datastore/Gopkg.toml
+++ b/mongodb-datastore/Gopkg.toml
@@ -57,9 +57,9 @@
   name = "go.mongodb.org/mongo-driver"
   version = "~1.0.4"
 
-[[constraint]]
+[[override]]
   name = "github.com/keptn/go-utils"
-  version = "0.1.1"
+  branch = "develop"
 
 [[override]]
   name = "contrib.go.opencensus.io/exporter/ocagent"

--- a/mongodb-datastore/handlers/config.go
+++ b/mongodb-datastore/handlers/config.go
@@ -7,3 +7,5 @@ var mongoDBName = os.Getenv("MONGO_DB_NAME")
 
 const eventsCollectionName = "events"
 const logsCollectionName = "logs"
+
+const serviceName = "mongodb-datastore"

--- a/mongodb-datastore/handlers/events.go
+++ b/mongodb-datastore/handlers/events.go
@@ -19,7 +19,7 @@ import (
 
 // SaveEvent to data store
 func SaveEvent(body event.SaveEventBody) error {
-	logger := keptnutils.NewLogger("", "", "mongodb-datastore")
+	logger := keptnutils.NewLogger("", "", serviceName)
 	logger.Debug("save event to datastore")
 
 	client, err := mongo.NewClient(options.Client().ApplyURI(mongoDBConnection))
@@ -48,7 +48,7 @@ func SaveEvent(body event.SaveEventBody) error {
 
 // GetEvents gets all events from the data store sorted by time
 func GetEvents(params event.GetEventsParams) (result *event.GetEventsOKBody, err error) {
-	logger := keptnutils.NewLogger("", "", "mongodb-datastore")
+	logger := keptnutils.NewLogger("", "", serviceName)
 	logger.Debug("getting events from the datastore")
 
 	client, err := mongo.NewClient(options.Client().ApplyURI(mongoDBConnection))

--- a/mongodb-datastore/handlers/events.go
+++ b/mongodb-datastore/handlers/events.go
@@ -19,11 +19,12 @@ import (
 
 // SaveEvent to data store
 func SaveEvent(body event.SaveEventBody) error {
-	keptnutils.Debug("", "save event to datastore")
+	logger := keptnutils.NewLogger("", "", "mongodb-datastore")
+	logger.Debug("save event to datastore")
 
 	client, err := mongo.NewClient(options.Client().ApplyURI(mongoDBConnection))
 	if err != nil {
-		keptnutils.Error("", fmt.Sprintf("error creating client: %s", err.Error()))
+		logger.Error(fmt.Sprintf("error creating client: %s", err.Error()))
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -31,26 +32,28 @@ func SaveEvent(body event.SaveEventBody) error {
 
 	err = client.Connect(ctx)
 	if err != nil {
-		keptnutils.Error("", fmt.Sprintf("could not connect: %s", err.Error()))
+		logger.Error(fmt.Sprintf("could not connect: %s", err.Error()))
 	}
 
 	collection := client.Database(mongoDBName).Collection(eventsCollectionName)
 
 	res, err := collection.InsertOne(ctx, body)
 	if err != nil {
-		keptnutils.Error("", fmt.Sprintf("error inserting into collection: %s", err.Error()))
+		logger.Error(fmt.Sprintf("error inserting into collection: %s", err.Error()))
 	}
-	keptnutils.Debug("", fmt.Sprintf("insertedID: %s", res.InsertedID))
+	logger.Debug(fmt.Sprintf("insertedID: %s", res.InsertedID))
 
 	return err
 }
 
 // GetEvents gets all events from the data store sorted by time
 func GetEvents(params event.GetEventsParams) (result *event.GetEventsOKBody, err error) {
-	keptnutils.Debug("", "getting events from the datastore")
+	logger := keptnutils.NewLogger("", "", "mongodb-datastore")
+	logger.Debug("getting events from the datastore")
+
 	client, err := mongo.NewClient(options.Client().ApplyURI(mongoDBConnection))
 	if err != nil {
-		keptnutils.Error("", fmt.Sprintf("error creating client: %s", err.Error()))
+		logger.Error(fmt.Sprintf("error creating client: %s", err.Error()))
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -58,7 +61,7 @@ func GetEvents(params event.GetEventsParams) (result *event.GetEventsOKBody, err
 
 	err = client.Connect(ctx)
 	if err != nil {
-		keptnutils.Error("", fmt.Sprintf("could not connect: %s", err.Error()))
+		logger.Error(fmt.Sprintf("could not connect: %s", err.Error()))
 	}
 
 	collection := client.Database(mongoDBName).Collection(eventsCollectionName)
@@ -95,12 +98,12 @@ func GetEvents(params event.GetEventsParams) (result *event.GetEventsOKBody, err
 
 	totalCount, err := collection.CountDocuments(ctx, searchOptions)
 	if err != nil {
-		keptnutils.Error("", fmt.Sprintf("error counting elements in events collection: %s", err.Error()))
+		logger.Error(fmt.Sprintf("error counting elements in events collection: %s", err.Error()))
 	}
 
 	cur, err := collection.Find(ctx, searchOptions, sortOptions)
 	if err != nil {
-		keptnutils.Error("", fmt.Sprintf("error finding elements in events collection: %s", err.Error()))
+		logger.Error(fmt.Sprintf("error finding elements in events collection: %s", err.Error()))
 	}
 
 	var resultEvents []*event.EventsItems0
@@ -115,7 +118,7 @@ func GetEvents(params event.GetEventsParams) (result *event.GetEventsOKBody, err
 		myMap := data.Map()
 		flat, err := flatten.Flatten(myMap, "", flatten.RailsStyle)
 		if err != nil {
-			keptnutils.Error("", fmt.Sprintf("could not flatten element: %s", err.Error()))
+			logger.Error(fmt.Sprintf("could not flatten element: %s", err.Error()))
 		}
 		result.Data = flat
 		resultEvents = append(resultEvents, &result)

--- a/mongodb-datastore/handlers/logs.go
+++ b/mongodb-datastore/handlers/logs.go
@@ -17,11 +17,12 @@ import (
 
 // SaveLog to datastore
 func SaveLog(body []*logs.SaveLogParamsBodyItems0) (err error) {
-	keptnutils.Debug("", "save log to datastore")
+	logger := keptnutils.NewLogger("", "", "mongodb-datastore")
+	logger.Debug("save log to datastore")
 
 	client, err := mongo.NewClient(options.Client().ApplyURI(mongoDBConnection))
 	if err != nil {
-		keptnutils.Error("", fmt.Sprintf("error creating client: %s", err.Error()))
+		logger.Error(fmt.Sprintf("error creating client: %s", err.Error()))
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -29,7 +30,7 @@ func SaveLog(body []*logs.SaveLogParamsBodyItems0) (err error) {
 
 	err = client.Connect(ctx)
 	if err != nil {
-		keptnutils.Error("", fmt.Sprintf("could not connect: %s", err.Error()))
+		logger.Error(fmt.Sprintf("could not connect: %s", err.Error()))
 	}
 
 	collection := client.Database(mongoDBName).Collection(logsCollectionName)
@@ -38,25 +39,25 @@ func SaveLog(body []*logs.SaveLogParamsBodyItems0) (err error) {
 		if l.KeptnService != "" {
 			res, err := collection.InsertOne(ctx, l)
 			if err != nil {
-				keptnutils.Error("", fmt.Sprintf("could not insert: %s", err.Error()))
+				logger.Error(fmt.Sprintf("could not insert: %s", err.Error()))
 			}
-			keptnutils.Debug("", fmt.Sprintf("insertedID: %s", res.InsertedID))
+			logger.Debug(fmt.Sprintf("insertedID: %s", res.InsertedID))
 		} else {
-			keptnutils.Info("", "no KepntService set, log not stored in datastore")
+			logger.Info("no KepntService set, log not stored in datastore")
 		}
 	}
 
 	return err
-
 }
 
 // GetLogs returns logs
 func GetLogs(params logs.GetLogsParams) (result *logs.GetLogsOKBody, err error) {
-	keptnutils.Debug("", "getting logs from datastore")
+	logger := keptnutils.NewLogger("", "", "mongodb-datastore")
+	logger.Debug("getting logs from datastore")
 
 	client, err := mongo.NewClient(options.Client().ApplyURI(mongoDBConnection))
 	if err != nil {
-		keptnutils.Error("", fmt.Sprintf("error creating client: %s", err.Error()))
+		logger.Error(fmt.Sprintf("error creating client: %s", err.Error()))
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -64,7 +65,7 @@ func GetLogs(params logs.GetLogsParams) (result *logs.GetLogsOKBody, err error) 
 
 	err = client.Connect(ctx)
 	if err != nil {
-		keptnutils.Error("", fmt.Sprintf("could not connect: %s", err.Error()))
+		logger.Error(fmt.Sprintf("could not connect: %s", err.Error()))
 	}
 
 	collection := client.Database(mongoDBName).Collection(logsCollectionName)
@@ -90,12 +91,12 @@ func GetLogs(params logs.GetLogsParams) (result *logs.GetLogsOKBody, err error) 
 
 	totalCount, err := collection.CountDocuments(ctx, searchOptions)
 	if err != nil {
-		keptnutils.Error("", fmt.Sprintf("error counting elements in logs collection: %s", err.Error()))
+		logger.Error(fmt.Sprintf("error counting elements in logs collection: %s", err.Error()))
 	}
 
 	cur, err := collection.Find(ctx, searchOptions, sortOptions)
 	if err != nil {
-		keptnutils.Error("", fmt.Sprintf("error finding elements in logs collection: %s", err.Error()))
+		logger.Error(fmt.Sprintf("error finding elements in logs collection: %s", err.Error()))
 	}
 
 	var resultLogs []*logs.LogsItems0

--- a/mongodb-datastore/handlers/logs.go
+++ b/mongodb-datastore/handlers/logs.go
@@ -17,7 +17,7 @@ import (
 
 // SaveLog to datastore
 func SaveLog(body []*logs.SaveLogParamsBodyItems0) (err error) {
-	logger := keptnutils.NewLogger("", "", "mongodb-datastore")
+	logger := keptnutils.NewLogger("", "", serviceName)
 	logger.Debug("save log to datastore")
 
 	client, err := mongo.NewClient(options.Client().ApplyURI(mongoDBConnection))
@@ -52,7 +52,7 @@ func SaveLog(body []*logs.SaveLogParamsBodyItems0) (err error) {
 
 // GetLogs returns logs
 func GetLogs(params logs.GetLogsParams) (result *logs.GetLogsOKBody, err error) {
-	logger := keptnutils.NewLogger("", "", "mongodb-datastore")
+	logger := keptnutils.NewLogger("", "", serviceName)
 	logger.Debug("getting logs from datastore")
 
 	client, err := mongo.NewClient(options.Client().ApplyURI(mongoDBConnection))

--- a/mongodb-datastore/restapi/configure_mongodb_datastore.go
+++ b/mongodb-datastore/restapi/configure_mongodb_datastore.go
@@ -13,7 +13,6 @@ import (
 	middleware "github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/swag"
 
-	keptnutils "github.com/keptn/go-utils/pkg/utils"
 	"github.com/keptn/keptn/mongodb-datastore/handlers"
 	"github.com/keptn/keptn/mongodb-datastore/restapi/operations"
 	"github.com/keptn/keptn/mongodb-datastore/restapi/operations/event"
@@ -27,9 +26,6 @@ func configureFlags(api *operations.MongodbDatastoreAPI) {
 }
 
 func configureAPI(api *operations.MongodbDatastoreAPI) http.Handler {
-	// set service name for logging
-	keptnutils.ServiceName = "mongodb-datastore"
-
 	// configure the api here
 	api.ServeError = errors.ServeError
 


### PR DESCRIPTION
This PR adapts the mongodb-datastore service to support the latest go-utils version. 

Mainly, the logging mechanism has changed. 

When creating a logger (`logger := keptnutils.NewLogger("", "", serviceName)`), the first two parameters are empty, because the mongodb-datastore does not receive a keptn context or event ID; this is as designed. 
