### PR TITLE
#1482 Fix unit tests for keptn install

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -19,6 +19,11 @@ You can execute unit tests using
 go test ./...
 ```
 
+If you want to make sure tests don't influence your local environment (or vice versa), you can run them in a Docker container:
+```console
+docker run --rm -it -v "$PWD":/usr/src/myapp -w /usr/src/myapp golang:1.13 go test -race -v ./...
+```
+
 ### Structure
 
 The cli consists of 

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -44,6 +44,7 @@ func TestPrepareInstallerManifest(t *testing.T) {
 	installParams.Gateway = LoadBalancer
 	installParams.UseCase = AllUseCases
 	installParams.IstioInstallOption = StopIfInstalled
+	*installParams.Domain = ""
 
 	res := prepareInstallerManifest()
 	expected := `---
@@ -70,6 +71,8 @@ spec:
           value: gke
         - name: GATEWAY_TYPE
           value: LoadBalancer
+        - name: DOMAIN
+          value: 
         - name: INGRESS
           value: istio
         - name: USE_CASE
@@ -88,6 +91,7 @@ func resetFlagValues() {
 	*installParams.InstallerImage = ""
 	*installParams.PlatformIdentifier = "gke"
 	*installParams.GatewayInput = "LoadBalancer"
+	*installParams.Domain = ""
 	*installParams.UseCaseInput = "all"
 	*installParams.IstioInstallOptionInput = "StopIfInstalled"
 }
@@ -171,6 +175,60 @@ spec:
           value: gke
         - name: GATEWAY_TYPE
           value: NodePort
+        - name: DOMAIN
+          value: 
+        - name: INGRESS
+          value: istio
+        - name: USE_CASE
+          value: all
+        - name: ISTIO_INSTALL_OPTION
+          value: StopIfInstalled
+      restartPolicy: Never
+`
+	if res != expected {
+		t.Error("installation manifest does not match")
+	}
+}
+
+func TestInstallCmdWithDomain(t *testing.T) {
+	credentialmanager.MockAuthCreds = true
+
+	cmd := fmt.Sprintf("install --platform=gke --gateway=NodePort --domain=127.0.0.1.nip.io --mock")
+
+	resetFlagValues()
+
+	_, err := executeActionCommandC(cmd)
+	if err != nil {
+		t.Errorf(unexpectedErrMsg, err)
+	}
+
+	res := prepareInstallerManifest()
+	expected := `---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: installer
+  namespace: default
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app: installer
+    spec:
+      volumes:
+      - name: kubectl
+        emptyDir: {}
+      containers:
+      - name: keptn-installer
+        image: docker.io/keptn/installer:latest
+        env:
+        - name: PLATFORM
+          value: gke
+        - name: GATEWAY_TYPE
+          value: NodePort
+        - name: DOMAIN
+          value: 127.0.0.1.nip.io
         - name: INGRESS
           value: istio
         - name: USE_CASE
@@ -221,6 +279,8 @@ spec:
           value: gke
         - name: GATEWAY_TYPE
           value: LoadBalancer
+        - name: DOMAIN
+          value: 
         - name: INGRESS
           value: nginx
         - name: USE_CASE
@@ -271,6 +331,8 @@ spec:
           value: gke
         - name: GATEWAY_TYPE
           value: LoadBalancer
+        - name: DOMAIN
+          value: 
         - name: INGRESS
           value: istio
         - name: USE_CASE

--- a/cli/pkg/credentialmanager/handler_linux.go
+++ b/cli/pkg/credentialmanager/handler_linux.go
@@ -53,7 +53,14 @@ func (cm *CredentialManager) SetCreds(endPoint url.URL, apiToken string) error {
 
 // GetCreds reads the credentials and returns an endpoint, the api token, or potentially an error.
 func (cm *CredentialManager) GetCreds() (url.URL, string, error) {
+	// mock credentials if encessary
+	if MockAuthCreds {
+		return url.URL{}, "", nil
+	}
+
+	// try to read credentials from password-store
 	if _, err := os.Stat(passwordStoreDirectory); os.IsNotExist(err) {
+		// password-store not found, read credentials from apiTokenFile
 		data, err := ioutil.ReadFile(cm.apiTokenFile)
 		if err != nil {
 			return url.URL{}, "", err


### PR DESCRIPTION
builds on PR #1687 

* PR #1674 broke unit tests for `keptn install`. This PR fixes it.
* Also fixes mocking authentication for Linux auth handler
