### PR TITLE
#1450 Better Support of Dynatrace Monitoring for Keptn core services

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -32,16 +32,12 @@ RUN sed -i "s/version: develop/${REPLACE}/g" /go/src/github.com/keptn/keptn/api/
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, 
 # either manually or with a tool like "godep".)
-RUN CGO_ENABLED=0 GOOS=linux go build $BUILDFLAGS -v cmd/api-server/main.go
+RUN GOOS=linux go build $BUILDFLAGS -v cmd/api-server/main.go
 
 # Use a Docker multi-stage build to create a lean production image.
 FROM alpine:3.7
-RUN apk add --no-cache ca-certificates
-
-ARG debugBuild
-
-# IF we are debugging, we need to install libc6-compat for delve to work on alpine based containers
-RUN if [ ! -z "$debugBuild" ]; then apk add --no-cache libc6-compat; fi
+# we need to install ca-certificates and libc6-compat for go programs to work properly
+RUN apk add --no-cache ca-certificates libc6-compat
 
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /go/src/github.com/keptn/keptn/api/main /api

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,6 +1,6 @@
 # Use the offical Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
-FROM golang:1.12 as builder
+FROM golang:1.12.13-alpine as builder
 ARG version=develop
 
 WORKDIR /go/src/github.com/keptn/keptn/api
@@ -9,6 +9,8 @@ WORKDIR /go/src/github.com/keptn/keptn/api
 ENV GO111MODULE=on
 ENV BUILDFLAGS=""
 ENV GOPROXY=https://proxy.golang.org
+
+RUN apk add --no-cache gcc libc-dev git
 
 # Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
 # in case of a change in the dependencies
@@ -32,10 +34,10 @@ RUN sed -i "s/version: develop/${REPLACE}/g" /go/src/github.com/keptn/keptn/api/
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, 
 # either manually or with a tool like "godep".)
-RUN GOOS=linux go build $BUILDFLAGS -v cmd/api-server/main.go
+RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v cmd/api-server/main.go
 
 # Use a Docker multi-stage build to create a lean production image.
-FROM alpine:3.7
+FROM alpine:3.11
 # we need to install ca-certificates and libc6-compat for go programs to work properly
 RUN apk add --no-cache ca-certificates libc6-compat
 

--- a/api/deploy/service.yaml
+++ b/api/deploy/service.yaml
@@ -24,7 +24,7 @@ spec:
               memory: "64Mi"
               cpu: "50m"
             limits:
-              memory: "128Mi"
+              memory: "256Mi"
               cpu: "500m"
           env:
             - name: EVENTBROKER_URI

--- a/configuration-service/Dockerfile
+++ b/configuration-service/Dockerfile
@@ -1,6 +1,6 @@
 # Use the offical Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
-FROM golang:1.12 as builder
+FROM golang:1.12.13-alpine as builder
 ARG version=develop
 
 WORKDIR /go/src/github.com/keptn/keptn/configuration-service
@@ -9,6 +9,8 @@ WORKDIR /go/src/github.com/keptn/keptn/configuration-service
 ENV GO111MODULE=on
 ENV BUILDFLAGS=""
 ENV GOPROXY=https://proxy.golang.org
+
+RUN apk add --no-cache gcc libc-dev git
 
 # Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
 # in case of a change in the dependencies
@@ -28,10 +30,10 @@ COPY . .
 # Build the command inside the container. 
 # (You may fetch or manage dependencies here, 
 # either manually or with a tool like "godep".)
-RUN GOOS=linux go build $BUILDFLAGS -v cmd/configuration-service-server/main.go
+RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v cmd/configuration-service-server/main.go
 
 # Use a Docker multi-stage build to create a lean production image.
-FROM alpine:3.7
+FROM alpine:3.11
 
 ENV env=production
 

--- a/configuration-service/Dockerfile
+++ b/configuration-service/Dockerfile
@@ -28,21 +28,18 @@ COPY . .
 # Build the command inside the container. 
 # (You may fetch or manage dependencies here, 
 # either manually or with a tool like "godep".)
