### PR TITLE
#1777 Update supported K8s version to 1.14-1.18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
 - VERSION="unknownversion"
 - DATE="$(date +'%Y%m%d.%H%M')"
 - GIT_SHA="$(git rev-parse --short HEAD)"
-- KUBE_CONSTRAINTS=">= 1.13, <= 1.15"
+- KUBE_CONSTRAINTS=">= 1.14, <= 1.18" # don't forget to udpate the defaults in cli/main.go
 
 # store all changed files from this commit in files.txt (careful - travis commit range might fail)
 - git diff --name-only $TRAVIS_COMMIT_RANGE > files.txt || echo ""

--- a/cli/main.go
+++ b/cli/main.go
@@ -12,7 +12,7 @@ var (
 	Version = "develop"
 
 	// KubeServerVersionConstraints the Kubernetes Cluster version's constraints is passed by ldflags
-	KubeServerVersionConstraints = ">= 1.13, <= 1.15"
+	KubeServerVersionConstraints = ">= 1.14, <= 1.18"
 )
 
 func init() {


### PR DESCRIPTION
This PR updates the supported K8s version of the CLI to check for `>= 1.14` and `<= 1.18`.