### PR TITLE
#1777 Added a bigger minikube test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -521,11 +521,14 @@ jobs:
 
   - &minikubeStandaloneTest
     stage: Test Minikube Standalone (--platform=kubernetes --use-case=quality-gates)
+    # for detailed Minikube versions see https://github.com/kubernetes/minikube/blob/master/CHANGELOG.md
     env:
-      - MINIKUBE_VERSION=v1.2.0
+      - MINIKUBE_VERSION=v1.3.1 # from 2019-08-13; uses K8s 1.15
     if: (branch = master or branch =~ ^release.*$) AND (type = cron OR type = push) # run for any change on master/release-* on push as well as cron
     os: linux
     before_script:
+      # install conntrack (required for newer minikube versions)
+      - sudo apt-get install -y conntrack
       # download and install kubectl
       - curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.17.0/bin/linux/amd64/kubectl && chmod +x ./kubectl && sudo mv ./kubectl /usr/local/bin/kubectl
       - test/utils/download_and_install_keptn_cli.sh
@@ -552,8 +555,20 @@ jobs:
 
   - <<: *minikubeStandaloneTest
     env:
-      - MINIKUBE_VERSION=v1.3.1
+      - MINIKUBE_VERSION=v1.4.0 # from 2019-09-17; uses K8s 1.16
 
   - <<: *minikubeStandaloneTest
     env:
-      - MINIKUBE_VERSION=v1.4.0
+      - MINIKUBE_VERSION=v1.6.2 # from 2019-12-19; uses K8s 1.17
+
+  - <<: *minikubeStandaloneTest
+    env:
+      - MINIKUBE_VERSION=v1.7.3 # from 2020-02-20; uses K8s 1.17.3
+
+  - <<: *minikubeStandaloneTest
+    env:
+      - MINIKUBE_VERSION=v1.9.2 # from 2020-04-02; uses K8s 1.18
+
+  - <<: *minikubeStandaloneTest
+    env:
+      - MINIKUBE_VERSION=v1.10.1 # from 2020-05-12; uses K8s 1.18.2


### PR DESCRIPTION
This provides some insight for #1777, as we are trying out multiple versions of Minikube, including the latest version using K8s 1.18.2.

Within this PR, we test the compatibility of Keptn control-plane with Minikube versions 1.3.1, 1.6.2, 1.7.3, 1.9.2 and 1.10.1, which results in the following K8s versions: 1.15, 1.16, 1.17, 1.17.3, 1.18, 1.18.2 (I've added this as comments next to the travis-ci jobs as well).

I believe this is more than enough for the quality-gates use-case for now.

![Screenshot from 2020-05-13 12-55-49](https://user-images.githubusercontent.com/56065213/81804256-1bb83700-9519-11ea-8852-80a7c2347ea9.png)
