### PR TITLE
Update glcoud cli to 289

### DIFF
--- a/travis-scripts/install_gcloud.sh
+++ b/travis-scripts/install_gcloud.sh
@@ -7,7 +7,7 @@ if [ ! -d "$HOME/google-cloud-sdk/bin" ]; then
   rm -rf $HOME/google-cloud-sdk;
   export CLOUDSDK_CORE_DISABLE_PROMPTS=1;
   # download
-  curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-284.0.0-${OS_TYPE}-x86_64.tar.gz > gcloud.tar.gz
+  curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-289.0.0-${OS_TYPE}-x86_64.tar.gz > gcloud.tar.gz
   gunzip -c gcloud.tar.gz | tar xopf -
   ./google-cloud-sdk/install.sh
   source ./google-cloud-sdk/completion.bash.inc


### PR DESCRIPTION
This PR updates the gcloud cli installation within travis-ci to version 289.

