### PR TITLE
Set travis to use golang 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: true
 language: go
 go:
-  - 1.12.x
+  - 1.13.x
 cache:
   directories:
     - "$HOME/google-cloud-sdk/"


### PR DESCRIPTION
We upgraded to go 1.13 for all our microservices during go-utils refactoring, but travis was still running on 1.12