### PR TITLE
Updated readme and contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,9 @@
 
 First off, thank you for considering contributing to Keptn. It's people like you that make Keptn great.
 
-### Where do I go from here?
-
 If you've noticed a bug, want to contribute features, or simply ask a question that for whatever reason you don't want to ask in the [Keptn Slack workspace](keptn.slack.com), please [search the issue tracker](https://github.com/keptn/keptn/issues?q=something) to see if someone else in the community has already created a ticket. If not, go ahead and [make one](https://github.com/keptn/keptn/issues/new).
+
+If you want to work on an issue and contribute code, this is the right document to get started.
 
 ### Read the docs
 
@@ -12,6 +12,30 @@ We are in the process of making sure that each repository and each service withi
 We are aware that some parts are currently missing, in the meantime please get in touch with us through the [Keptn Slack workspace](keptn.slack.com) if you have any questions.
 
 As a starting point, please read the docs within the [docs/](docs/) folder in this repository.
+
+
+### Tell us if you start working on an issue
+
+In case you want to work on an unassigned [GitHub issue](https://github.com/keptn/keptn/issues), please let us know via
+ a quick comment in the issue itself. We will then try to assign it to you.
+
+### Propose/design new features
+
+Proposing new functionality for Keptn is done via a so called [Enhancement Proposal](https://github.com/keptn/enhancement-proposals).
+This is required when it is intended to introduce new behaviour, change desired behaviour, or otherwise modify requirements of Keptn.
+
+If all you want to propose is a simple addition to a Keptn-service or the CLI, or even a bugfix, you can just open 
+[a new issue on GitHub](https://github.com/keptn/keptn/issues/new/choose).
+
+### Follow Coding style
+
+When contributing code to Keptn, we politely ask you to follow the coding style suggested by the [Golang community](https://github.com/golang/go/wiki/CodeReviewComments).
+We are running automated code style checks for pull requests using the following tools:
+
+* [reviewdog](.reviewdog.yml) - automatic code review
+  * ``golint ./...``
+  * ``gofmt -l -s .`` 
+* [codecov.io](codecov.yml) - tracks code coverage based on unit tests
 
 ### Fork and create a branch
 
@@ -38,7 +62,34 @@ For Hotfixes please branch away from the master branch, and create a PR to maste
 
 ### Run Tests
 
-Currently Keptn has only limited automated end-to-end tests. To verify Keptn still works as it's supposed to, please make sure that the tutorials described on the [Keptn website](https://keptn.sh/docs/) can be completed successfully.
+Keptn currently has two types of tests:
+
+* end-to-end tests (integration tests) - run automatically once per day (see [test/](test/))
+* unit tests - run for every Pull Request in every directory that contains Go code
+
+Before pushing your code to the repository, please run unit tests locally. When creating features, please also consider
+ writing unit tests.
+
+### Deploy your local changes to an existing cluster
+
+If you are changing behaviour or a large part of the code, please verify Keptn still works as it's supposed to, by following the tutorials described on the [Keptn website](https://keptn.sh/docs/).
+
+To deploy your local changes to an existing Kubernetes cluster with Keptn running on it, we recommend using [skaffold](https://skaffold.dev).
+We provide a `skaffold.yaml` file in every repository/directory, which you can use to automatically deploy the service using
+```console
+skaffold run --tail --default-repo=your-docker-registry
+```
+
+Please replace `your-docker-registry` with your DockerHub username and repository name.
+This should 
+
+* automatically build the docker image for the service,
+* push the docker image to the defined container registry/repository,
+* deploy the service to the Kubernetes cluster using the image that was just built, and
+* print log output to your terminal.
+
+In case you are using JetBrains GoLand, you can also use the built-in debugging features using Skaffold and Google Cloud Code as described [here](docs/debugging.md).
+
 
 ### Make a Pull Request
 
@@ -59,4 +110,4 @@ git push --set-upstream origin feature/123/foo
 ```
 
 Finally, go to GitHub and make a Pull Request. Please describe what this PR is about and add a link to relevant GitHub issues.
-Your PR will usually be reviewed automatically, but feel free to let us know about your PR via Slack.
+Your PR will usually be reviewed by the Keptn team within a couple of days, but feel free to let us know about your PR via Slack.

--- a/README.md
+++ b/README.md
@@ -11,157 +11,36 @@ Keptn is an event-based control plane for continuous delivery and automated oper
 Please find the documentation on our [website](https://keptn.sh), and read the motivation about Keptn on our 
 [Why Keptn?](https://keptn.sh/why-keptn/) page.
 
+In addition, you can find the roadmap of the Keptn project [here](https://github.com/orgs/keptn/projects/1). It provides 
+an overview of user stories that are currently in the focus of development for the next release.
+
 ## Usage
 
-Please find the documentation of how to get started with Keptn in the [Quick Start](https://keptn.sh/docs/quickstart/) and the [Installation instructions](https://keptn.sh/docs/0.6.0/installation/setup-keptn/). We recommend using the [latest stable release](https://github.com/keptn/keptn/releases).
+**Download CLI (Linux and Mac OS)**:
+```console
+curl -sL https://get.keptn.sh | sudo -E bash
+```
+or download a release for your platform from the [release page](https://github.com/keptn/keptn/releases)
 
-Furthermore, you can learn about our current releases, release candidates and pre-releases on the [release section](https://github.com/keptn/keptn/releases).
+You can find documentation on how to get started with Keptn in our [Quick Start Guide](https://keptn.sh/docs/quickstart/) and the [Installation instructions](https://keptn.sh/docs/0.6.0/installation/setup-keptn/). 
+We recommend using the [latest stable release](https://github.com/keptn/keptn/releases) as provided in the [release section](https://github.com/keptn/keptn/releases).
 
-## Versions compatibilities
-We manage the Keptn core components in versions. The respective images in their versions are stored on [DockerHub](https://hub.docker.com/?namespace=keptn).
-The versions of the Keptn core components and the services have to be compatible with each other.
-Therefore, this section shows the compatibility between these versions.
+## Community
 
-**Keptn in [version 0.6.1](https://github.com/keptn/keptn/releases/tag/0.6.1) requires:**
+Please find details on regular hosted community events as well as our Slack workspace in the 
+[keptn/community repo](https://github.com/keptn/community).
 
-*Keptn core:*
-- keptn/api:0.6.1
-- keptn/bridge:0.6.1
-- keptn/configuration-service:0.6.1
-- keptn/distributor:0.6.1
-- keptn/eventbroker-go:0.6.1
-- keptn/gatekeeper-service:0.6.1
-- keptn/helm-service:0.6.1
-- keptn/jmeter-service:0.6.1
-- keptn/lighthouse-service:0.6.1
-- keptn/mongodb-datastore:0.6.1
-- keptn/shipyard-service:0.6.1
-- keptn/wait-service:0.6.1
-- keptn/remediation-service:0.6.1
+## Keptn Versions compatibilities
 
-*for Openshift:*
-- keptn/openshift-route-service:0.6.1
+We manage the Keptn *core components* in versions. The respective images in their versions are stored on [DockerHub](https://hub.docker.com/?namespace=keptn).
+The versions of the Keptn *core components* and the services are compatible with each other. However, contributed services
+as well as services that are not considered *core components* might not follow the same versioning schema.
 
-<details><summary>Keptn version 0.6.0</summary>
-<p>
+Since Keptn 0.6.1, we are tracking compatibility of those services [on our website](https://keptn.sh/docs/integrations/).
 
-*Keptn core:*
-- keptn/api:0.6.0
-- keptn/bridge:0.6.0
-- keptn/configuration-service:0.6.0
-- keptn/distributor:0.6.0
-- keptn/eventbroker-go:0.6.0
-- keptn/gatekeeper-service:0.6.0
-- keptn/helm-service:0.6.0
-- keptn/jmeter-service:0.6.0
-- keptn/lighthouse-service:0.6.0
-- keptn/mongodb-datastore:0.6.0
-- keptn/shipyard-service:0.6.0
-- keptn/wait-service:0.6.0
-- keptn/remediation-service:0.6.0
-
-*for Openshift:*
-- keptn/openshift-route-service:0.6.0
-
-</p>
-</details>
-
-<details><summary>Keptn version 0.5.2</summary>
-<p>
-
-*Keptn core:*
-- keptn/api:0.5.0
-- keptn/bridge:0.5.0
-- keptn/configuration-service:0.5.0
-- keptn/distributor:0.5.0
-- keptn/eventbroker-go:0.5.0
-- keptn/gatekeeper-service:0.5.0
-- keptn/helm-service:0.5.1
-- keptn/jmeter-service:0.5.0
-- keptn/mongodb-datastore:0.5.0
-- keptn/pitometer-service:0.5.0
-- keptn/shipyard-service:0.5.0
-- keptn/wait-service:0.5.0
-- keptn/remediation-service:0.5.0
-
-
-*Keptn uniform:*
-- keptn/dynatrace-service:0.2.0
-- keptn/prometheus-service:0.2.0
-- keptn/servicenow-service:0.1.4
-
-*for Openshift:*
-- keptn/openshift-route-service:0.5.0
-
-</p>
-</details>
-
-<details><summary>Keptn version 0.5.1</summary>
-<p>
-
-*Keptn core:*
-- keptn/api:0.5.0
-- keptn/bridge:0.5.0
-- keptn/configuration-service:0.5.0
-- keptn/distributor:0.5.0
-- keptn/eventbroker-go:0.5.0
-- keptn/gatekeeper-service:0.5.0
-- keptn/helm-service:0.5.1
-- keptn/jmeter-service:0.5.0
-- keptn/mongodb-datastore:0.5.0
-- keptn/pitometer-service:0.5.0
-- keptn/shipyard-service:0.5.0
-- keptn/wait-service:0.5.0
-- keptn/remediation-service:0.5.0
-
-
-*Keptn uniform:*
-- keptn/dynatrace-service:0.3.1
-- keptn/prometheus-service:0.2.0
-- keptn/servicenow-service:0.1.4
-
-*for Openshift:*
-- keptn/openshift-route-service:0.5.0
-
-</p>
-</details>
-<details><summary>Keptn version 0.5.0</summary>
-<p>
-
-Keptn in [version 0.5.0](https://github.com/keptn/keptn/releases/tag/0.5.0) requires:
-
-*Keptn core:*
-- keptn/api:0.5.0
-- keptn/bridge:0.5.0
-- keptn/configuration-service:0.5.0
-- keptn/distributor:0.5.0
-- keptn/eventbroker-go:0.5.0
-- keptn/gatekeeper-service:0.5.0
-- keptn/helm-service:0.5.0
-- keptn/jmeter-service:0.5.0
-- keptn/mongodb-datastore:0.5.0
-- keptn/pitometer-service:0.5.0
-- keptn/shipyard-service:0.5.0
-- keptn/wait-service:0.5.0
-- keptn/remediation-service:0.5.0
-
-
-*Keptn uniform:*
-- keptn/dynatrace-service:0.3.1
-- keptn/prometheus-service:0.2.0
-- keptn/servicenow-service:0.1.4
-
-*for Openshift:*
-- keptn/openshift-route-service:0.5.0
-
-</p>
-</details>
-
-Please check out the [GitHub releases page](https://github.com/keptn/keptn/releases) if you need information for older Keptn versions.
-
-## Roadmap
-
-The roadmap of the Keptn project can be found [here](https://github.com/orgs/keptn/projects/1). It gives you an overview of user stories that are currently in the focus of development for the next release.
+You can find information on older versions 
+[here](https://github.com/keptn/keptn/tree/release-0.6.0/#versions-compatibilities) and on the
+ [GitHub releases page](https://github.com/keptn/keptn/releases).
 
 ## Contributions
 
@@ -171,6 +50,10 @@ Please also check out our list of [good first issues](https://github.com/keptn/k
 ## License
 
 Keptn is an Open Source Project. Please see [LICENSE](LICENSE) for more information.
+
+## Adopters
+
+For a list of users, please refer to [ADOPTERS.md](ADOPTERS.md).
 
 ## Further information
 


### PR DESCRIPTION
- Updated contribution guide with coding style information
- Updated contribution guide with info about tests
- Updated README with info about adopters
- Moved info about our roadmap to the top of the README file
- Added a direct link to the Keptn community in the top section of the README
- Removed version information from README as the Keptn core services are compatible with each other anyway, and external/contributed services/integrations are now listed on the website

PREVIEW: 
* [README.md](https://github.com/keptn/keptn/tree/readme#keptn)
* [CONTRIBUTING.md](https://github.com/keptn/keptn/blob/readme/CONTRIBUTING.md)
