### PR TITLE
#1078 adapt jmeter service to use test-finished and evaluation-done events

### DIFF
--- a/jmeter-service/Dockerfile
+++ b/jmeter-service/Dockerfile
@@ -8,24 +8,30 @@ WORKDIR /go/src/github.com/keptn/keptn/jmeter-service
 
 # Force the go compiler to use modules 
 ENV GO111MODULE=on
+ENV BUILDFLAGS=""
 
 # Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
 # in case of a change in the dependencies
 COPY go.mod go.sum ./
 
 # Download dependencies
-RUN go mod download 
+RUN go mod download
+
+ARG debugBuild
+
+# set buildflags for debug build
+RUN if [ ! -z "$debugBuild" ]; then export BUILDFLAGS='-gcflags "all=-N -l"'; fi
 
 # Copy local code to the container image.
 COPY . .
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN CGO_ENABLED=0 GOOS=linux go build -v -o jmeter-service
+RUN CGO_ENABLED=0 GOOS=linux go build $BUILDFLAGS -v -o jmeter-service
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM alpine
+FROM alpine:3.7
 ENV env=production
 ARG JMETER_VERSION="5.1.1"
 ENV JMETER_HOME /opt/apache-jmeter-${JMETER_VERSION}
@@ -52,9 +58,21 @@ RUN    apk update \
 # Set global PATH such that "jmeter" command is found
 ENV PATH $PATH:$JMETER_BIN
 
+# IF we are debugging, we need to install libc6-compat for delve to work on alpine based containers
+RUN if [ ! -z "$debugBuild" ]; then apk add --no-cache libc6-compat; fi
+
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /go/src/github.com/keptn/keptn/jmeter-service/jmeter-service /jmeter-service
-ADD MANIFEST /
+
+EXPOSE 8080
+
+# required for external tools to detect this as a go binary
+ENV GOTRACEBACK=all
+
+# KEEP THE FOLLOWING LINES COMMENTED OUT!!! (they will be included within the travis-ci build)
+#travis-uncomment ADD MANIFEST /
+#travis-uncomment COPY entrypoint.sh /
+#travis-uncomment ENTRYPOINT ["/entrypoint.sh"]
 
 # Run the web service on container startup.
-CMD ["sh", "-c", "cat MANIFEST && /jmeter-service"]
+CMD ["/jmeter-service"]

--- a/jmeter-service/README.md
+++ b/jmeter-service/README.md
@@ -5,7 +5,9 @@ The *jmeter-service* is a Keptn core component and used for triggering JMeter te
 The *jmeter-service* listens to Keptn events of type:
 - `sh.keptn.events.deployment-finished`
 
-In case the tests succeeed, this service sends a `sh.keptn.events.test-finished` event. In case the tests do not succeed (e.g., the error rate is too high), this service sends an `sh.keptn.events.evaluation-done` event with the data `evaluationpassed=false`.
+In case the tests succeeded, this service sends a `sh.keptn.events.test-finished` event. In case the tests do not
+ succeed (e.g., the error rate is too high), this service sends an `sh.keptn.events.evaluation-done` event with the 
+ data `result="fail"` (used to be `evaluationpassed=false` before Keptn 0.6.0).
 
 ## Installation
 

--- a/jmeter-service/deploy/service.yaml
+++ b/jmeter-service/deploy/service.yaml
@@ -18,6 +18,9 @@ spec:
         image: keptn/jmeter-service:latest
         ports:
         - containerPort: 8080
+        env:
+        - name: EVENTBROKER
+          value: 'http://event-broker.keptn.svc.cluster.local/keptn'
 ---
 apiVersion: v1
 kind: Service

--- a/jmeter-service/go.mod
+++ b/jmeter-service/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cloudevents/sdk-go v0.10.0
 	github.com/google/uuid v1.1.1
 	github.com/kelseyhightower/envconfig v1.3.0
-	github.com/keptn/go-utils v0.3.0
+	github.com/keptn/go-utils v0.0.0-20191107120119-a4a5f8adcc8b
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 // indirect
 	google.golang.org/appengine v1.5.0 // indirect
 	k8s.io/apimachinery v0.0.0-20190313205120-d7deff9243b1

