### PR TITLE
#1611 Added command to auto-generate docs

### DIFF
--- a/cli/cmd/add_resource.go
+++ b/cli/cmd/add_resource.go
@@ -26,12 +26,25 @@ var addResourceCmdParams *addResourceCommandParameters
 
 var addResourceCmd = &cobra.Command{
 	Use:   "add-resource --project=PROJECT --stage=STAGE --service=SERVICE --resource=FILEPATH --resourceUri=FILEPATH",
-	Short: "Adds a resource to a service within your project in the specified stage",
-	Long: `Adds a resource to a service within your project in the specified stage.
-	
-Example: 
-	keptn add-resource --project=sockshop --stage=dev --service=carts --resource=./jmeter.jmx --resourceUri=jmeter/functional.jmx`,
-	SilenceUsage: true,
+	Short: "Adds a local resource to a service within your project in the specified stage",
+	Long: `Adds a local resource to a service within your project in the specified stage. The resource is then stored within the Git Repo.
+
+This command allows adding, for example, *test files* to a service, which will then be used by a test service (e.g., jmeter-service) during the continuous delivery.
+
+To specify a unique resource identifier (URI) for this resource, the optional flag *--resourceUri* can be set to a file path. 
+By default, the URI is set to the file path specified at the *--resource* flag. 
+From a technical perspective, the file provided via the *--resource* flag is stored with the path and name specified within *--resourceUri* flag.
+
+**The target location of the resource:**
+
+- *--project* - is mandatory. The resource will be added to the root folder in the master branch. 
+- *--stage* - is optional (when the *--service* flag is not used). The resource will be added to the root folder in the stage branch.
+- *--service* - is optional. The resource will be added to the service folder in the stage branch.
+`,
+	Example: `keptn add-resource --project=musicshop --stage=hardening --service=catalogue --resource=slo.yaml
+keptn add-resource --project=musicshop --stage=hardening --service=catalogue --resource=slo-quality-gates.yaml --resourceUri=slo.yaml
+keptn add-resource --project=sockshop --stage=dev --service=carts --resource=./jmeter.jmx --resourceUri=jmeter/functional.jmx
+keptn add-resource --project=rockshop --stage=production --service=shop --resource=./basiccheck.jmx --resourceUri=jmeter/basiccheck.jmx`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds()
 		if err != nil {

--- a/cli/cmd/auth.go
+++ b/cli/cmd/auth.go
@@ -84,7 +84,7 @@ func init() {
 
 	endPoint = authCmd.Flags().StringP("endpoint", "e", "", "The endpoint exposed by the Keptn installation (e.g., api.keptn.127.0.0.1.xip.io)")
 	authCmd.MarkFlagRequired("endpoint")
-	apiToken = authCmd.Flags().StringP("api-token", "a", "", "The API token to communicate with the by Keptn installation")
+	apiToken = authCmd.Flags().StringP("api-token", "a", "", "The API token to communicate with the Keptn installation")
 	authCmd.MarkFlagRequired("api-token")
 }
 

--- a/cli/cmd/auth.go
+++ b/cli/cmd/auth.go
@@ -26,11 +26,13 @@ var authCmd = &cobra.Command{
 	Use:   "auth --endpoint=https://api.keptn.MY.DOMAIN.COM --api-token=SECRET_TOKEN",
 	Short: "Authenticates the Keptn CLI against a Keptn installation",
 	Long: `Authenticates the Keptn CLI against a Keptn installation using an endpoint
-and an API token. The endpoint and API token are exposed during the Keptn installation.
-If the authentication is successful, the endpoint and the API token are stored in a password store. 
+and an API token. The endpoint and API token are automatically configured during the Keptn installation.
+If the authentication is successful, the endpoint and the API token are stored in a password store of the underlying operating system.
+More precisely, the keptn CLI stores the endpoint and API token using *pass* in case of Linux, using *Keychain* in case of macOS, or *Wincred* in case of Windows.
 
-Example:
-	keptn auth --endpoint=https://api.keptn.my.domain.com --api-token=abcd-0123-wxyz-7890`,
+**Note**: If you receive a warning *Using a file-based storage for the key because the password-store seems to be not set up.* this is because a password store could not be found in your environment. In this case, the credentials are stored in *~/.keptn/.keptn* in your home directory.
+	`,
+	Example: `keptn auth --endpoint=https://api.keptn.MY.DOMAIN.COM --api-token=abcd-0123-wxyz-7890`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		logging.PrintLog("Starting to authenticate", logging.InfoLevel)
@@ -80,9 +82,9 @@ Example:
 func init() {
 	rootCmd.AddCommand(authCmd)
 
-	endPoint = authCmd.Flags().StringP("endpoint", "e", "", "The endpoint exposed by keptn")
+	endPoint = authCmd.Flags().StringP("endpoint", "e", "", "The endpoint exposed by the Keptn installation (e.g., api.keptn.127.0.0.1.xip.io)")
 	authCmd.MarkFlagRequired("endpoint")
-	apiToken = authCmd.Flags().StringP("api-token", "a", "", "The API token provided by keptn")
+	apiToken = authCmd.Flags().StringP("api-token", "a", "", "The API token to communicate with the by Keptn installation")
 	authCmd.MarkFlagRequired("api-token")
 }
 

--- a/cli/cmd/configure.go
+++ b/cli/cmd/configure.go
@@ -6,9 +6,8 @@ import (
 
 // configureCmd represents the configure command
 var configureCmd = &cobra.Command{
-	Use:          "configure [domain | monitoring]",
-	Short:        "configure is the parent command for \"configure domain\" and \"configure monitoring\"",
-	Long:         "configure is the parent command for \"configure domain\" and \"configure monitoring\". \"configure\" without subcommand cannot be used.",
+	Use:          "configure [domain | monitoring | bridge]",
+	Short:        "Configures one of the specified parts of Keptn",
 	SilenceUsage: true,
 }
 

--- a/cli/cmd/configure_bridge.go
+++ b/cli/cmd/configure_bridge.go
@@ -39,8 +39,10 @@ var bridgeCmd = &cobra.Command{
 	Short: "Exposes or locks down the bridge",
 	Long: `Exposes or locks down the Keptn's bridge.
 
-Example:
-	keptn configure bridge --action=expose
+When exposing Keptn's Bridge it will be available publicly. 
+Make sure to protect Keptn's Bridge using Basic authentication.
+`,
+	Example: `keptn configure bridge --action=expose
 	keptn configure bridge --action=lockdown`,
 	SilenceUsage: true,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -87,6 +89,8 @@ func configureBridge(endpoint string, apiToken string, configureBridgeParams *co
 			return errors.New("Could not " + *configureBridgeParams.Action + " bridge: " + err.Error())
 		}
 		fmt.Printf("Bridge exposed successfully. You can reach it here: https://%s", strings.Trim(string(body), "\""))
+		// Todo: migrate docs for exposing keptn's bridge into keptn.github.io
+		fmt.Printf("Make sure to add basic authentication as described here: https://github.com/keptn/keptn/blob/master/bridge/README.md#setting-up-basic-authentication")
 	} else {
 		if err != nil {
 			return errors.New("Could not " + *configureBridgeParams.Action + " bridge: " + err.Error())

--- a/cli/cmd/configure_domain.go
+++ b/cli/cmd/configure_domain.go
@@ -40,12 +40,17 @@ const domainConfigMapSuffix = "/installer/manifests/keptn/keptn-domain-configmap
 
 // domainCmd represents the domain command
 var domainCmd = &cobra.Command{
-	Use:   "domain MY.DOMAIN.COM",
-	Short: "Configures the domain",
-	Long: `Configures the domain of Keptn.
-	
-Example:
-	keptn configure domain my.domain.com`,
+	Use:   "domain YOUR.DOMAIN.COM",
+	Short: "Configures the domain used for Keptn",
+	Long: `Configures the domain used for Keptn.
+
+This is mandatory if *xip.io* cannot be used (e.g., when running Keptn on EKS, AWS will create an ELB).
+
+**Note:** This command requires a *kubernetes current context* pointing to the cluster where you would like to configure your domain. After installing Keptn this is guaranteed.
+
+Please find more information on https://keptn.sh/docs/develop/reference/troubleshooting/#verify-kubernetes-context-with-keptn-installation
+`,
+	Example: `keptn configure domain YOUR.DOMAIN.COM`,
 	SilenceUsage: true,
 	Args: func(cmd *cobra.Command, args []string) error {
 

--- a/cli/cmd/configure_monitoring.go
+++ b/cli/cmd/configure_monitoring.go
@@ -37,7 +37,15 @@ var allowedMonitoringTypes = []string{
 var monitoringCmd = &cobra.Command{
 	// Use:          "monitoring <monitoring_provider> --project=<project> --service=<service> --service-indicators=<service_indicators_file_path> --service-objectives=<service_objectives_file_path> --remediation=<remediation_file_path>",
 	Use:          "monitoring <monitoring_provider> --project=<project> --service=<service>",
-	Short:        "Configures monitoring",
+	Short:        "Configures monitoring provider",
+	Long: `Configure a monitoring solution for a Keptn cluster. This command sets up Dynatrace or Prometheus monitoring in case it is not installed yet. 
+
+**Note:** If you are executing *keptn configure monitoring dynatrace*, the service flag is optional since Keptn automatically detects the services of a project.
+
+See https://keptn.sh/docs/develop/reference/monitoring/ for more information.
+`,
+    Example: `keptn configure monitoring dynatrace --project=PROJECTNAME
+keptn configure monitoring prometheus --project=PROJECTNAME --service=SERVICENAME`,
 	SilenceUsage: true,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 1 {

--- a/cli/cmd/configure_monitoring.go
+++ b/cli/cmd/configure_monitoring.go
@@ -38,7 +38,7 @@ var monitoringCmd = &cobra.Command{
 	// Use:          "monitoring <monitoring_provider> --project=<project> --service=<service> --service-indicators=<service_indicators_file_path> --service-objectives=<service_objectives_file_path> --remediation=<remediation_file_path>",
 	Use:          "monitoring <monitoring_provider> --project=<project> --service=<service>",
 	Short:        "Configures monitoring provider",
-	Long: `Configure a monitoring solution for a Keptn cluster. This command sets up Dynatrace or Prometheus monitoring in case it is not installed yet. 
+	Long: `Configure a monitoring solution for a Keptn cluster. This command sets up Dynatrace or Prometheus monitoring if it is not installed. Before executing the command, the dynatrace-service or prometheus-service has to be deployed.
 
 **Note:** If you are executing *keptn configure monitoring dynatrace*, the service flag is optional since Keptn automatically detects the services of a project.
 

--- a/cli/cmd/create.go
+++ b/cli/cmd/create.go
@@ -6,9 +6,7 @@ import (
 
 // createCmd implements the create command
 var createCmd = &cobra.Command{
-	Use:   "create [project,service]",
-	Short: `"create" can be used with the subcommand "project" or "service"`,
-	Long:  `"create" can be used with the subcommand "project" or "service"`,
+	Use:   "create [project | service]",
 }
 
 func init() {

--- a/cli/cmd/create_project.go
+++ b/cli/cmd/create_project.go
@@ -39,8 +39,13 @@ var crProjectCmd = &cobra.Command{
 The shipyard file describes the used stages. These stages are defined by name, 
 deployment-, test-, and remediation strategy.
 
-Example:
-	keptn create project sockshop --shipyard=./shipyard.yaml`,
+By executing the *create project* command, Keptn initializes an internal Git repository that is used to maintain all project-related resources. 
+To upstream this internal Git repository to a remote repository, the Git user (*--git-user*), an access token (*--git-token*), and the remote URL (*--git-remote-url*) are required.
+
+For more information about Shipyard files, creating projects or upstream repositories visit https://keptn.sh/docs/develop/manage/project/ .
+`,
+	Example: `keptn create project PROJECTNAME --shipyard=FILEPATH
+keptn create project PROJECTNAME --shipyard=FILEPATH --git-user=GIT_USER --git-token=GIT_TOKEN --git-remote-url=GIT_REMOTE_URL`,
 	SilenceUsage: true,
 	Args: func(cmd *cobra.Command, args []string) error {
 		_, _, err := credentialmanager.NewCredentialManager().GetCreds()

--- a/cli/cmd/create_service.go
+++ b/cli/cmd/create_service.go
@@ -24,10 +24,11 @@ var createServiceParams *createServiceCmdParams
 var crServiceCmd = &cobra.Command{
 	Use:   "service SERVICENAME --project=PROJECTNAME",
 	Short: "Creates a new service",
-	Long: `Creates a new service with the provided name and in the specified project. 
+	Long: `Creates a new service with the provided name and in the specified project.
 
-Example:
-	keptn create service carts --project=sockshop`,
+Please note: This command is different from keptn onboard service (which requires a helm chart).
+`,
+	Example: `keptn create service carts --project=sockshop`,
 	SilenceUsage: true,
 	Args: func(cmd *cobra.Command, args []string) error {
 		_, _, err := credentialmanager.NewCredentialManager().GetCreds()

--- a/cli/cmd/create_service.go
+++ b/cli/cmd/create_service.go
@@ -24,7 +24,7 @@ var createServiceParams *createServiceCmdParams
 var crServiceCmd = &cobra.Command{
 	Use:   "service SERVICENAME --project=PROJECTNAME",
 	Short: "Creates a new service",
-	Long: `Creates a new service with the provided name and in the specified project.
+	Long: `Creates a new service with the provided name in the specified project.
 
 Please note: This command is different from keptn onboard service (which requires a helm chart).
 `,

--- a/cli/cmd/delete_project.go
+++ b/cli/cmd/delete_project.go
@@ -19,8 +19,13 @@ var delProjectCmd = &cobra.Command{
 	Short: "Deletes a project identified by project name",
 	Long: `Deletes a project identified by project name. 
 
-Example:
-	keptn delete project sockshop`,
+**Known Limitations**:
+
+* If a Git upstream is configured for this project, the referenced upstream repository (e.g., on GitHub) will not be deleted. 
+* Services that have been deployed to the Kubernetes cluster are not deleted (same goes for the namespaces).
+* Helm-releases created for deployments are not deleted - see https://keptn.sh/docs/develop/reference/helm/#clean-up-after-deleting-a-project
+`,
+	Example: `keptn delete project sockshop`,
 	SilenceUsage: true,
 	Args: func(cmd *cobra.Command, args []string) error {
 		_, _, err := credentialmanager.NewCredentialManager().GetCreds()

--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -1,0 +1,16 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// deleteCmd represents the delete command
+var generateCmd = &cobra.Command{
+	Use:   "generate [docs]",
+	Short: `generate is the parent command of "generate docs"`,
+	Long:  `generate is the parent command of "generate docs". "generate" without subcommand cannot be used.`,
+}
+
+func init() {
+	rootCmd.AddCommand(generateCmd)
+}

--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -7,8 +7,6 @@ import (
 // deleteCmd represents the delete command
 var generateCmd = &cobra.Command{
 	Use:   "generate [docs]",
-	Short: `generate is the parent command of "generate docs"`,
-	Long:  `generate is the parent command of "generate docs". "generate" without subcommand cannot be used.`,
 }
 
 func init() {

--- a/cli/cmd/generate_docs.go
+++ b/cli/cmd/generate_docs.go
@@ -1,0 +1,85 @@
+// Inspired by `hugo gen doc`  - see https://github.com/gohugoio/hugo/blob/release-0.69.0/commands/gendoc.go
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+
+type generateDocsCmdParams struct {
+	Directory  *string
+}
+
+var generateDocsParams *generateDocsCmdParams
+
+const gendocFrontmatterTemplate = `---
+date: "%s"
+title: "%s"
+slug: %s
+---
+`
+
+// crprojectCmd represents the project command
+var generateDocsCmd = &cobra.Command{
+	Use:   "docs",
+	Short: "Generates Markdown documentation for the keptn CLI.",
+	Long: `Generates Markdown documentation for the keptn CLI.
+
+This command can be used to create an up-to-date documentation of Keptn's command-line interface for https://keptn.sh.
+
+It creates one Markdown file per command, suitable for rendering in Hugo.
+`,
+	Example: `keptn generate docs
+keptn generate docs --dir=/some/directory`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// generate current datetime for prepender
+		now := time.Now().Format(time.RFC3339)
+
+		outputDir := "./docs"
+		if *generateDocsParams.Directory != "" {
+			outputDir = *generateDocsParams.Directory
+		}
+
+		// check if output directory exists
+		if _, err := os.Stat(outputDir); os.IsNotExist(err) {
+			// outputDir does not exist
+			return err
+		}
+
+		// define a prepender function for compatibility with Hugo templates
+		prepender := func(filename string) string {
+			name := filepath.Base(filename)
+			base := strings.TrimSuffix(name, path.Ext(name))
+			return fmt.Sprintf(gendocFrontmatterTemplate, now, strings.Replace(base, "_", " ", -1), base)
+		}
+
+		// links need to be converted to be compatible with hugo
+		linkHandler := func(name string) string {
+			base := strings.TrimSuffix(name, path.Ext(name))
+			return "../" + strings.ToLower(base) + "/"
+		}
+
+
+		// generate docs
+		fmt.Println("Generating docs now...")
+		doc.GenMarkdownTreeCustom(cmd.Root(), outputDir, prepender, linkHandler)
+		fmt.Printf("Docs have been written to %s!\n", outputDir)
+
+		return nil
+	},
+}
+
+func init() {
+	generateCmd.AddCommand(generateDocsCmd)
+
+	generateDocsParams = &generateDocsCmdParams{}
+	generateDocsParams.Directory = generateDocsCmd.Flags().StringP("dir", "", "", "directory where the docs should be written to")
+}

--- a/cli/cmd/generate_docs.go
+++ b/cli/cmd/generate_docs.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
@@ -51,7 +52,7 @@ keptn generate docs --dir=/some/directory`,
 		// check if output directory exists
 		if _, err := os.Stat(outputDir); os.IsNotExist(err) {
 			// outputDir does not exist
-			return err
+			return errors.New(fmt.Sprintf("Error trying to access directory %s. Please make sure the directory exists.", outputDir))
 		}
 
 		// define a prepender function for compatibility with Hugo templates
@@ -81,5 +82,5 @@ func init() {
 	generateCmd.AddCommand(generateDocsCmd)
 
 	generateDocsParams = &generateDocsCmdParams{}
-	generateDocsParams.Directory = generateDocsCmd.Flags().StringP("dir", "", "", "directory where the docs should be written to")
+	generateDocsParams.Directory = generateDocsCmd.Flags().StringP("dir", "", "./docs", "directory where the docs should be written to")
 }

--- a/cli/cmd/generate_docs_test.go
+++ b/cli/cmd/generate_docs_test.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/keptn/keptn/cli/pkg/credentialmanager"
+	"github.com/keptn/keptn/cli/pkg/logging"
+	"github.com/magiconair/properties/assert"
+)
+
+func init() {
+	logging.InitLoggers(os.Stdout, os.Stdout, os.Stderr)
+}
+
+func TestGenerateDocsDirectoryDoesNotExist(t *testing.T) {
+	credentialmanager.MockAuthCreds = true
+
+	cmd := fmt.Sprintf("generate docs --dir=%s --mock", "does/not/exist")
+	_, err := executeActionCommandC(cmd)
+	assert.Equal(t, err.Error(), "stat does/not/exist: no such file or directory", "Received unexpected error")
+}
+
+// Tests generating docs in a temp directory
+func TestGenerateDocs(t *testing.T) {
+	credentialmanager.MockAuthCreds = true
+
+	// create tempo directory
+	dname, err := ioutil.TempDir("", "docs_temp")
+	defer os.RemoveAll(dname)
+
+	if err != nil {
+		t.Errorf(unexpectedErrMsg, err)
+	}
+
+	cmd := fmt.Sprintf("generate docs --dir=%s --mock", dname)
+	_, err = executeActionCommandC(cmd)
+
+	if err != nil {
+		t.Errorf(unexpectedErrMsg, err)
+	}
+}

--- a/cli/cmd/get_event_evaluationDone.go
+++ b/cli/cmd/get_event_evaluationDone.go
@@ -36,10 +36,8 @@ var evaluationDone evaluationDoneStruct
 var evaluationDoneCmd = &cobra.Command{
 	Use:   "evaluation-done",
 	Short: "Returns the latest Keptn sh.keptn.events.evaluation-done event from a specific Keptn context",
-	Long: `Returns the latest Keptn sh.keptn.events.evaluation-done event from a specific Keptn context.
-	
-Example:
-	keptn get event evaluation-done --keptn-context=1234-5678-90ab-cdef`,
+	Long: `Returns the latest Keptn sh.keptn.events.evaluation-done event from a specific Keptn context.`,
+	Example: `keptn get event evaluation-done --keptn-context=1234-5678-90ab-cdef`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds()

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -125,7 +125,7 @@ var p platform
 var installCmd = &cobra.Command{
 	Use:   "install",
 	Short: "Installs Keptn on a Kubernetes cluster",
-	Long: `The Keptn CLI allows installing Keptn on Azure Kubernetes Services (AKS), Amazon Elastic Kubernetes Service (EKS), Google Kubernetes Engine (GKE), Pivotal Container Service (PKS), and on OpenShift.
+	Long: `The Keptn CLI allows installing Keptn on Azure Kubernetes Services (AKS), Amazon Elastic Kubernetes Service (EKS), Google Kubernetes Engine (GKE), Pivotal Container Service (PKS), any Kubernetes derivate to which your kube config is pointing to, and on OpenShift.
 
 For more information, please consult the following docs:
 

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -125,10 +125,16 @@ var p platform
 var installCmd = &cobra.Command{
 	Use:   "install",
 	Short: "Installs Keptn on a Kubernetes cluster",
-	Long: `Installs Keptn on a Kubernetes cluster
+	Long: `The Keptn CLI allows installing Keptn on Azure Kubernetes Services (AKS), Amazon Elastic Kubernetes Service (EKS), Google Kubernetes Engine (GKE), Pivotal Container Service (PKS), and on OpenShift.
 
-Example:
-	keptn install`,
+For more information, please consult the following docs:
+
+* https://keptn.sh/docs/develop/installation/setup-keptn/
+
+`,
+	Example: `keptn install --platform=aks # install on Azure Kubernetes Service
+keptn install --platform=gke --use-case=quality-gates # install quality-gates on Google Kubernetes Engine
+keptn install --platform=kubernetes --gateway=NodePort # install on a Kubernetes instance with gateway NodePort`,
 	SilenceUsage: true,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 
@@ -285,8 +291,7 @@ func init() {
 		"The platform to run keptn on [aks,eks,gke,pks,openshift,kubernetes]")
 
 	installParams.ConfigFilePath = installCmd.Flags().StringP("creds", "c", "",
-		"The name of the creds file")
-	installCmd.Flags().MarkHidden("creds")
+		"Specify a JSON file containing cluster information needed for the installation (this allows skipping user prompts to execute a *silent* Keptn installation)")
 
 	installParams.InstallerImage = installCmd.Flags().StringP("keptn-installer-image", "k",
 		"", "The installer image which is used for the installation")
@@ -299,11 +304,9 @@ func init() {
 
 	installParams.GatewayInput = installCmd.Flags().StringP("gateway", "g", LoadBalancer.String(),
 		"The ingress-loadbalancer type ["+LoadBalancer.String()+","+NodePort.String()+"]")
-	installCmd.Flags().MarkHidden("gateway")
 
 	installParams.UseCaseInput = installCmd.Flags().StringP("use-case", "u", "all",
 		"The use case to install Keptn for ["+AllUseCases.String()+","+QualityGates.String()+"]")
-	installCmd.Flags().MarkHidden("use-case")
 
 	installParams.IstioInstallOptionInput = installCmd.Flags().StringP("istio-install-option", "",
 		StopIfInstalled.String(), "Installation options for istio ["+StopIfInstalled.String()+","+

--- a/cli/cmd/onboard_service.go
+++ b/cli/cmd/onboard_service.go
@@ -29,12 +29,12 @@ var onboardServiceParams *onboardServiceCmdParams
 // serviceCmd represents the service command
 var serviceCmd = &cobra.Command{
 	Use:   "service SERVICENAME --project=PROJECTNAME --chart=FILEPATH",
-	Short: "Onboards a new service to a project",
-	Long: `Onboards a new service to the provided project. Therefore, this command 
+	Short: "Onboards a new service and its Helm chart to a project",
+	Long: `Onboards a new service and its Helm chart to the provided project. Therefore, this command 
 takes a folder to a Helm chart or an already packed Helm chart as .tgz.
-	
-Example:
-	keptn onboard service carts --project=sockshop --chart=./carts-chart.tgz`,
+`,
+	Example: `keptn onboard service SERVICENAME --project=PROJECTNAME --chart=FILEPATH
+keptn onboard service SERVICENAME --project=PROJECTNAME --chart=HELM_CHART.tgz`,
 	SilenceUsage: true,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 1 {

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -25,43 +25,16 @@ var kubectlOptions string
 
 const authErrorMsg = "This command requires to be authenticated. See \"keptn auth\" for details"
 
-const logo = `                                                                                                                                     
-                ##########*                                                                                                                                    
-           ,#############    ##                                                                                                                                
-       (###############    ####    *                                                                                                                           
-    ##################    ###*    ###.                                                                                                                         
-   #######      ####    ####    ####                                                                                                                           
-   #####          ,   (###    ####    ##                 .&&&&                                                                                                 
-  (####   #####      ####    ####    ###                 .&&&&                                                                                                 
-  #####    ####    ####    ####    ####                  .&&&&                                                              &&&&&                              
- .######         .###    *###    ####                    .&&&&                                                              &&&&&                              
- ##########     ####    ####    ####    #(               .&&&&                                                              &&&&&                              
- #########    ####    ####    ####    ####               .&&&&       &&&&&/       &&&&&&&&&&/        &&&&&&&&&&&&&%         &&&&&&&&&&&&,     &&&&&&&&&&&&&&   
-#########    ####    ####   .###/   /#####               .&&&&     &&&&&&       &&&&&&&&&&&&&&%      &&&&&&&&&&&&&&&&       &&&&&&&&&&&&,     &&&&&&&&&&&&&&&& 
-#######    ####    ####    ####    ########              .&&&&   &&&&&&        &&&&&.     /&&&&&     &&&&&       &&&&&(     &&&&&             &&&&&      &&&&&&
- ####(   .###    (###    ####    #########               .&&&& &&&&&&         &&&&&        *&&&&     &&&&&        &&&&&     &&&&&             &&&&&       &&&&&
-  ##    ####    ####    ####    ########                 .&&&&&&&&&           &&&&&&&&&&&&&&&&&&     &&&&&         &&&&&    &&&&&             &&&&&       &&&&&
-      ####    ####    ####    #########                  .&&&&&&&&&&          &&&&&&&&&&&&&&&&&&     &&&&&         &&&&&    &&&&&             &&&&&       &&&&&
-     ####    ###/   (###,   (########                    .&&&&  &&&&         &&&&&                   &&&&&         &&&&&    &&&&&             &&&&&       &&&&&
-           ####    ####    ########*                     .&&&&   .&&&&&       #&&&&&                 &&&&&        &&&&&     /&&&&             &&&&&       &&&&&
-         ####    ####    #########                       .&&&&     &&&&&&      &&&&&&&%    ,&&&      &&&&&&&( .&&&&&&&       &&&&&&/  %&&     &&&&&       &&&&&
-          ##    ####    ########                         .&&&&       &&&&      &&&&&&&&&&&&&&        &&&&&&&&&&&&&&&&         &&&&&&&&&&&     &&&&&       &&&&&
-                                                                                    .&&&&&&&*        &&&&&  *&&&&                 (&&%                         
-                                                                                                     &&&&&                                                     
-                                                                                                     &&&&&                                                     
-                                                                                                     &&&&&`
-
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "keptn",
 	Short: "This is a CLI for using keptn",
 	Long: `This is a CLI for using keptn. The CLI allows to authenticate against keptn, to configure your Github organization,
 to create projects, and to onboard services.
-	
-	` + logo,
+	`,
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
-	//	Run: func(cmd *cobra.Command, args []string) { },
+	// Run: func(cmd *cobra.Command, args []string) {},
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cli/cmd/send_event.go
+++ b/cli/cmd/send_event.go
@@ -37,10 +37,13 @@ var eventFilePath *string
 var sendEventCmd = &cobra.Command{
 	Use:   "event --file=FILEPATH --stream-websocket",
 	Short: "Sends a Keptn event",
-	Long: `Allows to send an arbitrary Keptn event that is defined in the passed file.
+	Long: `Allows to send an arbitrary Keptn event that is defined in the provided JSON file.
+An event has to follow the Cloud Events specification (https://cloudevents.io/) in version 0.2 and has to be written in JSON.
+In addition, the payload of the Cloud Event needs to follow the Keptn spec (https://github.com/keptn/spec/blob/0.1.3/cloudevents.md).
 
-Example:
-	keptn send event --file=./new_artifact_event.json --stream-websocket`,
+For convenience, this command offers the *--stream-websocket* flag to open a web socket communication to Keptn. Consequently, messages from the receiving Keptn service, which processes the event, are sent to the CLI via WebSocket.
+	`,
+	Example: `keptn send event --file=./new_artifact_event.json --stream-websocket`,
 	SilenceUsage: true,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		eventString, err := file.ReadFile(*eventFilePath)

--- a/cli/cmd/send_event_evaluationStart.go
+++ b/cli/cmd/send_event_evaluationStart.go
@@ -52,12 +52,13 @@ var evaluationStartCmd = &cobra.Command{
 	Short: "Sends an start-evaluation event to Keptn in order to evaluate a test " +
 		"for the specified service in the provided project and stage",
 	Long: `Sends a start-evaluation event to Keptn in order to evaluate a test
-for the specified service in the provided project and stage. The time frame flag defines
-the time frame that is considered in this evaluation. If a specific start point need to be set,
-a start flag is provided that takes a time in the format: 2006-01-02T15:04:05
-	
-Example:
-	keptn send event start-evaluation --project=sockshop --stage=hardening --service=carts --timeframe=5m --start=2019-10-31T11:59:59
+for the specified service in the provided project and stage. 
+
+This command takes the project (*--project*), stage (*--stage*), and the service (*--service*), which should be
+evaluated. Besides, it is necessary to specify a time frame (*--timeframe*) of the evaluation. If, for example, the 
+flag is set to *--timeframe=5m*, the evaluation is conducted for the last 5 minutes. To specify a particular starting
+point, the flag *--start* flag can be used. In this case, the specified time frame is added to the starting point.`,
+	Example: `keptn send event start-evaluation --project=sockshop --stage=hardening --service=carts --timeframe=5m --start=2019-10-31T11:59:59
     keptn send event start-evaluation --project=sockshop --stage=hardening --service=carts --start=2019-10-31T11:59:59 --end=2019-10-31T12:04:59 --labels=test-id=1234,test-name=performance-test`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/cmd/send_event_newArtifact.go
+++ b/cli/cmd/send_event_newArtifact.go
@@ -54,9 +54,16 @@ var newArtifactCmd = &cobra.Command{
 	Long: `Sends a new-artifact event to Keptn in order to deploy a new artifact
 for the specified service in the provided project.
 Therefore, this command takes the project, service, image, and tag of the new artifact.
-	
-Example:
-	keptn send event new-artifact --project=sockshop --service=carts --image=docker.io/keptnexamples/carts --tag=0.7.0`,
+
+The artifact is the name of a Docker image, which can be located at Docker Hub, Quay, or any other registry storing docker images. 
+The new artifact is pushed in the first stage specified in the projects *shipyard.yaml* file. Afterwards, Keptn takes care of deploying this new artifact to the other stages.
+
+Furthermore, please note that the value provided in the *image* flag has to contain the full path to your Docker registry. The only exception is *docker.io* because this is the default in Kubernetes and, hence, can be omitted.
+
+**Note:** This command does not send the actual Docker image to Keptn, just the image name and tag. Instead, Keptn uses Kubernetes functionalities for pulling this image.
+For pulling an image from a private registry, we would like to refer to the Kubernetes documentation (https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
+`,
+	Example: `keptn send event new-artifact --project=sockshop --service=carts --image=docker.io/keptnexamples/carts --tag=0.7.0`,
 	SilenceUsage: true,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		trimmedImage := strings.TrimSuffix(*newArtifact.Image, "/")

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -13,9 +13,8 @@ var statusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Checks the status of the CLI",
 	Long: `Checks the status of the CLI. This includes a test whether the CLI is authenticated against the Keptn API. 
-
-Example:
-	keptn status`,
+`,
+	Example: `keptn status`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds()

--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -22,9 +22,9 @@ var uninstallCmd = &cobra.Command{
 This command does *not* delete: 
 
 * Istio
-* Tiller 
 * Dynatrace monitoring
 * Prometheus monitoring
+* Any (third-party) service installed in addition to Keptn (e.g., notification-service, slackbot-service, ...)
 
 Besides, deployed services and the configuration on the Git upstream (i.e., GitHub, GitLab, or Bitbucket) are not deleted. To clean-up created projects and services, instructions are provided [here](../../manage/project#delete-a-project).
 

--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -17,6 +17,20 @@ var uninstallVersion *string
 var uninstallCmd = &cobra.Command{
 	Use:          "uninstall",
 	Short:        "Uninstalls Keptn from a Kubernetes cluster",
+	Long: `Uninstalls Keptn from a Kubernetes cluster.
+
+This command does *not* delete: 
+
+* Istio
+* Tiller 
+* Dynatrace monitoring
+* Prometheus monitoring
+
+Besides, deployed services and the configuration on the Git upstream (i.e., GitHub, GitLab, or Bitbucket) are not deleted. To clean-up created projects and services, instructions are provided [here](../../manage/project#delete-a-project).
+
+**Note:** This command requires a *kubernetes current context* pointing to the cluster where Keptn should get uninstalled.
+`,
+	Example: `keptn uninstall`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -33,11 +33,9 @@ var (
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Shows the CLI version for the current context",
-	Long: `Shows the CLI version for the current context
-
-Example:
-	keptn version`,
+	Short: "Shows the CLI version of Keptn.",
+	Long: `Shows the CLI version of Keptn, as well as an indication whether a new version is available.`,
+	Example: `keptn version`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("CLI version: " + Version)
 

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -120,6 +120,7 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/cyphar/filepath-securejoin v0.2.2 h1:jCwT2GTP+PY5nBz3c/YL5PAIbusElVrPujOBSCj8xRg=
@@ -478,6 +479,7 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
+github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=


### PR DESCRIPTION
This implements #1611.

I also removed the Keptn Logo from the root command, as it uses a lot of space and does not render correctly in Markdown.

A preview of the auto-generated markdown is available in https://github.com/keptn/keptn.github.io/pull/501
