### PR TITLE
Improved time duration visualization

### DIFF
--- a/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.html
+++ b/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.html
@@ -1,4 +1,4 @@
-<p class="m-0 mt-1"><span [textContent]="evaluationData.data.evaluationdetails.timeStart | amDateFormat:'L LT'"></span> - <span [textContent]="evaluationData.data.evaluationdetails.timeEnd | amDateFormat:'L LT'"></span> (<span [textContent]="evaluationData.data.evaluationdetails.timeEnd | amDifference: evaluationData.data.evaluationdetails.timeStart :'minutes'"></span> Minutes)</p>
+<p class="m-0 mt-1"><span [textContent]="evaluationData.data.evaluationdetails.timeStart | amDateFormat:'L LT'"></span> - <span [textContent]="evaluationData.data.evaluationdetails.timeEnd | amDateFormat:'L LT'"></span> (<span [textContent]="getDuration(evaluationData.data.evaluationdetails.timeStart, evaluationData.data.evaluationdetails.timeEnd)"></span>)</p>
 <div class="mb-1" *ngIf="evaluationData.data.evaluationdetails.sloFileContent">
   <p class="m-0 mb-1">
     <a class="dt-link" (click)="$event.stopPropagation();sloFile.toggle();">

--- a/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
+++ b/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
@@ -297,6 +297,10 @@ export class KtbEvaluationDetailsComponent implements OnInit {
     return DateUtil.getCalendarFormats().sameElse;
   }
 
+  getDuration(start, end) {
+    return DateUtil.getDurationFormatted(start, end);
+  }
+
   private binarySearch(ar, el, compare_fn) {
     if(compare_fn(el, ar[0]) < 0)
       return 0;

--- a/bridge/client/app/_components/ktb-event-item/ktb-event-item.component.html
+++ b/bridge/client/app/_components/ktb-event-item/ktb-event-item.component.html
@@ -28,7 +28,7 @@
           </div>
         </div>
         <div *ngIf="_event.data.start && _event.data.end">
-          <p class="m-0 mt-1 nobreak"><span [textContent]="_event.data.start | amDateFormat:'L LT'"></span> - <span [textContent]="_event.data.end | amDateFormat:'L LT'"></span> (<span [textContent]="_event.data.end | amDifference: _event.data.start :'minutes'"></span> Minutes)</p>
+          <p class="m-0 mt-1 nobreak"><span [textContent]="_event.data.start | amDateFormat:'L LT'"></span> - <span [textContent]="_event.data.end | amDateFormat:'L LT'"></span> (<span [textContent]="getDuration(_event.data.start, _event.data.end)"></span>)</p>
         </div>
         <div *ngIf="_event.data.labels">
           <div fxLayout="row" fxLayoutAlign="start center">

--- a/bridge/client/app/_components/ktb-event-item/ktb-event-item.component.ts
+++ b/bridge/client/app/_components/ktb-event-item/ktb-event-item.component.ts
@@ -1,3 +1,5 @@
+import * as moment from 'moment';
+
 import {ChangeDetectorRef, Component, Directive, Input, OnInit} from '@angular/core';
 import {Trace} from "../../_models/trace";
 import DateUtil from "../../_utils/date.utils";
@@ -35,6 +37,10 @@ export class KtbEventItemComponent implements OnInit {
 
   getCalendarFormat() {
     return DateUtil.getCalendarFormats().sameElse;
+  }
+
+  getDuration(start, end) {
+    return DateUtil.getDurationFormatted(start, end);
   }
 
 }

--- a/bridge/client/app/_utils/date.utils.ts
+++ b/bridge/client/app/_utils/date.utils.ts
@@ -1,4 +1,21 @@
+import * as moment from "moment";
+
 export default class DateUtil {
+  static getDurationFormatted(start, end) {
+    let diff = moment(start).diff(moment(end));
+    let duration = moment.duration(diff);
+
+    let result = moment.utc(diff).format("s")+' seconds';
+
+    if(duration.asMinutes() > 0)
+      result = moment.utc(diff).format("mm")+' minutes '+result;
+
+    if(duration.asHours() > 0)
+      result = Math.floor(duration.asHours())+' hours '+result;
+
+    return result;
+  }
+
   static getCalendarFormats(showSeconds?: boolean) {
     if(showSeconds) {
       return {

--- a/bridge/client/app/_utils/date.utils.ts
+++ b/bridge/client/app/_utils/date.utils.ts
@@ -7,10 +7,10 @@ export default class DateUtil {
 
     let result = moment.utc(diff).format("s")+' seconds';
 
-    if(duration.asMinutes() > 0)
+    if(Math.abs(duration.asMinutes()) > 1)
       result = moment.utc(diff).format("mm")+' minutes '+result;
 
-    if(duration.asHours() > 0)
+    if(Math.abs(duration.asHours()) > 1)
       result = Math.floor(duration.asHours())+' hours '+result;
 
     return result;


### PR DESCRIPTION
The time is now visualized in the format `x hours y minutes z seconds`. If hours or minutes is 0 they are omitted.

![image](https://user-images.githubusercontent.com/6098219/81174022-55c98c00-8fa1-11ea-8f03-a169fd294d16.png)
