### PR TITLE
#1128 Deploy NGINX when installing keptn on plain Kubernetes

### DIFF
--- a/installer/manifests/installer/installer.yaml
+++ b/installer/manifests/installer/installer.yaml
@@ -14,7 +14,7 @@ spec:
         emptyDir: {}
       containers:
       - name: keptn-installer
-        image: keptn/installer:2376b1a
+        image: keptn/installer:latest
         env:       
         - name: PLATFORM
           value: PLATFORM_PLACEHOLDER

--- a/installer/manifests/installer/installer.yaml
+++ b/installer/manifests/installer/installer.yaml
@@ -14,7 +14,7 @@ spec:
         emptyDir: {}
       containers:
       - name: keptn-installer
-        image: keptn/installer:latest
+        image: keptn/installer:2376b1a
         env:       
         - name: PLATFORM
           value: PLATFORM_PLACEHOLDER

--- a/installer/manifests/nginx/nginx-configmap-eks.yaml
+++ b/installer/manifests/nginx/nginx-configmap-eks.yaml
@@ -1,0 +1,12 @@
+# Source: https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/aws/patch-configmap-l4.yaml
+
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: nginx-configuration
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+data:
+  use-proxy-protocol: "true"

--- a/installer/manifests/nginx/nginx-svc-eks.yaml
+++ b/installer/manifests/nginx/nginx-svc-eks.yaml
@@ -1,0 +1,32 @@
+# Source: https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/aws/service-l4.yaml
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  annotations:
+    # Enable PROXY protocol
+    service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+    # Ensure the ELB idle timeout is less than nginx keep-alive timeout. By default,
+    # NGINX keep-alive is set to 75s. If using WebSockets, the value will need to be
+    # increased to '3600' to avoid any potential issues.
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
+spec:
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+    - name: https
+      port: 443
+      targetPort: https
+
+---
+

--- a/installer/manifests/nginx/nginx-svc-nodeport.yaml
+++ b/installer/manifests/nginx/nginx-svc-nodeport.yaml
@@ -1,0 +1,27 @@
+# Source: https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/baremetal/service-nodeport.yaml
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  type: NodePort
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+      protocol: TCP
+    - name: https
+      port: 443
+      targetPort: 443
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+
+---
+

--- a/installer/manifests/nginx/nginx-svc.yaml
+++ b/installer/manifests/nginx/nginx-svc.yaml
@@ -1,0 +1,25 @@
+# Source: https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/cloud-generic.yaml
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+    - name: https
+      port: 443
+      targetPort: https
+
+---

--- a/installer/scripts/common/utils.sh
+++ b/installer/scripts/common/utils.sh
@@ -140,7 +140,7 @@ function wait_for_crds() {
   fi
 }
 
