### PR TITLE
#542 Changed jmeter-service to not send evaluationDone events

### DIFF
--- a/jmeter-service/go.mod
+++ b/jmeter-service/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cloudevents/sdk-go v0.10.0
 	github.com/google/uuid v1.1.1
 	github.com/kelseyhightower/envconfig v1.3.0
-	github.com/keptn/go-utils v0.0.0-20200110071026-d4fa14c30eb3
+	github.com/keptn/go-utils v0.0.0-20200110130143-dc59c468fc77
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 // indirect
 	google.golang.org/appengine v1.5.0 // indirect
 	k8s.io/apimachinery v0.0.0-20190313205120-d7deff9243b1

--- a/jmeter-service/go.mod
+++ b/jmeter-service/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cloudevents/sdk-go v0.10.0
 	github.com/google/uuid v1.1.1
 	github.com/kelseyhightower/envconfig v1.3.0
-	github.com/keptn/go-utils v0.5.0
+	github.com/keptn/go-utils v0.0.0-20200110071026-d4fa14c30eb3
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 // indirect
 	google.golang.org/appengine v1.5.0 // indirect
 	k8s.io/apimachinery v0.0.0-20190313205120-d7deff9243b1

--- a/jmeter-service/go.sum
+++ b/jmeter-service/go.sum
@@ -195,6 +195,8 @@ github.com/keptn/go-utils v0.0.0-20191107120119-a4a5f8adcc8b h1:91Z0MF5xA3jqr6lW
 github.com/keptn/go-utils v0.0.0-20191107120119-a4a5f8adcc8b/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZzmyoE98c=
 github.com/keptn/go-utils v0.0.0-20191111100301-bff0cac85494 h1:pjYdyfDxE4ApPCIkI/f9H39qErNEAUjlUF7v+t5ZonI=
 github.com/keptn/go-utils v0.0.0-20191111100301-bff0cac85494/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZzmyoE98c=
+github.com/keptn/go-utils v0.0.0-20200110071026-d4fa14c30eb3 h1:fkRRxiwNWFyLplgHspplG31z0I/Or+iI++OIe5GpKkE=
+github.com/keptn/go-utils v0.0.0-20200110071026-d4fa14c30eb3/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZzmyoE98c=
 github.com/keptn/go-utils v0.2.4 h1:ibiIyUl8q65JCLFu4aUT6L9hA62BIeO4gKoRl+F6OQY=
 github.com/keptn/go-utils v0.2.4/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZzmyoE98c=
 github.com/keptn/go-utils v0.3.0 h1:0Gm3Kmv3EXmlq1i3YcHiwLs9j6wCw0COe+IR2pNKq5k=

--- a/jmeter-service/go.sum
+++ b/jmeter-service/go.sum
@@ -197,6 +197,8 @@ github.com/keptn/go-utils v0.0.0-20191111100301-bff0cac85494 h1:pjYdyfDxE4ApPCIk
 github.com/keptn/go-utils v0.0.0-20191111100301-bff0cac85494/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZzmyoE98c=
 github.com/keptn/go-utils v0.0.0-20200110071026-d4fa14c30eb3 h1:fkRRxiwNWFyLplgHspplG31z0I/Or+iI++OIe5GpKkE=
 github.com/keptn/go-utils v0.0.0-20200110071026-d4fa14c30eb3/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZzmyoE98c=
+github.com/keptn/go-utils v0.0.0-20200110130143-dc59c468fc77 h1:333rrzeKyp86UDYiMTgQ1rpE8IzSCbVjEsxY2m8WZT0=
+github.com/keptn/go-utils v0.0.0-20200110130143-dc59c468fc77/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZzmyoE98c=
 github.com/keptn/go-utils v0.2.4 h1:ibiIyUl8q65JCLFu4aUT6L9hA62BIeO4gKoRl+F6OQY=
 github.com/keptn/go-utils v0.2.4/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZzmyoE98c=
 github.com/keptn/go-utils v0.3.0 h1:0Gm3Kmv3EXmlq1i3YcHiwLs9j6wCw0COe+IR2pNKq5k=

