### PR TITLE
#1026 fixed dockerfile for configuration service

### DIFF
--- a/configuration-service/Dockerfile
+++ b/configuration-service/Dockerfile
@@ -2,7 +2,7 @@
 # This is based on Debian and sets the GOPATH to /go.
 FROM golang:1.12 as builder
 
-WORKDIR /go/src/github.com/keptn/keptn/jmeter-service
+WORKDIR /go/src/github.com/keptn/keptn/configuration-service
 
 # Force the go compiler to use modules 
 ENV GO111MODULE=on


### PR DESCRIPTION
Dockerfile for configuration service had a copy-paste error (was building jmeter instead of configuration service)