### PR TITLE
#216 Support creating service without Helm chart 

### DIFF
--- a/api/handlers/event_test.go
+++ b/api/handlers/event_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/kinbiko/jsonassert"
 )
 
-func TestAddingChannelInfo(t *testing.T) {
+func TestAddingEventContext(t *testing.T) {
 
 	ja := jsonassert.New(t)
 	ceData := make(map[string]interface{})
@@ -19,9 +19,9 @@ func TestAddingChannelInfo(t *testing.T) {
 
 	channelID := "id"
 	token := "token"
-	channelInfo := models.ChannelInfo{ChannelID: &channelID, Token: &token}
+	channelInfo := models.EventContext{KeptnContext: &channelID, Token: &token}
 
-	forwardData := addChannelInfoInCE(ceData, channelInfo)
+	forwardData := addEventContextInCE(ceData, channelInfo)
 	actual, _ := json.Marshal(forwardData)
-	ja.Assertf(string(actual), `{"project":"sockshop", "channelInfo":{"channelID":"id", "token":"token"}}`)
+	ja.Assertf(string(actual), `{"project":"sockshop", "eventContext":{"keptnContext":"id", "token":"token"}}`)
 }

--- a/api/handlers/service.go
+++ b/api/handlers/service.go
@@ -49,7 +49,7 @@ func PostServiceHandlerFunc(params service.PostProjectProjectNameServiceParams, 
 	serviceData := keptnevents.ServiceCreateEventData{
 		Project:              params.ProjectName,
 		Service:              *params.Service.ServiceName,
-		HelmChart:            *params.Service.HelmChart,
+		HelmChart:            params.Service.HelmChart,
 		DeploymentStrategies: deploymentStrategies,
 	}
 	forwardData := serviceCreateEventData{ServiceCreateEventData: serviceData, EventContext: eventContext}

--- a/api/models/service.go
+++ b/api/models/service.go
@@ -21,8 +21,7 @@ type Service struct {
 	DeploymentStrategies map[string]string `json:"deploymentStrategies,omitempty"`
 
 	// helm chart
-	// Required: true
-	HelmChart *string `json:"helmChart"`
+	HelmChart string `json:"helmChart,omitempty"`
 
 	// service name
 	// Required: true
@@ -33,10 +32,6 @@ type Service struct {
 func (m *Service) Validate(formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.validateHelmChart(formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.validateServiceName(formats); err != nil {
 		res = append(res, err)
 	}
@@ -44,15 +39,6 @@ func (m *Service) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
-	return nil
-}
-
-func (m *Service) validateHelmChart(formats strfmt.Registry) error {
-
-	if err := validate.Required("helmChart", "body", m.HelmChart); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/api/restapi/embedded_spec.go
+++ b/api/restapi/embedded_spec.go
@@ -54,7 +54,7 @@ func init() {
         "tags": [
           "Event"
         ],
-        "summary": "Get the youngest event matching the parameters.",
+        "summary": "Get the latest event matching the parameters",
         "parameters": [
           {
             "type": "string",
@@ -413,7 +413,7 @@ func init() {
         "tags": [
           "Event"
         ],
-        "summary": "Get the youngest event matching the parameters.",
+        "summary": "Get the latest event matching the parameters",
         "parameters": [
           {
             "type": "string",
@@ -850,8 +850,7 @@ func init() {
     "service": {
       "type": "object",
       "required": [
-        "serviceName",
-        "helmChart"
+        "serviceName"
       ],
       "properties": {
         "deploymentStrategies": {

--- a/api/restapi/operations/event/get_event.go
+++ b/api/restapi/operations/event/get_event.go
@@ -33,7 +33,7 @@ func NewGetEvent(ctx *middleware.Context, handler GetEventHandler) *GetEvent {
 
 /*GetEvent swagger:route GET /event Event getEvent
 
-Get the youngest event matching the parameters.
+Get the latest event matching the parameters
 
 */
 type GetEvent struct {

--- a/api/service_model.yaml
+++ b/api/service_model.yaml
@@ -4,7 +4,6 @@ definitions:
     type: object
     required:
       - serviceName
-      - helmChart
     properties:
       serviceName:
         type: string

--- a/cli/Gopkg.lock
+++ b/cli/Gopkg.lock
@@ -299,11 +299,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:31785352df956b10a0e82cc3e31bfd30785b58a433120bc8878cb66df35f9d05"
+  digest = "1:156e8134a4ab3efcbcbc6e3dd5069bfb70ed8cbb1cdd7db557bd9035c363f335"
   name = "github.com/golang/groupcache"
   packages = ["lru"]
   pruneopts = ""
-  revision = "404acd9df4cc9859d64fb9eed42e5c026187287a"
+  revision = "611e8accdfc92c4187d399e95ce826046d4c8d73"
 
 [[projects]]
   digest = "1:b852d2b62be24e445fcdbad9ce3015b44c207815d631230dfce3f14e7803f5bf"
@@ -467,7 +467,7 @@
 
 [[projects]]
   branch = "develop"
-  digest = "1:40c3b527af082d959a432d8167883d81665d5adcef949833118408ba72de4701"
+  digest = "1:087370c5ec3d0761b879f8115cd714d9000b1cd6721bfaba7bcf307a8916cb03"
   name = "github.com/keptn/go-utils"
   packages = [
     "pkg/api/models",
@@ -479,7 +479,7 @@
     "pkg/utils",
   ]
   pruneopts = ""
-  revision = "aa38fada9f5dfdf61cf5283c61dd3c66711043e5"
+  revision = "44dc5c89d47ea7ca2d2411f26ba47ed8b00c811f"
 
 [[projects]]
   digest = "1:91317956b340c9e61a4287fd94c870bfad3f1922280c3e0a65db91c29017e8de"
@@ -558,12 +558,12 @@
   version = "1.0.1"
 
 [[projects]]
-  digest = "1:67d84c0ff107908e53fb2c9f42f1181a1b8b33f0c230d47281cc20ab21824c0e"
+  digest = "1:5f347ea0b4656f17f0ddffae1419dafaac4bc6ed57c92d58cadc7452f8a9ac3f"
   name = "github.com/pelletier/go-toml"
   packages = ["."]
   pruneopts = ""
-  revision = "8fe62057ea2d46ce44254c98e84e810044dbe197"
-  version = "v1.5.0"
+  revision = "903d9455db9ff1d7ac1ab199062eca7266dd11a3"
+  version = "v1.6.0"
 
 [[projects]]
   branch = "master"
@@ -752,7 +752,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:acd465770451fe2dd4c15565afc8244859dbcf490bde15cc3447741181e10f29"
+  digest = "1:196c20449a0cc94113029193d7ce9e36e46e676c27a2fe06522243f57ced19c5"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -765,7 +765,7 @@
     "proxy",
   ]
   pruneopts = ""
-  revision = "ec77196f6094c3492a8b61f2c11cf937f78992ae"
+  revision = "fe3aa8a4527195a6057b3fad46619d7d090e99b5"
 
 [[projects]]
   branch = "master"
@@ -783,7 +783,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:19c0f90f7eff54a72fb07c6b783bbdd92a89d58966d891d7382583a00b98d719"
+  digest = "1:b242a834d9ec2ad78a2a2894d4696b021290a405643ab45bb52fee86da57ca42"
   name = "golang.org/x/sys"
   packages = [
     "cpu",
@@ -791,7 +791,7 @@
     "windows",
   ]
   pruneopts = ""
-  revision = "742c48ecaeb7c624c475e02f3eb0827ebb4970d4"
+  revision = "f8518d3b3627146e88bd43ca73045e1b8d8eb6c6"
 
 [[projects]]
   digest = "1:740b51a55815493a8d0f2b1e0d0ae48fe48953bf7eaf3fcc4198823bf67768c0"
@@ -821,11 +821,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:cda80f57e101bff19a8ae77dd8aaa57ed2eede63d1fcaaeeb4b294dac799daaa"
+  digest = "1:c43c206d0f8927031df6fc877cf58502af5ff875b76b4ceb6b617b676f7731f7"
   name = "golang.org/x/time"
   packages = ["rate"]
   pruneopts = ""
-  revision = "6d3f0bb11be5e03f8353894b7240e7d793e40a8f"
+  revision = "555d28b269f0569763d25dbe1a237ae74c6bcc82"
 
 [[projects]]
   digest = "1:c4404231035fad619a12f82ae3f0f8f9edc1cc7f34e7edad7a28ccac5336cc96"

--- a/cli/cmd/create_project.go
+++ b/cli/cmd/create_project.go
@@ -63,7 +63,7 @@ Example:
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 
 		if _, err := os.Stat(keptnutils.ExpandTilde(*createProjectParams.Shipyard)); os.IsNotExist(err) {
-			return fmt.Errorf("Cannot find file %s", *createProjectParams.Shipyard)
+			return fmt.Errorf("Cannot find shipyard file %s", *createProjectParams.Shipyard)
 		}
 
 		// validate shipyard file

--- a/cli/cmd/create_service.go
+++ b/cli/cmd/create_service.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"github.com/keptn/keptn/cli/utils/websockethelper"
+
+	apimodels "github.com/keptn/go-utils/pkg/api/models"
+	apiutils "github.com/keptn/go-utils/pkg/api/utils"
+	"github.com/keptn/keptn/cli/pkg/logging"
+	"github.com/keptn/keptn/cli/utils"
+	"github.com/keptn/keptn/cli/utils/credentialmanager"
+	"github.com/spf13/cobra"
+)
+
+type createServiceCmdParams struct {
+	Project  *string
+}
+
+var createServiceParams *createServiceCmdParams
+
+// crProjectCmd represents the project command
+var crServiceCmd = &cobra.Command{
+	Use:   "service SERVICENAME --project=PROJECTNAME",
+	Short: "Creates a new service",
+	Long: `Creates a new service with the provided name and in the specified project. 
+
+Example:
+	keptn create service carts --project=sockshop`,
+	SilenceUsage: true,
+	Args: func(cmd *cobra.Command, args []string) error {
+		_, _, err := credentialmanager.GetCreds()
+		if err != nil {
+			return errors.New(authErrorMsg)
+		}
+
+		if len(args) != 1 {
+			cmd.SilenceUsage = false
+			return errors.New("required argument SERVICENAME not set")
+		}
+
+		if !utils.ValidateK8sName(args[0]) {
+			errorMsg := "Service name contains upper case letter(s) or special character(s).\n"
+			return errors.New(errorMsg)
+		}
+		return nil
+	},
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		return nil
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		endPoint, apiToken, err := credentialmanager.GetCreds()
+		if err != nil {
+			return errors.New(authErrorMsg)
+		}
+		logging.PrintLog("Starting to create service", logging.InfoLevel)
+
+		service := apimodels.Service{
+			ServiceName:     &args[0],
+		}
+
+		serviceHandler := apiutils.NewAuthenticatedServiceHandler(endPoint.String(), apiToken, "x-token", nil, "https")
+		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)
+
+		if !mocking {
+			eventContext, err := serviceHandler.CreateService(*createServiceParams.Project, service)
+			if err != nil {
+				fmt.Println("Create service was unsuccessful")
+				return fmt.Errorf("Create service was unsuccessful. %s", *err.Message)
+			}
+
+			// if eventContext is available, open WebSocket communication
+			if eventContext != nil {
+				return websockethelper.PrintWSContentEventContext(eventContext, endPoint)
+			}
+
+			return nil
+		}
+
+		fmt.Println("Skipping create service due to mocking flag set to true")
+		return nil
+	},
+}
+
+func init() {
+	createCmd.AddCommand(crServiceCmd)
+	createServiceParams = &createServiceCmdParams{}
+	createServiceParams.Project = crServiceCmd.Flags().StringP("project", "p", "", "The project in which to create the service")
+	crServiceCmd.MarkFlagRequired("project")
+}

--- a/cli/cmd/create_service.go
+++ b/cli/cmd/create_service.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+
 	"github.com/keptn/keptn/cli/utils/websockethelper"
 
 	apimodels "github.com/keptn/go-utils/pkg/api/models"
@@ -14,7 +15,7 @@ import (
 )
 
 type createServiceCmdParams struct {
-	Project  *string
+	Project *string
 }
 
 var createServiceParams *createServiceCmdParams
@@ -45,9 +46,6 @@ Example:
 		}
 		return nil
 	},
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		return nil
-	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		endPoint, apiToken, err := credentialmanager.GetCreds()
 		if err != nil {
@@ -56,7 +54,7 @@ Example:
 		logging.PrintLog("Starting to create service", logging.InfoLevel)
 
 		service := apimodels.Service{
-			ServiceName:     &args[0],
+			ServiceName: &args[0],
 		}
 
 		serviceHandler := apiutils.NewAuthenticatedServiceHandler(endPoint.String(), apiToken, "x-token", nil, "https")

--- a/cli/cmd/create_service_test.go
+++ b/cli/cmd/create_service_test.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/keptn/keptn/cli/utils/credentialmanager"
+	"os"
+	"testing"
+
+	"github.com/keptn/keptn/cli/pkg/logging"
+)
+
+func init() {
+	logging.InitLoggers(os.Stdout, os.Stdout, os.Stderr)
+}
+
+// TestCreateProjectCmd tests the default use of the create project command
+func TestCreateServiceCmd(t *testing.T) {
+	credentialmanager.MockAuthCreds = true
+
+	project := "sockshop"
+
+	args := []string{
+		"create",
+		"service",
+		"carts",
+		fmt.Sprintf("--project=%s", project),
+		"--mock",
+	}
+	rootCmd.SetArgs(args)
+	err := rootCmd.Execute()
+
+	if err != nil {
+		t.Errorf("An error occured: %v", err)
+	}
+}

--- a/cli/cmd/onboard_service.go
+++ b/cli/cmd/onboard_service.go
@@ -98,7 +98,7 @@ Example:
 		helmChart := base64.StdEncoding.EncodeToString(chartData)
 		service := apimodels.Service{
 			ServiceName: &args[0],
-			HelmChart:   &helmChart,
+			HelmChart:   helmChart,
 		}
 
 		if *onboardServiceParams.DeploymentStrategy != "" {

--- a/helm-service/controller/helm/umbrella_chart_handler.go
+++ b/helm-service/controller/helm/umbrella_chart_handler.go
@@ -34,43 +34,40 @@ func NewUmbrellaChartHandler(mesh mesh.Mesh) *UmbrellaChartHandler {
 
 // initUmbrellaChart creates Umbrella charts for each stage of a project.
 // Therefore, it creats for each stage the required resources
-func (u *UmbrellaChartHandler) InitUmbrellaChart(event *keptnevents.ServiceCreateEventData, stages []*configmodels.Stage) (bool, error) {
+func (u *UmbrellaChartHandler) InitUmbrellaChart(event *keptnevents.ServiceCreateEventData, stages []*configmodels.Stage) error {
 
 	rootChart, err := u.createRootChartResource(event)
 	if err != nil {
-		return false, err
+		return err
 	}
 	requirements, err := u.createRequirementsResource()
 	if err != nil {
-		return false, err
+		return err
 	}
 	values, err := u.createValuesResource()
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	url, err := serviceutils.GetConfigServiceURL()
 	if err != nil {
-		return false, err
+		return err
 	}
 
-	initialized := false
 	rHandler := configutils.NewResourceHandler(url.String())
 	for _, stage := range stages {
 
 		gateway, err := u.createGatewayResource(event, stage.StageName)
 		if err != nil {
-			return false, err
+			return err
 		}
 		resources := []*configmodels.Resource{rootChart, requirements, values, gateway}
 		_, err = rHandler.CreateStageResources(event.Project, stage.StageName, resources)
 		if err != nil {
-			return false, err
+			return err
 		}
-
-		initialized = true
 	}
-	return initialized, nil
+	return nil
 }
 
 // GetUmbrellaChart stores the resources of the umbrella chart in the provided directory
@@ -269,7 +266,7 @@ func (u *UmbrellaChartHandler) IsUmbrellaChartAvailableInAllStages(project strin
 			}
 		}
 
-		if countChartFiles != 3 {
+		if countChartFiles != len(resourcePrefixes) {
 			return false, nil
 		}
 	}

--- a/helm-service/controller/onboarder.go
+++ b/helm-service/controller/onboarder.go
@@ -306,22 +306,3 @@ func (o *Onboarder) isBlueGreenStage(project string, stageName string) bool {
 	}
 	return false
 }
-
-func (o *Onboarder) isFirstServiceOfProject(event *keptnevents.ServiceCreateEventData, stages []*configmodels.Stage) (bool, error) {
-
-	if len(stages) == 0 {
-		return false, errors.New("Cannot onboard service because no stage is available")
-	}
-	url, err := serviceutils.GetConfigServiceURL()
-	if err != nil {
-		return false, err
-	}
-	svcHandler := configutils.NewServiceHandler(url.String())
-
-	// Use any stage for checking whether there is already a service created
-	services, err := svcHandler.GetAllServices(event.Project, stages[0].StageName)
-	if err != nil {
-		return false, err
-	}
-	return len(services) == 0, nil
-}

--- a/helm-service/controller/onboarder_test.go
+++ b/helm-service/controller/onboarder_test.go
@@ -17,7 +17,6 @@ import (
 	configmodels "github.com/keptn/go-utils/pkg/configuration-service/models"
 	configutils "github.com/keptn/go-utils/pkg/configuration-service/utils"
 	keptnevents "github.com/keptn/go-utils/pkg/events"
-	keptnmodels "github.com/keptn/go-utils/pkg/models"
 	keptnutils "github.com/keptn/go-utils/pkg/utils"
 	"github.com/stretchr/testify/assert"
 )


### PR DESCRIPTION
This PR contains: 
- Fix of broken test in API
- Helm chart parameter is not mandatory when creating a service
- CLI support of: `keptn create service SERVICENAME --project=PROJECTNAME`
- Now, the helm-service creates an umbrella chart when no umbrella chart is available Before, it created an umbrella chart when the first service was onboarded.