### PR TITLE
added distributor for configuration service

### DIFF
--- a/installer/manifests/keptn/core.yaml
+++ b/installer/manifests/keptn/core.yaml
@@ -438,3 +438,40 @@ spec:
       protocol: TCP
   selector:
     run: configuration-service
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: configuration-service-distributor
+  namespace: keptn
+spec:
+  selector:
+    matchLabels:
+      run: distributor
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: distributor
+    spec:
+      containers:
+        - name: distributor
+          image: keptn/distributor:latest
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "50m"
+            limits:
+              memory: "128Mi"
+              cpu: "500m"
+          env:
+            - name: PUBSUB_URL
+              value: 'nats://keptn-nats-cluster'
+            - name: PUBSUB_TOPIC
+              value: 'sh.keptn.>'
+            - name: PUBSUB_RECIPIENT
+              value: 'configuration-service'
+            - name: PUBSUB_RECIPIENT_PATH
+              value: '/v1/event'


### PR DESCRIPTION
we need the distributor to subscribe the configuration service to all events in order to update service-relevant information defined in #1673 