### PR TITLE
#950 Gatekeeper needs to use new evaluation done result

### DIFF
--- a/.idea/runConfigurations/keptn_gatekeeper__Kube_ContDeploy_.xml
+++ b/.idea/runConfigurations/keptn_gatekeeper__Kube_ContDeploy_.xml
@@ -1,0 +1,13 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="keptn/gatekeeper [Kube ContDeploy]" type="google-container-tools-skaffold-run-config" factoryName="google-container-tools-skaffold-run-config-dev" show_console_on_std_err="false" show_console_on_std_out="false">
+    <option name="allowRunningInParallel" value="false" />
+    <option name="cleanupDeployments" value="true" />
+    <option name="envVariables" />
+    <option name="imageRepositoryOverride" />
+    <option name="kubernetesContext" />
+    <option name="skaffoldConfigurationFilePath" value="$PROJECT_DIR$/gatekeeper-service/skaffold.yaml" />
+    <option name="skaffoldNamespace" />
+    <option name="skaffoldProfile" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/gatekeeper-service/README.md
+++ b/gatekeeper-service/README.md
@@ -5,7 +5,11 @@ The *gatekeeper-service* is a Keptn core component and implements the quality ga
 The *gatekeeper-service* listens to Keptn events of type:
 - `sh.keptn.events.evaluation-done`
 
-The `evaluation-done` contains the result of the evaluation. If the evaluation result is positive, this service sends a `new-artifact` event for the next stage. If the evaluation result is negative and the service is deployed with a blue/green strategy, this service changes the configuration back to the old version and sends a `configuration-changed` event.
+The `evaluation-done` contains the result of the evaluation. If the evaluation result is positive (e.g., 
+ `result = "pass" || result = "warning"`), this service promotes the artifact to the next stage by sending a 
+ `new-artifact` event for the next stage. If the evaluation result is negative (e.g., `result = "fail"`) and the 
+ service is deployed with a blue/green strategy, this service changes the configuration back to the old version and 
+ sends a `configuration-changed` event.
 
 ## Installation
 

--- a/gatekeeper-service/go.mod
+++ b/gatekeeper-service/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/uuid v1.1.1
 	github.com/kelseyhightower/envconfig v1.3.0
-	github.com/keptn/go-utils v0.3.0
+	github.com/keptn/go-utils v0.0.0-20191106155153-e9c1ee2aac31
 )
 
 replace github.com/cloudevents/sdk-go => github.com/cloudevents/sdk-go v0.0.0-20190509003705-56931988abe3

--- a/gatekeeper-service/go.sum
+++ b/gatekeeper-service/go.sum
@@ -171,6 +171,12 @@ github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/u
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kelseyhightower/envconfig v1.3.0 h1:IvRS4f2VcIQy6j4ORGIf9145T/AsUB+oY8LyvN8BXNM=
 github.com/kelseyhightower/envconfig v1.3.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
+github.com/keptn/go-utils v0.0.0-20191106153926-7f5de3e50cca h1:IL+t37E4MFKI8phzkDHsv3mIPXgqPbPkoQzZtcGLuGI=
+github.com/keptn/go-utils v0.0.0-20191106153926-7f5de3e50cca/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZzmyoE98c=
+github.com/keptn/go-utils v0.0.0-20191106154634-2de54f623dc9 h1:oQhr6M1RiMLiMj77TTZElDldzDwcebPP4tJuHDeRfnM=
+github.com/keptn/go-utils v0.0.0-20191106154634-2de54f623dc9/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZzmyoE98c=
+github.com/keptn/go-utils v0.0.0-20191106155153-e9c1ee2aac31 h1:GbxrmguiYldjQIntgpPkp9N6qNfEUIsKyt3onVS53Do=
+github.com/keptn/go-utils v0.0.0-20191106155153-e9c1ee2aac31/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZzmyoE98c=
 github.com/keptn/go-utils v0.2.4 h1:ibiIyUl8q65JCLFu4aUT6L9hA62BIeO4gKoRl+F6OQY=
 github.com/keptn/go-utils v0.2.4/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZzmyoE98c=
 github.com/keptn/go-utils v0.3.0 h1:0Gm3Kmv3EXmlq1i3YcHiwLs9j6wCw0COe+IR2pNKq5k=

--- a/gatekeeper-service/skaffold.yaml
+++ b/gatekeeper-service/skaffold.yaml
@@ -1,0 +1,13 @@
+apiVersion: skaffold/v1beta13
+kind: Config
+build:
+  artifacts:
+    - image: keptn/gatekeeper-service
+      docker:    # 	beta describes an artifact built from a Dockerfile.
+        dockerfile: Dockerfile
+        buildArgs:
+          debugBuild: true
+deploy:
+  kubectl:
+    manifests:
+      - deploy/service.yaml


### PR DESCRIPTION
The new evaluation results do not contain `evaluationPassed: true/false`, but `result = pass | warning | fail`.

In addition, I removed the struct containing the definition of the `EvaluationDoneEventData` payload from gatekeeper, and use the current version of go-utils (develop branch) which contains the correct version of `EvaluationDoneEventData` (see PR https://github.com/keptn/go-utils/pull/109 ).