### PR TITLE
#1591 Improve integration test for quality-gates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,7 +117,6 @@ gke_full: &gke_full
     # print some debug info
     - echo "Keptn Installation Log:"
     - cat ~/.keptn/keptn-installer.log
-    - cat ~/.keptn/keptn-installer-err.log
     - kubectl get events --sort-by='.lastTimestamp' --all-namespaces
     - kubectl get pods --all-namespaces
     - kubectl get services --all-namespaces
@@ -473,7 +472,7 @@ jobs:
       - test/utils/minishift_create_cluster.sh
     script:
       - kubectl get nodes || travis_terminate 1
-      # finally install keptn
+      # finally install keptn quality gates
       - test/test_install_minishift_quality_gates.sh
       - keptn status
       - export PROJECT=musicshop
@@ -485,7 +484,6 @@ jobs:
       # print some debug info
       - echo "Keptn Installation Log:"
       - cat ~/.keptn/keptn-installer.log
-      - cat ~/.keptn/keptn-installer-err.log
       - kubectl get events --sort-by='.lastTimestamp' --all-namespaces
       - kubectl get pods --all-namespaces
       - kubectl get services --all-namespaces
@@ -513,7 +511,6 @@ jobs:
       # print some debug info
       - echo "Keptn Installation Log:"
       - cat ~/.keptn/keptn-installer.log
-      - cat ~/.keptn/keptn-installer-err.log
       - kubectl get events --sort-by='.lastTimestamp' --all-namespaces
       - kubectl get pods --all-namespaces
       - kubectl get services --all-namespaces
@@ -536,6 +533,7 @@ jobs:
       - test/utils/minikube_create_cluster.sh
     script:
       - kubectl get nodes || travis_terminate 1
+      # finally install keptn quality gates
       - test/test_install_kubernetes_quality_gates.sh
       - keptn status
       - export PROJECT=musicshop
@@ -547,7 +545,6 @@ jobs:
       # print some debug info
       - echo "Keptn Installation Log:"
       - cat ~/.keptn/keptn-installer.log
-      - cat ~/.keptn/keptn-installer-err.log
       - kubectl get events --sort-by='.lastTimestamp' --all-namespaces
       - kubectl get pods --all-namespaces
       - kubectl get services --all-namespaces

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,12 +9,13 @@ This folder contains docs for developers. If you are looking for the usage docum
   onboarded a service (etc...)
 * Kubernetes Cluster: 
   For testing your changes it is strongly recommended to have access to a (throwaway) Kubernetes Cluster on any of the 
