### PR TITLE
#1124 Set ingress host if hostname was found

### DIFF
--- a/installer/scripts/common/setupIstio.sh
+++ b/installer/scripts/common/setupIstio.sh
@@ -26,6 +26,7 @@ if [[ "$GATEWAY_TYPE" == "LoadBalancer" ]]; then
   if [[ $? != 0 ]]; then
       print_error "Failed to get ingress gateway information." && exit 1
   fi
+  export INGRESS_HOST=$DOMAIN
 
   if [[ "$DOMAIN" == "null" ]]; then
       print_info "Could not get ingress gateway domain name. Trying to retrieve IP address instead."

--- a/installer/scripts/installIngressForApi.sh
+++ b/installer/scripts/installIngressForApi.sh
@@ -10,6 +10,7 @@ if [[ "$GATEWAY_TYPE" == "LoadBalancer" ]]; then
   if [[ $? != 0 ]]; then
       print_error "Failed to get k8s ingress gateway information." && exit 1
   fi
+  export INGRESS_HOST=$DOMAIN
 
   if [[ "$DOMAIN" == "null" ]]; then
       print_info "Could not get ingress gateway domain name. Trying to retrieve IP address instead."


### PR DESCRIPTION
The variable $INGRESS_HOST was not set in case a hostname was found in the ingressgateway.
This was the case for Istio as well as nginx.