### PR TITLE
Preselect evaluation result of current root event

### DIFF
--- a/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.html
+++ b/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.html
@@ -1,5 +1,5 @@
-<p class="m-0 mt-1"><span [textContent]="evaluationData.evaluationdetails.timeStart | amDateFormat:'L LT'"></span> - <span [textContent]="evaluationData.evaluationdetails.timeEnd | amDateFormat:'L LT'"></span> (<span [textContent]="evaluationData.evaluationdetails.timeEnd | amDifference: evaluationData.evaluationdetails.timeStart :'minutes'"></span> Minutes)</p>
-<div class="mb-1" *ngIf="evaluationData.evaluationdetails.sloFileContent">
+<p class="m-0 mt-1"><span [textContent]="evaluationData.data.evaluationdetails.timeStart | amDateFormat:'L LT'"></span> - <span [textContent]="evaluationData.data.evaluationdetails.timeEnd | amDateFormat:'L LT'"></span> (<span [textContent]="evaluationData.data.evaluationdetails.timeEnd | amDifference: evaluationData.data.evaluationdetails.timeStart :'minutes'"></span> Minutes)</p>
+<div class="mb-1" *ngIf="evaluationData.data.evaluationdetails.sloFileContent">
   <p class="m-0 mb-1">
     <a class="dt-link" (click)="$event.stopPropagation();sloFile.toggle();">
       <span *ngIf="!sloFile.expanded">Show SLOs</span>
@@ -8,40 +8,23 @@
   </p>
   <dt-expandable-panel #sloFile>
     <div class="container dark">
-      <pre>{{ evaluationData.evaluationdetails.sloFileContent | atob }}</pre>
+      <pre>{{ evaluationData.data.evaluationdetails.sloFileContent | atob }}</pre>
     </div>
   </dt-expandable-panel>
 </div>
 <div class="mb-1 mt-1">
-  <div fxLayout="row" class="pr-4">
+  <div fxLayout="row" class="pr-2">
     <div fxFlex>
-      <dt-button-group (valueChange)="switchEvaluationView()">
-        <dt-button-group-item>Single evaluation</dt-button-group-item>
-        <dt-button-group-item>Evaluation comparison</dt-button-group-item>
-      </dt-button-group>
     </div>
     <div fxLayout="column" fxLayoutAlign="start end">
-      <dt-button-group *ngIf="_view == 'evaluationcomparison'" [(value)]="_comparisonView">
+      <dt-button-group [(value)]="_comparisonView">
         <dt-button-group-item [value]="'heatmap'" (click)="_comparisonView = 'heatmap'">Heatmap</dt-button-group-item>
         <dt-button-group-item [value]="'chart'" (click)="_comparisonView = 'chart'">Chart</dt-button-group-item>
       </dt-button-group>
     </div>
   </div>
 </div>
-<div class="p-2" *ngIf="_view == 'singleevaluation'">
-  <dt-consumption [max]="evaluationData.evaluationdetails.indicatorResults ? 100 : 0" [value]="evaluationData.evaluationdetails.score" [color]="evaluationData.result == 'fail' ? 'error' : 'recovered'">
-    <dt-consumption-icon aria-label="Test">
-      <dt-icon name="summary"></dt-icon>
-    </dt-consumption-icon>
-    <dt-consumption-title>SLO evaluation of <span [textContent]="evaluationData.teststrategy"></span> test</dt-consumption-title>
-    <dt-consumption-count>
-      <span [textContent]="evaluationData.evaluationdetails.score | number:'1.0-0'"></span>/<span [textContent]="evaluationData.evaluationdetails.indicatorResults ? 100 : 0"></span>
-    </dt-consumption-count>
-    <dt-consumption-label>SLO evaluation result: <span [textContent]="evaluationData.result"></span></dt-consumption-label>
-  </dt-consumption>
-  <ktb-sli-breakdown *ngIf="evaluationData.evaluationdetails.indicatorResults" [indicatorResults]="evaluationData.evaluationdetails.indicatorResults"></ktb-sli-breakdown>
-</div>
-<div *ngIf="_view == 'evaluationcomparison'" (click)="$event.stopPropagation();">
+<div (click)="$event.stopPropagation();">
   <dt-chart *ngIf="_comparisonView == 'heatmap'"
     [options]="_heatmapOptions"
     [series]="_heatmapSeries"
@@ -68,16 +51,16 @@
     </dt-chart-tooltip>
   </dt-chart>
   <div class="p-3" *ngIf="_selectedEvaluationData">
-    <dt-consumption [max]="_selectedEvaluationData.evaluationdetails.indicatorResults ? 100 : 0" [value]="_selectedEvaluationData.evaluationdetails.score" [color]="_evaluationState[_selectedEvaluationData.result]">
+    <dt-consumption [max]="_selectedEvaluationData.data.evaluationdetails.indicatorResults ? 100 : 0" [value]="_selectedEvaluationData.data.evaluationdetails.score" [color]="_evaluationState[_selectedEvaluationData.data.result]">
       <dt-consumption-icon aria-label="Test">
         <dt-icon name="summary"></dt-icon>
       </dt-consumption-icon>
