### PR TITLE
Introduce reviewdog

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,0 +1,19 @@
+name: reviewdog
+on: [pull_request]
+jobs:
+  reviewdog:
+    name: reviewdog
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code.
+        uses: actions/checkout@v1
+      - name: Setup reviewdog
+        run: |
+          mkdir -p $HOME/bin && curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b $HOME/bin
+          echo ::add-path::$HOME/bin
+          echo ::add-path::$(go env GOPATH)/bin # for Go projects
+      - name: Run reviewdog
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          reviewdog -reporter=github-pr-review

--- a/.reviewdog.yml
+++ b/.reviewdog.yml
@@ -1,0 +1,11 @@
+runner:
+  # examples
+  golint:
+    cmd: golint ./...
+    errorformat:
+      - "%f:%l:%c: %m"
+    level: warning
+  gofmt:
+    cmd: gofmt -l .
+    errorformat:
+      - "%f:%l:%c: %m"

--- a/.travis.yml
+++ b/.travis.yml
@@ -239,26 +239,6 @@ jobs:
       - cat ~/.keptn/keptn-installer.log
       - cat ~/.keptn/keptn-installer-err.log
 
-  # always check code style for all directories
-  - stage: codestyle
-    # Check Codestyle using go fmt
-    services: []
-    language: go
-    go:
-      - 1.12.x
-    # skip install
-    install: true
-    script:
-      - echo "Checking code style..."
-      - unformatted=$(gofmt -l .)
-      - |
-        if [ ! -z "$unformatted" ]; then
-          echo "Code Style Check failed for the following files: ${unformatted}".
-          echo "Please run: gofmt -w ."
-          echo "After that amend your commit (e.g.: git add ${unformatted} && git commit --amend --no-edit) and force push the changes (git push -f)."
-          travis_terminate 1
-        fi
-
     # always execute unit tests for all directories
   - stage: Unit tests
     os: linux


### PR DESCRIPTION
This PR introduces reviewdog for automated PR review (using gofmt, govet and golint), and removes the linting task from travis-ci.

This is also a going to be introduced in our keptn-contrib repos as well as our go template.

As a working example, please see PR #1571 