-RUN CGO_ENABLED=0 GOOS=linux go build $BUILDFLAGS -v cmd/configuration-service-server/main.go
+RUN GOOS=linux go build $BUILDFLAGS -v cmd/configuration-service-server/main.go
 
 # Use a Docker multi-stage build to create a lean production image.
 FROM alpine:3.7
 
 ENV env=production
-RUN apk add --no-cache ca-certificates
+
+# we need to install ca-certificates and libc6-compat for go programs to work properly
+RUN apk add --no-cache ca-certificates libc6-compat
 
 # Install git
 RUN apk --update add --no-cache git
-
-ARG debugBuild
-
-# IF we are debugging, we need to install libc6-compat for delve to work on alpine based containers
-RUN if [ ! -z "$debugBuild" ]; then apk add --no-cache libc6-compat; fi
 
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /go/src/github.com/keptn/keptn/configuration-service/main /configuration-service

--- a/distributor/Dockerfile
+++ b/distributor/Dockerfile
@@ -1,7 +1,7 @@
 # Use the offical Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.12 as builder
+FROM golang:1.12.13-alpine as builder
 ARG version=develop
 
 ARG debugBuild
@@ -11,6 +11,8 @@ WORKDIR /go/src/github.com/keptn/keptn/distributor
 # Force the go compiler to use modules 
 ENV GO111MODULE=on
 ENV GOPROXY=https://proxy.golang.org
+
+RUN apk add --no-cache gcc libc-dev git
 
 # Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
 # in case of a change in the dependencies
@@ -29,17 +31,12 @@ COPY . .
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN CGO_ENABLED=0 GOOS=linux go build $BUILDFLAGS -v -o distributor ./cmd/
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o distributor ./cmd/
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM alpine:3.7
-RUN apk add --no-cache ca-certificates
-
-ARG debugBuild
-
-# IF we are debugging, we need to install libc6-compat for delve to work on alpine based containers
-RUN if [ ! -z "$debugBuild" ]; then apk add --no-cache libc6-compat; fi
+FROM alpine:3.11
+RUN apk add --no-cache ca-certificates libc6-compat
 
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /go/src/github.com/keptn/keptn/distributor/distributor /distributor

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -29,14 +29,12 @@ Most of our services should already have a working setup. But just in case the s
     COPY . .
     
     # Build the command inside the container.
-    RUN CGO_ENABLED=0 GOOS=linux go build -gcflags "all=-N -l" -v -o some-go-binary
+    RUN GOOS=linux go build -gcflags "all=-N -l" -v -o some-go-binary
     
     # Use a Docker multi-stage build to create a lean production image.
     FROM alpine:3.7
-    RUN apk add --no-cache ca-certificates
-    
-    # IF we are debugging, we need to install libc6-compat for delve to work on alpine based containers
-    RUN apk add --no-cache libc6-compat
+    # we need to install ca-certificates and libc6-compat for go programs to work properly
+    RUN apk add --no-cache ca-certificates libc6-compat
     
     # Copy the binary to the production image from the builder stage.
     COPY --from=builder /go/src/github.com/keptn-contrib/some-go-service/some-go-binary /some-go-binary

--- a/eventbroker/Dockerfile
+++ b/eventbroker/Dockerfile
@@ -1,7 +1,7 @@
 # Use the offical Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.12 as builder
+FROM golang:1.12.13-alpine as builder
 ARG version=develop
 
 WORKDIR /go/src/github.com/keptn/keptn/eventbroker
@@ -10,6 +10,8 @@ WORKDIR /go/src/github.com/keptn/keptn/eventbroker
 ENV GO111MODULE=on
 ENV BUILDFLAGS=""
 ENV GOPROXY=https://proxy.golang.org
+
+RUN apk add --no-cache gcc libc-dev git
 
 # Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
 # in case of a change in the dependencies
@@ -29,11 +31,11 @@ COPY . .
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, 
 # either manually or with a tool like "godep".)
