### PR TITLE
#1529 Change APIVersion from apps/v1beta1 to apps/v1

### DIFF
--- a/configuration-service/common/git.go
+++ b/configuration-service/common/git.go
@@ -194,7 +194,7 @@ func StoreGitCredentials(project string, user string, token string, remoteURI st
 	secret := &v1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
-			APIVersion: "apps/v1beta1",
+			APIVersion: "apps/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "git-credentials-" + project,


### PR DESCRIPTION
**apiVersion** for the Secret. 
Since we are using the k8s core library v1 (v1 "k8s.io/api/core/v1"), the `apiVersion` is actually set to: `apps/v1`. 
Nevertheless, I fixed the wrong `apiVersion` when creating a Git Secret in `\keptn\configuration-service\common\git.go`.