### PR TITLE
Fix bridge version not being applied in dockerfile

### DIFF
--- a/bridge/.dockerignore
+++ b/bridge/.dockerignore
@@ -2,3 +2,4 @@
 .idea/
 deploy/
 Dockerfile
+node_modules/

--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -23,6 +23,7 @@ EXPOSE 3000
 ENV DATASTORE "http://mongodb-datastore.keptn-datastore.svc.cluster.local:8080/"
 ENV CONFIGURATION_SERVICE "http://configuration-service.keptn.svc.cluster.local:8080/v1/"
 ENV NODE_ENV "production"
+ARG version=develop
 ENV VERSION="${version}"
 
 RUN addgroup mygroup && adduser -D -G mygroup myuser && mkdir -p /usr/src/app && chown -R myuser /usr/src/app


### PR DESCRIPTION
The version of Keptn's Bridge needs to be available as an environment variable in the second stage.