### PR TITLE
Update integration test for quality gates standalone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -160,7 +160,7 @@ jobs:
       # download and install kubectl
       - curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.17.0/bin/linux/amd64/kubectl && chmod +x ./kubectl && sudo mv ./kubectl /usr/local/bin/kubectl
       - test/utils/microk8s_create_cluster.sh
-      - export KUBECONFIG=./kubeconfig
+      - export KUBECONFIG=~/kubeconfig
     script:
       - kubectl get nodes || travis_terminate 1
       - test/test_install_kubernetes_quality_gates.sh || travis_terminate 1

--- a/test/utils/microk8s_create_cluster.sh
+++ b/test/utils/microk8s_create_cluster.sh
@@ -9,7 +9,7 @@ sudo microk8s.enable dns ingress
 sudo microk8s.enable storage
 
 # store kubeconfig
-sudo /snap/bin/microk8s.config > kubeconfig
-export KUBECONFIG=./kubeconfig
+sudo /snap/bin/microk8s.config > ~/kubeconfig
+export KUBECONFIG=~/kubeconfig
 kubectl apply -f https://raw.githubusercontent.com/google/metallb/v0.8.3/manifests/metallb.yaml
 


### PR DESCRIPTION
This improves the integration test for the quality-gates variant.

We now can also check that configure monitoring is creating a new configmap for lighthouse!