-RUN GOOS=linux go build $BUILDFLAGS -v -o eventbroker
+RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o eventbroker
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM alpine:3.7
+FROM alpine:3.11
 # we need to install ca-certificates and libc6-compat for go programs to work properly
 RUN apk add --no-cache ca-certificates libc6-compat
 

--- a/eventbroker/Dockerfile
+++ b/eventbroker/Dockerfile
@@ -29,17 +29,13 @@ COPY . .
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, 
 # either manually or with a tool like "godep".)
-RUN CGO_ENABLED=0 GOOS=linux go build $BUILDFLAGS -v -o eventbroker
+RUN GOOS=linux go build $BUILDFLAGS -v -o eventbroker
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.7
-RUN apk add --no-cache ca-certificates
-
-ARG debugBuild
-
-# IF we are debugging, we need to install libc6-compat for delve to work on alpine based containers
-RUN if [ ! -z "$debugBuild" ]; then apk add --no-cache libc6-compat; fi
+# we need to install ca-certificates and libc6-compat for go programs to work properly
+RUN apk add --no-cache ca-certificates libc6-compat
 
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /go/src/github.com/keptn/keptn/eventbroker/eventbroker /eventbroker

--- a/gatekeeper-service/Dockerfile
+++ b/gatekeeper-service/Dockerfile
@@ -28,17 +28,13 @@ COPY . .
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN CGO_ENABLED=0 GOOS=linux go build $BUILDFLAGS -v -o gatekeeper-service
+RUN GOOS=linux go build $BUILDFLAGS -v -o gatekeeper-service
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.7
-RUN apk add --no-cache ca-certificates
-
-ARG debugBuild
-
-# IF we are debugging, we need to install libc6-compat for delve to work on alpine based containers
-RUN if [ ! -z "$debugBuild" ]; then apk add --no-cache libc6-compat; fi
+# we need to install ca-certificates and libc6-compat for go programs to work properly
+RUN apk add --no-cache ca-certificates libc6-compat
 
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /go/src/github.com/keptn/keptn/gatekeeper-service/gatekeeper-service /gatekeeper-service

--- a/gatekeeper-service/Dockerfile
+++ b/gatekeeper-service/Dockerfile
@@ -1,7 +1,7 @@
 # Use the offical Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.12 as builder
+FROM golang:1.12.13-alpine as builder
 ARG version=develop
 
 WORKDIR /go/src/github.com/keptn/keptn/gatekeeper-service
@@ -10,6 +10,8 @@ WORKDIR /go/src/github.com/keptn/keptn/gatekeeper-service
 ENV GO111MODULE=on
 ENV BUILDFLAGS=""
 ENV GOPROXY=https://proxy.golang.org
+
+RUN apk add --no-cache gcc libc-dev git
 
 # Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
 # in case of a change in the dependencies
@@ -28,11 +30,11 @@ COPY . .
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN GOOS=linux go build $BUILDFLAGS -v -o gatekeeper-service
+RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o gatekeeper-service
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM alpine:3.7
+FROM alpine:3.11
 # we need to install ca-certificates and libc6-compat for go programs to work properly
 RUN apk add --no-cache ca-certificates libc6-compat
 

--- a/helm-service/Dockerfile
+++ b/helm-service/Dockerfile
@@ -1,7 +1,7 @@
 # Use the offical Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.12 as builder
+FROM golang:1.12.13-alpine as builder
 ARG version=develop
 
 WORKDIR /go/src/github.com/keptn/keptn/helm-service
@@ -10,6 +10,8 @@ WORKDIR /go/src/github.com/keptn/keptn/helm-service
 ENV GO111MODULE=on
 ENV BUILDFLAGS=""
 ENV GOPROXY=https://proxy.golang.org
+
+RUN apk add --no-cache gcc libc-dev git
 
 # Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
 # in case of a change in the dependencies
@@ -28,7 +30,7 @@ COPY . .
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN GOOS=linux go build $BUILDFLAGS -v -o helm-service
+RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o helm-service
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds

--- a/jmeter-service/Dockerfile
+++ b/jmeter-service/Dockerfile
@@ -1,7 +1,7 @@
 # Use the offical Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.12 as builder
