### PR TITLE
#950 Reworked lighthouse service

### DIFF
--- a/lighthouse-service/event_handler/handler.go
+++ b/lighthouse-service/event_handler/handler.go
@@ -1,21 +1,69 @@
 package event_handler
 
 import (
+	"encoding/json"
 	"errors"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
+	"github.com/google/uuid"
 	keptnevents "github.com/keptn/go-utils/pkg/events"
 	keptnutils "github.com/keptn/go-utils/pkg/utils"
 	"net/http"
+	"net/url"
+	"time"
 )
 
 type EvaluationEventHandler interface {
 	HandleEvent() error
 }
 
+// converts a TestsFinishedEventType into a StartEvaluationEventType
+func convertTestsFinishedToStartEvaluationEvent(previousEvent cloudevents.Event) cloudevents.Event {
+	var shkeptncontext string
+	endtime := previousEvent.Time().String()
+
+	var data map[string]string
+
+	previousEvent.Context.ExtensionAs("shkeptncontext", &shkeptncontext)
+	previousEvent.Context.ExtensionAs("time", &endtime)
+	// eventData := &keptnevents.TestsFinishedEventData{}
+	_ = previousEvent.DataAs(&data)
+
+	getSLIEvent := keptnevents.StartEvaluationEventData{
+		Project:     data["project"],
+		Service:     data["service"],
+		Stage:       data["stage"],
+		Start:       data["startedat"],
+		End:         endtime,
+		TestStrategy: data["teststrategy"],
+	}
+
+	source, _ := url.Parse("lighthouse-service")
+	contentType := "application/json"
+
+	getSLIEventJson, _ := json.Marshal(getSLIEvent)
+
+	event := cloudevents.Event{
+		Context: cloudevents.EventContextV02{
+			ID:          uuid.New().String(),
+			Time:        &types.Timestamp{Time: time.Now()},
+			Type:        keptnevents.StartEvaluationEventType,
+			Source:      types.URLRef{URL: *source},
+			ContentType: &contentType,
+			Extensions:  map[string]interface{}{"shkeptncontext": shkeptncontext},
+		}.AsV02(),
+		Data: getSLIEventJson,
+	}
+
+	return event
+}
+
 func NewEventHandler(event cloudevents.Event, logger *keptnutils.Logger) (EvaluationEventHandler, error) {
 	switch event.Type() {
+	case keptnevents.TestFinishedEventType_0_5_0_Compatible:
+		return &StartEvaluationHandler{Logger: logger, Event: convertTestsFinishedToStartEvaluationEvent(event)}, nil // backwards compatibility to Keptn versions <= 0.5.x
 	case keptnevents.TestsFinishedEventType:
-		return &StartEvaluationHandler{Logger: logger, Event: event}, nil // backwards compatibility to Keptn versions <= 0.5.x
+		return &StartEvaluationHandler{Logger: logger, Event: convertTestsFinishedToStartEvaluationEvent(event)}, nil
 	case keptnevents.StartEvaluationEventType:
 		return &StartEvaluationHandler{Logger: logger, Event: event}, nil // new event type in Keptn versions >= 0.6
 	case keptnevents.InternalGetSLIDoneEventType:

--- a/lighthouse-service/go.mod
+++ b/lighthouse-service/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.2.5-0.20191030134731-341284448a02
+	github.com/keptn/go-utils v0.0.0-20191106155153-e9c1ee2aac31
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/stretchr/testify v1.4.0

--- a/lighthouse-service/go.sum
+++ b/lighthouse-service/go.sum
@@ -220,10 +220,15 @@ github.com/keptn/go-utils v0.0.0-20191029135713-fade430cc75b h1:YeB0jezwYi3Xw8FC
 github.com/keptn/go-utils v0.0.0-20191029135713-fade430cc75b/go.mod h1:YwobU0bBWWvx1b7N++ohTcYyEuz7VZjlbjkZAhzBiS8=
 github.com/keptn/go-utils v0.0.0-20191029142517-7ffc20585ada h1:szTT/PEBIIhGPBHxx5FL0cVsWu0vnTIs90YAgCp5caw=
 github.com/keptn/go-utils v0.0.0-20191029142517-7ffc20585ada/go.mod h1:YwobU0bBWWvx1b7N++ohTcYyEuz7VZjlbjkZAhzBiS8=
+github.com/keptn/go-utils v0.0.0-20191106101041-83f93d8232d2 h1:1HHKttv05sKeI+COAZHs488Ys4WSOGY1gJ+UzpNgbH8=
+github.com/keptn/go-utils v0.0.0-20191106101041-83f93d8232d2/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZzmyoE98c=
+github.com/keptn/go-utils v0.0.0-20191106155153-e9c1ee2aac31 h1:GbxrmguiYldjQIntgpPkp9N6qNfEUIsKyt3onVS53Do=
+github.com/keptn/go-utils v0.0.0-20191106155153-e9c1ee2aac31/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZzmyoE98c=
 github.com/keptn/go-utils v0.2.3 h1:Jf9sxb+IIrjeR0/2DpDEFVNoqA6gf9hgiDZ2UjK7bIE=
 github.com/keptn/go-utils v0.2.3/go.mod h1:Kk866wN1r/uX0Bn3GaDgOXpEpaaf1wxDRIq4SkFnqzc=
 github.com/keptn/go-utils v0.2.5-0.20191030134731-341284448a02 h1:ogKkIv1PKO+ZhUb30ZfBwf2h97QgsRUlR678wLdWb5Q=
 github.com/keptn/go-utils v0.2.5-0.20191030134731-341284448a02/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZzmyoE98c=
+github.com/keptn/go-utils v0.3.0 h1:0Gm3Kmv3EXmlq1i3YcHiwLs9j6wCw0COe+IR2pNKq5k=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd h1:Coekwdh0v2wtGp9Gmz1Ze3eVRAWJMLokvN3QjdzCHLY=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=


### PR DESCRIPTION
1. Pre-Filter evaluation results by status before evaluating them based on `IncludeResultWithScore`
2. Refactored `getPreviousEvaluations` and added some checks for errors
3. Added a `convertTestsFinishedToStartEvaluationEvent` which we need to convert the current tests-finished event to a start-evaluation event
4. Handle `TestFinishedEventType_0_5_0_Compatible` events
5. Return "pass" for `testStrategy == "functional"` (same as with pitometer service)
6. Added `TestStrategy` to several events