### PR TITLE
#946 provide latest version of the CLI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -291,8 +291,9 @@ jobs:
         echo "Build keptn cli"
         cd ./cli
         go test ./...
-        TAG="${DATE}-latest"
-        source ../travis-scripts/build_cli.sh "${TAG}"
+        TAG="latest"
+        VERSION="${DATE}-latest"
+        source ../travis-scripts/build_cli.sh "${VERSION}"
         cd ..
       fi
   - if: branch = develop AND type = push


### PR DESCRIPTION
At the moment we upload every change of the CLI within the develop branch into a new sub-folder.

To be in sync with our docker images, I propose that we upload the latest build of the CLI (within the develop branch) into a folder called "develop".
To understand this change, here is the relevant code of `build_CLI`:

```sh
#!/bin/bash

VERSION=$1
echo "$VERSION" > version
...
env GOOS=darwin GOARCH=amd64 go build -ldflags="-X 'main.Version=$VERSION'" -o keptn

gsutil cp keptn-macOS.zip gs://keptn-cli/${TAG}/keptn-macOS.zip
gsutil cp keptn-macOS.tar.gz gs://keptn-cli/${TAG}/keptn-macOS.tar.gz

...

env GOOS=linux GOARCH=amd64 go build -ldflags="-X 'main.Version=$VERSION'" -o keptn

gsutil cp keptn-linux.zip gs://keptn-cli/${TAG}/keptn-linux.zip
gsutil cp keptn-linux.tar.gz gs://keptn-cli/${TAG}/keptn-linux.tar.gz

...

```