### PR TITLE
#1482 allow specifying domain for installer

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -45,6 +45,7 @@ type installCmdParams struct {
 	PlatformIdentifier      *string
 	GatewayInput            *string
 	Gateway                 gateway
+	Domain                  *string
 	UseCaseInput            *string
 	UseCase                 usecase
 	IstioInstallOptionInput *string
@@ -87,6 +88,8 @@ spec:
           value: PLATFORM_PLACEHOLDER
         - name: GATEWAY_TYPE
           value: GATEWAY_TYPE_PLACEHOLDER
+        - name: DOMAIN
+          value: DOMAIN_PLACEHOLDER
         - name: INGRESS
           value: INGRESS_PLACEHOLDER
         - name: USE_CASE
@@ -301,6 +304,10 @@ func init() {
 		"The ingress-loadbalancer type ["+LoadBalancer.String()+","+NodePort.String()+"]")
 	installCmd.Flags().MarkHidden("gateway")
 
+	installParams.Domain = installCmd.Flags().StringP("domain", "d", "",
+		"Experimental: Overwrite the ingress domain (e.g., 127.0.0.1.xip.io)")
+	installCmd.Flags().MarkHidden("gateway-domain")
+
 	installParams.UseCaseInput = installCmd.Flags().StringP("use-case", "u", "all",
 		"The use case to install Keptn for ["+AllUseCases.String()+","+QualityGates.String()+"]")
 	installCmd.Flags().MarkHidden("use-case")
@@ -323,6 +330,7 @@ func prepareInstallerManifest() (installerManifest string) {
 
 	installerManifest = strings.ReplaceAll(installerManifest, "PLATFORM_PLACEHOLDER", strings.ToLower(*installParams.PlatformIdentifier))
 	installerManifest = strings.ReplaceAll(installerManifest, "GATEWAY_TYPE_PLACEHOLDER", installParams.Gateway.String())
+	installerManifest = strings.ReplaceAll(installerManifest, "DOMAIN_PLACEHOLDER", *installParams.Domain)
 	installerManifest = strings.ReplaceAll(installerManifest, "USE_CASE_PLACEHOLDER", installParams.UseCase.String())
 	installerManifest = strings.ReplaceAll(installerManifest, "ISTIO_INSTALL_OPTION_PLACEHOLDER", installParams.IstioInstallOption.String())
 

--- a/installer/scripts/common/install.sh
+++ b/installer/scripts/common/install.sh
@@ -8,7 +8,7 @@ if [[ "$USE_CASE" == "all" ]]; then
   setupKeptnDomain "istio" "istio-ingressgateway" "istio-system"
 
   cat ../manifests/keptn/keptn-api-virtualservice.yaml | \
-    sed 's~DOMAIN_PLACEHOLDER~'"$INGRESS_HOST"'~' | kubectl apply -f -
+    sed 's~DOMAIN_PLACEHOLDER~'"$DOMAIN"'~' | kubectl apply -f -
   verify_kubectl $? "Deploying keptn api virtualservice failed."
 else
   # Install NGINX
@@ -18,7 +18,7 @@ else
   # Add config map in keptn namespace that contains the domain - this will be used by other services as well
   # Update ingress with updated hosts
   cat ../manifests/keptn/keptn-ingress.yaml | \
-    sed 's~domain.placeholder~'"$INGRESS_HOST"'~' | sed 's~ingress.placeholder~nginx~' | kubectl apply -f -
+    sed 's~domain.placeholder~'"$DOMAIN"'~' | sed 's~ingress.placeholder~nginx~' | kubectl apply -f -
   verify_kubectl $? "Deploying ingress failed."
 fi
 


### PR DESCRIPTION
This partially provides an implementation for #1482 as follows:

* Added `--domain` flag for `keptn install`
* Installer checks for the `--domain` flag. If it exists, it uses the domain provided there, instead of determining the domain by themselves
* Also added a fallback if the installer can not reliably determine `NODE_IP` using `curl ifconfig.me`
* Fixed an issue with the istio virtualservice for the api (api.keptn.KEPTN_DOMAIN:PORT was not reachable without specifying the host header `Host: api.keptn` - so basically it did not work in the browser).


# Verification

I have performed the following steps to verify that my extension works (and that I didn't break anything):

* Download and install cli for feature 1482 for [linux](https://storage.googleapis.com/keptn-cli/feature-1482%2B20200422.1412/keptn-linux.zip) / [osx](https://storage.googleapis.com/keptn-cli/feature-1482%2B20200422.1412/keptn-macOS.zip) / [windows](https://storage.googleapis.com/keptn-cli/feature-1482%2B20200422.1412/keptn-windows.zip)
* Install Keptn on K8s using `keptn install --keptn-installer-image=keptn/installer:feature.1482.20200422.1411 --gateway=NodePort --domain=PUT-IP-OF-CLUSTER-HERE.dns.keptn.sh --platform=kubernetes`
* Onboard sockshop; send new artifact
* I was able to access the following addresses in my web browser without any problem:
   * https://api.keptn.PUT-IP-OF-CLUSTER-HERE.nip.io:31390/swagger-ui/
   * https://carts.sockshop-production.PUT-IP-OF-CLUSTER-HERE.nip.io:31390/
   * https://carts.sockshop-staging.PUT-IP-OF-CLUSTER-HERE.nip.io:31390/
   * https://carts.sockshop-dev.PUT-IP-OF-CLUSTER-HERE.nip.io:31390/

I also verified that a normal installation like `keptn install --keptn-installer-image=keptn/installer:feature.1482.20200422.1411` without any other option still works.

In addition, I verified that the installation using `--use-case=quality-gates` also works.
