### PR TITLE
#1300 Remove eventContext from events when delivered from mongodb datastore

### DIFF
--- a/mongodb-datastore/deploy/mongodb-datastore.yaml
+++ b/mongodb-datastore/deploy/mongodb-datastore.yaml
@@ -23,11 +23,11 @@ spec:
         - containerPort: 8080
         resources:
           requests:
-            memory: "32Mi"
-            cpu: "50m"
-          limits:
             memory: "128Mi"
-            cpu: "500m"
+            cpu: "100m"
+          limits:
+            memory: "256Mi"
+            cpu: "1000m"
         env:
         - name: MONGO_DB_CONNECTION_STRING
           value: 'mongodb://user:password@mongodb:27017/keptn'

--- a/mongodb-datastore/handlers/events.go
+++ b/mongodb-datastore/handlers/events.go
@@ -150,6 +150,7 @@ func GetEvents(params event.GetEventsParams) (*event.GetEventsOKBody, error) {
 				continue
 				// return nil, err
 			}
+
 			result.Events = append(result.Events, &keptnEvent)
 		}
 	} else {
@@ -198,6 +199,7 @@ func GetEvents(params event.GetEventsParams) (*event.GetEventsOKBody, error) {
 				continue
 				// return nil, err
 			}
+
 			result.Events = append(result.Events, &keptnEvent)
 		}
 
@@ -227,7 +229,11 @@ func flattenRecursively(i interface{}, logger *keptnutils.Logger) (interface{}, 
 			if err != nil {
 				return nil, err
 			}
-			flat[k] = res
+			if k == "eventContext" {
+				flat[k] = nil
+			} else {
+				flat[k] = res
+			}
 		}
 		return flat, nil
 	} else if _, ok := i.(bson.A); ok {


### PR DESCRIPTION
I've implemented this change in the `flattenRecursively` function as every event that is returned goes through this function.