### PR TITLE
Lighthouse Service is added to the nightly script, pipeline improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
   if [ ! -d "$HOME/google-cloud-sdk/bin" ]; then 
     rm -rf $HOME/google-cloud-sdk;
     export CLOUDSDK_CORE_DISABLE_PROMPTS=1;
-    curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-247.0.0-${OS_TYPE}-x86_64.tar.gz > gcloud.tar.gz 
+    curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-270.0.0-${OS_TYPE}-x86_64.tar.gz > gcloud.tar.gz
     gunzip -c gcloud.tar.gz | tar xopf - 
     ./google-cloud-sdk/install.sh
     source ./google-cloud-sdk/completion.bash.inc

--- a/.travis.yml
+++ b/.travis.yml
@@ -132,11 +132,16 @@ jobs:
     - cd ..
     - source ./travis-scripts/build_develop.sh "${WAIT_SVC_IMAGE}" "${WAIT_SVC_FOLDER}" "${GIT_SHA}" "${DATE}"
     - cd ..
+    - source ./travis-scripts/build_develop.sh "${LIGHTHOUSE_SVC_IMAGE}" "${LIGHTHOUSE_SVC_FOLDER}" "${GIT_SHA}" "${DATE}"
+    - cd ..
     - source ./travis-scripts/build_develop.sh "${MONGODB_DS_IMAGE}" "${MONGODB_DS_FOLDER}" "${GIT_SHA}" "${DATE}"
     - cd ..
     - source ./travis-scripts/build_develop.sh "${INSTALLER_IMAGE}" "${INSTALLER_FOLDER}" "${GIT_SHA}" "${DATE}"
     - cd ..
       ### ATTENTION: please make sure installer is always the last in this list to be built
+    after_script:
+      - echo "The following images have been built and pushed to dockerhub:"
+      - docker images | grep keptn
 
 
   - stage: cron
@@ -281,6 +286,9 @@ jobs:
         cd ..
       fi
       ### ATTENTION: please make sure installer is always the last in this list to be built
+    after_script:
+      - echo "The following images have been built and pushed to dockerhub:"
+      - docker images | grep keptn
 
   - stage: develop
     if: branch = develop AND type = push
@@ -384,6 +392,9 @@ jobs:
         cd ..
       fi
       ### ATTENTION: please make sure installer is always the last in this list to be built
+    after_script:
+      - echo "The following images have been built and pushed to dockerhub:"
+      - docker images | grep keptn
 
   - stage: release
     if: branch =~ ^release.*$ AND NOT type = pull_request
@@ -435,6 +446,9 @@ jobs:
     - source ./travis-scripts/build_release.sh "${INSTALLER_IMAGE}" "${INSTALLER_FOLDER}" "${GIT_SHA}" "${DATE}" "${VERSION}"
     - cd ..
     ### ATTENTION: please make sure installer is always the last in this list to be built
+    after_script:
+      - echo "The following images have been built and pushed to dockerhub:"
+      - docker images | grep keptn
 
   - stage: master
     if: branch = master AND NOT type = pull_request

--- a/travis-scripts/build_develop.sh
+++ b/travis-scripts/build_develop.sh
@@ -14,9 +14,5 @@ cd ./${FOLDER}
 sed -i '/#travis-uncomment/s/^#travis-uncomment //g' Dockerfile
 
 cat MANIFEST
-docker build . -t "${IMAGE}:${GIT_SHA}" --build-arg version=$VERSION
-docker tag "${IMAGE}:${GIT_SHA}" "${IMAGE}:${DATE}"
-docker tag "${IMAGE}:${GIT_SHA}" "${IMAGE}:latest"
-docker push "${IMAGE}:${GIT_SHA}"
-docker push "${IMAGE}:${DATE}"
-docker push "${IMAGE}:latest"
+docker build . -t "${IMAGE}:${GIT_SHA}" -t "${IMAGE}:${DATE}" -t "${IMAGE}:latest" --build-arg version=$VERSION
+docker push "${IMAGE}"

--- a/travis-scripts/build_feature.sh
+++ b/travis-scripts/build_feature.sh
@@ -16,7 +16,5 @@ cd ./${FOLDER}
 sed -i '/#travis-uncomment/s/^#travis-uncomment //g' Dockerfile
 
 cat MANIFEST
-docker build . -t "${IMAGE}:${GIT_SHA}"  --build-arg version=$DATE
-docker tag "${IMAGE}:${GIT_SHA}" "${IMAGE}:${TYPE}.${NUMBER}.${DATE}"
-docker push "${IMAGE}:${GIT_SHA}"
-docker push "${IMAGE}:${TYPE}.${NUMBER}.${DATE}"
+docker build . -t "${IMAGE}:${GIT_SHA}" -t "${IMAGE}:${TYPE}.${NUMBER}.${DATE}" --build-arg version=$DATE
+docker push "${IMAGE}"

--- a/travis-scripts/build_release.sh
+++ b/travis-scripts/build_release.sh
@@ -15,9 +15,5 @@ cd ./${FOLDER}
 sed -i '/#travis-uncomment/s/^#travis-uncomment //g' Dockerfile
 
 cat MANIFEST
-docker build . -t "${IMAGE}:${GIT_SHA}" --build-arg version=$VERSION
-docker tag "${IMAGE}:${GIT_SHA}" "${IMAGE}:${VERSION}.${DATE}"
-docker tag "${IMAGE}:${GIT_SHA}" "${IMAGE}:${VERSION}.latest"
-docker push "${IMAGE}:${GIT_SHA}"
-docker push "${IMAGE}:${VERSION}.${DATE}"
-docker push "${IMAGE}:${VERSION}.latest"
+docker build . -t "${IMAGE}:${GIT_SHA}" -t "${IMAGE}:${VERSION}.${DATE}" -t "${IMAGE}:${VERSION}.latest" --build-arg version=$VERSION
+docker push "${IMAGE}"


### PR DESCRIPTION
**Note**: While making this PR I managed to hit the 50-minute limit of travis-ci (when building all images at once).

- Added Lighthouse Service to the "nightly" build script
- Improved docker build/tag/push workflow (slightly speeds up the pipeline)
- Added an output in the `after_script` section of travis that lists all images that have been build for this PR/push
- Raise gcloud version number to 270 to slightly speed up setup time of travis-ci