### PR TITLE
Update go-utils to latest version

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/websocket v1.4.1
 	github.com/jessevdk/go-flags v1.4.0
-	github.com/keptn/go-utils v0.6.1-compat.0.20200406125548-5337a2e806c4
+	github.com/keptn/go-utils v0.6.2-alpha
 	github.com/keptn/kubernetes-utils v0.0.0-20200401103501-ae44a5ee0656
 	github.com/kinbiko/jsonassert v1.0.1
 	github.com/magiconair/properties v1.8.1

--- a/api/go.sum
+++ b/api/go.sum
@@ -253,6 +253,8 @@ github.com/keptn/go-utils v0.6.1-compat.0.20200406125548-5337a2e806c4 h1:D6m0Bxm
 github.com/keptn/go-utils v0.6.1-compat.0.20200406125548-5337a2e806c4/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/keptn/go-utils v0.6.1 h1:zpMDtWbrrp+C9R4A8fiBje720BQjsRLUb1NAWpHtIkI=
 github.com/keptn/go-utils v0.6.1/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZzmyoE98c=
+github.com/keptn/go-utils v0.6.2-alpha h1:GVphpKB7lAUrzKOUbrsWtYQqugVbQP7L+21PV4hHYDo=
+github.com/keptn/go-utils v0.6.2-alpha/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/keptn/keptn v0.0.0-20191203073718-08fcca449c2c h1:0+bI5c4xmoMIfThsKHoEIzYjNfu2oqhHi9o7DzS13SQ=
 github.com/keptn/keptn v0.0.0-20200403105706-0a4568eeaba5 h1:w1JHMAO3ljSYwzsojSkGx17dUa28rUlj8s7RJgqcJS0=
 github.com/keptn/keptn v0.0.0-20200403121323-f0098529b472 h1:9isXhmJxeheh0XKWM59J01ZzJracEPp1Bbj228BI3yc=

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/websocket v1.4.1
 	github.com/hashicorp/go-version v1.2.0
-	github.com/keptn/go-utils v0.6.1-compat.0.20200429125908-17c6026062a1
+	github.com/keptn/go-utils v0.6.2-alpha
 	github.com/keptn/kubernetes-utils v0.0.0-20200401103501-ae44a5ee0656
 	github.com/magiconair/properties v1.8.1
 	github.com/mattn/go-shellwords v1.0.10

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -348,6 +348,8 @@ github.com/keptn/go-utils v0.6.1-compat h1:Uqd0fmbPRxIqXpRv4q/q/O+KjAnJa+moZ85H1
 github.com/keptn/go-utils v0.6.1-compat/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/keptn/go-utils v0.6.1-compat.0.20200429125908-17c6026062a1 h1:ioKVVxBPAUFm/kkP0dXiqeJKa2IbcE2EJhcTJFpdr6k=
 github.com/keptn/go-utils v0.6.1-compat.0.20200429125908-17c6026062a1/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
+github.com/keptn/go-utils v0.6.2-alpha h1:GVphpKB7lAUrzKOUbrsWtYQqugVbQP7L+21PV4hHYDo=
+github.com/keptn/go-utils v0.6.2-alpha/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/keptn/kubernetes-utils v0.0.0-20200401103501-ae44a5ee0656 h1:uGdzQ+DT+/KqzMJF+5F+B+/h0nOfwmmSA7ClxsI1y6Y=
 github.com/keptn/kubernetes-utils v0.0.0-20200401103501-ae44a5ee0656/go.mod h1:7MQMS/jqKM4eVZ0S1S7LWdZNcBTJn5QeERircdADWzo=
 github.com/keptn/kubernetes-utils v0.0.0-20200414115508-d18721552e01 h1:E7VbURzJxMXDhh2p03j1Ij8DLprfnO5UOrKIJj3rhwM=

