### PR TITLE
#1404 Link deploymentURIPublic in Bridge

### DIFF
--- a/bridge/client/app/_components/ktb-event-item/ktb-event-item.component.html
+++ b/bridge/client/app/_components/ktb-event-item/ktb-event-item.component.html
@@ -2,7 +2,10 @@
   <ktb-expandable-tile-header>
     <div fxLayout="row" class="pr-4">
       <div fxFlex>
-        <h4 class="m-0 mt-1 mb-1" [textContent]="getEventLabel(_event.type)"></h4>
+        <div fxLayout="row" fxLayoutAlign="start" fxLayoutGap="5px">
+          <h4 class="m-0 mt-1 mb-1" [textContent]="getEventLabel(_event.type)"></h4>
+          <a *ngIf="_event.data.deploymentURIPublic" [href]="_event.data.deploymentURIPublic" target="_blank"><button dt-icon-button variant="nested"><dt-icon name="externallink"></dt-icon></button></a>
+        </div>
         <p class="m-0 nobreak"><span class="bold">Source: </span><span [textContent]="_event.source"></span></p>
         <div *ngIf="_event.data.canary">
           <p class="m-0 nobreak"><span class="bold">Action: </span><span [textContent]="_event.data.canary.action"></span> <span [textContent]="_event.data.canary.value"></span></p>

--- a/bridge/client/app/_models/trace.ts
+++ b/bridge/client/app/_models/trace.ts
@@ -13,6 +13,9 @@ export class Trace {
     service: string;
     stage: string;
 
+    deploymentURILocal: string;
+    deploymentURIPublic: string;
+
     deploymentstrategy: string;
     labels: object;
     result: string;


### PR DESCRIPTION
If available the `deploymentURIPublic` is shown as `externallink` next to the event title.

![image](https://user-images.githubusercontent.com/6098219/75368199-a6e24300-58c1-11ea-94d5-bfef26ef4131.png)