--- a/lighthouse-service/event_handler/start_evaluation_handler_test.go
+++ b/lighthouse-service/event_handler/start_evaluation_handler_test.go
@@ -1,0 +1,100 @@
+package event_handler
+
+import (
+	"github.com/cloudevents/sdk-go/pkg/cloudevents"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
+	"github.com/google/uuid"
+	keptnevents "github.com/keptn/go-utils/pkg/events"
+	keptnutils "github.com/keptn/go-utils/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestHasTestPassedTrue(t *testing.T) {
+	contentType := "application/json"
+	source, _ := url.Parse("lighthouse-service")
+	shkeptncontext := "0000-1111-2222-3333"
+
+	// test TestsFinishedEvent
+	testsFinishedEventData := keptnevents.TestsFinishedEventData{
+		Result:             "pass",
+		Project:            "sockshop",
+		Service:            "carts",
+		Stage:              "staging",
+		TestStrategy:       "functional",
+		DeploymentStrategy: "direct",
+	}
+
+	testsFinishedEvent := cloudevents.Event{
+		Context: cloudevents.EventContextV02{
+			ID:          uuid.New().String(),
+			Time:        &types.Timestamp{Time: time.Now()},
+			Type:        keptnevents.TestsFinishedEventType,
+			Source:      types.URLRef{URL: *source},
+			ContentType: &contentType,
+			Extensions:  map[string]interface{}{"shkeptncontext": shkeptncontext},
+		}.AsV02(),
+		Data: testsFinishedEventData,
+	}
+
+	logger := keptnutils.NewLogger(shkeptncontext, testsFinishedEvent.Context.GetID(), "lighthouse-service")
+	eh := StartEvaluationHandler{Logger: logger, Event: testsFinishedEvent}
+	assert.EqualValues(t, eh.hasTestPassed(), true)
+
+	// test StartEvaluationEvent
+	startEvaluationEventData := keptnevents.StartEvaluationEventData{
+		Project:            "sockshop",
+		Service:            "carts",
+		Stage:              "staging",
+		TestStrategy:       "functional",
+		DeploymentStrategy: "direct",
+	}
+
+	startEvaluationEvent := cloudevents.Event{
+		Context: cloudevents.EventContextV02{
+			ID:          uuid.New().String(),
+			Time:        &types.Timestamp{Time: time.Now()},
+			Type:        keptnevents.StartEvaluationEventType,
+			Source:      types.URLRef{URL: *source},
+			ContentType: &contentType,
+			Extensions:  map[string]interface{}{"shkeptncontext": shkeptncontext},
+		}.AsV02(),
+		Data: startEvaluationEventData,
+	}
+
+	eh = StartEvaluationHandler{Logger: logger, Event: startEvaluationEvent}
+	assert.EqualValues(t, eh.hasTestPassed(), true)
+}
+
+func TestHasTestPassedFalse(t *testing.T) {
+	contentType := "application/json"
+	source, _ := url.Parse("lighthouse-service")
+	shkeptncontext := "0000-1111-2222-3333"
+
+	testFinishedEvent := keptnevents.TestsFinishedEventData{
+		Result:             "fail",
+		Project:            "sockshop",
+		Service:            "carts",
+		Stage:              "staging",
+		TestStrategy:       "functional",
+		DeploymentStrategy: "direct",
+	}
+
+	event := cloudevents.Event{
+		Context: cloudevents.EventContextV02{
+			ID:          uuid.New().String(),
+			Time:        &types.Timestamp{Time: time.Now()},
+			Type:        keptnevents.EvaluationDoneEventType,
+			Source:      types.URLRef{URL: *source},
+			ContentType: &contentType,
+			Extensions:  map[string]interface{}{"shkeptncontext": shkeptncontext},
+		}.AsV02(),
+		Data: testFinishedEvent,
+	}
+
+	logger := keptnutils.NewLogger(shkeptncontext, event.Context.GetID(), "lighthouse-service")
+	eh := StartEvaluationHandler{Logger: logger, Event: event}
+	assert.EqualValues(t, eh.hasTestPassed(), false)
+}

--- a/lighthouse-service/go.mod
+++ b/lighthouse-service/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.0.0-20200110071026-d4fa14c30eb3
+	github.com/keptn/go-utils v0.0.0-20200110130143-dc59c468fc77
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/stretchr/testify v1.4.0