--- a/configuration-service/go.mod
+++ b/configuration-service/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/imdario/mergo v0.3.9 // indirect
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/json-iterator/go v1.1.9 // indirect
-	github.com/keptn/go-utils v0.6.1-compat.0.20200414111241-846f2becaf21
+	github.com/keptn/go-utils v0.6.2-alpha
 	github.com/keptn/kubernetes-utils v0.0.0-20200427084646-ad3b436aff25
 	github.com/mholt/archiver v3.1.1+incompatible
 	github.com/mitchellh/mapstructure v1.2.2

--- a/configuration-service/go.sum
+++ b/configuration-service/go.sum
@@ -360,6 +360,8 @@ github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0Lh
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/keptn/go-utils v0.6.1-compat.0.20200414111241-846f2becaf21 h1:OM7GZMYc/A80JL+OQPPrStz/h+MNjWmPS3kLonFH0nU=
 github.com/keptn/go-utils v0.6.1-compat.0.20200414111241-846f2becaf21/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
+github.com/keptn/go-utils v0.6.2-alpha h1:GVphpKB7lAUrzKOUbrsWtYQqugVbQP7L+21PV4hHYDo=
+github.com/keptn/go-utils v0.6.2-alpha/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/keptn/kubernetes-utils v0.0.0-20200427084646-ad3b436aff25 h1:KJDIDNYxesVYO6C6QCDpJ4Vzh0JeTD9BeYn6RnD2ZXA=
 github.com/keptn/kubernetes-utils v0.0.0-20200427084646-ad3b436aff25/go.mod h1:YoWRuV28Guz5/mzjo9jVxtMsWAEn0MDXwxK/ScAQlZc=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/eventbroker/go.mod
+++ b/eventbroker/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/cloudevents/sdk-go v0.10.0
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.6.1-compat
+	github.com/keptn/go-utils v0.6.2-alpha
 	github.com/nats-io/gnatsd v1.4.1
 	github.com/nats-io/go-nats v1.7.0
 	github.com/nats-io/nats-server v1.4.1

--- a/eventbroker/go.sum
+++ b/eventbroker/go.sum
@@ -201,6 +201,8 @@ github.com/keptn/go-utils v0.6.1-0.20200331064125-beb163c41650/go.mod h1:aDNFm3o
 github.com/keptn/go-utils v0.6.1-a h1:nxLpQhg3i/14f5fpZhSCYql5qP0hxji1gaEsj5pd//Q=
 github.com/keptn/go-utils v0.6.1-a/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZzmyoE98c=
 github.com/keptn/go-utils v0.6.1-compat/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
+github.com/keptn/go-utils v0.6.2-alpha h1:GVphpKB7lAUrzKOUbrsWtYQqugVbQP7L+21PV4hHYDo=
+github.com/keptn/go-utils v0.6.2-alpha/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd h1:Coekwdh0v2wtGp9Gmz1Ze3eVRAWJMLokvN3QjdzCHLY=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=

--- a/gatekeeper-service/go.mod
+++ b/gatekeeper-service/go.mod
@@ -7,6 +7,6 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/uuid v1.1.1
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.6.1-compat.0.20200406125548-5337a2e806c4
+	github.com/keptn/go-utils v0.6.2-alpha
 	github.com/keptn/kubernetes-utils v0.0.0-20200401103501-ae44a5ee0656
 )

--- a/gatekeeper-service/go.sum
+++ b/gatekeeper-service/go.sum
@@ -215,6 +215,8 @@ github.com/keptn/go-utils v0.6.1-0.20200402063250-be7a84038be8/go.mod h1:aDNFm3o
 github.com/keptn/go-utils v0.6.1-compat/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/keptn/go-utils v0.6.1-compat.0.20200406125548-5337a2e806c4 h1:D6m0BxmTvNiRiDDBz35vcOU14jMrZTvPCS9qz2L8BR4=
 github.com/keptn/go-utils v0.6.1-compat.0.20200406125548-5337a2e806c4/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
