### PR TITLE
Patch/self healing fixes

### DIFF
--- a/jmeter-service/main.go
+++ b/jmeter-service/main.go
@@ -58,6 +58,9 @@ func gotEvent(ctx context.Context, event cloudevents.Event) error {
 		return errors.New(errorMsg)
 	}
 
+	if data.TestStrategy == "real-user" {
+		logger.Info("Received 'real-user' test strategy, hence no tests are triggered")
+	}
 	go runTests(event, shkeptncontext, *data, logger)
 
 	return nil

--- a/jmeter-service/main.go
+++ b/jmeter-service/main.go
@@ -60,6 +60,7 @@ func gotEvent(ctx context.Context, event cloudevents.Event) error {
 
 	if data.TestStrategy == "real-user" {
 		logger.Info("Received 'real-user' test strategy, hence no tests are triggered")
+		return nil
 	}
 	go runTests(event, shkeptncontext, *data, logger)
 

--- a/lighthouse-service/event_handler/evaluate_sli_handler.go
+++ b/lighthouse-service/event_handler/evaluate_sli_handler.go
@@ -484,7 +484,10 @@ func (eh *EvaluateSLIHandler) getPreviousEvaluations(e *keptnevents.InternalGetS
 		if ok {
 			// make sure that this event contains evaluationdetails (e.g., old events do not contain that element)
 			if _, ok := dataMap["evaluationdetails"]; ok {
-				evaluationDetails := dataMap["evaluationdetails"].(map[string]interface{})
+				evaluationDetails, ok := dataMap["evaluationdetails"].(map[string]interface{})
+				if !ok {
+					continue
+				}
 
 				// make sure evaluation details contains indicatorResults
 				if evaluationDetails["indicatorResults"] != nil && len(evaluationDetails["indicatorResults"].([]interface{})) > 0 {


### PR DESCRIPTION
added additional check in lighthouse service to ensure only valid evaluation-done events are used for the comparison

Disabled execution of jmeter-tests when test strategy has been set to `real-user`