--- a/lighthouse-service/go.mod
+++ b/lighthouse-service/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.5.0
+	github.com/keptn/go-utils v0.0.0-20200110071026-d4fa14c30eb3
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/stretchr/testify v1.4.0

--- a/lighthouse-service/go.sum
+++ b/lighthouse-service/go.sum
@@ -232,6 +232,8 @@ github.com/keptn/go-utils v0.0.0-20191202115658-0601a485f12a h1:yF/vAcHuzcHwQotf
 github.com/keptn/go-utils v0.0.0-20191202115658-0601a485f12a/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZzmyoE98c=
 github.com/keptn/go-utils v0.0.0-20200110071026-d4fa14c30eb3 h1:fkRRxiwNWFyLplgHspplG31z0I/Or+iI++OIe5GpKkE=
 github.com/keptn/go-utils v0.0.0-20200110071026-d4fa14c30eb3/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZzmyoE98c=
+github.com/keptn/go-utils v0.0.0-20200110130143-dc59c468fc77 h1:333rrzeKyp86UDYiMTgQ1rpE8IzSCbVjEsxY2m8WZT0=
+github.com/keptn/go-utils v0.0.0-20200110130143-dc59c468fc77/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZzmyoE98c=
 github.com/keptn/go-utils v0.2.3 h1:Jf9sxb+IIrjeR0/2DpDEFVNoqA6gf9hgiDZ2UjK7bIE=
 github.com/keptn/go-utils v0.2.3/go.mod h1:Kk866wN1r/uX0Bn3GaDgOXpEpaaf1wxDRIq4SkFnqzc=
 github.com/keptn/go-utils v0.2.5-0.20191030134731-341284448a02 h1:ogKkIv1PKO+ZhUb30ZfBwf2h97QgsRUlR678wLdWb5Q=

--- a/lighthouse-service/go.sum
+++ b/lighthouse-service/go.sum
@@ -230,6 +230,8 @@ github.com/keptn/go-utils v0.0.0-20191127072851-f11e3f2bbacf h1:r4YuY5e5JFc3TRC2
 github.com/keptn/go-utils v0.0.0-20191127072851-f11e3f2bbacf/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZzmyoE98c=
 github.com/keptn/go-utils v0.0.0-20191202115658-0601a485f12a h1:yF/vAcHuzcHwQotf+pCPMYkR4d2Fu3TeOobGY+SEQYs=
 github.com/keptn/go-utils v0.0.0-20191202115658-0601a485f12a/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZzmyoE98c=
+github.com/keptn/go-utils v0.0.0-20200110071026-d4fa14c30eb3 h1:fkRRxiwNWFyLplgHspplG31z0I/Or+iI++OIe5GpKkE=
+github.com/keptn/go-utils v0.0.0-20200110071026-d4fa14c30eb3/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZzmyoE98c=
 github.com/keptn/go-utils v0.2.3 h1:Jf9sxb+IIrjeR0/2DpDEFVNoqA6gf9hgiDZ2UjK7bIE=
 github.com/keptn/go-utils v0.2.3/go.mod h1:Kk866wN1r/uX0Bn3GaDgOXpEpaaf1wxDRIq4SkFnqzc=
 github.com/keptn/go-utils v0.2.5-0.20191030134731-341284448a02 h1:ogKkIv1PKO+ZhUb30ZfBwf2h97QgsRUlR678wLdWb5Q=

--- a/lighthouse-service/main.go
+++ b/lighthouse-service/main.go
@@ -52,7 +52,7 @@ func gotEvent(ctx context.Context, event cloudevents.Event) error {
 	var shkeptncontext string
 	_ = event.Context.ExtensionAs("shkeptncontext", &shkeptncontext)
 
-	logger := keptnutils.NewLogger(shkeptncontext, event.Context.GetID(), "prometheus-sli-service")
+	logger := keptnutils.NewLogger(shkeptncontext, event.Context.GetID(), "lighthouse-service")
 
 	handler, err := event_handler.NewEventHandler(event, logger)
 


### PR DESCRIPTION
The behavior of the jmeter-service has been changed. Thus, it does not send an evaluation-done event when the test execution failed. Instead, it sends a tests-finished event with `result: fail`.
The lighthouse-service has been adapted to react to this new behavior. 