-  supported platforms (e.g., Google Kubernetes Engine, Azure Kubernetes Service). Currently we can not support 
-  environments such as minishift and minikube, but we are keeping this in our minds for a **future** version.
+  supported platforms (e.g., Google Kubernetes Engine, Azure Kubernetes Service). 
+  You can also run Keptn on Minikube and Minishift, which is the recommended way for developing and running integration tests.
+  You can find more information in [here](integration_tests.md).
 * Kubernetes CLI tool [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 * Docker
 * Dockerhub Account (any other container registry works too)
-* Go (Version 1.12.x)
+* Go (Version 1.13.x)
 * GitHub Account (required for making Pull Requests)
 * If you want to use in-cluster debugging, please take a look at our [debugging guide](debugging.md).
 
@@ -22,8 +23,8 @@ This folder contains docs for developers. If you are looking for the usage docum
 
 While this is not a requirement, we recommend you to use any of the following
 
-* Visual Studio Code
-* JetBrains GoLand
+* Visual Studio Code (with several Go Plugins)
+* JetBrains GoLand (with Google Cloud Code)
 
 
 ## Where to go

--- a/docs/integration_tests.md
+++ b/docs/integration_tests.md
@@ -1,0 +1,255 @@
+# Running Integration Tests
+
+Several tests are specified in [.travis.yml](../.travis.yml). They usually follow this layout:
+
+```yaml
+    stage: Some Integration Test (--platform=kubernetes --use-case=quality-gates)
+    os: linux
+    before_script:
+      # download and install kubectl
+      - curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.17.0/bin/linux/amd64/kubectl && chmod +x ./kubectl && sudo mv ./kubectl /usr/local/bin/kubectl
+      - test/utils/download_and_install_keptn_cli.sh
+      - test/utils/minikube_create_cluster.sh
+    script:
+      - kubectl get nodes || travis_terminate 1
+      # finally install keptn quality gates
+      - test/test_install_kubernetes_quality_gates.sh
+      - keptn status
+      - export PROJECT=musicshop
+      - test/test_quality_gates_standalone.sh
+    after_success:
+      # delete google kubernetes cluster only on success (in case of an error we want to be able to dig into the cluster)
+      - echo "Tests were successful, cleaning up the cluster now..."
+    after_failure:
+      # print some debug info
+      - echo "Keptn Installation Log:"
+      - cat ~/.keptn/keptn-installer.log
+```
+
+* `before_script`: Set up `kubectl`, `keptn cli` and create a Kubernetes cluster
+* `script`: Verify connection to the kubernetes cluster, install Keptn (e.g., `test/test_install_kubernetes_quality_gates.sh`),
+  verify connection to Keptn (`keptn status`) and run the actual test (e.g., `test/test_quality_gates_standalone.sh`)
+* `after_success`: Perform some cleanup (e.g., delete the cluster if necessary)
+* `after_failure`: Print some debug output
+
+## Run Integration Tests in Travis-CI
+
+There are some caveats when creating a Kubernetes cluster on Travis-CI:
+
+* It is possible to create and connect to an external cluster (e.g., GKE, AWS, ...). However, this requires secrets
+  for the cloud provider to be set on Travis-CI, and accessing those secrets only works for commits that are pushed
+  within the current repository. It does **not work** for Pull Requests from forks.
+* It is possible to run docker on Travis-CI.
+* It is not possible to create a virtual-machine on Travis-CI. Therefore setting up Minishift or Minikube on Travis-CI
+  only works with some specific settings (e.g., `minishift start --vm-driver=generic` or `minikube start --vm-driver=none`).
+  With this, `minishift` and `minikube` use the local docker installation of Travis-CI. Please note, with this setup
+  we are limited to 2 vCPUs and 4 GB of memory (see [https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system](https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system) for details)
+
+Above limitations lead to the following setup with Keptn's `.travis.yml`:
+
+* We test the full installation on `GKE` once per day on the master branch via a Travis-CI cron job.
+* We test the `--use-case=quality-gates` installation on Minikube, MicroK8s and Minishift for every push on the master branch (e.g., after merging a pull-request).
+  * This type of installation is limited to `--gateway=NodePort`
+
+## Prepare your local environment to run integration tests
+
+When running integration tests locally, we recommend using either Minikube or Minishift.
+
+### Set-up steps for Minikube
+
+In case you plan to use Minikube, the following steps are necessary to get Keptn running on Minikube:
+
+1. Download and install Minikube (versions 1.4 to 1.10 should work) from [https://github.com/kubernetes/minikube/releases](https://github.com/kubernetes/minikube/releases) for your operating system.
+1. Make sure you create a fresh Minikube cluster (using a VM):
+    ```console
+    minikube stop # optional
+    minikube delete # optional
+    minikube start [--vm-driver=...] --cpus 2 --memory 4096 # or: minikube start --cpus 6 --memory 12200
+    ```
+    **Note**: In some cases you have to specify `--vm-driver=...` to select virtualbox, kvm, hyperv, etc... - please find out more that the [official MiniKube docs](https://kubernetes.io/docs/setup/learning-environment/minikube/#specifying-the-vm-driver)
+    
+    **Note**: On Linux `--vm-driver=docker` *should* work in most cases
+    
+    **Note**: For the quality gates use case 2 CPUs and 4096 MB memory is enough, for the full installation we recommend at least 6 CPUs and 12200 MB memory
+
+1. Verify that everything has worked using `kubectl get nodes`
+
+### Set-up steps for Minishift
+
+In case you plan to use Minishift, the following steps are necessary to get Keptn running on Minishift (1.34.2):
+
+1. Download and install Minishift 1.34.2 (from [https://github.com/minishift/minishift/releases](https://github.com/minishift/minishift/releases))
+   for your operating system
+1. Setup Minishift profile, cpu and memory limits:
+   ```console
+   # make sure you have a profile is set correctly
+   minishift profile set keptn-dev
+   # minimum memory required for the minishift VM
+   minishift config set memory 4GB # Note: use 12 GB for full installation
+   # the minimum required vCpus for the minishift vm
+   minishift config set cpus 2 # Note: use 6 for full installation
+   # Add new user called admin with password admin having role cluster-admin
+   minishift addons enable admin-user
+   # Allow the containers to be run with uid 0
+   minishift addons enable anyuid
+   ```
+   
+   **Note**: For the quality-gates use-case 2 vCPUs and 4 GB memory is enough. For the full installation you should use
+   more CPUs (e.g., 6) and more memory (e.g., 12 GB)
+   
+1. Start Minishift:
+   ```console
+   minishift start
+   ```
+1. Enable admission WebHooks on your OpenShift master node:
+   ```console
+   minishift openshift config set --target=kube --patch '{
+       "admissionConfig": {
+           "pluginConfig": {
+               "ValidatingAdmissionWebhook": {
+                   "configuration": {
+                       "apiVersion": "apiserver.config.k8s.io/v1alpha1",
+                       "kind": "WebhookAdmission",
+                       "kubeConfigFile": "/dev/null"
+                   }
+               },
+               "MutatingAdmissionWebhook": {
+                   "configuration": {
+                       "apiVersion": "apiserver.config.k8s.io/v1alpha1",
+                       "kind": "WebhookAdmission",
+                       "kubeConfigFile": "/dev/null"
+                   }
+               }
+           }
+       }
+   }'
+   ```
+1. Login via `oc` cli (you might need to try a couple of times):
+   ```console
+   oc login -u admin -p admin
+   ```
+   **Note**: It takes a couple of minutes before your Minishift cluster is ready. Expect error messages like
+   ```
+   Error from server (InternalError): Internal error occurred: unexpected response: 400
+   ```
+   and retry again.
+1. Set policies/permissions:
+   ```console
+   oc adm policy --as system:admin add-cluster-role-to-user cluster-admin admin
+   oc adm policy  add-cluster-role-to-user cluster-admin system:serviceaccount:default:default
+   oc adm policy  add-cluster-role-to-user cluster-admin system:serviceaccount:kube-system:default
+   ```
+1. Note down the Minishift server URL printed by `oc status` (e.g., `https://192.168.99.101:8443`)
+
+
+## Run the integration tests locally
+
+### Run the quality-gates integration test (with dynatrace-sli-service) locally
+
+Pre-requesits:
+
+* Minikube (1.4 - 1.10) or Minishift (1.34.2) in a VM
+* `kubectl`
+* `keptn` cli
+* A local copy of this repository (keptn/keptn)
+* Linux, Mac OS or Linux Subsystem for Windows
+* Bash
+* Dynatrace Tenant with a service that has the tags `FrontEnd` and `testdeploy`
+* Dynatrace API Token that is allowed to read metrics from the Dynatrace Tenant
+* working internet connection
+* 4 GB of free memory (less is possible but you will notice a significant slowdown)
+* at least 4 CPU cores on your system (less is possible but you will notice a significant slowdown)
+
+1. Setup Minikube or Minishift (see above)
+1. Verify `kubectl` is properly configured:
+   ```console
+   kubectl get nodes
+   ```
+1. Install Keptn
+   * Minikube
+       ```console
+       keptn install --keptn-installer-image=keptn/installer:latest --platform=kubernetes --gateway=NodePort --verbose
+       ```
+       **Note**: You can skip the `--gateway=NodePort` if you run `minikube tunnel`
+   * Minishift
+      ```console
+      keptn install --keptn-installer-image=keptn/installer:latest --platform=openshift --verbose
+      ```
+   **Note**: Change `--keptn-installer-image=keptn/installer:latest` to the desired installer version you want to use
+1. Verify the installation has worked
+   ```console
+   keptn status
+   ```
+1. Verify which images have been deployed
+   ```console
+   kubectl -n keptn get deployments -owide
+   ```
+1. Expose Keptn Bridge for better troubleshooting and debugging
+   ```console
+   keptn configure bridge --action=expose
+   ```
+1. Verify accessing Keptn Bridge works
+1. Configuration for the test:
+   ```console
+   export PROJECT=easytravel
+   export SERVICE=frontend
+   export STAGE=hardening
+   export QG_INTEGRATION_TEST_DT_TENANT=<INSERT_YOUR_DT_TENANT_HERE>
+   export QG_INTEGRATION_TEST_DT_API_TOKEN=<INSERT_YOUR_DT_API_TOKEN_HERE>
+   ```
+1. Run the test
+   ```console
+   bash ./test/test_quality_gates_standalone.sh
+   ```
+
+### Run the full installation integration test locally
+
+Pre-requesits:
+
+* Minikube (1.4 - 1.10) or Minishift (1.34.2) in a VM
+* `kubectl`
+* `keptn` cli
+* A local copy of this repository (keptn/keptn)
+* Linux, Mac OS or Linux Subsystem for Windows
+* Bash
+* working internet connection
+* 12 GB of free memory (less is possible but you will notice a significant slowdown)
+* at least 6 CPU cores on your system (less is possible but you will notice a significant slowdown)
+
+1. Setup Minikube or Minishift (see above)
+1. Install Keptn
+   * Minikube
+       ```console
+       keptn install --keptn-installer-image=keptn/installer:latest --platform=kubernetes --gateway=NodePort --verbose
+       ```
+       **Note**: You can skip the `--gateway=NodePort` if you run `minikube tunnel`
+   * Minishift
+      ```console
+      keptn install --keptn-installer-image=keptn/installer:latest --platform=openshift --verbose
+      ```
+   **Note**: Change `--keptn-installer-image=keptn/installer:latest` to the desired installer version you want to use
+1. Verify the installation has worked
+   ```console
+   keptn status
+   ```
+1. Verify which images have been deployed
+   ```console
+   kubectl -n keptn get deployments -owide
+   ```
+1. Expose Keptn Bridge for better troubleshooting and debugging
+   ```console
+   keptn configure bridge --action=expose
+   ```
+1. Verify accessing Keptn Bridge works
+1. Configuration for the test:
+   ```console
+   export PROJECT=sockshop
+   ```
+1. Run the test for onboarding a service
+   ```console
+   bash ./test/test_onboard_service.sh
+   ```
+1. Run the test for sending a new artifact
+   ```console
+   bash ./test/test_new_artifact.sh
+   ```

--- a/test/assets/quality_gates_standalone_sli_dynatrace_step1.yaml
+++ b/test/assets/quality_gates_standalone_sli_dynatrace_step1.yaml
@@ -1,0 +1,8 @@
+---
+spec_version: '1.0'
+indicators:
+  throughput: "metricSelector=builtin:service.requestCount.total:merge(0):sum&entitySelector=type(SERVICE),tag(FrontEnd),tag(testdeploy)"
+  error_rate: "metricSelector=builtin:service.errors.total.count:merge(0):avg&entitySelector=type(SERVICE),tag(FrontEnd),tag(testdeploy)"
+  response_time_p50: "metricSelector=builtin:service.response.time:merge(0):percentile(50)&entitySelector=type(SERVICE),tag(FrontEnd),tag(testdeploy)"
+  response_time_p90: "metricSelector=builtin:service.response.time:merge(0):percentile(90)&entitySelector=type(SERVICE),tag(FrontEnd),tag(testdeploy)"
+  response_time_p95: "metricSelector=builtin:service.response.time:merge(0):percentile(95)&entitySelector=type(SERVICE),tag(FrontEnd),tag(testdeploy)"

--- a/test/assets/quality_gates_standalone_sli_dynatrace_step2.yaml
+++ b/test/assets/quality_gates_standalone_sli_dynatrace_step2.yaml
@@ -1,0 +1,10 @@
+---
+spec_version: '1.0'
+indicators:
+  throughput: "metricSelector=builtin:service.requestCount.total:merge(0):sum&entitySelector=type(SERVICE),tag(FrontEnd),tag(testdeploy)"
+  error_rate: "metricSelector=builtin:service.errors.total.count:merge(0):avg&entitySelector=type(SERVICE),tag(FrontEnd),tag(testdeploy)"
+  response_time_p50: "metricSelector=builtin:service.response.time:merge(0):percentile(50)&entitySelector=type(SERVICE),tag(FrontEnd),tag(testdeploy)"
+  response_time_p90: "metricSelector=builtin:service.response.time:merge(0):percentile(90)&entitySelector=type(SERVICE),tag(FrontEnd),tag(testdeploy)"
+  response_time_p95: "metricSelector=builtin:service.response.time:merge(0):percentile(95)&entitySelector=type(SERVICE),tag(FrontEnd),tag(testdeploy)"
+  number_calls_other_services: "metricSelector=builtin:service.nonDbChildCallCount:merge(0):avg&entitySelector=type(SERVICE),tag(FrontEnd),tag(testdeploy)"
+  number_of_time_calls_other_services: "metricSelector=builtin:service.nonDbChildCallTime:merge(0):avg&entitySelector=type(SERVICE),tag(FrontEnd),tag(testdeploy)"

--- a/test/assets/quality_gates_standalone_slo_step1.yaml
+++ b/test/assets/quality_gates_standalone_slo_step1.yaml
@@ -1,0 +1,28 @@
+---
+spec_version: "0.1.1"
+comparison:
+  aggregate_function: "avg"
+  compare_with: "single_result"
+  include_result_with_score: "pass"
+  number_of_comparison_results: 1
+filter:
+objectives:
+  - sli: "response_time_p95"
+    key_sli: false
+    pass:             # pass if (relative change <= 10% AND absolute value is < 600ms)
+      - criteria:
+          - "<=+10%"  # relative values require a prefixed sign (plus or minus)
+          - "<75"    # absolute values only require a logical operator
+    warning:          # if the response time is below 800ms, the result should be a warning
+      - criteria:
+          - "<=200"
+    weight: 1
+  - sli: "throughput"
+    pass:
+      - criteria:
+          - "<=+10%"
+          - ">=-10%"
+  - sli: "error_rate"
+total_score:
+  pass: "90%"
+  warning: "75%"

--- a/test/assets/quality_gates_standalone_slo_step2.yaml
+++ b/test/assets/quality_gates_standalone_slo_step2.yaml
@@ -1,0 +1,30 @@
+---
+spec_version: "0.1.1"
+comparison:
+  aggregate_function: "avg"
+  compare_with: "single_result"
+  include_result_with_score: "pass"
+  number_of_comparison_results: 1
+filter:
+objectives:
+  - sli: "response_time_p95"
+    key_sli: false
+    pass:             # pass if (relative change <= 10% AND absolute value is < 600ms)
+      - criteria:
+          - "<=+10%"  # relative values require a prefixed sign (plus or minus)
+          - "<75"    # absolute values only require a logical operator
+    warning:          # if the response time is below 800ms, the result should be a warning
+      - criteria:
+          - "<=200"
+    weight: 1
+  - sli: "throughput"
+    pass:
+      - criteria:
+          - "<=+10%"
+          - ">=-10%"
+  - sli: "error_rate"
+  - sli: "number_calls_other_services"
+  - sli: "number_of_time_calls_other_services"
+total_score:
+  pass: "90%"
+  warning: "75%"

--- a/test/assets/quality_gates_standalone_slo_step3.yaml
+++ b/test/assets/quality_gates_standalone_slo_step3.yaml
@@ -1,0 +1,37 @@
+---
+spec_version: "0.1.1"
+comparison:
+  aggregate_function: "avg"
+  compare_with: "single_result"
+  include_result_with_score: "pass"
+  number_of_comparison_results: 1
+filter:
+objectives:
+  - sli: "response_time_p95"
+    key_sli: false
+    pass:             # pass if (relative change <= 10% AND absolute value is < 600ms)
+      - criteria:
+          - "<=+10%"  # relative values require a prefixed sign (plus or minus)
+          - "<75"    # absolute values only require a logical operator
+    warning:          # if the response time is below 800ms, the result should be a warning
+      - criteria:
+          - "<=200"
+    weight: 1
+  - sli: "throughput"
+    pass:
+      - criteria:
+          - "<=+10%"
+          - ">=-10%"
+  - sli: "error_rate"
+  - sli: "number_calls_other_services"
+    pass:
+      - criteria:
+          - "<=+10%"
+          - "<6000"
+    warning:
+      - criteria:
+          - "<10000"
+  - sli: "number_of_time_calls_other_services"
+total_score:
+  pass: "90%"
+  warning: "75%"

--- a/test/test_install_minishift_quality_gates.sh
+++ b/test/test_install_minishift_quality_gates.sh
@@ -12,3 +12,28 @@ echo "Installing keptn on minishift cluster"
 
 # Install keptn (using the develop version, which should point the :latest docker images)
 keptn install --platform=openshift --keptn-installer-image="${KEPTN_INSTALLER_IMAGE}" --use-case=quality-gates --creds=creds.json --verbose
+
+verify_test_step $? "keptn install failed"
+
+# verify that the keptn CLI has successfully authenticated
+echo "Checking that keptn is authenticated..."
+ls -la ~/.keptn/.keptn
+verify_test_step $? "Could not find keptn credentials in ~/.keptn folder"
+
+
+echo "Verifying that services and namespaces have been created"
+
+# verify the deployments within the keptn namespace
+verify_deployment_in_namespace "api-gateway-nginx" "keptn"
+verify_deployment_in_namespace "api-service" "keptn"
+verify_deployment_in_namespace "bridge" "keptn"
+verify_deployment_in_namespace "configuration-service" "keptn"
+verify_deployment_in_namespace "lighthouse-service" "keptn"
+
+# verify the pods within the keptn-datastore namespace
+verify_deployment_in_namespace "mongodb" "keptn-datastore"
+verify_deployment_in_namespace "mongodb-datastore" "keptn-datastore"
+
+echo "Installation done!"
+
+exit 0

--- a/test/test_quality_gates_standalone.sh
+++ b/test/test_quality_gates_standalone.sh
@@ -2,11 +2,62 @@
 
 source test/utils.sh
 
+# test configuration
+DYNATRACE_SLI_SERVICE_VERSION=${DYNATRACE_SLI_SERVICE_VERSION:-0.4.1}
+KEPTN_EXAMPLES_BRANCH=${KEPTN_EXAMPLES_BRANCH:-master}
+PROJECT=${PROJECT:-easytravel}
+
+# get keptn api details
+KEPTN_ENDPOINT=https://api.keptn.$(kubectl get cm keptn-domain -n keptn -ojsonpath={.data.app_domain})
+KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token} | base64 --decode)
+
+########################################################################################################################
+# Pre-requesits
+########################################################################################################################
+
+# ensure dynatrace-sli-service is not installed yet
+kubectl -n keptn get deployment dynatrace-sli-service
+
+if [[ $? -eq 0 ]]; then
+  echo "Found dynatrace-sli-service. Please uninstall it using"
+  echo "kubectl -n keptn delete deployment dynatrace-sli-service"
+  exit 1
+fi
+
+
+# verify that the project does not exiset yet via the Keptn API
+response=$(curl -X GET "${KEPTN_ENDPOINT}/configuration-service/v1/project/${PROJECT}" -H  "accept: application/json" -H  "x-token: ${KEPTN_API_TOKEN}" -k 2>/dev/null | jq -r '.projectName')
+
+if [[ "$response" == "${PROJECT}" ]]; then
+  echo "Project ${PROJECT} already exists. Please delete it using"
+  echo "keptn delete project ${PROJECT}"
+  exit 2
+fi
+
+# verify that the lighthouse configmap for the project does not exiset yet
+kubectl -n keptn get cm lighthouse-config-${PROJECT}
+
+if [[ $? -eq 0 ]]; then
+  echo "Found configmap lighthouse-config-${PROJECT}. Please remove it using"
+  echo "kubectl -n keptn delete configmap lighthouse-config-${PROJECT}"
+  exit 1
+fi
+
+# verify that the Dynatrace credential secret does not exist yet
+kubectl -n keptn get secret dynatrace-credentials-${PROJECT}
+
+if [[ $? -eq 0 ]]; then
+  echo "Found secret dynatrace-credentials-${PROJECT}. Please remove it using"
+  echo "kubectl -n keptn delete secret dynatrace-credentials-${PROJECT}"
+  exit 1
+fi
+
+
 echo "Testing quality gates standalone for project $PROJECT ..."
 
 # Test keptn create-project and create service
 rm -rf examples
-git clone --branch master https://github.com/keptn/examples --single-branch
+git clone --branch ${KEPTN_EXAMPLES_BRANCH} https://github.com/keptn/examples --single-branch
 cd examples/onboarding-carts
 
 echo "Creating a new project without git upstream"
@@ -14,72 +65,496 @@ keptn create project $PROJECT --shipyard=./shipyard-quality-gates.yaml
 verify_test_step $? "keptn create project command failed."
 sleep 10
 
+cd ../..
+
+# verify that the project has been created via the Keptn API
+response=$(curl -X GET "${KEPTN_ENDPOINT}/configuration-service/v1/project/${PROJECT}" -H  "accept: application/json" -H  "x-token: ${KEPTN_API_TOKEN}" -k 2>/dev/null | jq -r '.projectName')
+
+if [[ "$response" != "${PROJECT}" ]]; then
+  echo "Failed to check that the project exists via the API."
+  exit 2
+else
+  echo "Verified that Project exists via api"
+fi
+
+
 ###########################################
 # create service catalogue                #
 ###########################################
-keptn create service catalogue --project=$PROJECT
-verify_test_step $? "keptn create service catalogue failed."
+SERVICE=frontend
+keptn create service $SERVICE --project=$PROJECT
+verify_test_step $? "keptn create service ${SERVICE} failed."
 sleep 10
+
+########################################################################################################################
+# Testcase 1:
+# Project and service should have been created, but no SLO file added and no SLI provider configured
+# Sending a start-evaluation event now should pass with an appropriate message
+########################################################################################################################
+
+echo "Sending start-evaluation event for service $SERVICE in stage hardening"
+
+keptn_context_id=$(send_start_evaluation_event $PROJECT hardening $SERVICE)
+sleep 10
+
+echo "Getting evaluation-done event with context-id ${keptn_context_id}"
+
+# try to fetch a evaluation-done event
+response=$(get_evaluation_done_event ${keptn_context_id})
+
+# print the response
+echo $response | jq .
+
+# validate the response
+verify_using_jq "$response" ".source" "lighthouse-service"
+verify_using_jq "$response" ".type" "sh.keptn.events.evaluation-done"
+verify_using_jq "$response" ".data.project" "${PROJECT}"
+verify_using_jq "$response" ".data.stage" "hardening"
+verify_using_jq "$response" ".data.service" "${SERVICE}"
+verify_using_jq "$response" ".data.result" ""
+verify_using_jq "$response" ".data.evaluationdetails.result" "no evaluation performed by lighthouse because no SLO found for service ${SERVICE}"
+verify_using_jq "$response" ".data.evaluationdetails.score" "0"
+verify_using_jq "$response" ".data.evaluationdetails.sloFileContent" ""
+
+
+########################################################################################################################
+# Testcase 2: Send a start-evaluation event with an SLO file specified, but without an SLI provider configured
+########################################################################################################################
 
 # add SLO file for service
-keptn add-resource --project=$PROJECT --stage=hardening --service=catalogue --resource=slo-quality-gates.yaml --resourceUri=slo.yaml
-verify_test_step $? "keptn add-resource failed."
+echo "Adding SLO File: test/assets/quality_gates_standalone_slo_step1.yaml"
+keptn add-resource --project=$PROJECT --stage=hardening --service=$SERVICE --resource=test/assets/quality_gates_standalone_slo_step1.yaml --resourceUri=slo.yaml
+verify_test_step $? "keptn add-resource slo.yaml failed."
 
-# send start evaluation command
-response=$(keptn send event start-evaluation --project=$PROJECT --stage=hardening --service=catalogue --timeframe=5m)
+# add SLI file for service
+echo "Adding SLI File: test/assets/quality_gates_standalone_sli_dynatrace_step1.yaml"
+keptn add-resource --project=$PROJECT --stage=hardening --service=$SERVICE --resource=test/assets/quality_gates_standalone_sli_dynatrace_step1.yaml --resourceUri=dynatrace/sli.yaml
+verify_test_step $? "keptn add-resource sli.yaml failed."
 
-echo $response
+echo "Sending start-evaluation event for service $SERVICE in stage hardening"
 
-keptn_context_id=$(echo $response | awk -F'Keptn context:' '{ print $2 }' | xargs)
-
+keptn_context_id=$(send_start_evaluation_event $PROJECT hardening $SERVICE)
 sleep 10
-# parse output of above command and extract keptn context)
-response=$(keptn get event evaluation-done --keptn-context=${keptn_context_id})
 
-verify_test_step $? "ERROR: Command keptn get event evaluation-done --keptn-context=${keptn_context_id}) returned a non-zero exit code"
+echo "Getting evaluation-done event with context-id ${keptn_context_id}"
 
-echo $response | grep "no SLI-provider configured for project $PROJECT"
+# try to fetch a evaluation-done event
+response=$(get_evaluation_done_event ${keptn_context_id})
 
-if [[ $? -eq 0 ]]; then
-  echo "Result was as expected (no SLI-provider found)"
-else
-  echo "Got result"
-  echo $response
-  echo "ERROR: Expected string 'no SLI-provider configured for project $PROJECT' in output"
-  exit 1
-fi
+# print the response
+echo $response | jq .
 
-# okay so far, now we install a SLI provider
-kubectl apply -f https://raw.githubusercontent.com/keptn-contrib/dynatrace-sli-service/0.3.1/deploy/service.yaml
+# validate the response
+verify_using_jq "$response" ".source" "lighthouse-service"
+verify_using_jq "$response" ".type" "sh.keptn.events.evaluation-done"
+verify_using_jq "$response" ".data.project" "${PROJECT}"
+verify_using_jq "$response" ".data.stage" "hardening"
+verify_using_jq "$response" ".data.service" "${SERVICE}"
+verify_using_jq "$response" ".data.result" "failed"
+verify_using_jq "$response" ".data.evaluationdetails.result" "no evaluation performed by lighthouse because no SLI-provider configured for project ${PROJECT}"
+verify_using_jq "$response" ".data.evaluationdetails.score" "0"
+verify_using_jq "$response" ".data.evaluationdetails.sloFileContent" ""
+
+########################################################################################################################
+# Testcase 3: Send a start-evaluation event with an SLO file specified and with an SLI provider set, but no Dynatrace
+#             Tenant/API Token configured
+########################################################################################################################
+
+kubectl apply -f https://raw.githubusercontent.com/keptn-contrib/dynatrace-sli-service/${DYNATRACE_SLI_SERVICE_VERSION}/deploy/service.yaml
 sleep 10
 
 wait_for_deployment_in_namespace "dynatrace-sli-service" "keptn"
 
-echo "Sending 'configure monitoring'..."
-
 # now configure monitoring for Dynatrace
-keptn configure monitoring dynatrace --project=$PROJECT
+echo "Calling keptn configure monitoring dynatrace --project=$PROJECT"
+keptn configure monitoring dynatrace --project=$PROJECT --suppress-websocket
 sleep 5
-# this should set the configmap
+# this should set the configmap 'lighthouse-config-$PROJECT' - verify that it exists
 
-kubectl -n keptn get configmap lighthouse-config-$PROJECT -oyaml
+kubectl -n keptn get configmap "lighthouse-config-${PROJECT}" -oyaml
 verify_test_step $? "ERROR: Could not find configmap lighthouse-config-$PROJECT (this is expected to be created by keptn configure monitoring dynatrace --project=$PROJECT)"
 
+echo "Sending start-evaluation event for service $SERVICE in stage hardening"
+
 # now that this is set, let's send the start evaluation command again
-response=$(keptn send event start-evaluation --project=$PROJECT --stage=hardening --service=catalogue --timeframe=5m)
+keptn_context_id=$(send_start_evaluation_event $PROJECT hardening $SERVICE)
+sleep 30
 
-echo $response
+# Wait until a evaluation-done event is retrieved
+echo "Trying to get evaluation-done event with context-id ${keptn_context_id}"
 
-keptn_context_id=$(echo $response | awk -F'Keptn context:' '{ print $2 }' | xargs)
+RETRY=0; RETRY_MAX=30;
 
-sleep 10
-# parse output of above command and extract keptn context)
-response=$(keptn get event evaluation-done --keptn-context=${keptn_context_id})
+while [[ $RETRY -lt $RETRY_MAX ]]; do
+  # try to fetch the evaluation-done event
+  response=$(get_evaluation_done_event ${keptn_context_id})
 
-echo $response
+  # check if this contains an error
+  echo $response | grep "Get evaluation-done event was unsuccessful"
 
-verify_test_step $? "ERROR: Command keptn get event evaluation-done --keptn-context=${keptn_context_id}) returned a non-zero exit code"
+  if [[ $? -ne 0 ]]; then
+    echo "Received an evaluation-done event, continuing..."
+    break
+  else
+    RETRY=$[$RETRY+1]
+    echo "Retry: ${RETRY}/${RETRY_MAX} - Wait 10s for evaluation-done event"
+    sleep 10
+  fi
+done
+
+if [[ $RETRY == $RETRY_MAX ]]; then
+  kubectl -n keptn logs svc/dynatrace-sli-service
+  print_error "evaluation-done event could not be retrieved"
+  # exit 1 - Todo - see below
+fi
+
+# ToDo: there is no response here right now, but in fact dynatrace-sli-service should send a note...
+echo $response | grep "Get evaluation-done event was unsuccessful"
+
+if [[ $? -ne 0 ]]; then
+  # print logs of dynatrace-sli-service
+  kubectl -n keptn logs svc/dynatrace-sli-service
+  echo "Expected an 'Get evaluation-done event was unsuccessful' in the response, but got"
+  echo $response
+  exit 1
+fi
+
+########################################################################################################################
+# Testcase 4: Run tests with Dynatrace credentials (tenant and api token) set
+########################################################################################################################
+
+# create secret from file
+kubectl -n keptn create secret generic dynatrace-credentials-${PROJECT} --from-literal="DT_TENANT=$QG_INTEGRATION_TEST_DT_TENANT" --from-literal="DT_API_TOKEN=$QG_INTEGRATION_TEST_DT_API_TOKEN"
+
+# now that this is set, let's send the start evaluation command again
+keptn_context_id=$(send_start_evaluation_event $PROJECT hardening $SERVICE)
+sleep 30
+
+# Wait until a evaluation-done event is retrieved
+echo "Trying to get evaluation-done event with context-id ${keptn_context_id}"
+
+RETRY=0; RETRY_MAX=30;
+
+while [[ $RETRY -lt $RETRY_MAX ]]; do
+  # try to fetch the evaluation-done event
+  response=$(get_evaluation_done_event ${keptn_context_id})
+
+  # check if this contains an error
+  echo $response | grep "Get evaluation-done event was unsuccessful"
+
+  if [[ $? -ne 0 ]]; then
+    echo "Received an evaluation-done event, continuing..."
+    break
+  else
+    RETRY=$[$RETRY+1]
+    echo "Retry: ${RETRY}/${RETRY_MAX} - Wait 10s for evaluation-done event"
+    sleep 10
+  fi
+done
+
+if [[ $RETRY == $RETRY_MAX ]]; then
+  # print logs of dynatrace-sli-service
+  kubectl -n keptn logs svc/dynatrace-sli-service
+  print_error "evaluation-done event could not be retrieved"
+  exit 1
+fi
+
+# okay, evaluation-done event retrieved, parse it
+echo $response | jq .
+
+# validate the response
+verify_using_jq "$response" ".source" "lighthouse-service"
+verify_using_jq "$response" ".type" "sh.keptn.events.evaluation-done"
+verify_using_jq "$response" ".data.project" "${PROJECT}"
+verify_using_jq "$response" ".data.stage" "hardening"
+verify_using_jq "$response" ".data.service" "${SERVICE}"
+verify_using_jq "$response" ".data.result" "pass"
+
+# Verify .data.evaluationdetails: There should be 3 results that are true, and 0 false
+number_of_true_results=$(echo $response | jq -r '.data.evaluationdetails.indicatorResults[].value.success' | grep -c "true")
+number_of_false_results=$(echo $response | jq -r '.data.evaluationdetails.indicatorResults[].value.success' | grep -c "false")
+
+if [[ $number_of_true_results -ne 3 ]]; then
+  echo "Expected 3 results with success: true, but found $number_of_true_results"
+fi
+
+if [[ $number_of_false_results -ne 0 ]]; then
+  echo "Expected 0 results with success: false, but found $number_of_false_results"
+fi
+
+# Verify .data.evaluationsdetails: There should be 2 results with status: pass, and 1 with status: info
+number_of_pass_results=$(echo $response | jq -r '.data.evaluationdetails.indicatorResults[].status' | grep -c "pass")
+number_of_warning_results=$(echo $response | jq -r '.data.evaluationdetails.indicatorResults[].status' | grep -c "warning")
+number_of_info_results=$(echo $response | jq -r '.data.evaluationdetails.indicatorResults[].status' | grep -c "info")
+
+if [[ $number_of_pass_results -ne 2 ]]; then
+  echo "Expected 2 results with status: pass, but found $number_of_pass_results"
+fi
+
+if [[ $number_of_warning_results -ne 0 ]]; then
+  echo "Expected 0 results with status: warning, but found $number_of_warning_results"
+fi
+
+if [[ $number_of_info_results -ne 1 ]]; then
+  echo "Expected 1 results with status: info, but found $number_of_info_results"
+fi
+
+########################################################################################################################
+# Testcase 5: Run the test again
+########################################################################################################################
+sleep 30
+
+# send start-evaluation event
+keptn_context_id=$(send_start_evaluation_event $PROJECT hardening $SERVICE)
+sleep 30
+
+# Wait until a evaluation-done event is retrieved
+echo "Trying to get evaluation-done event with context-id ${keptn_context_id}"
+
+RETRY=0; RETRY_MAX=30;
+
+while [[ $RETRY -lt $RETRY_MAX ]]; do
+  # try to fetch the evaluation-done event
+  response=$(get_evaluation_done_event ${keptn_context_id})
+
+  # check if this contains an error
+  echo $response | grep "Get evaluation-done event was unsuccessful"
+
+  if [[ $? -ne 0 ]]; then
+    echo "Received an evaluation-done event, continuing..."
+    break
+  else
+    RETRY=$[$RETRY+1]
+    echo "Retry: ${RETRY}/${RETRY_MAX} - Wait 10s for evaluation-done event"
+    sleep 10
+  fi
+done
+
+if [[ $RETRY == $RETRY_MAX ]]; then
+  # print logs of dynatrace-sli-service
+  kubectl -n keptn logs svc/dynatrace-sli-service
+  print_error "evaluation-done event could not be retrieved"
+  exit 1
+fi
+
+# okay, evaluation-done event retrieved, parse it
+echo $response | jq .
+
+# validate the response
+verify_using_jq "$response" ".source" "lighthouse-service"
+verify_using_jq "$response" ".type" "sh.keptn.events.evaluation-done"
+verify_using_jq "$response" ".data.project" "${PROJECT}"
+verify_using_jq "$response" ".data.stage" "hardening"
+verify_using_jq "$response" ".data.service" "${SERVICE}"
+verify_using_jq "$response" ".data.result" "pass"
+
+# Verify .data.evaluationdetails: There should be 3 results that are true, and 0 false
+number_of_true_results=$(echo $response | jq -r '.data.evaluationdetails.indicatorResults[].value.success' | grep -c "true")
+number_of_false_results=$(echo $response | jq -r '.data.evaluationdetails.indicatorResults[].value.success' | grep -c "false")
+
+if [[ $number_of_true_results -ne 3 ]]; then
+  echo "Expected 3 results with success: true, but found $number_of_true_results"
+fi
+
+if [[ $number_of_false_results -ne 0 ]]; then
+  echo "Expected 0 results with success: false, but found $number_of_false_results"
+fi
+
+# Verify .data.evaluationsdetails: There should be 2 results with status: pass, and 1 with status: info
+number_of_pass_results=$(echo $response | jq -r '.data.evaluationdetails.indicatorResults[].status' | grep -c "pass")
+number_of_warning_results=$(echo $response | jq -r '.data.evaluationdetails.indicatorResults[].status' | grep -c "warning")
+number_of_info_results=$(echo $response | jq -r '.data.evaluationdetails.indicatorResults[].status' | grep -c "info")
+
+if [[ $number_of_pass_results -ne 2 ]]; then
+  echo "Expected 2 results with status: pass, but found $number_of_pass_results"
+fi
+
+if [[ $number_of_warning_results -ne 0 ]]; then
+  echo "Expected 0 results with status: warning, but found $number_of_warning_results"
+fi
+
+if [[ $number_of_info_results -ne 1 ]]; then
+  echo "Expected 1 results with status: info, but found $number_of_info_results"
+fi
+
+########################################################################################################################
+# Testcase 6: Add slo step2 which contains values that are not handled by dynatrace-sli-service
+########################################################################################################################
+echo "Adding SLO File: test/assets/quality_gates_standalone_slo_step2.yaml"
+keptn add-resource --project=$PROJECT --stage=hardening --service=$SERVICE --resource=test/assets/quality_gates_standalone_slo_step2.yaml --resourceUri=slo.yaml
+verify_test_step $? "keptn add-resource slo.yaml failed."
+
+# send start-evaluation event
+keptn_context_id=$(send_start_evaluation_event $PROJECT hardening $SERVICE)
+sleep 30
+
+# Wait until a evaluation-done event is retrieved
+echo "Trying to get evaluation-done event with context-id ${keptn_context_id}"
+
+RETRY=0; RETRY_MAX=30;
+
+while [[ $RETRY -lt $RETRY_MAX ]]; do
+  # try to fetch the evaluation-done event
+  response=$(get_evaluation_done_event ${keptn_context_id})
+
+  # check if this contains an error
+  echo $response | grep "Get evaluation-done event was unsuccessful"
+
+  if [[ $? -ne 0 ]]; then
+    echo "Received an evaluation-done event, continuing..."
+    break
+  else
+    RETRY=$[$RETRY+1]
+    echo "Retry: ${RETRY}/${RETRY_MAX} - Wait 10s for evaluation-done event"
+    sleep 10
+  fi
+done
+
+if [[ $RETRY == $RETRY_MAX ]]; then
+  # print logs of dynatrace-sli-service
+  kubectl -n keptn logs svc/dynatrace-sli-service
+  print_error "evaluation-done event could not be retrieved"
+  exit 1
+fi
+
+# okay, evaluation-done event retrieved, parse it
+echo $response | jq .
+
+# validate the response
+verify_using_jq "$response" ".source" "lighthouse-service"
+verify_using_jq "$response" ".type" "sh.keptn.events.evaluation-done"
+verify_using_jq "$response" ".data.project" "${PROJECT}"
+verify_using_jq "$response" ".data.stage" "hardening"
+verify_using_jq "$response" ".data.service" "${SERVICE}"
+verify_using_jq "$response" ".data.result" "pass"
+
+# Verify .data.evaluationdetails: There should be 3 results that are true, and 2 false
+number_of_true_results=$(echo $response | jq -r '.data.evaluationdetails.indicatorResults[].value.success' | grep -c "true")
+number_of_false_results=$(echo $response | jq -r '.data.evaluationdetails.indicatorResults[].value.success' | grep -c "false")
+
+if [[ $number_of_true_results -ne 3 ]]; then
+  echo "Expected 3 results with success: true, but found $number_of_true_results"
+fi
+
+if [[ $number_of_false_results -ne 2 ]]; then
+  echo "Expected 2 results with success: false, but found $number_of_false_results"
+fi
+
+# Verify .data.evaluationsdetails: There should be 2 results with status: pass, and 3 with status: info
+number_of_pass_results=$(echo $response | jq -r '.data.evaluationdetails.indicatorResults[].status' | grep -c "pass")
+number_of_warning_results=$(echo $response | jq -r '.data.evaluationdetails.indicatorResults[].status' | grep -c "warning")
+number_of_info_results=$(echo $response | jq -r '.data.evaluationdetails.indicatorResults[].status' | grep -c "info")
+
+if [[ $number_of_pass_results -ne 2 ]]; then
+  echo "Expected 2 results with status: pass, but found $number_of_pass_results"
+fi
+
+if [[ $number_of_warning_results -ne 0 ]]; then
+  echo "Expected 0 results with status: warning, but found $number_of_warning_results"
+fi
+
+if [[ $number_of_info_results -ne 3 ]]; then
+  echo "Expected 3 results with status: info, but found $number_of_info_results"
+fi
 
 
+########################################################################################################################
+# Testcase 7: Also add sli step2 such that dynatrace-sli-service finally has the correct sli configs
+########################################################################################################################
+
+# add SLI file for service
+echo "Adding SLI File: test/assets/quality_gates_standalone_sli_dynatrace_step2.yaml"
+keptn add-resource --project=$PROJECT --stage=hardening --service=$SERVICE --resource=test/assets/quality_gates_standalone_sli_dynatrace_step2.yaml --resourceUri=dynatrace/sli.yaml
+verify_test_step $? "keptn add-resource sli.yaml failed."
+
+
+# send start-evaluation event
+keptn_context_id=$(send_start_evaluation_event $PROJECT hardening $SERVICE)
+sleep 30
+
+# Wait until a evaluation-done event is retrieved
+echo "Trying to get evaluation-done event with context-id ${keptn_context_id}"
+
+RETRY=0; RETRY_MAX=30;
+
+while [[ $RETRY -lt $RETRY_MAX ]]; do
+  # try to fetch the evaluation-done event
+  response=$(get_evaluation_done_event ${keptn_context_id})
+
+  # check if this contains an error
+  echo $response | grep "Get evaluation-done event was unsuccessful"
+
+  if [[ $? -ne 0 ]]; then
+    echo "Received an evaluation-done event, continuing..."
+    break
+  else
+    RETRY=$[$RETRY+1]
+    echo "Retry: ${RETRY}/${RETRY_MAX} - Wait 10s for evaluation-done event"
+    sleep 10
+  fi
+done
+
+if [[ $RETRY == $RETRY_MAX ]]; then
+  # print logs of dynatrace-sli-service
+  kubectl -n keptn logs svc/dynatrace-sli-service
+  print_error "evaluation-done event could not be retrieved"
+  exit 1
+fi
+
+# okay, evaluation-done event retrieved, parse it
+echo $response | jq .
+
+# validate the response
+verify_using_jq "$response" ".source" "lighthouse-service"
+verify_using_jq "$response" ".type" "sh.keptn.events.evaluation-done"
+verify_using_jq "$response" ".data.project" "${PROJECT}"
+verify_using_jq "$response" ".data.stage" "hardening"
+verify_using_jq "$response" ".data.service" "${SERVICE}"
+verify_using_jq "$response" ".data.result" "pass"
+
+# Verify .data.evaluationdetails: There should be 5 results that are true, and 0 false
+number_of_true_results=$(echo $response | jq -r '.data.evaluationdetails.indicatorResults[].value.success' | grep -c "true")
+number_of_false_results=$(echo $response | jq -r '.data.evaluationdetails.indicatorResults[].value.success' | grep -c "false")
+
+if [[ $number_of_true_results -ne 5 ]]; then
+  echo "Expected 5 results with success: true, but found $number_of_true_results"
+fi
+
+if [[ $number_of_false_results -ne 0 ]]; then
+  echo "Expected 0 results with success: false, but found $number_of_false_results"
+fi
+
+# Verify .data.evaluationsdetails: There should be 2 results with status: pass, and 3 with status: info
+number_of_pass_results=$(echo $response | jq -r '.data.evaluationdetails.indicatorResults[].status' | grep -c "pass")
+number_of_warning_results=$(echo $response | jq -r '.data.evaluationdetails.indicatorResults[].status' | grep -c "warning")
+number_of_info_results=$(echo $response | jq -r '.data.evaluationdetails.indicatorResults[].status' | grep -c "info")
+
+if [[ $number_of_pass_results -ne 2 ]]; then
+  echo "Expected 2 results with status: pass, but found $number_of_pass_results"
+fi
+
+if [[ $number_of_warning_results -ne 0 ]]; then
+  echo "Expected 0 results with status: warning, but found $number_of_warning_results"
+fi
+
+if [[ $number_of_info_results -ne 3 ]]; then
+  echo "Expected 3 results with status: info, but found $number_of_info_results"
+fi
+
+
+########################################################################################################################
+# cleanup
+########################################################################################################################
+
+echo "Deleting project ${PROJECT}"
+keptn delete project $PROJECT
+
+echo "Uninstalling dynatrace-sli-service"
+kubectl -n keptn delete deployment dynatrace-sli-service
+
+echo "Removing secret dynatrace-credentials-${PROJECT}"
+kubectl -n keptn delete secret dynatrace-credentials-${PROJECT}
+
+echo "Done!"
 
 exit 0

--- a/test/utils.sh
+++ b/test/utils.sh
@@ -6,6 +6,39 @@ function print_error() {
   echo "[keptn|ERROR] $(timestamp) $1"
 }
 
+function send_start_evaluation_event() {
+  PROJECT=$1
+  STAGE=$2
+  SERVICE=$3
+
+  response=$(keptn send event start-evaluation --project=$PROJECT --stage=$STAGE --service=$SERVICE --timeframe=5m)
+  keptn_context_id=$(echo $response | awk -F'Keptn context:' '{ print $2 }' | xargs)
+
+  echo "$keptn_context_id"
+}
+
+function get_evaluation_done_event() {
+  keptn_context_id=$1
+  keptn get event evaluation-done --keptn-context="${keptn_context_id}" | tail -n +2
+}
+
+function verify_using_jq() {
+  payload=$1
+  attribute=$2
+  expected=$3
+
+  actual=$(echo "${payload}" | jq -r "${attribute}")
+
+  if [[ "${actual}" != "${expected}" ]]; then
+    print_error "ERROR: Checking $attribute, expected '${expected}', got '${actual}' ❌"
+    exit 1
+  else
+    echo "Checking $attribute: ${actual} ✓"
+  fi
+
+  return 0
+}
+
 function verify_test_step() {
   if [[ $1 != '0' ]]; then
     print_error "$2"


### PR DESCRIPTION
This implements #1591

* Added several utility functions for easier verification of test steps
* So far, I was able to add the following steps from #1591: 
  * no configmap for sli provider defined
  * install sli provider (dynatrace and retrieve some data of a monitored service, e.g., *demo-

The following cases I can not implement right now:
* use different SLO configurations per stage
  **Reason**: We do not support multi-stage quality-gates only use-case

* mix default an  non-default SLIs
  **Reason**: Default SLIs do not work in the quality-gates standalone use-case with dynatrace, as we are expecting tags etc... to be set correct
  However, I've added several SLIs and SLOs that are not used by default, to verify that things still work as expected.


In addition, I added documentation about running integration tests locally (both on Minikube and Minishift).

I also removed the `- cat ~/.keptn/keptn-installer-err.log` line from .travis.yml as this file does not exist.

# Issues discovered 
While implementing the test, I stumbled across several smaller issues that I have documented and sometimes already fixed.

- keptn/installer was using version 0.6.1 for some manifests in the installer - changed to latest https://github.com/keptn/keptn/pull/1799 (fixed)
- keptn-contrib/dynatrace-sli-service secret format has changed https://github.com/keptn-contrib/dynatrace-sli-service/pull/53 (fixed)
- keptn/core: configure domain with `--gateway=NodePort` does not work properly https://github.com/keptn/keptn/issues/1796 (not fixed)
- keptn/bridge: evaluation-done ressult should display the error message of info slis https://github.com/keptn/keptn/issues/1790 (not fixed)
