### PR TITLE
disable K8s version check for openshift

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -196,7 +196,7 @@ Example:
 Please see https://kubernetes.io/docs/tasks/tools/install-kubectl/`)
 		}
 
-		if *installParams.UseCase == "all" {
+		if *installParams.UseCase == "all" && *installParams.PlatformIdentifier != "openshift" {
 			if err := utils.CheckKubeServerVersion(KubeServerVersionConstraints); err != nil {
 				logging.PrintLog(err.Error(), logging.VerboseLevel)
 				return errors.New(`Keptn requires Kubernetes Server Version: ` + KubeServerVersionConstraints)


### PR DESCRIPTION
Openshift 3.11 always uses K8s 1.11 so there is no need to check