--- a/jmeter-service/go.sum
+++ b/jmeter-service/go.sum
@@ -189,6 +189,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kelseyhightower/envconfig v1.3.0 h1:IvRS4f2VcIQy6j4ORGIf9145T/AsUB+oY8LyvN8BXNM=
 github.com/kelseyhightower/envconfig v1.3.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
+github.com/keptn/go-utils v0.0.0-20191107120119-a4a5f8adcc8b h1:91Z0MF5xA3jqr6lWzlDeC1ldHMGvCLRAo4uz2RoD4HI=
+github.com/keptn/go-utils v0.0.0-20191107120119-a4a5f8adcc8b/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZzmyoE98c=
 github.com/keptn/go-utils v0.2.4 h1:ibiIyUl8q65JCLFu4aUT6L9hA62BIeO4gKoRl+F6OQY=
 github.com/keptn/go-utils v0.2.4/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZzmyoE98c=
 github.com/keptn/go-utils v0.3.0 h1:0Gm3Kmv3EXmlq1i3YcHiwLs9j6wCw0COe+IR2pNKq5k=

--- a/jmeter-service/main.go
+++ b/jmeter-service/main.go
@@ -18,8 +18,11 @@ import (
 	"github.com/google/uuid"
 	"github.com/kelseyhightower/envconfig"
 	keptnutils "github.com/keptn/go-utils/pkg/utils"
+	keptnevents "github.com/keptn/go-utils/pkg/events"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+const eventbroker = "EVENTBROKER"
 
 type envConfig struct {
 	// Port on which to listen for cloudevents
@@ -196,22 +199,24 @@ func getGatewayFromConfigmap() (string, error) {
 }
 
 func sendTestsFinishedEvent(shkeptncontext string, incomingEvent cloudevents.Event, startedAt time.Time, logger *keptnutils.Logger) error {
-
 	source, _ := url.Parse("jmeter-service")
 	contentType := "application/json"
 
-	var testFinishedData interface{}
+	testFinishedData := keptnevents.TestsFinishedEventData{}
+	// fill in data from incoming event (e.g., project, service, stage, teststrategy, deploymentstrategy)
 	if err := incomingEvent.DataAs(&testFinishedData); err != nil {
 		logger.Error(fmt.Sprintf("Got Data Error: %s", err.Error()))
 		return err
 	}
-	testFinishedData.(map[string]interface{})["startedat"] = startedAt
+	// fill in timestamps
+	testFinishedData.Start = startedAt.Format(time.RFC3339)
+	testFinishedData.End = time.Now().Format(time.RFC3339)
 
 	event := cloudevents.Event{
 		Context: cloudevents.EventContextV02{
 			ID:          uuid.New().String(),
 			Time:        &types.Timestamp{Time: time.Now()},
-			Type:        "sh.keptn.events.tests-finished",
+			Type:        "sh.keptn.event.tests.finished",
 			Source:      types.URLRef{URL: *source},
 			ContentType: &contentType,
 			Extensions:  map[string]interface{}{"shkeptncontext": shkeptncontext},
@@ -219,23 +224,7 @@ func sendTestsFinishedEvent(shkeptncontext string, incomingEvent cloudevents.Eve
 		Data: testFinishedData,
 	}
 
-	t, err := cloudeventshttp.New(
-		cloudeventshttp.WithTarget("http://event-broker.keptn.svc.cluster.local/keptn"),
-		cloudeventshttp.WithEncoding(cloudeventshttp.StructuredV02),
-	)
-	if err != nil {
-		return errors.New("Failed to create transport:" + err.Error())
-	}
-
-	c, err := client.New(t)
-	if err != nil {
-		return errors.New("Failed to create HTTP client:" + err.Error())
-	}
-
-	if _, err := c.Send(context.Background(), event); err != nil {
-		return errors.New("Failed to send cloudevent:, " + err.Error())
-	}
-	return nil
+	return sendEvent(event)
 }
 
 func sendEvaluationDoneEvent(shkeptncontext string, incomingEvent cloudevents.Event, logger *keptnutils.Logger) error {
@@ -243,12 +232,14 @@ func sendEvaluationDoneEvent(shkeptncontext string, incomingEvent cloudevents.Ev
 	source, _ := url.Parse("jmeter-service")
 	contentType := "application/json"
 
-	var evaluationDoneData interface{}
+	evaluationDoneData := keptnevents.EvaluationDoneEventData{}
+	// fill in data from incoming event (e.g., project, service, stage, teststrategy, deploymentstrategy)
 	if err := incomingEvent.DataAs(&evaluationDoneData); err != nil {
 		logger.Error(fmt.Sprintf("Got Data Error: %s", err.Error()))
 		return err
 	}
-	evaluationDoneData.(map[string]interface{})["evaluationpassed"] = false
+	// set result to fail
+	evaluationDoneData.Result = "fail"
 
 	event := cloudevents.Event{
 		Context: cloudevents.EventContextV02{
@@ -262,23 +253,7 @@ func sendEvaluationDoneEvent(shkeptncontext string, incomingEvent cloudevents.Ev
 		Data: evaluationDoneData,
 	}
 
-	t, err := cloudeventshttp.New(
-		cloudeventshttp.WithTarget("http://event-broker.keptn.svc.cluster.local/keptn"),
-		cloudeventshttp.WithEncoding(cloudeventshttp.StructuredV02),
-	)
-	if err != nil {
-		return errors.New("Failed to create transport:" + err.Error())
-	}
-
-	c, err := client.New(t)
-	if err != nil {
-		return errors.New("Failed to create HTTP client:" + err.Error())
-	}
-
-	if _, err := c.Send(context.Background(), event); err != nil {
-		return errors.New("Failed to send cloudevent:, " + err.Error())
-	}
-	return nil
+	return sendEvent(event)
 }
 
 func _main(args []string, env envConfig) int {
@@ -302,3 +277,47 @@ func _main(args []string, env envConfig) int {
 
 	return 0
 }
+
+func sendEvent(event cloudevents.Event) error {
+	endPoint, err := getServiceEndpoint(eventbroker)
+	if err != nil {
+		return errors.New("Failed to retrieve endpoint of eventbroker. %s" + err.Error())
+	}
+
+	if endPoint.Host == "" {
+		return errors.New("Host of eventbroker not set")
+	}
+
+	transport, err := cloudeventshttp.New(
+		cloudeventshttp.WithTarget(endPoint.String()),
+		cloudeventshttp.WithEncoding(cloudeventshttp.StructuredV02),
+	)
+	if err != nil {
+		return errors.New("Failed to create transport:" + err.Error())
+	}
+
+	c, err := client.New(transport)
+	if err != nil {
+		return errors.New("Failed to create HTTP client:" + err.Error())
+	}
+
+	if _, err := c.Send(context.Background(), event); err != nil {
+		return errors.New("Failed to send cloudevent:, " + err.Error())
+	}
+	return nil
+}
+
+// getServiceEndpoint gets an endpoint stored in an environment variable and sets http as default scheme
+func getServiceEndpoint(service string) (url.URL, error) {
+	url, err := url.Parse(os.Getenv(service))
+	if err != nil {
+		return *url, fmt.Errorf("Failed to retrieve value from ENVIRONMENT_VARIABLE: %s", service)
+	}
+
+	if url.Scheme == "" {
+		url.Scheme = "http"
+	}
+
+	return *url, nil
+}
+

--- a/jmeter-service/main.go
+++ b/jmeter-service/main.go
@@ -216,7 +216,7 @@ func sendTestsFinishedEvent(shkeptncontext string, incomingEvent cloudevents.Eve
 		Context: cloudevents.EventContextV02{
 			ID:          uuid.New().String(),
 			Time:        &types.Timestamp{Time: time.Now()},
-			Type:        "sh.keptn.event.tests.finished",
+			Type:        keptnevents.TestsFinishedEventType,
 			Source:      types.URLRef{URL: *source},
 			ContentType: &contentType,
 			Extensions:  map[string]interface{}{"shkeptncontext": shkeptncontext},
@@ -245,7 +245,7 @@ func sendEvaluationDoneEvent(shkeptncontext string, incomingEvent cloudevents.Ev
 		Context: cloudevents.EventContextV02{
 			ID:          uuid.New().String(),
 			Time:        &types.Timestamp{Time: time.Now()},
-			Type:        "sh.keptn.events.evaluation-done",
+			Type:        keptnevents.EvaluationDoneEventType,
 			Source:      types.URLRef{URL: *source},
 			ContentType: &contentType,
 			Extensions:  map[string]interface{}{"shkeptncontext": shkeptncontext},

--- a/jmeter-service/skaffold.yaml
+++ b/jmeter-service/skaffold.yaml
@@ -1,0 +1,13 @@
+apiVersion: skaffold/v1beta13
+kind: Config
+build:
+  artifacts:
+    - image: keptn/jmeter-service
+      docker:    # 	beta describes an artifact built from a Dockerfile.
+        dockerfile: Dockerfile
+        buildArgs:
+          debugBuild: true
+deploy:
+  kubectl:
+    manifests:
+      - deploy/service.yaml

--- a/lighthouse-service/deploy/distributor.yaml
+++ b/lighthouse-service/deploy/distributor.yaml
@@ -1,4 +1,4 @@
-## lighthouse-service: sh.keptn.events.tests-finished
+## lighthouse-service: sh.keptn.event.tests-finished
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -30,7 +30,7 @@ spec:
             - name: PUBSUB_URL
               value: 'nats://keptn-nats-cluster'
             - name: PUBSUB_TOPIC
-              value: 'sh.keptn.events.tests-finished'
+              value: 'sh.keptn.event.tests.finished'
             - name: PUBSUB_RECIPIENT
               value: 'lighthouse-service'
 ---

--- a/lighthouse-service/event_handler/handler.go
+++ b/lighthouse-service/event_handler/handler.go
@@ -1,70 +1,21 @@
 package event_handler
 
 import (
-	"encoding/json"
 	"errors"
-	"net/http"
-	"net/url"
-	"time"
-
 	"github.com/cloudevents/sdk-go/pkg/cloudevents"
-	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
-	"github.com/google/uuid"
 	keptnevents "github.com/keptn/go-utils/pkg/events"
 	keptnutils "github.com/keptn/go-utils/pkg/utils"
+	"net/http"
 )
 
 type EvaluationEventHandler interface {
 	HandleEvent() error
 }
 
-// converts a TestsFinishedEventType into a StartEvaluationEventType
-func convertTestsFinishedToStartEvaluationEvent(previousEvent cloudevents.Event) cloudevents.Event {
-	var shkeptncontext string
-	endtime := previousEvent.Time().String()
-
-	var data map[string]string
-
-	previousEvent.Context.ExtensionAs("shkeptncontext", &shkeptncontext)
-	previousEvent.Context.ExtensionAs("time", &endtime)
-	// eventData := &keptnevents.TestsFinishedEventData{}
-	_ = previousEvent.DataAs(&data)
-
-	getSLIEvent := keptnevents.StartEvaluationEventData{
-		Project:      data["project"],
-		Service:      data["service"],
-		Stage:        data["stage"],
-		Start:        data["startedat"],
-		End:          endtime,
-		TestStrategy: data["teststrategy"],
-	}
-
-	source, _ := url.Parse("lighthouse-service")
-	contentType := "application/json"
-
-	getSLIEventJson, _ := json.Marshal(getSLIEvent)
-
-	event := cloudevents.Event{
-		Context: cloudevents.EventContextV02{
-			ID:          uuid.New().String(),
-			Time:        &types.Timestamp{Time: time.Now()},
-			Type:        keptnevents.StartEvaluationEventType,
-			Source:      types.URLRef{URL: *source},
-			ContentType: &contentType,
-			Extensions:  map[string]interface{}{"shkeptncontext": shkeptncontext},
-		}.AsV02(),
-		Data: getSLIEventJson,
-	}
-
-	return event
-}
-
 func NewEventHandler(event cloudevents.Event, logger *keptnutils.Logger) (EvaluationEventHandler, error) {
 	switch event.Type() {
-	case keptnevents.TestFinishedEventType_0_5_0_Compatible:
-		return &StartEvaluationHandler{Logger: logger, Event: convertTestsFinishedToStartEvaluationEvent(event)}, nil // backwards compatibility to Keptn versions <= 0.5.x
 	case keptnevents.TestsFinishedEventType:
-		return &StartEvaluationHandler{Logger: logger, Event: convertTestsFinishedToStartEvaluationEvent(event)}, nil
+		return &StartEvaluationHandler{Logger: logger, Event: event}, nil
 	case keptnevents.StartEvaluationEventType:
 		return &StartEvaluationHandler{Logger: logger, Event: event}, nil // new event type in Keptn versions >= 0.6
 	case keptnevents.InternalGetSLIDoneEventType:

--- a/lighthouse-service/event_handler/start_evaluation_handler.go
+++ b/lighthouse-service/event_handler/start_evaluation_handler.go
@@ -2,6 +2,7 @@ package event_handler
 
 import (
 	"errors"
+	"fmt"
 	"net/url"
 	"time"
 
@@ -31,21 +32,22 @@ func (eh *StartEvaluationHandler) HandleEvent() error {
 	}
 
 	// functional tests dont need to be evaluated
-	if e.TestStrategy == "functional" {
+	if e.TestStrategy == "functional" || e.TestStrategy == "" {
 		evaluationDetails := keptnevents.EvaluationDetails{
 			IndicatorResults: nil,
 			TimeStart:        e.Start,
 			TimeEnd:          e.End,
-			Result:           "no evaluation performed by lighthouse service (functional test)",
+			Result:           fmt.Sprintf("no evaluation performed by lighthouse service (TestStrategy=%s)", e.TestStrategy),
 		}
 		// send the evaluation-done-event
 		evaluationResult := keptnevents.EvaluationDoneEventData{
-			EvaluationDetails: &evaluationDetails,
-			Result:            "pass",
-			Project:           e.Project,
-			Service:           e.Service,
-			Stage:             e.Stage,
-			TestStrategy:      e.TestStrategy,
+			EvaluationDetails:  &evaluationDetails,
+			Result:             "pass",
+			Project:            e.Project,
+			Service:            e.Service,
+			Stage:              e.Stage,
+			TestStrategy:       e.TestStrategy,
+			DeploymentStrategy: e.DeploymentStrategy,
 		}
 
 		err = eh.sendEvaluationDoneEvent(keptnContext, &evaluationResult)

--- a/lighthouse-service/go.mod
+++ b/lighthouse-service/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.0.0-20191106155153-e9c1ee2aac31
+	github.com/keptn/go-utils v0.0.0-20191107120119-a4a5f8adcc8b
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/stretchr/testify v1.4.0

--- a/lighthouse-service/go.sum
+++ b/lighthouse-service/go.sum
@@ -224,6 +224,8 @@ github.com/keptn/go-utils v0.0.0-20191106101041-83f93d8232d2 h1:1HHKttv05sKeI+CO
 github.com/keptn/go-utils v0.0.0-20191106101041-83f93d8232d2/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZzmyoE98c=
 github.com/keptn/go-utils v0.0.0-20191106155153-e9c1ee2aac31 h1:GbxrmguiYldjQIntgpPkp9N6qNfEUIsKyt3onVS53Do=
 github.com/keptn/go-utils v0.0.0-20191106155153-e9c1ee2aac31/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZzmyoE98c=
+github.com/keptn/go-utils v0.0.0-20191107120119-a4a5f8adcc8b h1:91Z0MF5xA3jqr6lWzlDeC1ldHMGvCLRAo4uz2RoD4HI=
+github.com/keptn/go-utils v0.0.0-20191107120119-a4a5f8adcc8b/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZzmyoE98c=
 github.com/keptn/go-utils v0.2.3 h1:Jf9sxb+IIrjeR0/2DpDEFVNoqA6gf9hgiDZ2UjK7bIE=
 github.com/keptn/go-utils v0.2.3/go.mod h1:Kk866wN1r/uX0Bn3GaDgOXpEpaaf1wxDRIq4SkFnqzc=
 github.com/keptn/go-utils v0.2.5-0.20191030134731-341284448a02 h1:ogKkIv1PKO+ZhUb30ZfBwf2h97QgsRUlR678wLdWb5Q=


### PR DESCRIPTION
Jmeter service was constructing events on its own, rather than using the events from go-utils.

I've fixed that, and also removed the "fallback code" I had to introduce in lighthouse-service because of the original behaviour of jmeter service.

Also, I've added skaffold.yaml and Dockerfile stuff to jmeter service for easier debugging.