-# Waits for ip of gateway
+# Waits for ip of Istio ingress gateway (max wait time 20sec)
 function wait_for_istio_ingressgateway() {
   PROPERTY=$1;
   RETRY=0; RETRY_MAX=4;
@@ -162,8 +162,9 @@ function wait_for_istio_ingressgateway() {
   done
 }
 
+# Waits for ip of ingress gateway (max wait time 180sec)
 function wait_for_ingress() {
-  RETRY=0; RETRY_MAX=20;
+  RETRY=0; RETRY_MAX=36;
   DOMAIN="";
 
   while [[ $RETRY -lt $RETRY_MAX ]]; do

--- a/installer/scripts/installIngress.sh
+++ b/installer/scripts/installIngress.sh
@@ -14,11 +14,11 @@ case $PLATFORM in
         # Install nginx service mesh
         print_info "Installing nginx on AKS"
         kubectl apply -f ../manifests/nginx/nginx.yaml
-        verify_install_step $? "Installing nginx failed."
+        verify_install_step $? "Installing nginx deployment failed."
         wait_for_deployment_in_namespace "nginx-ingress-controller" "ingress-nginx"
-        verify_install_step $? "Installing nginx failed."
-        kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/cloud-generic.yaml
-        verify_install_step $? "Installing nginx failed."
+        verify_install_step $? "Installing nginx failed because deployment not available"
+        kubectl apply -f ../manifests/nginx/nginx-svc.yaml
+        verify_install_step $? "Installing nginx service failed."
 
         source ./installIngressForApi.sh
     fi    
@@ -35,14 +35,14 @@ case $PLATFORM in
         # Install nginx service mesh
         print_info "Installing nginx on EKS"
         kubectl apply -f ../manifests/nginx/nginx.yaml
-        verify_install_step $? "Installing nginx failed."
+        verify_install_step $? "Installing nginx deployment failed."
         wait_for_deployment_in_namespace "nginx-ingress-controller" "ingress-nginx"
-        verify_install_step $? "Installing nginx failed."
-        kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/cloud-generic.yaml
-        verify_install_step $? "Installing nginx failed."
-        kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/aws/service-l4.yaml
-        kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/aws/patch-configmap-l4.yaml
-        verify_install_step $? "Installing nginx failed."
+        verify_install_step $? "Installing nginx failed because deployment not available"
+        kubectl apply -f ../manifests/nginx/nginx-svc.yaml
+        verify_install_step $? "Installing nginx service failed."
+        kubectl apply -f ../manifests/nginx/nginx-svc-eks.yaml
+        kubectl apply -f ../manifests/nginx/nginx-configmap-eks.yaml
+        verify_install_step $? "Installing nginx configmap for EKS failed."
 
         source ./installIngressForApi.sh
     fi
@@ -60,9 +60,11 @@ case $PLATFORM in
         # Install nginx service mesh
         print_info "Installing nginx on OpenShift"
         kubectl apply -f ../manifests/nginx/nginx.yaml
-        verify_install_step $? "Installing nginx failed."
+        verify_install_step $? "Installing nginx deployment failed."
         wait_for_deployment_in_namespace "nginx-ingress-controller" "ingress-nginx"
-        verify_install_step $? "Installing nginx failed."
+        verify_install_step $? "Installing nginx failed because deployment not available"
+        kubectl apply -f ../manifests/nginx/nginx-svc.yaml
+        verify_install_step $? "Installing nginx service failed."
 
         source ./installIngressForApi.sh
     fi 
@@ -79,11 +81,11 @@ case $PLATFORM in
         # Install nginx service mesh
         print_info "Installing nginx on GKE"
         kubectl apply -f ../manifests/nginx/nginx.yaml
-        verify_install_step $? "Installing nginx failed."
+        verify_install_step $? "Installing nginx deployment failed."
         wait_for_deployment_in_namespace "nginx-ingress-controller" "ingress-nginx"
-        verify_install_step $? "Installing nginx failed."
-        kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/cloud-generic.yaml
-        verify_install_step $? "Installing nginx failed."      
+        verify_install_step $? "Installing nginx failed because deployment not available"
+        kubectl apply -f ../manifests/nginx/nginx-svc.yaml
+        verify_install_step $? "Installing nginx service failed."     
 
         source ./installIngressForApi.sh
     fi 
@@ -100,9 +102,11 @@ case $PLATFORM in
         # Install nginx service mesh
         print_info "Installing nginx on PKS"
         kubectl apply -f ../manifests/nginx/nginx.yaml
-        verify_install_step $? "Installing nginx failed."
+        verify_install_step $? "Installing nginx deployment failed."
         wait_for_deployment_in_namespace "nginx-ingress-controller" "ingress-nginx"
-        verify_install_step $? "Installing nginx failed."   
+        verify_install_step $? "Installing nginx failed because deployment not available" 
+        kubectl apply -f ../manifests/nginx/nginx-svc.yaml
+        verify_install_step $? "Installing nginx service failed."   
 
         source ./installIngressForApi.sh     
     fi 
@@ -119,13 +123,16 @@ case $PLATFORM in
         # Install nginx service mesh
         print_info "Installing nginx on Kubernetes"
         kubectl apply -f ../manifests/nginx/nginx.yaml
-        verify_install_step $? "Installing nginx failed."
+        verify_install_step $? "Installing nginx deployment failed."
         wait_for_deployment_in_namespace "nginx-ingress-controller" "ingress-nginx"
-        verify_install_step $? "Installing nginx failed."
+        verify_install_step $? "Installing nginx failed because deployment not available"
 
         if [ "$GATEWAY_TYPE" = "NodePort" ]; then
-          kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/baremetal/service-nodeport.yaml
-          verify_install_step $? "Installing nginx failed."
+          kubectl apply -f ../manifests/nginx/nginx-svc-nodeport.yaml
+          verify_install_step $? "Installing nginx service failed."  
+        else 
+          kubectl apply -f ../manifests/nginx/nginx-svc.yaml
+          verify_install_step $? "Installing nginx service failed."  
         fi
 
         source ./installIngressForApi.sh

--- a/installer/scripts/installIngressForApi.sh
+++ b/installer/scripts/installIngressForApi.sh
@@ -2,7 +2,8 @@
 source ./common/utils.sh
 
 kubectl apply -f ../manifests/keptn/api-ingress.yaml
-verify_install_step $? "Installing ingress failed."
+verify_install_step $? "Installing Keptn api-ingress failed."
+
 wait_for_ingress
 
 export DOMAIN=$(kubectl get ingress api-ingress -n keptn -o json | jq -r .status.loadBalancer.ingress[0].ip)
@@ -21,5 +22,6 @@ rm certificate.pem
 # Update ingress with updates hosts
 cat ../manifests/keptn/api-ingress.yaml | \
     sed 's~domain.placeholder~'"$DOMAIN"'~' > ../manifests/keptn/gen/api-ingress.yaml
+
 kubectl apply -f ../manifests/keptn/gen/api-ingress.yaml
-verify_kubectl $? "Deploying keptn ingress failed."
+verify_kubectl $? "Deploying Keptn ingress failed."


### PR DESCRIPTION
- Removed references to GitHub. Instead, provide manifest files with installer.
- Improved logging of install steps
- Increased wait time for ingress IP