### PR TITLE
Fix readme for 0.5.1, 0.5.2 and 0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Therefore, this section shows the compatibility between these versions.
 
 <details><summary>Keptn version 0.6.0</summary>
 <p>
+
 *Keptn core:*
 - keptn/api:0.6.0
 - keptn/bridge:0.6.0
@@ -61,11 +62,13 @@ Therefore, this section shows the compatibility between these versions.
 
 *for Openshift:*
 - keptn/openshift-route-service:0.6.0
+
 </p>
 </details>
 
 <details><summary>Keptn version 0.5.2</summary>
 <p>
+
 *Keptn core:*
 - keptn/api:0.5.0
 - keptn/bridge:0.5.0
@@ -95,6 +98,7 @@ Therefore, this section shows the compatibility between these versions.
 
 <details><summary>Keptn version 0.5.1</summary>
 <p>
+
 *Keptn core:*
 - keptn/api:0.5.0
 - keptn/bridge:0.5.0


### PR DESCRIPTION
Fixes the wrong display of services in readme:

![Screenshot from 2020-03-23 09-20-54](https://user-images.githubusercontent.com/56065213/77296234-a766d180-6ce7-11ea-9905-f617e79dd20a.png)
