### PR TITLE
Added integration for existing istio installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,36 @@ before_install:
 - INSTALLER_FOLDER="installer/"
 ### ATTENTION: please make sure installer is always the last in this list
 
+
+# template for gke tests
+gke_full: &gke_full
+  os: linux
+  before_script:
+    - source ./travis-scripts/install_gcloud.sh
+    # auth gcloud
+    - echo ${GCLOUD_SERVICE_KEY} | base64 --decode > ~/gcloud-service-key.json
+    - gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
+    - test/utils/download_and_install_keptn_cli.sh
+    # create gke cluster on gcloud
+    - test/utils/gke_create_cluster.sh
+  script:
+    # test installation on gcloud
+    - test/test_install_gke.sh || travis_terminate 1
+    # test onboarding and new artifcat for sockshop
+    - export PROJECT=sockshop
+    - test/test_onboard_service.sh || travis_terminate 1
+    - test/test_new_artifact.sh || travis_terminate 1
+    - test/test_delete_project.sh || travis_terminate 1
+  after_success:
+    # delete google kubernetes cluster only on success (in case of an error we want to be able to dig into the cluster)
+    - echo "Tests were successful, cleaning up the cluster now..."
+    - test/utils/gke_delete_cluster.sh
+  after_failure:
+    # print some debug info
+    - echo "Keptn Installation Log:"
+    - cat ~/.keptn/keptn-installer.log
+    - cat ~/.keptn/keptn-installer-err.log
+
 jobs:
   include:
   # nightly image builds - build all images
@@ -127,32 +157,13 @@ jobs:
 
   - stage: Cron GKE Full (--platform=gke)
     if: branch = master AND type = cron
-    os: linux
-    before_script:
-    - source ./travis-scripts/install_gcloud.sh
-    # auth gcloud
-    - echo ${GCLOUD_SERVICE_KEY} | base64 --decode > ~/gcloud-service-key.json
-    - gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
-    - test/utils/download_and_install_keptn_cli.sh
-    # create gke cluster on gcloud
-    - test/utils/gke_create_cluster.sh
-    script:
-    # test installation on gcloud
-    - test/test_install_gke.sh || travis_terminate 1
-    # test onboarding and new artifcat for sockshop
-    - export PROJECT=sockshop
-    - test/test_onboard_service.sh || travis_terminate 1
-    - test/test_new_artifact.sh || travis_terminate 1
-    - test/test_delete_project.sh || travis_terminate 1
-    after_success:
-    # delete google kubernetes cluster only on success (in case of an error we want to be able to dig into the cluster)
-    - echo "Tests were successful, cleaning up the cluster now..."
-    - test/utils/gke_delete_cluster.sh
-    after_failure:
-    # print some debug info
-    - echo "Keptn Installation Log:"
-    - cat ~/.keptn/keptn-installer.log
-    - cat ~/.keptn/keptn-installer-err.log
+    env: KEPTN_INSTALLATION_TYPE=FULL
+    <<: *gke_full # use template
+
+  - stage: Cron GKE Full with Istio (--platform=gke --istio-install-option=Reuse)
+    if: branch = master AND type = cron
+    env: KEPTN_INSTALLATION_TYPE=REUSE-ISTIO
+    <<: *gke_full # use template
 
   - stage: Cron Minishift Standalone (--platform=openshift --use-case=quality-gates)
     if: branch = master AND type = cron

--- a/test/test_install_gke.sh
+++ b/test/test_install_gke.sh
@@ -2,21 +2,32 @@
 
 source test/utils.sh
 
+KEPTN_INSTALLER_IMAGE=${KEPTN_INSTALLER_IMAGE:-keptn/installer:latest}
+KEPTN_INSTALLATION_TYPE=${KEPTN_INSTALLATION_TYPE:-FULL}
+PROJECT_NAME=${PROJECT_NAME:-sockshop}
+
 # Prepare creds.json file
 cd ./installer/scripts
 
 export CLN=$CLUSTER_NAME_NIGHTLY
 export CLZ=$CLOUDSDK_COMPUTE_ZONE	
-export PROJ=$PROJECT_NAME	
+export PROJ=$PROJECT_NAME
 
 source ./gke/defineCredentialsHelper.sh
 replaceCreds
 
 echo "Installing keptn on cluster"
 
