### PR TITLE
#1210 Set query parameters for /event endpoint as required

### DIFF
--- a/api/handlers/event.go
+++ b/api/handlers/event.go
@@ -68,16 +68,17 @@ func PostEventHandlerFunc(params event.PostEventParams, principal *models.Princi
 // GetEventHandlerFunc returns an event specified by keptnContext and eventType
 func GetEventHandlerFunc(params event.GetEventParams, principal *models.Principal) middleware.Responder {
 
-	logger := keptnutils.NewLogger(*params.KeptnContext, "", "api")
+	keptnContext := uuid.New().String()
+	logger := keptnutils.NewLogger(keptnContext, "", "api")
 
 	eventHandler := datastore.NewEventHandler(getDatastoreURL())
-	cloudEvent, errObj := eventHandler.GetEvent(*params.KeptnContext, *params.Type)
+	cloudEvent, errObj := eventHandler.GetEvent(params.KeptnContext, params.Type)
 	if errObj != nil {
 		return sendInternalErrorForGet(fmt.Errorf("%s", *errObj.Message), logger)
 	}
 
 	if cloudEvent == nil {
-		return sendInternalErrorForGet(fmt.Errorf("No "+*params.Type+" event found for Keptn context: "+*params.KeptnContext), logger)
+		return sendInternalErrorForGet(fmt.Errorf("No "+params.Type+" event found for Keptn context: "+params.KeptnContext), logger)
 	}
 
 	eventByte, err := json.Marshal(cloudEvent)

--- a/api/handlers/event.go
+++ b/api/handlers/event.go
@@ -68,8 +68,7 @@ func PostEventHandlerFunc(params event.PostEventParams, principal *models.Princi
 // GetEventHandlerFunc returns an event specified by keptnContext and eventType
 func GetEventHandlerFunc(params event.GetEventParams, principal *models.Principal) middleware.Responder {
 
-	keptnContext := uuid.New().String()
-	logger := keptnutils.NewLogger(keptnContext, "", "api")
+	logger := keptnutils.NewLogger(params.KeptnContext, "", "api")
 
 	eventHandler := datastore.NewEventHandler(getDatastoreURL())
 	cloudEvent, errObj := eventHandler.GetEvent(params.KeptnContext, params.Type)

--- a/api/restapi/embedded_spec.go
+++ b/api/restapi/embedded_spec.go
@@ -60,13 +60,15 @@ func init() {
             "type": "string",
             "description": "KeptnContext of the events to get",
             "name": "keptnContext",
-            "in": "query"
+            "in": "query",
+            "required": true
           },
           {
             "type": "string",
             "description": "Type of the Keptn cloud event",
             "name": "type",
-            "in": "query"
+            "in": "query",
+            "required": true
           }
         ],
         "responses": {
@@ -492,13 +494,15 @@ func init() {
             "type": "string",
             "description": "KeptnContext of the events to get",
             "name": "keptnContext",
-            "in": "query"
+            "in": "query",
+            "required": true
           },
           {
             "type": "string",
             "description": "Type of the Keptn cloud event",
             "name": "type",
-            "in": "query"
+            "in": "query",
+            "required": true
           }
         ],
         "responses": {

--- a/api/restapi/operations/event/get_event_parameters.go
+++ b/api/restapi/operations/event/get_event_parameters.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/validate"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -32,13 +33,15 @@ type GetEventParams struct {
 	HTTPRequest *http.Request `json:"-"`
 
 	/*KeptnContext of the events to get
+	  Required: true
 	  In: query
 	*/
-	KeptnContext *string
+	KeptnContext string
 	/*Type of the Keptn cloud event
+	  Required: true
 	  In: query
 	*/
-	Type *string
+	Type string
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -70,36 +73,42 @@ func (o *GetEventParams) BindRequest(r *http.Request, route *middleware.MatchedR
 
 // bindKeptnContext binds and validates parameter KeptnContext from query.
 func (o *GetEventParams) bindKeptnContext(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	if !hasKey {
+		return errors.Required("keptnContext", "query")
+	}
 	var raw string
 	if len(rawData) > 0 {
 		raw = rawData[len(rawData)-1]
 	}
 
-	// Required: false
+	// Required: true
 	// AllowEmptyValue: false
-	if raw == "" { // empty values pass all other validations
-		return nil
+	if err := validate.RequiredString("keptnContext", "query", raw); err != nil {
+		return err
 	}
 
-	o.KeptnContext = &raw
+	o.KeptnContext = raw
 
 	return nil
 }
 
 // bindType binds and validates parameter Type from query.
 func (o *GetEventParams) bindType(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	if !hasKey {
+		return errors.Required("type", "query")
+	}
 	var raw string
 	if len(rawData) > 0 {
 		raw = rawData[len(rawData)-1]
 	}
 
-	// Required: false
+	// Required: true
 	// AllowEmptyValue: false
-	if raw == "" { // empty values pass all other validations
-		return nil
+	if err := validate.RequiredString("type", "query", raw); err != nil {
+		return err
 	}
 
-	o.Type = &raw
+	o.Type = raw
 
 	return nil
 }

--- a/api/restapi/operations/event/get_event_urlbuilder.go
+++ b/api/restapi/operations/event/get_event_urlbuilder.go
@@ -13,8 +13,8 @@ import (
 
 // GetEventURL generates an URL for the get event operation
 type GetEventURL struct {
-	KeptnContext *string
-	Type         *string
+	KeptnContext string
+	Type         string
 
 	_basePath string
 	// avoid unkeyed usage
@@ -50,18 +50,12 @@ func (o *GetEventURL) Build() (*url.URL, error) {
 
 	qs := make(url.Values)
 
-	var keptnContextQ string
-	if o.KeptnContext != nil {
-		keptnContextQ = *o.KeptnContext
-	}
+	keptnContextQ := o.KeptnContext
 	if keptnContextQ != "" {
 		qs.Set("keptnContext", keptnContextQ)
 	}
 
-	var typeVarQ string
-	if o.Type != nil {
-		typeVarQ = *o.Type
-	}
+	typeVarQ := o.Type
 	if typeVarQ != "" {
 		qs.Set("type", typeVarQ)
 	}

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -52,17 +52,17 @@ paths:
     get:
       tags:
         - Event
-      summary: Get the latest event matching the parameters
+      summary: Get the latest event matching the required query parameters
       parameters:
         - name: keptnContext
           in: query
           type: string
-          required: false
+          required: true
           description: KeptnContext of the events to get
         - name: type
           in: query
           type: string
-          required: false
+          required: true
           description: Type of the Keptn cloud event
       responses:
         200:


### PR DESCRIPTION
Set the query parameters `keptnContext` and `type` for api endpoint GET `v1/event` since this endpoint is designed to get an event of a particular type from a certain keptnContext. 