### PR TITLE
Fix tests for microk8s

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -154,7 +154,7 @@ jobs:
     - cat ~/.keptn/keptn-installer-err.log
 
   - stage: Cron MicroK8s Standalone (--platform=kubernetes --use-case=quality-gates)
-    if: branch = master AND type = cron
+    # if: branch = master AND type = cron
     os: linux
     before_script:
       # download and install kubectl

--- a/test/utils/microk8s_create_cluster.sh
+++ b/test/utils/microk8s_create_cluster.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 # install micro k8s via snap
-sudo snap install microk8s --classic
+sudo snap install microk8s --channel=1.15/stable --classic
+
+sudo microk8s.start
 
 sudo iptables -P FORWARD ACCEPT
 sudo microk8s.enable dns


### PR DESCRIPTION
[Tests for Microk8s fail](https://travis-ci.org/keptn/keptn/jobs/653343215) as we now check for the kubectl cluster version.

```
Installing keptn on cluster
keptn creates the folder /home/travis/.keptn/ to store logs and possibly creds.
Availability of provided image cannot be checked.
Used Installer version: keptn/installer:latest
The Kubernetes Server Version '1.17' doesn't satisfy constraints '>= 1.13, <= 1.15'
Error: Keptn requires Kubernetes Server Version: >= 1.13, <= 1.15
[keptn|ERROR] [2020-02-21 09:45:39] keptn install failed
[keptn|ERROR] [2020-02-21 09:45:39] Keptn Test failed.
```

**Note**: Actually, the quality-gates  installation works fine with newer cluster versions, just if we install full Keptn (with istio) it doesn't work.

I've fixed this in the tests by using an older microk8s version. We will also have to update this in our docs.