+FROM golang:1.12.13-alpine as builder
 ARG version=develop
 
 WORKDIR /go/src/github.com/keptn/keptn/jmeter-service
@@ -10,6 +10,8 @@ WORKDIR /go/src/github.com/keptn/keptn/jmeter-service
 ENV GO111MODULE=on
 ENV BUILDFLAGS=""
 ENV GOPROXY=https://proxy.golang.org
+
+RUN apk add --no-cache gcc libc-dev git
 
 # Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
 # in case of a change in the dependencies
@@ -28,11 +30,11 @@ COPY . .
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN GOOS=linux go build $BUILDFLAGS -v -o jmeter-service
+RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o jmeter-service
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM alpine:3.7
+FROM alpine:3.11
 ENV env=production
 ARG JMETER_VERSION="5.1.1"
 ENV JMETER_HOME /opt/apache-jmeter-${JMETER_VERSION}

--- a/jmeter-service/Dockerfile
+++ b/jmeter-service/Dockerfile
@@ -28,7 +28,7 @@ COPY . .
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN CGO_ENABLED=0 GOOS=linux go build $BUILDFLAGS -v -o jmeter-service
+RUN GOOS=linux go build $BUILDFLAGS -v -o jmeter-service
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
@@ -45,7 +45,7 @@ ENV	JMETER_DOWNLOAD_URL  https://archive.apache.org/dist/jmeter/binaries/apache-
 ARG TZ="Europe/Amsterdam"
 RUN    apk update \
 	&& apk upgrade \
-	&& apk add ca-certificates \
+	&& apk add ca-certificates libc6-compat \
 	&& update-ca-certificates \
 	&& apk add --update openjdk8-jre tzdata curl unzip bash \
 	&& apk add --no-cache nss \
@@ -58,9 +58,6 @@ RUN    apk update \
 
 # Set global PATH such that "jmeter" command is found
 ENV PATH $PATH:$JMETER_BIN
-
-# IF we are debugging, we need to install libc6-compat for delve to work on alpine based containers
-RUN if [ ! -z "$debugBuild" ]; then apk add --no-cache libc6-compat; fi
 
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /go/src/github.com/keptn/keptn/jmeter-service/jmeter-service /jmeter-service

--- a/lighthouse-service/Dockerfile
+++ b/lighthouse-service/Dockerfile
@@ -31,17 +31,13 @@ COPY . .
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN CGO_ENABLED=0 GOOS=linux go build $BUILDFLAGS -v -o lighthouse-service
+RUN GOOS=linux go build $BUILDFLAGS -v -o lighthouse-service
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.7
-RUN apk add --no-cache ca-certificates
-
-ARG debugBuild
-
-# IF we are debugging, we need to install libc6-compat for delve to work on alpine based containers
-RUN if [ ! -z "$debugBuild" ]; then apk add --no-cache libc6-compat; fi
+# we need to install ca-certificates and libc6-compat for go programs to work properly
+RUN apk add --no-cache ca-certificates libc6-compat
 
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /go/src/github.com/keptn/keptn/lighthouse-service/lighthouse-service /lighthouse-service

--- a/lighthouse-service/Dockerfile
+++ b/lighthouse-service/Dockerfile
@@ -1,7 +1,7 @@
 # Use the offical Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.12 as builder
+FROM golang:1.12.13-alpine as builder
 ARG version=develop
 
 # Copy local code to the container image.
@@ -11,6 +11,8 @@ WORKDIR /go/src/github.com/keptn/keptn/lighthouse-service
 ENV GO111MODULE=on
 ENV BUILDFLAGS=""
 ENV GOPROXY=https://proxy.golang.org
+
+RUN apk add --no-cache gcc libc-dev git
 
 # Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
 # in case of a change in the dependencies
@@ -26,16 +28,13 @@ RUN if [ ! -z "$debugBuild" ]; then export BUILDFLAGS='-gcflags "all=-N -l"'; fi
 
 COPY . .
 
