### PR TITLE
Fix: url.Host contains the port as well, use url.Hostname() strips the port

### DIFF
--- a/cli/cmd/auth.go
+++ b/cli/cmd/auth.go
@@ -46,7 +46,7 @@ Example:
 		if !mocking {
 			authenticated := false
 
-			if !lookupHostname(url.Host) {
+			if !lookupHostname(url.Hostname()) {
 				return fmt.Errorf("Authentication was unsuccessful - could not resolve hostname.")
 			}
 


### PR DESCRIPTION
With #1579 I introduced faulty behaviour, which caused issues when using NodePort, e.g.:

```console
Received Keptn Domain: 10.20.0.35.xip.io:30543
Starting to authenticate
Failed to resolve hostname api.keptn.10.20.0.35.xip.io:30543
Retrying...
Failed to resolve hostname api.keptn.10.20.0.35.xip.io:30543
Retrying...
Failed to resolve hostname api.keptn.10.20.0.35.xip.io:30543
Retrying...
[keptn|ERROR] [2020-04-02 08:59:48] keptn install failed
[keptn|ERROR] [2020-04-02 08:59:48] Keptn Test failed.
```

I've changed the call from `.Host` to `.Hostname()` which strips the port of the domain :)