### PR TITLE
#1791 expose mongodb datastore via API gateway

### DIFF
--- a/api/swagger-ui/index.html
+++ b/api/swagger-ui/index.html
@@ -56,6 +56,9 @@
         }, {
           url: "/configuration-service/swagger-ui/swagger.yaml",
           name: "configuration-service"
+        }, {
+          url: "/mongodb-datastore/swagger-ui/swagger.yaml",
+          name: "mongodb-datastore"
         }],
       })
       // End Swagger UI call region

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -52,7 +52,8 @@ paths:
     get:
       tags:
         - Event
-      summary: Get the latest event matching the required query parameters
+      deprecated: true
+      summary: 'Deprecated endpoint - please use /mongodb-datastore/v1/event'
       parameters:
         - name: keptnContext
           in: query

--- a/gatekeeper-service/deploy/service.yaml
+++ b/gatekeeper-service/deploy/service.yaml
@@ -20,8 +20,8 @@ spec:
         - containerPort: 8080
         resources:
           requests:
-            memory: "256Mi"
-            cpu: "500m"
+            memory: "32Mi"
+            cpu: "50m"
           limits:
             memory: "256Mi"
             cpu: "500m"
@@ -46,58 +46,3 @@ spec:
     protocol: TCP
   selector:
     run: gatekeeper-service
-
----
-apiVersion: extensions/v1beta1
-kind: Deployment
-metadata:
-  annotations:
-    deployment.kubernetes.io/revision: "1"
-    kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{},"name":"gatekeeper-service-evaluation-done-distributor","namespace":"keptn"},"spec":{"replicas":1,"selector":{"matchLabels":{"run":"distributor"}},"template":{"metadata":{"labels":{"run":"distributor"}},"spec":{"containers":[{"env":[{"name":"PUBSUB_URL","value":"nats://keptn-nats-cluster"},{"name":"PUBSUB_TOPIC","value":"sh.keptn.events.evaluation-done"},{"name":"PUBSUB_RECIPIENT","value":"gatekeeper-service"}],"image":"keptn/distributor:latest","name":"distributor","ports":[{"containerPort":8080}],"resources":{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"50m","memory":"32Mi"}}}]}}}}
-  creationTimestamp: "2020-05-08T07:50:00Z"
-  generation: 1
-  name: gatekeeper-service-evaluation-done-distributor
-  namespace: keptn
-  resourceVersion: "594181"
-  selfLink: /apis/extensions/v1beta1/namespaces/keptn/deployments/gatekeeper-service-evaluation-done-distributor
-  uid: 84dff9d8-9100-11ea-9b9a-42010a80002c
-spec:
-  progressDeadlineSeconds: 600
-  replicas: 1
-  revisionHistoryLimit: 10
-  selector:
-    matchLabels:
-      run: distributor
-  strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
-    type: RollingUpdate
-  template:
-    metadata:
-      creationTimestamp: null
-      labels:
-        run: distributor
-    spec:
-      containers:
-        - env:
-            - name: PUBSUB_URL
-              value: nats://keptn-nats-cluster
-            - name: PUBSUB_TOPIC
-              value: sh.keptn.>
-            - name: PUBSUB_RECIPIENT
-              value: gatekeeper-service
-          image: keptn/distributor:latest
-          imagePullPolicy: Always
-          name: distributor
-          ports:
-            - containerPort: 8080
-              protocol: TCP
-          resources:
-            limits:
-              cpu: 500m
-              memory: 128Mi
-            requests:
-              cpu: 50m
-              memory: 32Mi

--- a/gatekeeper-service/deploy/service.yaml
+++ b/gatekeeper-service/deploy/service.yaml
@@ -20,16 +20,18 @@ spec:
         - containerPort: 8080
         resources:
           requests:
-            memory: "32Mi"
-            cpu: "50m"
+            memory: "256Mi"
+            cpu: "500m"
           limits:
-            memory: "128Mi"
+            memory: "256Mi"
             cpu: "500m"
         env:
         - name: CONFIGURATION_SERVICE
           value: 'http://configuration-service.keptn.svc.cluster.local:8080'
         - name: EVENTBROKER
           value: 'http://event-broker.keptn.svc.cluster.local/keptn'
