### PR TITLE
#1398 check KubeServer version only for full installation

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -196,9 +196,11 @@ Example:
 Please see https://kubernetes.io/docs/tasks/tools/install-kubectl/`)
 		}
 
-		if err := utils.CheckKubeServerVersion(KubeServerVersionConstraints); err != nil {
-			logging.PrintLog(err.Error(), logging.VerboseLevel)
-			return errors.New(`Keptn requires Kubernetes Server Version: ` + KubeServerVersionConstraints)
+		if *installParams.UseCase == "all" {
+			if err := utils.CheckKubeServerVersion(KubeServerVersionConstraints); err != nil {
+				logging.PrintLog(err.Error(), logging.VerboseLevel)
+				return errors.New(`Keptn requires Kubernetes Server Version: ` + KubeServerVersionConstraints)
+			}
 		}
 
 		if installParams.ConfigFilePath != nil && *installParams.ConfigFilePath != "" {


### PR DESCRIPTION
we limited the compatibility to Kubernetes Server Version >= 1.13, <= 1.15 because we ran into troubles with Istio in other versions. Since we only use Istio in the full installation, there is currently no need to check the version if the  quality-gates standalone version is installed 