### PR TITLE
#1123 Added GOPROXY to several builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   global:
     - GOOGLE_APPLICATION_CREDENTIALS=~/gcloud-service-key.json
     - GO111MODULE=on
+    - GOPROXY=https://proxy.golang.org
 
 before_install:
 # determine OS type (either osx for linux) - will be used for downloading dependencies

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /go/src/github.com/keptn/keptn/api
 # Force the go compiler to use modules 
 ENV GO111MODULE=on
 ENV BUILDFLAGS=""
+ENV GOPROXY=https://proxy.golang.org
 
 # Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
 # in case of a change in the dependencies

--- a/configuration-service/Dockerfile
+++ b/configuration-service/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /go/src/github.com/keptn/keptn/configuration-service
 # Force the go compiler to use modules 
 ENV GO111MODULE=on
 ENV BUILDFLAGS=""
+ENV GOPROXY=https://proxy.golang.org
 
 # Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
 # in case of a change in the dependencies

--- a/distributor/Dockerfile
+++ b/distributor/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /go/src/github.com/keptn/keptn/distributor
 
 # Force the go compiler to use modules 
 ENV GO111MODULE=on
+ENV GOPROXY=https://proxy.golang.org
 
 # Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
 # in case of a change in the dependencies

--- a/eventbroker/Dockerfile
+++ b/eventbroker/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /go/src/github.com/keptn/keptn/eventbroker
 # Force the go compiler to use modules 
 ENV GO111MODULE=on
 ENV BUILDFLAGS=""
+ENV GOPROXY=https://proxy.golang.org
 
 # Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
 # in case of a change in the dependencies

--- a/gatekeeper-service/Dockerfile
+++ b/gatekeeper-service/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /go/src/github.com/keptn/keptn/gatekeeper-service
 # Force the go compiler to use modules 
 ENV GO111MODULE=on
 ENV BUILDFLAGS=""
+ENV GOPROXY=https://proxy.golang.org
 
 # Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
 # in case of a change in the dependencies

--- a/helm-service/Dockerfile
+++ b/helm-service/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /go/src/github.com/keptn/keptn/helm-service
 # Force the go compiler to use modules 
 ENV GO111MODULE=on
 ENV BUILDFLAGS=""
+ENV GOPROXY=https://proxy.golang.org
 
 # Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
 # in case of a change in the dependencies

--- a/jmeter-service/Dockerfile
+++ b/jmeter-service/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /go/src/github.com/keptn/keptn/jmeter-service
 # Force the go compiler to use modules 
 ENV GO111MODULE=on
 ENV BUILDFLAGS=""
+ENV GOPROXY=https://proxy.golang.org
 
 # Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
 # in case of a change in the dependencies

--- a/lighthouse-service/Dockerfile
+++ b/lighthouse-service/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /go/src/github.com/keptn/keptn/lighthouse-service
 # Force the go compiler to use modules
 ENV GO111MODULE=on
 ENV BUILDFLAGS=""
+ENV GOPROXY=https://proxy.golang.org
 
 # Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
 # in case of a change in the dependencies

--- a/mongodb-datastore/Dockerfile
+++ b/mongodb-datastore/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /go/src/github.com/keptn/keptn/mongodb-datastore
 # Force the go compiler to use modules 
 ENV GO111MODULE=on
 ENV BUILDFLAGS=""
+ENV GOPROXY=https://proxy.golang.org
 
 # Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
 # in case of a change in the dependencies

--- a/platform-support/openshift-route-service/Dockerfile
+++ b/platform-support/openshift-route-service/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /go/src/github.com/keptn/keptn/platform-support/openshift-route-service
 
 # Force the go compiler to use modules 
 ENV GO111MODULE=on
+ENV GOPROXY=https://proxy.golang.org
 
 # Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
 # in case of a change in the dependencies


### PR DESCRIPTION
we often run into the issue of external go dependencies not being available (using  `go mod download`). By using the `GOPROXY` setting with an official proxy offered by Google we should be able to bypass this problem and most likely also improve our build speeds.

For more details see #1123 

