### PR TITLE
Fix error in travis.yaml regarding unit tests / code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -271,7 +271,7 @@ jobs:
           go test -race -v -coverprofile=coverage.txt -covermode=atomic ./...
           cd ..
       - |
-          cd "${REMEDIATION_SVC_IMAGE}"
+          cd "${REMEDIATION_SVC_FOLDER}"
           go test -race -v -coverprofile=coverage.txt -covermode=atomic ./...
           cd ..
       - |


### PR DESCRIPTION
This error prevented unit tests for the following services to be executed:

* remediation service
* wait service
* lighthouse service
* mongodb datastore service
