### PR TITLE
Added basic authentication to Keptn's Bridge

### DIFF
--- a/.idea/runConfigurations/keptn_bridge__Kube_ContDeploy_.xml
+++ b/.idea/runConfigurations/keptn_bridge__Kube_ContDeploy_.xml
@@ -1,0 +1,15 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="keptn/bridge [Kube ContDeploy]" type="google-container-tools-skaffold-run-config" factoryName="google-container-tools-skaffold-run-config-dev" show_console_on_std_err="false" show_console_on_std_out="false">
+    <option name="allowRunningInParallel" value="false" />
+    <option name="cleanupDeployments" value="true" />
+    <option name="envVariables" />
+    <option name="imageRepositoryOverride" />
+    <option name="kubeconfigFile" />
+    <option name="kubernetesContext" />
+    <option name="redeployOnChanges" value="true" />
+    <option name="skaffoldConfigurationFilePath" value="$PROJECT_DIR$/bridge/skaffold.yaml" />
+    <option name="skaffoldNamespace" />
+    <option name="skaffoldProfile" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -14,6 +14,34 @@ To deploy the current version of the bridge in your Keptn Kubernetes cluster, us
 kubectl apply -f deploy/bridge.yaml
 ```
 
+### Setting up Basic Authentication
+
+Keptn's Bridge comes with a very simple basic authentication feature. To enable it, edit the deployment using
+```console
+kubectl -n keptn edit deployment bridge
+```
+and add two environment variables to the `bridge` container:
+
+* `BASIC_AUTH_USERNAME` - username
+* `BASIC_AUTH_PASSWORD` - password
+
+In the end, your container spec should look something like this:
+
+```yaml
+    spec:
+      containers:
+      - name: bridge
+        image: keptn/bridge2:0.6.1
+        imagePullPolicy: Always
+        env:
+          - name: BASIC_AUTH_USERNAME
+            value: YourKeptnUser
+          - name: BASIC_AUTH_PASSWORD
+            value: YourKeptnpassword
+        ports:
+        - containerPort: 3000
+```
+
 ### Delete in your Kubernetes cluster
 
 To delete a deployed bridge, use the file `deploy/bridge.yaml` from this repository and delete the Kubernetes resources:

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -16,30 +16,53 @@ kubectl apply -f deploy/bridge.yaml
 
 ### Setting up Basic Authentication
 
-Keptn's Bridge comes with a very simple basic authentication feature. To enable it, edit the deployment using
-```console
-kubectl -n keptn edit deployment bridge
-```
-and add two environment variables to the `bridge` container:
+Keptn's Bridge comes with a very simple basic authentication feature, which can be controlled by setting the following two environment variables:
 
 * `BASIC_AUTH_USERNAME` - username
 * `BASIC_AUTH_PASSWORD` - password
 
-In the end, your container spec should look something like this:
+To enable it within your Kubernetes cluster, we recommend first creating a secret which holds the two variables, and then apply this secret within the Kubernetes deployment for Keptn's Bridge.
 
-```yaml
-    spec:
-      containers:
-      - name: bridge
-        image: keptn/bridge2:0.6.1
-        imagePullPolicy: Always
-        env:
-          - name: BASIC_AUTH_USERNAME
-            value: YourKeptnUser
-          - name: BASIC_AUTH_PASSWORD
-            value: YourKeptnpassword
-        ports:
-        - containerPort: 3000
+1. Create the secret using
+
+    ```console
+    kubectl -n keptn create secret generic bridge-credentials --from-literal="BASIC_AUTH_USERNAME=<USERNAME>" --from-literal="BASIC_AUTH_PASSWORD=<PASSWORD>"
+    ```
+    *Note: Replace `<USERNAME>` and `<PASSWORD>` with the desired credentials.*
+
+2. In case you are using Keptn 0.6.1 or older, edit the deployment using
+
+    ```console
+    kubectl -n keptn edit deployment bridge
+    ```
+   
+    and add the secret to the `bridge` container, such that the container spec looks like this:
+
+    ```yaml
+        ...
+        spec:
+          containers:
+          - name: bridge
+            image: keptn/bridge2:0.6.1
+            imagePullPolicy: Always
+            # EDIT STARTS HERE
+            envFrom:
+              - secretRef:
+                  name: bridge-credentials
+                  optional: true
+            # EDIT ENDS HERE
+            ports:
+            - containerPort: 3000
+            ...
+    ```
+   
+**Note 1**: To disable authentication, just delete the secret using ``kubectl -n keptn delete secret bridge-credentials``.
+
+**Note 2**: If you delete or edit the secret, you need to restart the respective pod by executing
+
+```console
+kubectl -n keptn scale deployment bridge --replicas=0
+kubectl -n keptn scale deployment bridge --replicas=1
 ```
 
 ### Delete in your Kubernetes cluster

--- a/bridge/deploy/bridge.yaml
+++ b/bridge/deploy/bridge.yaml
@@ -18,11 +18,10 @@ spec:
       - name: bridge
         image: keptn/bridge2:latest
         imagePullPolicy: Always
-        env:
-          - name: BASIC_AUTH_USERNAME
-            value: Keptn
-          - name: BASIC_AUTH_PASSWORD
-            value: Password
+        envFrom:
+          - secretRef:
+              name: bridge-credentials
+              optional: true
         ports:
         - containerPort: 3000
         resources:

--- a/bridge/deploy/bridge.yaml
+++ b/bridge/deploy/bridge.yaml
@@ -18,6 +18,11 @@ spec:
       - name: bridge
         image: keptn/bridge2:latest
         imagePullPolicy: Always
+        env:
+          - name: BASIC_AUTH_USERNAME
+            value: Keptn
+          - name: BASIC_AUTH_PASSWORD
+            value: Password
         ports:
         - containerPort: 3000
         resources:

--- a/installer/manifests/keptn/core.yaml
+++ b/installer/manifests/keptn/core.yaml
@@ -79,6 +79,10 @@ spec:
       containers:
       - name: bridge
         image: keptn/bridge2:latest
+        envFrom:
+          - secretRef:
+              name: bridge-credentials
+              optional: true
         ports:
         - containerPort: 3000
         resources:


### PR DESCRIPTION
This provides an implementation and an example on how to enable Basic Authentication within Keptn's Bridge in the Readme file of Keptn's Bridge.

Using Kubernetes secrets and `optional: true`, I was able to add it to the Installer Manifest as well.