### PR TITLE
#1357 Fix Kubernetes Installer getCreds.json

### DIFF
--- a/cli/cmd/installKubernetes.go
+++ b/cli/cmd/installKubernetes.go
@@ -22,15 +22,20 @@ import (
 	keptnutils "github.com/keptn/go-utils/pkg/utils"
 )
 
+type kubernetesCredentials struct{}
+
 type kubernetesPlatform struct {
+	creds *kubernetesCredentials
 }
 
 func newKubernetesPlatform() *kubernetesPlatform {
-	return &kubernetesPlatform{}
+	return &kubernetesPlatform{
+		creds: &kubernetesCredentials{},
+	}
 }
 
 func (p kubernetesPlatform) getCreds() interface{} {
-	return nil
+	return p.creds
 }
 
 func (p kubernetesPlatform) checkRequirements() error {


### PR DESCRIPTION
As of right now the following command does not work:

```console
$ keptn install --platform=kubernetes
Error: json: Unmarshal(nil)
```

This PR fixes that.