-# run tests (Todo: this should really be done within the travis ci pipeline)
-# RUN go test ./...
-
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN GOOS=linux go build $BUILDFLAGS -v -o lighthouse-service
+RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o lighthouse-service
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM alpine:3.7
+FROM alpine:3.11
 # we need to install ca-certificates and libc6-compat for go programs to work properly
 RUN apk add --no-cache ca-certificates libc6-compat
 

--- a/mongodb-datastore/Dockerfile
+++ b/mongodb-datastore/Dockerfile
@@ -1,7 +1,7 @@
 # Use the offical Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.12 as builder
+FROM golang:1.12.13-alpine as builder
 ARG version=develop
 
 WORKDIR /go/src/github.com/keptn/keptn/mongodb-datastore
@@ -10,6 +10,8 @@ WORKDIR /go/src/github.com/keptn/keptn/mongodb-datastore
 ENV GO111MODULE=on
 ENV BUILDFLAGS=""
 ENV GOPROXY=https://proxy.golang.org
+
+RUN apk add --no-cache gcc libc-dev git
 
 # Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
 # in case of a change in the dependencies
@@ -28,11 +30,11 @@ COPY . .
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN cd cmd/mongodb-datastore-server && GOOS=linux go build $BUILDFLAGS -v -o mongodb-datastore
+RUN cd cmd/mongodb-datastore-server && GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o mongodb-datastore
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM alpine:3.7
+FROM alpine:3.11
 # we need to install ca-certificates and libc6-compat for go programs to work properly
 RUN apk add --no-cache ca-certificates libc6-compat
 

--- a/mongodb-datastore/Dockerfile
+++ b/mongodb-datastore/Dockerfile
@@ -28,17 +28,13 @@ COPY . .
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN cd cmd/mongodb-datastore-server && CGO_ENABLED=0 GOOS=linux go build $BUILDFLAGS -v -o mongodb-datastore
+RUN cd cmd/mongodb-datastore-server && GOOS=linux go build $BUILDFLAGS -v -o mongodb-datastore
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.7
-RUN apk add --no-cache ca-certificates
-
-ARG debugBuild
-
-# IF we are debugging, we need to install libc6-compat for delve to work on alpine based containers
-RUN if [ ! -z "$debugBuild" ]; then apk add --no-cache libc6-compat; fi
+# we need to install ca-certificates and libc6-compat for go programs to work properly
+RUN apk add --no-cache ca-certificates libc6-compat
 
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /go/src/github.com/keptn/keptn/mongodb-datastore/cmd/mongodb-datastore-server/mongodb-datastore /mongodb-datastore

--- a/remediation-service/Dockerfile
+++ b/remediation-service/Dockerfile
@@ -1,7 +1,7 @@
 # Use the offical Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.12 as builder
+FROM golang:1.12.13-alpine as builder
 ARG version=develop
 
 WORKDIR /go/src/github.com/keptn/keptn/remediation-service
@@ -9,6 +9,8 @@ WORKDIR /go/src/github.com/keptn/keptn/remediation-service
 # Force the go compiler to use modules 
 ENV GO111MODULE=on
 ENV BUILDFLAGS=""
+
+RUN apk add --no-cache gcc libc-dev git
 
 # Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
 # in case of a change in the dependencies
@@ -27,11 +29,11 @@ COPY . .
 
 # Build the command inside the container. 
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN GOOS=linux go build $BUILDFLAGS -v -o remediation-service
+RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o remediation-service
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM alpine
+FROM alpine:3.11
 # we need to install ca-certificates and libc6-compat for go programs to work properly
 RUN apk add --no-cache ca-certificates libc6-compat
 

--- a/remediation-service/Dockerfile
+++ b/remediation-service/Dockerfile
@@ -27,12 +27,13 @@ COPY . .
 
 # Build the command inside the container. 
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN CGO_ENABLED=0 GOOS=linux go build $BUILDFLAGS -v -o remediation-service
+RUN GOOS=linux go build $BUILDFLAGS -v -o remediation-service
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine
-RUN apk add --no-cache ca-certificates
+# we need to install ca-certificates and libc6-compat for go programs to work properly
+RUN apk add --no-cache ca-certificates libc6-compat
 
 ARG HELM_VERSION=2.12.3
 RUN wget https://storage.googleapis.com/kubernetes-helm/helm-v$HELM_VERSION-linux-amd64.tar.gz && \

