### PR TITLE
fix CLI typos

### DIFF
--- a/cli/cmd/send_event_evaluationStart.go
+++ b/cli/cmd/send_event_evaluationStart.go
@@ -49,7 +49,7 @@ var evaluationStart evaluationStartStruct
 // evaluationStartCmd represents the start-evaluation command
 var evaluationStartCmd = &cobra.Command{
 	Use: "start-evaluation",
-	Short: "Sends an start-evaluation event to Keptn in order to evaluate a test" +
+	Short: "Sends an start-evaluation event to Keptn in order to evaluate a test " +
 		"for the specified service in the provided project and stage",
 	Long: `Sends a start-evaluation event to Keptn in order to evaluate a test
 for the specified service in the provided project and stage. The time frame flag defines

--- a/cli/cmd/send_event_newArtifact.go
+++ b/cli/cmd/send_event_newArtifact.go
@@ -48,7 +48,7 @@ var newArtifact newArtifactStruct
 // newArtifactCmd represents the newArtifact command
 var newArtifactCmd = &cobra.Command{
 	Use: "new-artifact",
-	Short: "Sends a new-artifact event to Keptn in order to deploy a new artifact" +
+	Short: "Sends a new-artifact event to Keptn in order to deploy a new artifact " +
 		"for the specified service in the provided project",
 	Long: `Sends a new-artifact event to Keptn in order to deploy a new artifact
 for the specified service in the provided project.


### PR DESCRIPTION
Fix two typos with missing whitespace.

![image](https://user-images.githubusercontent.com/7677092/74561407-5bbd4d00-4f1d-11ea-9923-8c532b3bc705.png)