-# Install keptn (using the develop version, which should point the :latest docker images)
-keptn install --keptn-installer-image=keptn/installer:latest --creds=creds.json --verbose
+ISTIO_CONFIG=""
 
+# use a different installation method if re-using istio
+if [[ "$KEPTN_INSTALLATION_TYPE" == "REUSE-ISTIO" ]]; then
+  ISTIO_CONFIG="--istio-install-option=Reuse"
+  echo "... using existing istio"
+fi
+
+# Install keptn (using the develop version, which should point the :latest docker images)
+keptn install ${ISTIO_CONFIG} --keptn-installer-image="${KEPTN_INSTALLER_IMAGE}" --creds=creds.json --verbose
 verify_test_step $? "keptn install failed"
 
 # verify that the keptn CLI has successfully authenticated

--- a/test/utils/gke_create_cluster.sh
+++ b/test/utils/gke_create_cluster.sh
@@ -15,8 +15,21 @@ else
     echo "No nightly cluster need to be deleted"
 fi
 
+ISTIO_CONFIG=""
+ADDONS="HorizontalPodAutoscaling,HttpLoadBalancing"
+
+if [[ "$KEPTN_INSTALLATION_TYPE" == "REUSE-ISTIO" ]]; then
+  ISTIO_CONFIG="--istio-config=auth=MTLS_PERMISSIVE"
+  ADDONS="Istio,$ADDONS"
+fi
+
 # create a new cluster
-gcloud container --project $PROJECT_NAME clusters create $CLUSTER_NAME_NIGHTLY --zone $CLOUDSDK_COMPUTE_ZONE --username "admin" --cluster-version $GKE_VERSION --machine-type "n1-standard-8" --image-type "UBUNTU" --disk-type "pd-standard" --disk-size "100" --scopes "https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" --num-nodes "1" --enable-cloud-logging --enable-cloud-monitoring --no-enable-ip-alias --network "projects/sai-research/global/networks/default" --subnetwork "projects/sai-research/regions/$CLOUDSDK_REGION/subnetworks/default" --addons HorizontalPodAutoscaling,HttpLoadBalancing --no-enable-autoupgrade --no-enable-autorepair
+gcloud beta container --project $PROJECT_NAME clusters create $CLUSTER_NAME_NIGHTLY --zone $CLOUDSDK_COMPUTE_ZONE --username "admin" --cluster-version $GKE_VERSION \
+ --machine-type "n1-standard-8" --image-type "UBUNTU" --disk-type "pd-standard" --disk-size "100" \
+ --scopes "https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" --num-nodes "1" --enable-cloud-logging --enable-cloud-monitoring --no-enable-ip-alias --network "projects/sai-research/global/networks/default" --subnetwork "projects/sai-research/regions/$CLOUDSDK_REGION/subnetworks/default" \
+ --addons $ADDONS $ISTIO_CONFIG --no-enable-autoupgrade --no-enable-autorepair \
+ --labels owner=travis,expiry=auto-delete
+
 if [[ $? != '0' ]]; then
     echo "gcloud cluster create failed."
     exit 1

--- a/travis-scripts/install_gcloud.sh
+++ b/travis-scripts/install_gcloud.sh
@@ -7,7 +7,7 @@ if [ ! -d "$HOME/google-cloud-sdk/bin" ]; then
   rm -rf $HOME/google-cloud-sdk;
   export CLOUDSDK_CORE_DISABLE_PROMPTS=1;
   # download
-  curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-278.0.0-${OS_TYPE}-x86_64.tar.gz > gcloud.tar.gz
+  curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-284.0.0-${OS_TYPE}-x86_64.tar.gz > gcloud.tar.gz
   gunzip -c gcloud.tar.gz | tar xopf -
   ./google-cloud-sdk/install.sh
   source ./google-cloud-sdk/completion.bash.inc


### PR DESCRIPTION
I've split the integration test for GKE into one that has istio pre-installed.

Unfortunately we can not define a test-matrix for jobs in travis-ci (this is only possible for the full travis file), hence I'm using YAML templating syntax ``    <<: *gke_full # use template``

![Screenshot from 2020-03-19 09-26-41](https://user-images.githubusercontent.com/56065213/77046790-e8977280-69c3-11ea-8ab9-37a5a51fbc31.png)
