### PR TITLE
Fix integration tests

### DIFF
--- a/test/test_new_artifact.sh
+++ b/test/test_new_artifact.sh
@@ -13,6 +13,7 @@ verify_test_step $? "Send event new-artifact for carts-db failed"
 
 # lets wait a little bit until we are sure that mongodb has been deployed
 wait_for_deployment_in_namespace "carts-db" "$PROJECT-dev"
+verify_test_step $? "Deployment carts-db not available, exiting..."
 
 # okay, now we can start with carts
 test/utils/send_new_artifact_sockshop.sh $PROJECT docker.io/keptnexamples/carts 0.10.1

--- a/test/utils/send_new_artifact_sockshop.sh
+++ b/test/utils/send_new_artifact_sockshop.sh
@@ -35,7 +35,9 @@ echo ""
 wait_for_deployment_in_namespace "carts-db" "$PROJECT-dev"
 wait_for_deployment_in_namespace "carts" "$PROJECT-dev"
 verify_pod_in_namespace "carts" "$PROJECT-dev"
+verify_test_step $? "Pod carts not found, exiting..."
 verify_pod_in_namespace "carts-db" "$PROJECT-dev"
+verify_test_step $? "Pod carts-db not found, exiting..."
 
 # get URL for that deployment
 DEV_URL=$(echo http://carts.${PROJECT}-dev.$(kubectl get cm keptn-domain -n keptn -o=jsonpath='{.data.app_domain}'))
@@ -62,8 +64,11 @@ echo ""
 wait_for_deployment_in_namespace "carts-db" "$PROJECT-staging"
 wait_for_deployment_in_namespace "carts" "$PROJECT-staging"
 verify_pod_in_namespace "carts" "$PROJECT-staging"
+verify_test_step $? "Pod carts not found, exiting..."
 verify_pod_in_namespace "carts-primary" "$PROJECT-staging"
+verify_test_step $? "Pod carts-primary not found, exiting..."
 verify_pod_in_namespace "carts-db" "$PROJECT-staging"
+verify_test_step $? "Pod carts-db not found, exiting..."
 
 # get URL for that deployment
 STAGING_URL=$(echo http://carts.${PROJECT}-staging.$(kubectl get cm keptn-domain -n keptn -o=jsonpath='{.data.app_domain}'))
@@ -90,8 +95,11 @@ echo ""
 wait_for_deployment_in_namespace "carts-db" "$PROJECT-production"
 wait_for_deployment_in_namespace "carts" "$PROJECT-production"
 verify_pod_in_namespace "carts" "$PROJECT-production"
+verify_test_step $? "Pod carts not found, exiting..."
 verify_pod_in_namespace "carts-primary" "$PROJECT-production"
+verify_test_step $? "Pod carts-primary not found, exiting..."
 verify_pod_in_namespace "carts-db" "$PROJECT-production"
+verify_test_step $? "Pod carts-db not found, exiting..."
 
 # get URL for that deployment
 PRODUCTION_URL=$(echo http://carts.${PROJECT}-production.$(kubectl get cm keptn-domain -n keptn -o=jsonpath='{.data.app_domain}'))


### PR DESCRIPTION
Right now our integration test does not fail if one of the "wait for deployments" steps fails. This PR fixes that.