+github.com/keptn/go-utils v0.6.2-alpha h1:GVphpKB7lAUrzKOUbrsWtYQqugVbQP7L+21PV4hHYDo=
+github.com/keptn/go-utils v0.6.2-alpha/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/keptn/kubernetes-utils v0.0.0-20200401103501-ae44a5ee0656 h1:uGdzQ+DT+/KqzMJF+5F+B+/h0nOfwmmSA7ClxsI1y6Y=
 github.com/keptn/kubernetes-utils v0.0.0-20200401103501-ae44a5ee0656/go.mod h1:7MQMS/jqKM4eVZ0S1S7LWdZNcBTJn5QeERircdADWzo=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=

--- a/helm-service/go.mod
+++ b/helm-service/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/websocket v1.4.1
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.6.1-compat.0.20200406125548-5337a2e806c4
+	github.com/keptn/go-utils v0.6.2-alpha
 	github.com/keptn/kubernetes-utils v0.0.0-20200401103501-ae44a5ee0656
 	github.com/kinbiko/jsonassert v1.0.1
 	github.com/stretchr/testify v1.4.0

--- a/helm-service/go.sum
+++ b/helm-service/go.sum
@@ -206,6 +206,8 @@ github.com/keptn/go-utils v0.6.1-0.20200402063250-be7a84038be8/go.mod h1:aDNFm3o
 github.com/keptn/go-utils v0.6.1-compat/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/keptn/go-utils v0.6.1-compat.0.20200406125548-5337a2e806c4 h1:D6m0BxmTvNiRiDDBz35vcOU14jMrZTvPCS9qz2L8BR4=
 github.com/keptn/go-utils v0.6.1-compat.0.20200406125548-5337a2e806c4/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
+github.com/keptn/go-utils v0.6.2-alpha h1:GVphpKB7lAUrzKOUbrsWtYQqugVbQP7L+21PV4hHYDo=
+github.com/keptn/go-utils v0.6.2-alpha/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/keptn/kubernetes-utils v0.0.0-20200401103501-ae44a5ee0656 h1:uGdzQ+DT+/KqzMJF+5F+B+/h0nOfwmmSA7ClxsI1y6Y=
 github.com/keptn/kubernetes-utils v0.0.0-20200401103501-ae44a5ee0656/go.mod h1:7MQMS/jqKM4eVZ0S1S7LWdZNcBTJn5QeERircdADWzo=
 github.com/kinbiko/jsonassert v1.0.1 h1:8gdLmUaPWuxk2TzQSofKRqatFH6zwTF6AsUH4bugJYY=

--- a/jmeter-service/go.mod
+++ b/jmeter-service/go.mod
@@ -6,6 +6,6 @@ require (
 	github.com/cloudevents/sdk-go v0.10.0
 	github.com/google/uuid v1.1.1
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.6.1-compat.0.20200406125548-5337a2e806c4
+	github.com/keptn/go-utils v0.6.2-alpha
 	gopkg.in/yaml.v2 v2.2.8 // indirect
 )

--- a/jmeter-service/go.sum
+++ b/jmeter-service/go.sum
@@ -152,6 +152,8 @@ github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dv
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/keptn/go-utils v0.6.1-compat.0.20200406125548-5337a2e806c4 h1:D6m0BxmTvNiRiDDBz35vcOU14jMrZTvPCS9qz2L8BR4=
 github.com/keptn/go-utils v0.6.1-compat.0.20200406125548-5337a2e806c4/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
+github.com/keptn/go-utils v0.6.2-alpha h1:GVphpKB7lAUrzKOUbrsWtYQqugVbQP7L+21PV4hHYDo=
+github.com/keptn/go-utils v0.6.2-alpha/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=

--- a/lighthouse-service/go.mod
+++ b/lighthouse-service/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/json-iterator/go v1.1.9 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.6.1-compat.0.20200406125548-5337a2e806c4
+	github.com/keptn/go-utils v0.6.2-alpha
 	github.com/nats-io/nats-server/v2 v2.1.6
 	github.com/stretchr/testify v1.4.0
 	k8s.io/api v0.17.0