-      <dt-consumption-title>SLO evaluation of <span [textContent]="_selectedEvaluationData.teststrategy"></span> test from <span class="m-0 mt-1 mb-1" [textContent]="_selectedEvaluationData.evaluationdetails.timeStart | amDateFormat:getCalendarFormat()"></span></dt-consumption-title>
+      <dt-consumption-title>SLO evaluation of <span [textContent]="_selectedEvaluationData.data.teststrategy"></span> test from <span class="m-0 mt-1 mb-1" [textContent]="_selectedEvaluationData.data.evaluationdetails.timeStart | amDateFormat:getCalendarFormat()"></span></dt-consumption-title>
       <dt-consumption-count>
-        <span [textContent]="_selectedEvaluationData.evaluationdetails.score | number:'1.0-0'"></span>/<span [textContent]="_selectedEvaluationData.evaluationdetails.indicatorResults ? 100 : 0"></span>
+        <span [textContent]="_selectedEvaluationData.data.evaluationdetails.score | number:'1.0-0'"></span>/<span [textContent]="_selectedEvaluationData.data.evaluationdetails.indicatorResults ? 100 : 0"></span>
       </dt-consumption-count>
-      <dt-consumption-label>SLO evaluation result: <span [textContent]="_selectedEvaluationData.result"></span></dt-consumption-label>
+      <dt-consumption-label>SLO evaluation result: <span [textContent]="_selectedEvaluationData.data.result"></span></dt-consumption-label>
     </dt-consumption>
-    <ktb-sli-breakdown *ngIf="_selectedEvaluationData.evaluationdetails.indicatorResults" [indicatorResults]="_selectedEvaluationData.evaluationdetails.indicatorResults"></ktb-sli-breakdown>
+    <ktb-sli-breakdown *ngIf="_selectedEvaluationData.data.evaluationdetails.indicatorResults" [indicatorResults]="_selectedEvaluationData.data.evaluationdetails.indicatorResults"></ktb-sli-breakdown>
   </div>
 </div>

--- a/bridge/client/app/_components/ktb-events-list/ktb-events-list.component.html
+++ b/bridge/client/app/_components/ktb-events-list/ktb-events-list.component.html
@@ -5,7 +5,7 @@
     </ktb-horizontal-separator>
     <ktb-event-item [event]="event" [class.focused]="event.id == focusedEventId && scrollIntoView(eventRef)" (click)="focusEvent(event)">
       <ktb-event-item-detail>
-        <ktb-evaluation-details *ngIf="event.data.evaluationdetails" [evaluationData]="event.data" [evaluationSource]="event.source"></ktb-evaluation-details>
+        <ktb-evaluation-details *ngIf="event.data.evaluationdetails" [evaluationData]="event"></ktb-evaluation-details>
       </ktb-event-item-detail>
     </ktb-event-item>
   </div>

--- a/bridge/client/app/_models/trace.ts
+++ b/bridge/client/app/_models/trace.ts
@@ -74,6 +74,8 @@ export class Trace {
       timeStart: Date;
     };
 
+    evaluationHistory: Trace[];
+
     ProblemTitle: string;
     ImpactedEntity: string;
     ProblemDetails: {

--- a/bridge/client/app/_services/data.service.ts
+++ b/bridge/client/app/_services/data.service.ts
@@ -135,16 +135,16 @@ export class DataService {
       });
   }
 
-  public loadEvaluationResults(evaluationData, evaluationSource) {
+  public loadEvaluationResults(event: Trace) {
     let fromTime: Date;
-    if(evaluationData.evaluationHistory)
-      fromTime = new Date(evaluationData.evaluationHistory[evaluationData.evaluationHistory.length-1].time);
+    if(event.data.evaluationHistory)
+      fromTime = new Date(event.data.evaluationHistory[event.data.evaluationHistory.length-1].time);
 
-    this.apiService.getEvaluationResults(evaluationData.project, evaluationData.service, evaluationData.stage, evaluationSource, fromTime ? fromTime.toISOString() : null)
+    this.apiService.getEvaluationResults(event.data.project, event.data.service, event.data.stage, event.source, fromTime ? fromTime.toISOString() : null)
       .pipe(map(traces => traces.map(trace => Trace.fromJSON(trace))))
       .subscribe((traces: Trace[]) => {
-        evaluationData.evaluationHistory = [...traces||[], ...evaluationData.evaluationHistory||[]].sort((a, b) => new Date(a.time).getTime() - new Date(b.time).getTime());
-        this._evaluationResults.next(evaluationData);
+        event.data.evaluationHistory = [...traces||[], ...event.data.evaluationHistory||[]].sort((a, b) => new Date(a.time).getTime() - new Date(b.time).getTime());
+        this._evaluationResults.next(event);
       });
   }
 }

--- a/bridge/client/styles.scss
+++ b/bridge/client/styles.scss
@@ -173,6 +173,32 @@ span.italic {
   padding-bottom: .3em;
 }
 
+.pr-2 {
+  padding-right: .6em;
+}
+.pl-2 {
+  padding-left: .6em;
+}
+.pt-2 {
+  padding-top: .6em;
+}
+.pb-2 {
+  padding-bottom: .6em;
+}
+
+.pr-3 {
+  padding-right: 1.2em;
+}
+.pl-3 {
+  padding-left: 1.2em;
+}
+.pt-3 {
+  padding-top: 1.2em;
+}
+.pb-3 {
+  padding-bottom: 1.2em;
+}
+
 .pr-4 {
   padding-right: 2.5em;
 }


### PR DESCRIPTION
With this fix, the heatmap is also display immediately without having to toggle the view and the evaluation result of the current root event is preselected.