+        - name: DATASTORE
+          value: 'http://mongodb-datastore.keptn-datastore.svc.cluster.local:8080'
 ---
 apiVersion: v1
 kind: Service
@@ -44,3 +46,58 @@ spec:
     protocol: TCP
   selector:
     run: gatekeeper-service
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: "1"
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{},"name":"gatekeeper-service-evaluation-done-distributor","namespace":"keptn"},"spec":{"replicas":1,"selector":{"matchLabels":{"run":"distributor"}},"template":{"metadata":{"labels":{"run":"distributor"}},"spec":{"containers":[{"env":[{"name":"PUBSUB_URL","value":"nats://keptn-nats-cluster"},{"name":"PUBSUB_TOPIC","value":"sh.keptn.events.evaluation-done"},{"name":"PUBSUB_RECIPIENT","value":"gatekeeper-service"}],"image":"keptn/distributor:latest","name":"distributor","ports":[{"containerPort":8080}],"resources":{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"50m","memory":"32Mi"}}}]}}}}
+  creationTimestamp: "2020-05-08T07:50:00Z"
+  generation: 1
+  name: gatekeeper-service-evaluation-done-distributor
+  namespace: keptn
+  resourceVersion: "594181"
+  selfLink: /apis/extensions/v1beta1/namespaces/keptn/deployments/gatekeeper-service-evaluation-done-distributor
+  uid: 84dff9d8-9100-11ea-9b9a-42010a80002c
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      run: distributor
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        run: distributor
+    spec:
+      containers:
+        - env:
+            - name: PUBSUB_URL
+              value: nats://keptn-nats-cluster
+            - name: PUBSUB_TOPIC
+              value: sh.keptn.>
+            - name: PUBSUB_RECIPIENT
+              value: gatekeeper-service
+          image: keptn/distributor:latest
+          imagePullPolicy: Always
+          name: distributor
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 32Mi

--- a/installer/manifests/keptn/api-gateway-nginx.yaml
+++ b/installer/manifests/keptn/api-gateway-nginx.yaml
@@ -37,6 +37,37 @@ data:
           listen       80;
           server_name  _;
 
+          location /mongodb-datastore/swagger-ui/swagger.yaml {
+            # auth via backend (if the subrequest returns a 2xx response code, the access is allowed. If it returns 401 or 403,
+            # the access is denied) before we store the file
+            # see http://nginx.org/en/docs/http/ngx_http_auth_request_module.html
+
+            rewrite /mongodb-datastore/(.*) /$1  break;
+            proxy_pass         http://mongodb-datastore.keptn-datastore.svc.cluster.local:8080;
+            proxy_redirect     off;
+            proxy_set_header   Host $host;
+            proxy_http_version 1.1;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+          }
+
+          location  /mongodb-datastore {
+            # auth via backend (if the subrequest returns a 2xx response code, the access is allowed. If it returns 401 or 403,
+            # the access is denied) before we store the file
+            # see http://nginx.org/en/docs/http/ngx_http_auth_request_module.html
+            auth_request               /v1/auth;
+
+            rewrite /mongodb-datastore/(.*) /$1  break;
+            proxy_pass         http://mongodb-datastore.keptn-datastore.svc.cluster.local:8080;
+            proxy_redirect     off;
+            proxy_set_header   Host $host;
+            proxy_http_version 1.1;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+          }
+
           location /configuration-service/swagger-ui/swagger.yaml {
             # auth via backend (if the subrequest returns a 2xx response code, the access is allowed. If it returns 401 or 403,
             # the access is denied) before we store the file


### PR DESCRIPTION
This PR will make the mongodb-datastore available via the Keptn API.

This will allow for more flexibility in terms of retrieving events via the API, as needed in Issue #1749.

Deprecates the `GET v1/event` endpoint of the `api-service`, which only provided the possibility to retrieve a single event by its type and keptn context ID.

Closes #1791. 