### PR TITLE
#1081 send evaluation done event if no slo.yaml is available

### DIFF
--- a/lighthouse-service/event_handler/start_evaluation_handler.go
+++ b/lighthouse-service/event_handler/start_evaluation_handler.go
@@ -57,7 +57,25 @@ func (eh *StartEvaluationHandler) HandleEvent() error {
 	// get SLO file
 	objectives, err := getSLOs(e.Project, e.Stage, e.Service)
 	if err != nil {
-		// ToDo: We need to provide feedback to the user that evaluation failed because no SLO file found
+		// No SLO file found -> no need to evaluate
+		evaluationDetails := keptnevents.EvaluationDetails{
+			IndicatorResults: nil,
+			TimeStart:        e.Start,
+			TimeEnd:          e.End,
+			Result:           fmt.Sprintf("no evaluation performed by lighthouse service (no slo.yaml found)"),
+		}
+		// send the evaluation-done-event
+		evaluationResult := keptnevents.EvaluationDoneEventData{
+			EvaluationDetails:  &evaluationDetails,
+			Result:             "pass",
+			Project:            e.Project,
+			Service:            e.Service,
+			Stage:              e.Stage,
+			TestStrategy:       e.TestStrategy,
+			DeploymentStrategy: e.DeploymentStrategy,
+		}
+
+		err = eh.sendEvaluationDoneEvent(keptnContext, &evaluationResult)
 		return err
 	}
 


### PR DESCRIPTION
The default onboarding use case does not use a slo.yaml (similar to 0.5.0 where we did not provide resource indicators and object yaml files). Therefore lighthouse has no purpose other than to say that evaluation is done and has passed.