### PR TITLE
#1188 Add more debug output to installer and fix onboarding integration test

### DIFF
--- a/installer/scripts/common/install.sh
+++ b/installer/scripts/common/install.sh
@@ -8,7 +8,9 @@ print_info "Starting installation of Keptn"
 if [[ "$USE_CASE" == "all" ]]; then
   print_info "Installing Tiller"
   kubectl apply -f ../manifests/tiller/tiller.yaml
+  verify_kubectl $? "Applying Tiller manifest failed."
   helm init --service-account tiller
+  verify_install_step $? "Installing Tiller failed"
   print_info "Installing Tiller done"
 else
   print_debug "Installing Tiller is skipped since use case ${USE_CASE} does not need it." 

--- a/installer/scripts/common/utils.sh
+++ b/installer/scripts/common/utils.sh
@@ -113,6 +113,8 @@ function wait_for_all_pods_in_namespace() {
 
   if [[ $RETRY == $RETRY_MAX ]]; then
     print_error "Pods in namespace ${NAMESPACE} are not running."
+    # show the pods that have problems
+    kubectl get pods --field-selector=status.phase!=Running -n ${NAMESPACE}
     exit 1
   fi
 }

--- a/test/test_onboard_service.sh
+++ b/test/test_onboard_service.sh
@@ -6,7 +6,7 @@ echo "Testing onboarding for project $PROJECT ..."
 
 # Test keptn create-project and onboard
 rm -rf examples
-git clone --branch develop https://github.com/keptn/examples --single-branch
+git clone --branch master https://github.com/keptn/examples --single-branch
 cd examples/onboarding-carts
 
 echo "Creating a new project without git upstream"


### PR DESCRIPTION
As I was having some issues with debugging, I've added more helpful debug output for the `wait_for_pods_in_namespace` function.
Also, installing tiller caused some problems for me, therefore I added some additional checks for that (still needs to be verified if that works).

Also, the integration test for onboarding a service did not work anymore as we removed the "develop" branch in keptn/examples (and we are now using the master branch).