### PR TITLE
Set manifests to :latest

### DIFF
--- a/installer/manifests/keptn/continuous-deployment.yaml
+++ b/installer/manifests/keptn/continuous-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: gatekeeper-service
-        image: keptn/gatekeeper-service:0.6.1
+        image: keptn/gatekeeper-service:latest
         ports:
         - containerPort: 8080
         resources:

--- a/installer/manifests/logging/mongodb-datastore/k8s/mongodb-datastore.yaml
+++ b/installer/manifests/logging/mongodb-datastore/k8s/mongodb-datastore.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: mongodb-datastore
-        image: keptn/mongodb-datastore:0.6.1
+        image: keptn/mongodb-datastore:latest
         ports:
         - containerPort: 8080
         resources:

--- a/installer/manifests/logging/mongodb-datastore/mongodb-datastore-distributor.yaml
+++ b/installer/manifests/logging/mongodb-datastore/mongodb-datastore-distributor.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: distributor
-        image: keptn/distributor:0.6.1
+        image: keptn/distributor:latest
         ports:
         - containerPort: 8080
         resources:

--- a/installer/manifests/logging/mongodb-datastore/openshift/mongodb-datastore.yaml
+++ b/installer/manifests/logging/mongodb-datastore/openshift/mongodb-datastore.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: mongodb-datastore
-        image: keptn/mongodb-datastore:0.6.1
+        image: keptn/mongodb-datastore:latest
         ports:
         - containerPort: 8080
         resources:


### PR DESCRIPTION
After the 0.6.1 release we forgot to set some manifests to `:latest` again.