### PR TITLE
Added HTTPs support for integration tests

### DIFF
--- a/test/utils.sh
+++ b/test/utils.sh
@@ -19,7 +19,7 @@ function wait_for_url() {
   RETRY=0; RETRY_MAX=50;
 
   while [[ $RETRY -lt $RETRY_MAX ]]; do
-    curl $URL
+    curl $URL -k
 
     if [[ $? -eq 0 ]]; then
       echo "Verified access to ${URL}!"

--- a/test/utils/send_new_artifact_sockshop.sh
+++ b/test/utils/send_new_artifact_sockshop.sh
@@ -40,7 +40,7 @@ verify_pod_in_namespace "carts-db" "$PROJECT-dev"
 verify_test_step $? "Pod carts-db not found, exiting..."
 
 # get URL for that deployment
-DEV_URL=$(echo http://carts.${PROJECT}-dev.$(kubectl get cm keptn-domain -n keptn -o=jsonpath='{.data.app_domain}'))
+DEV_URL=$(echo https://carts.${PROJECT}-dev.$(kubectl get cm keptn-domain -n keptn -o=jsonpath='{.data.app_domain}'))
 # try to access that URL
 wait_for_url $DEV_URL/health
 verify_test_step $? "Trying to access $DEV_URL/health failed"
@@ -71,7 +71,7 @@ verify_pod_in_namespace "carts-db" "$PROJECT-staging"
 verify_test_step $? "Pod carts-db not found, exiting..."
 
 # get URL for that deployment
-STAGING_URL=$(echo http://carts.${PROJECT}-staging.$(kubectl get cm keptn-domain -n keptn -o=jsonpath='{.data.app_domain}'))
+STAGING_URL=$(echo https://carts.${PROJECT}-staging.$(kubectl get cm keptn-domain -n keptn -o=jsonpath='{.data.app_domain}'))
 # try to access that URL
 wait_for_url $STAGING_URL/health
 verify_test_step $? "Trying to access $STAGING_URL/health failed"
@@ -102,7 +102,7 @@ verify_pod_in_namespace "carts-db" "$PROJECT-production"
 verify_test_step $? "Pod carts-db not found, exiting..."
 
 # get URL for that deployment
-PRODUCTION_URL=$(echo http://carts.${PROJECT}-production.$(kubectl get cm keptn-domain -n keptn -o=jsonpath='{.data.app_domain}'))
+PRODUCTION_URL=$(echo https://carts.${PROJECT}-production.$(kubectl get cm keptn-domain -n keptn -o=jsonpath='{.data.app_domain}'))
 # try to access that URL
 wait_for_url $PRODUCTION_URL/health
 verify_test_step $? "Trying to access $PRODUCTION_URL/health failed"


### PR DESCRIPTION
Our integration tests only worked with `http://`, which fails for installations with `--gateway=NodePort`.

In addition, as we are using a self-signed certificate (= invalid certificate), I had to add the `-k` option to `curl`.