--- a/lighthouse-service/go.sum
+++ b/lighthouse-service/go.sum
@@ -188,6 +188,8 @@ github.com/keptn/go-utils v0.6.1-0.20200402063250-be7a84038be8/go.mod h1:aDNFm3o
 github.com/keptn/go-utils v0.6.1-compat/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/keptn/go-utils v0.6.1-compat.0.20200406125548-5337a2e806c4 h1:D6m0BxmTvNiRiDDBz35vcOU14jMrZTvPCS9qz2L8BR4=
 github.com/keptn/go-utils v0.6.1-compat.0.20200406125548-5337a2e806c4/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
+github.com/keptn/go-utils v0.6.2-alpha h1:GVphpKB7lAUrzKOUbrsWtYQqugVbQP7L+21PV4hHYDo=
+github.com/keptn/go-utils v0.6.2-alpha/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/mongodb-datastore/go.mod
+++ b/mongodb-datastore/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/go-openapi/validate v0.19.4
 	github.com/jeremywohl/flatten v0.0.0-20190921043622-d936035e55cf
 	github.com/jessevdk/go-flags v1.4.0
-	github.com/keptn/go-utils v0.6.1-compat
+	github.com/keptn/go-utils v0.6.2-alpha
 	github.com/magiconair/properties v1.8.1
 	github.com/xdg/stringprep v1.0.0 // indirect
 	go.mongodb.org/mongo-driver v1.3.1

--- a/mongodb-datastore/go.sum
+++ b/mongodb-datastore/go.sum
@@ -233,6 +233,8 @@ github.com/keptn/go-utils v0.6.1-a/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZ
 github.com/keptn/go-utils v0.6.1-compat/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/keptn/go-utils v0.6.1 h1:ukBe1qtBiUyltabVMhTsx09pwlQTTRn3hJJc/XD81EY=
 github.com/keptn/go-utils v0.6.1/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZzmyoE98c=
+github.com/keptn/go-utils v0.6.2-alpha h1:GVphpKB7lAUrzKOUbrsWtYQqugVbQP7L+21PV4hHYDo=
+github.com/keptn/go-utils v0.6.2-alpha/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/keptn/keptn v0.0.0-20191107135234-c0939707dff0 h1:Q5MSMeWKpgleVkZLE2kw/ELOGdBPyegqGc3+132geqE=
 github.com/keptn/keptn v0.0.0-20191108092506-3f8146d90389 h1:E/mUFUNxm76CvuxWjYrklg9agNNuz7wMxnZEOmsq3Rk=
 github.com/keptn/keptn v0.0.0-20191203073718-08fcca449c2c h1:0+bI5c4xmoMIfThsKHoEIzYjNfu2oqhHi9o7DzS13SQ=

--- a/remediation-service/go.mod
+++ b/remediation-service/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.6.1-compat.0.20200406125548-5337a2e806c4
+	github.com/keptn/go-utils v0.6.2-alpha
 	github.com/keptn/kubernetes-utils v0.0.0-20200401103501-ae44a5ee0656
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect

--- a/remediation-service/go.sum
+++ b/remediation-service/go.sum
@@ -191,6 +191,8 @@ github.com/keptn/go-utils v0.6.1-0.20200402063250-be7a84038be8/go.mod h1:aDNFm3o
 github.com/keptn/go-utils v0.6.1-compat/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/keptn/go-utils v0.6.1-compat.0.20200406125548-5337a2e806c4 h1:D6m0BxmTvNiRiDDBz35vcOU14jMrZTvPCS9qz2L8BR4=
 github.com/keptn/go-utils v0.6.1-compat.0.20200406125548-5337a2e806c4/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
