### PR TITLE
#1766 Enable GKE tests for 1.15, prepare of 1.16 and 1.17; enable tests for various minikube versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,8 @@ before_install:
     export KEPTN_INSTALLER_IMAGE=keptn/installer:${BRANCH#"release-"}
     export KEPTN_CLI_VERSION=${BRANCH#"release-"}
   fi
+# generate a lower-case slug of the branch name
+- BRANCH_SLUG=$(echo ${BRANCH} | sed -r s/[^a-zA-Z0-9]+/-/g | sed -r s/^-+\|-+$//g | tr A-Z a-z)
 ### ATTENTION: please make sure installer is always the last in this list
 
 
@@ -89,6 +91,8 @@ before_install:
 gke_full: &gke_full
   os: linux
   before_script:
+    # set CLUSTER_NAME_NIGHTLY according to current branch and GKE_VERSION
+    - export CLUSTER_NAME_NIGHTLY=${CLUSTER_NAME_NIGHTLY}-${BRANCH_SLUG:0:15}-gke${GKE_VERSION//./}
     - source ./travis-scripts/install_gcloud.sh
     # auth gcloud
     - echo ${GCLOUD_SERVICE_KEY} | base64 --decode > ~/gcloud-service-key.json
@@ -99,6 +103,7 @@ gke_full: &gke_full
   script:
     # test installation on gcloud
     - test/test_install_gke.sh
+    - test/utils/expose_keptn_bridge.sh
     # test onboarding and new artifcat for sockshop
     - export PROJECT=sockshop
     - test/test_onboard_service.sh
@@ -399,13 +404,63 @@ jobs:
 
   - stage: Test GKE Full (--platform=gke)
     if: branch = master AND type = cron # run for cron
-    env: KEPTN_INSTALLATION_TYPE=FULL
+    env:
+      - GKE_VERSION=1.14
+      - KEPTN_INSTALLATION_TYPE=FULL
+    <<: *gke_full # use template
+
+  - stage: Test GKE Full (--platform=gke)
+    if: branch = master AND type = cron # run for cron
+    env:
+      - GKE_VERSION=1.15
+      - KEPTN_INSTALLATION_TYPE=FULL
+    <<: *gke_full # use template
+
+  # Test GKE with 1.16 (not available yet)
+#  - stage: Test GKE Full (--platform=gke)
+#    if: branch = master AND type = cron # run for cron
+#    env:
+#      - GKE_VERSION=1.16
+#      - KEPTN_INSTALLATION_TYPE=FULL
+#    <<: *gke_full # use template
+
+  # Test GKE with 1.17 (not available yet)
+#  - stage: Test GKE Full (--platform=gke)
+#    if: branch = master AND type = cron # run for cron
+#    env:
+#      - GKE_VERSION=1.17
+#      - KEPTN_INSTALLATION_TYPE=FULL
+#    <<: *gke_full # use template
+
+  - stage: Test GKE Full with Istio (--platform=gke --ingress-install-option=Reuse)
+    if: branch = master AND type = cron # run for cron
+    env:
+      - KEPTN_INSTALLATION_TYPE=REUSE-ISTIO
+      - GKE_VERSION=1.14
     <<: *gke_full # use template
 
   - stage: Test GKE Full with Istio (--platform=gke --ingress-install-option=Reuse)
     if: branch = master AND type = cron # run for cron
-    env: KEPTN_INSTALLATION_TYPE=REUSE-ISTIO
+    env:
+      - KEPTN_INSTALLATION_TYPE=REUSE-ISTIO
+      - GKE_VERSION=1.15
     <<: *gke_full # use template
+
+  # Test GKE with 1.16 (not available yet)
+#  - stage: Test GKE Full with Istio (--platform=gke --ingress-install-option=Reuse)
+#    if: branch = master AND type = cron # run for cron
+#    env:
+#      - KEPTN_INSTALLATION_TYPE=REUSE-ISTIO
+#      - GKE_VERSION=1.16
+#    <<: *gke_full # use template
+
+  # Test GKE with 1.17 (not available yet)
+#  - stage: Test GKE Full with Istio (--platform=gke --ingress-install-option=Reuse)
+#    if: branch = master AND type = cron # run for cron
+#    env:
+#      - KEPTN_INSTALLATION_TYPE=REUSE-ISTIO
+#      - GKE_VERSION=1.17
+#    <<: *gke_full # use template
 
   - stage: Test Minishift Standalone (--platform=openshift --use-case=quality-gates)
     if: (branch = master or branch =~ ^release.*$) AND (type = cron OR type = push) # run for any change on master/release-* on push as well as cron
@@ -464,7 +519,10 @@ jobs:
       - kubectl get services --all-namespaces
       - kubectl get ingress --all-namespaces
 
-  - stage: Test Minikube Standalone (--platform=kubernetes --use-case=quality-gates)
+  - &minikubeStandaloneTest
+    stage: Test Minikube Standalone (--platform=kubernetes --use-case=quality-gates)
+    env:
+      - MINIKUBE_VERSION=v1.2.0
     if: (branch = master or branch =~ ^release.*$) AND (type = cron OR type = push) # run for any change on master/release-* on push as well as cron
     os: linux
     before_script:
@@ -491,3 +549,11 @@ jobs:
       - kubectl get pods --all-namespaces
       - kubectl get services --all-namespaces
       - kubectl get ingress --all-namespaces
+
+  - <<: *minikubeStandaloneTest
+    env:
+      - MINIKUBE_VERSION=v1.3.1
+
+  - <<: *minikubeStandaloneTest
+    env:
+      - MINIKUBE_VERSION=v1.4.0

--- a/test/utils/expose_keptn_bridge.sh
+++ b/test/utils/expose_keptn_bridge.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+echo "Exposing Keptn Bridge..."
+# expose Keptn's Bridge (for easier troubleshooting/debugging afterwards)
+kubectl -n keptn create secret generic bridge-credentials --from-literal="BASIC_AUTH_USERNAME=${NIGHTLY_BRIDGE_USERNAME}" --from-literal="BASIC_AUTH_PASSWORD=${NIGHTLY_BRIDGE_PASSWORD}"
+keptn configure bridge --action=expose
+# restart bridge pod to make use of the secret
+kubectl -n keptn delete pods --selector=run=bridge
+sleep 5
+# verify that bridge is available
+export BRIDGE_URL=$(echo https://bridge.keptn.$(kubectl get cm -n keptn keptn-domain -ojsonpath={.data.app_domain}))
+curl "${BRIDGE_URL}" -k
+
+if [[ $? != '0' ]]; then
+    echo "Accessing Keptn Bridge failed"
+    exit 1
+fi

--- a/test/utils/gke_create_cluster.sh
+++ b/test/utils/gke_create_cluster.sh
@@ -8,9 +8,9 @@ gcloud --quiet config set compute/zone ${CLOUDSDK_COMPUTE_ZONE}
 # clean up any nightly clusters
 clusters=$(gcloud container clusters list --zone $CLOUDSDK_COMPUTE_ZONE --project $PROJECT_NAME)
 if echo "$clusters" | grep $CLUSTER_NAME_NIGHTLY; then 
-    echo "Deleting nightly cluster..."
+    echo "Deleting nightly cluster ${CLUSTER_NAME_NIGHTLY}..."
     gcloud container clusters delete $CLUSTER_NAME_NIGHTLY --zone $CLOUDSDK_COMPUTE_ZONE --project $PROJECT_NAME --quiet
-    echo "Finished deleting nigtly cluster"
+    echo "Finished deleting nightly cluster"
 else 
     echo "No nightly cluster need to be deleted"
 fi
@@ -22,6 +22,8 @@ if [[ "$KEPTN_INSTALLATION_TYPE" == "REUSE-ISTIO" ]]; then
   ISTIO_CONFIG="--istio-config=auth=MTLS_PERMISSIVE"
   ADDONS="Istio,$ADDONS"
 fi
+
+echo "Creating nightly cluster ${CLUSTER_NAME_NIGHTLY}"
 
 # create a new cluster
 gcloud beta container --project $PROJECT_NAME clusters create $CLUSTER_NAME_NIGHTLY --zone $CLOUDSDK_COMPUTE_ZONE --username "admin" --cluster-version $GKE_VERSION \

--- a/test/utils/minikube_create_cluster.sh
+++ b/test/utils/minikube_create_cluster.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 # download and install minikube
-curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.2.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+MINIKUBE_VERSION=${MINIKUBE_VERSION:-"v1.2.0"}
+echo "Downlaoding and installing Minikube in Version ${MINIKUBE_VERSION}"
+curl -Lo minikube "https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64" && chmod +x minikube && sudo mv minikube /usr/local/bin/
 
 
 # create cluster (with size depending on params)


### PR DESCRIPTION
This PR will close issue #1766.

* Reworked the GKE tests for travis ci to allow more than one nightly cluster to be created. The name is now used based on the branch name and GKE version to be tested
* Added `GKE_VERSION` as an environment variable that allows matrix tests
* Also reworked the Minikube tests to use different Minikube versions as a matrix test
* Added a simple script for exposing the Keptn Bridge (for easier debugging/troubleshooting of failed integration tests). The username and password are stored as secret variables in travis-ci, and I have a copy of those values which I can hand out to anyone that needs them.

Please note: Matrix tests in travis are executed in parallel, so this change does not increase the overall test-time in travis-ci:

![Screenshot from 2020-05-08 12-58-10](https://user-images.githubusercontent.com/56065213/81399929-4460bb00-912c-11ea-956e-699dcedd99a4.png)
