### PR TITLE
#1802 adapt helm template commands to helm v3

### DIFF
--- a/installer/scripts/common/setupIstio.sh
+++ b/installer/scripts/common/setupIstio.sh
@@ -26,7 +26,7 @@ else
     print_info "Install Istio"
     kubectl create namespace istio-system
 
-    helm template ../manifests/istio/helm/istio-init --namespace istio-system | kubectl apply -f -
+    helm template istio-init ../manifests/istio/helm/istio-init --namespace istio-system | kubectl apply -f -
     verify_kubectl $? "Creating Istio resources failed"
     wait_for_crds "adapters.config.istio.io,attributemanifests.config.istio.io,authorizationpolicies.rbac.istio.io,clusterrbacconfigs.rbac.istio.io,destinationrules.networking.istio.io,envoyfilters.networking.istio.io,gateways.networking.istio.io,handlers.config.istio.io,httpapispecbindings.config.istio.io,httpapispecs.config.istio.io,instances.config.istio.io,meshpolicies.authentication.istio.io,policies.authentication.istio.io,quotaspecbindings.config.istio.io,quotaspecs.config.istio.io,rbacconfigs.rbac.istio.io,rules.config.istio.io,serviceentries.networking.istio.io,servicerolebindings.rbac.istio.io,serviceroles.rbac.istio.io,sidecars.networking.istio.io,templates.config.istio.io,virtualservices.networking.istio.io"
 
@@ -34,7 +34,7 @@ else
     # However, it did not work out. Therefore, we are using sed
     sed 's/LoadBalancer #change to NodePort, ClusterIP or LoadBalancer if need be/'$GATEWAY_TYPE'/g' ../manifests/istio/helm/istio/charts/gateways/values.yaml  > ../manifests/istio/helm/istio/charts/gateways/values_tmp.yaml
     mv ../manifests/istio/helm/istio/charts/gateways/values_tmp.yaml ../manifests/istio/helm/istio/charts/gateways/values.yaml
-    helm template ../manifests/istio/helm/istio --namespace istio-system --values ../manifests/istio/helm/istio/values-istio-minimal.yaml | kubectl apply -f -
+    helm template istio ../manifests/istio/helm/istio --namespace istio-system --values ../manifests/istio/helm/istio/values-istio-minimal.yaml | kubectl apply -f -
     verify_kubectl $? "Installing Istio failed."
     wait_for_deployment_in_namespace "istio-ingressgateway" "istio-system"
     wait_for_deployment_in_namespace "istio-pilot" "istio-system"

--- a/installer/scripts/openshift/setupIstio.sh
+++ b/installer/scripts/openshift/setupIstio.sh
@@ -3,7 +3,7 @@ source ./common/utils.sh
 
 kubectl create namespace istio-system
 
-helm template ../manifests/istio/helm/istio-init --name istio-init --namespace istio-system | kubectl apply -f -
+helm template istio-init ../manifests/istio/helm/istio-init --namespace istio-system | kubectl apply -f -
 verify_kubectl $? "Creating Istio resources failed"
 wait_for_crds "adapters.config.istio.io,attributemanifests.config.istio.io,authorizationpolicies.rbac.istio.io,clusterrbacconfigs.rbac.istio.io,destinationrules.networking.istio.io,envoyfilters.networking.istio.io,gateways.networking.istio.io,handlers.config.istio.io,httpapispecbindings.config.istio.io,httpapispecs.config.istio.io,instances.config.istio.io,meshpolicies.authentication.istio.io,policies.authentication.istio.io,quotaspecbindings.config.istio.io,quotaspecs.config.istio.io,rbacconfigs.rbac.istio.io,rules.config.istio.io,serviceentries.networking.istio.io,servicerolebindings.rbac.istio.io,serviceroles.rbac.istio.io,sidecars.networking.istio.io,templates.config.istio.io,virtualservices.networking.istio.io"
 
@@ -11,7 +11,7 @@ wait_for_crds "adapters.config.istio.io,attributemanifests.config.istio.io,autho
 # However, it did not work out. Therefore, we are using sed
 sed 's/LoadBalancer #change to NodePort, ClusterIP or LoadBalancer if need be/'$GATEWAY_TYPE'/g' ../manifests/istio/helm/istio/charts/gateways/values.yaml  > ../manifests/istio/helm/istio/charts/gateways/values_tmp.yaml
 mv ../manifests/istio/helm/istio/charts/gateways/values_tmp.yaml ../manifests/istio/helm/istio/charts/gateways/values.yaml
-helm template ../manifests/istio/helm/istio --name istio --namespace istio-system --values ../manifests/istio/helm/istio/values-istio-minimal.yaml | kubectl apply -f -
+helm template istio ../manifests/istio/helm/istio --namespace istio-system --values ../manifests/istio/helm/istio/values-istio-minimal.yaml | kubectl apply -f -
 verify_kubectl $? "Installing Istio failed."
 wait_for_deployment_in_namespace "istio-ingressgateway" "istio-system"
 wait_for_deployment_in_namespace "istio-pilot" "istio-system"


### PR DESCRIPTION
Closes #1802 
Due to the upgrade to Helm v3, the `--name` flag we previously used in the `helm template` commands, is not supported anymore. Instead, the name of the template is not a mandatory parameter, as described in the [Helm v3 docs](https://helm.sh/docs/helm/helm_template/)