+github.com/keptn/go-utils v0.6.2-alpha h1:GVphpKB7lAUrzKOUbrsWtYQqugVbQP7L+21PV4hHYDo=
+github.com/keptn/go-utils v0.6.2-alpha/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/keptn/kubernetes-utils v0.0.0-20200401103501-ae44a5ee0656 h1:uGdzQ+DT+/KqzMJF+5F+B+/h0nOfwmmSA7ClxsI1y6Y=
 github.com/keptn/kubernetes-utils v0.0.0-20200401103501-ae44a5ee0656/go.mod h1:7MQMS/jqKM4eVZ0S1S7LWdZNcBTJn5QeERircdADWzo=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=

--- a/shipyard-service/go.mod
+++ b/shipyard-service/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/websocket v1.4.1
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.6.1-compat.0.20200406125548-5337a2e806c4
+	github.com/keptn/go-utils v0.6.2-alpha
 	github.com/keptn/kubernetes-utils v0.0.0-20200401103501-ae44a5ee0656
 	github.com/magiconair/properties v1.8.1
 	gopkg.in/yaml.v2 v2.2.8

--- a/shipyard-service/go.sum
+++ b/shipyard-service/go.sum
@@ -216,6 +216,8 @@ github.com/keptn/go-utils v0.6.1-compat h1:Uqd0fmbPRxIqXpRv4q/q/O+KjAnJa+moZ85H1
 github.com/keptn/go-utils v0.6.1-compat/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/keptn/go-utils v0.6.1-compat.0.20200406125548-5337a2e806c4 h1:D6m0BxmTvNiRiDDBz35vcOU14jMrZTvPCS9qz2L8BR4=
 github.com/keptn/go-utils v0.6.1-compat.0.20200406125548-5337a2e806c4/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
+github.com/keptn/go-utils v0.6.2-alpha h1:GVphpKB7lAUrzKOUbrsWtYQqugVbQP7L+21PV4hHYDo=
+github.com/keptn/go-utils v0.6.2-alpha/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/keptn/kubernetes-utils v0.0.0-20200401103501-ae44a5ee0656 h1:uGdzQ+DT+/KqzMJF+5F+B+/h0nOfwmmSA7ClxsI1y6Y=
 github.com/keptn/kubernetes-utils v0.0.0-20200401103501-ae44a5ee0656/go.mod h1:7MQMS/jqKM4eVZ0S1S7LWdZNcBTJn5QeERircdADWzo=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=

--- a/wait-service/go.mod
+++ b/wait-service/go.mod
@@ -6,5 +6,5 @@ require (
 	github.com/cloudevents/sdk-go v0.10.0
 	github.com/google/uuid v1.1.1
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.6.1-compat.0.20200406125548-5337a2e806c4
+	github.com/keptn/go-utils v0.6.2-alpha
 )

--- a/wait-service/go.sum
+++ b/wait-service/go.sum
@@ -202,6 +202,8 @@ github.com/keptn/go-utils v0.6.1-compat.0.20200406125548-5337a2e806c4 h1:D6m0Bxm
 github.com/keptn/go-utils v0.6.1-compat.0.20200406125548-5337a2e806c4/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/keptn/go-utils v0.6.1 h1:ukBe1qtBiUyltabVMhTsx09pwlQTTRn3hJJc/XD81EY=
 github.com/keptn/go-utils v0.6.1/go.mod h1:R9a1HXkD+KCrhMFbLcEhtBtHGfYwXhO6dwZzmyoE98c=
+github.com/keptn/go-utils v0.6.2-alpha h1:GVphpKB7lAUrzKOUbrsWtYQqugVbQP7L+21PV4hHYDo=
+github.com/keptn/go-utils v0.6.2-alpha/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd h1:Coekwdh0v2wtGp9Gmz1Ze3eVRAWJMLokvN3QjdzCHLY=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=


### PR DESCRIPTION
Update go-utils to the latest version (v0.6.2-alpha).

https://github.com/keptn/go-utils/releases/tag/v0.6.2-alpha