### PR TITLE
#1532 Avoid connecting to external services when calling helm init

### DIFF
--- a/helm-service/controller/configuration_changer.go
+++ b/helm-service/controller/configuration_changer.go
@@ -21,7 +21,8 @@ import (
 )
 
 func init() {
-	_, err := keptnutils.ExecuteCommand("helm", []string{"init", "--client-only"})
+	// try to init helm and verify that it works
+	_, err := keptnutils.ExecuteCommand("helm", []string{"init", "--client-only", "--skip-refresh"})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/helm-service/main.go
+++ b/helm-service/main.go
@@ -86,6 +86,8 @@ func gotEvent(ctx context.Context, event cloudevents.Event) error {
 		return err
 	}
 
+	logger.Debug("Got event of type " + event.Type())
+
 	if event.Type() == keptnevents.ConfigurationChangeEventType {
 		configChanger := controller.NewConfigurationChanger(mesh, logger, keptnDomain, url.String())
 		go configChanger.ChangeAndApplyConfiguration(event, loggingDone)


### PR DESCRIPTION
Fixes #1532.

This avoids connecting to external services.

I also added a log statement for better troubleshooting.