### PR TITLE
Add a warning note to keptn configure bridge

### DIFF
--- a/cli/cmd/configure_bridge.go
+++ b/cli/cmd/configure_bridge.go
@@ -34,7 +34,7 @@ var configureBridgeParams *configureBridgeCmdParams
 const actionExpose = "expose"
 const actionLockdown = "lockdown"
 
-const featureDocuURL = "https://keptn.sh/docs/0.6.0/reference/keptnsbridge/#enable-authentication"
+const basicAuthDocuURL = "https://keptn.sh/docs/0.6.0/reference/keptnsbridge/#enable-authentication"
 
 var bridgeCmd = &cobra.Command{
 	Use:   "bridge --action=[expose|lockdown]",
@@ -90,14 +90,14 @@ func configureBridge(endpoint string, apiToken string, configureBridgeParams *co
 		if err != nil {
 			return errors.New("Could not " + *configureBridgeParams.Action + " bridge: " + err.Error())
 		}
-		fmt.Printf("Bridge exposed successfully. You can reach it here: https://%s\n", strings.Trim(strings.TrimSpace(string(body)), "\""))
-		// Todo: migrate docs for exposing keptn's bridge into keptn.github.io
-		fmt.Printf("Make sure to add basic authentication as described here: %s\n", featureDocuURL)
+		fmt.Printf("Bridge successfully exposed and can be reached here: https://%s\n", strings.Trim(strings.TrimSpace(string(body)), "\""))
+		// Todo: migrate docs for exposing keptn bridge into keptn.github.io
+		fmt.Printf("Warning: Make sure to enable basic authentication as described here: %s\n", basicAuthDocuURL)
 	} else {
 		if err != nil {
 			return errors.New("Could not " + *configureBridgeParams.Action + " bridge: " + err.Error())
 		}
-		fmt.Println("Bridge locked down successfully. Disabled public access.")
+		fmt.Println("Bridge successfully locked down so that public access is disabled.")
 	}
 	return nil
 }

--- a/cli/cmd/configure_bridge.go
+++ b/cli/cmd/configure_bridge.go
@@ -34,13 +34,15 @@ var configureBridgeParams *configureBridgeCmdParams
 const actionExpose = "expose"
 const actionLockdown = "lockdown"
 
+const featureDocuURL = "https://keptn.sh/docs/0.6.0/reference/keptnsbridge/#enable-authentication"
+
 var bridgeCmd = &cobra.Command{
 	Use:   "bridge --action=[expose|lockdown]",
 	Short: "Exposes or locks down the bridge",
-	Long: `Exposes or locks down the Keptn's bridge.
+	Long: `Exposes or locks down the Keptn Bridge.
 
-When exposing Keptn's Bridge it will be available publicly. 
-Make sure to protect Keptn's Bridge using Basic authentication.
+When exposing Keptn Bridge it will be available publicly. 
+Make sure to protect Keptn Bridge using basic authentication.
 `,
 	Example: `keptn configure bridge --action=expose
 	keptn configure bridge --action=lockdown`,
@@ -90,7 +92,7 @@ func configureBridge(endpoint string, apiToken string, configureBridgeParams *co
 		}
 		fmt.Printf("Bridge exposed successfully. You can reach it here: https://%s\n", strings.Trim(strings.TrimSpace(string(body)), "\""))
 		// Todo: migrate docs for exposing keptn's bridge into keptn.github.io
-		fmt.Printf("Make sure to add basic authentication as described here: https://github.com/keptn/keptn/blob/master/bridge/README.md#setting-up-basic-authentication")
+		fmt.Printf("Make sure to add basic authentication as described here: %s\n", featureDocuURL)
 	} else {
 		if err != nil {
 			return errors.New("Could not " + *configureBridgeParams.Action + " bridge: " + err.Error())

--- a/cli/cmd/configure_bridge_test.go
+++ b/cli/cmd/configure_bridge_test.go
@@ -111,3 +111,17 @@ func Test_configureBridge(t *testing.T) {
 		})
 	}
 }
+
+// Test whether the documentation fo the basic authentication is publicly available
+func Test_basicAuthDocuURL(t *testing.T) {
+	resp, err := http.Get(basicAuthDocuURL)
+	if err != nil {
+		t.Errorf("GET of %s ran into an error", basicAuthDocuURL)
+		return
+	}
+
+	if resp.StatusCode != 200 {
+		t.Errorf("Documentation of basic authentication not available under the URL: %s", basicAuthDocuURL)
+		return
+	}
+}


### PR DESCRIPTION
This PR adds a warning message to the command: `keptn configure bridge`. 

- The message shows: `Warning: Make sure to enable basic authentication as described here: https://keptn.sh/docs/0.6.0/reference/keptnsbridge/#enable-authentication`

 - A unit test verifies the availability of the documentation. 

Output:
```
PS C:\...\cli> .\keptn.exe configure bridge -a=expose
Bridge successfully exposed and can be reached here: https://bridge.keptn.xxx.xxx.xip.io
Warning: Make sure to enable basic authentication as described here: https://keptn.sh/docs/0.6.0/reference/keptnsbridge/#enable-authentication
PS C:\...\cli>
```