--- a/shipyard-service/Dockerfile
+++ b/shipyard-service/Dockerfile
@@ -1,13 +1,15 @@
 # Use the offical Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.12 as builder
+FROM golang:1.12.13-alpine as builder
 ARG version=develop
 WORKDIR /go/src/github.com/keptn/keptn/shipyard-service
 
 # Force the go compiler to use modules 
 ENV GO111MODULE=on
 ENV BUILDFLAGS=""
+
+RUN apk add --no-cache gcc libc-dev git
 
 # Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
 # in case of a change in the dependencies
@@ -26,11 +28,11 @@ COPY . .
 
 # Build the command inside the container. 
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN GOOS=linux go build $BUILDFLAGS -v -o shipyard-service
+RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o shipyard-service
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM alpine:3.7
+FROM alpine:3.11
 # we need to install ca-certificates and libc6-compat for go programs to work properly
 RUN apk add --no-cache ca-certificates libc6-compat
 

--- a/shipyard-service/Dockerfile
+++ b/shipyard-service/Dockerfile
@@ -26,17 +26,13 @@ COPY . .
 
 # Build the command inside the container. 
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN CGO_ENABLED=0 GOOS=linux go build $BUILDFLAGS -v -o shipyard-service
+RUN GOOS=linux go build $BUILDFLAGS -v -o shipyard-service
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.7
-RUN apk add --no-cache ca-certificates
-
-ARG debugBuild
-
-# IF we are debugging, we need to install libc6-compat for delve to work on alpine based containers
-RUN if [ ! -z "$debugBuild" ]; then apk add --no-cache libc6-compat; fi
+# we need to install ca-certificates and libc6-compat for go programs to work properly
+RUN apk add --no-cache ca-certificates libc6-compat
 
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /go/src/github.com/keptn/keptn/shipyard-service/shipyard-service /shipyard-service

--- a/wait-service/Dockerfile
+++ b/wait-service/Dockerfile
@@ -26,12 +26,13 @@ COPY . .
 
 # Build the command inside the container. 
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN CGO_ENABLED=0 GOOS=linux go build $BUILDFLAGS -v -o wait-service
+RUN GOOS=linux go build $BUILDFLAGS -v -o wait-service
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.7
-RUN apk add --no-cache ca-certificates
+# we need to install ca-certificates and libc6-compat for go programs to work properly
+RUN apk add --no-cache ca-certificates libc6-compat
 
 # IF we are debugging, we need to install libc6-compat for delve to work on alpine based containers
 RUN if [ ! -z "$debugBuild" ]; then apk add --no-cache libc6-compat; fi

--- a/wait-service/Dockerfile
+++ b/wait-service/Dockerfile
@@ -1,13 +1,15 @@
 # Use the offical Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.12 as builder
+FROM golang:1.12.13-alpine as builder
 ARG version=develop
 WORKDIR /go/src/github.com/keptn/keptn/wait-service
 
 # Force the go compiler to use modules 
 ENV GO111MODULE=on
 ENV BUILDFLAGS=""
+
+RUN apk add --no-cache gcc libc-dev git
 
 # Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
 # in case of a change in the dependencies
@@ -26,11 +28,11 @@ COPY . .
 
 # Build the command inside the container. 
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN GOOS=linux go build $BUILDFLAGS -v -o wait-service
+RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o wait-service
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM alpine:3.7
+FROM alpine:3.11
 # we need to install ca-certificates and libc6-compat for go programs to work properly
 RUN apk add --no-cache ca-certificates libc6-compat
 


### PR DESCRIPTION
This fixes #1450 .

By switching to a dynamically linked library, Dynatrace is able to detect the Keptn core services written in Go and provide some more insights ;)

