### PR TITLE
Fix gke cluster create for integration tests

### DIFF
--- a/test/utils/gke_create_cluster.sh
+++ b/test/utils/gke_create_cluster.sh
@@ -26,7 +26,7 @@ fi
 # create a new cluster
 gcloud beta container --project $PROJECT_NAME clusters create $CLUSTER_NAME_NIGHTLY --zone $CLOUDSDK_COMPUTE_ZONE --username "admin" --cluster-version $GKE_VERSION \
  --machine-type "n1-standard-8" --image-type "UBUNTU" --disk-type "pd-standard" --disk-size "100" \
- --scopes "https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" --num-nodes "1" --enable-cloud-logging --enable-cloud-monitoring --no-enable-ip-alias --network "projects/sai-research/global/networks/default" --subnetwork "projects/sai-research/regions/$CLOUDSDK_REGION/subnetworks/default" \
+ --scopes "https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" --num-nodes "1" --enable-cloud-logging --enable-cloud-monitoring --enable-ip-alias --network "projects/sai-research/global/networks/default" --subnetwork "projects/sai-research/regions/$CLOUDSDK_REGION/subnetworks/default" \
  --addons $ADDONS $ISTIO_CONFIG --no-enable-autoupgrade --no-enable-autorepair \
  --labels owner=travis,expiry=auto-delete
 


### PR DESCRIPTION
There seems to be a problem when creating a cluster via the CLI with `--no-enable-ip-alias`:

```
ERROR: (gcloud.beta.container.clusters.create) ResponseError: code=400, message=Request contains an invalid argument.
```

To fix this issue, we are now using `--enable-ip-alias`, which corresponds to the following option in the UI:
![Screenshot from 2020-04-21 11-09-04](https://user-images.githubusercontent.com/56065213/79847857-9b426280-83c0-11ea-9fc3-3eb218e3826e.png)
