### PR TITLE
Add environment variable for keptnDomain to helm-service

### DIFF
--- a/helm-service/controller/onboarder.go
+++ b/helm-service/controller/onboarder.go
@@ -37,7 +37,7 @@ func (o *Onboarder) DoOnboard(ce cloudevents.Event, loggingDone chan bool) error
 
 	defer func() { loggingDone <- true }()
 
-	keptnHandler, err := keptnevents.NewKeptn(&ce, keptnevents.KeptnOpts{})
+	keptnHandler, err := keptnevents.NewKeptn(&ce, keptnevents.KeptnOpts{ConfigurationServiceURL: o.configServiceURL})
 	if err != nil {
 		o.logger.Error("Could not initialize Keptn Handler: " + err.Error())
 		return err

--- a/helm-service/controller/onboarder.go
+++ b/helm-service/controller/onboarder.go
@@ -37,7 +37,7 @@ func (o *Onboarder) DoOnboard(ce cloudevents.Event, loggingDone chan bool) error
 
 	defer func() { loggingDone <- true }()
 
-	keptnHandler, err := keptnevents.NewKeptn(&ce, keptnevents.KeptnOpts{ConfigurationServiceURL: o.configServiceURL})
+	keptnHandler, err := keptnevents.NewKeptn(&ce, keptnevents.KeptnOpts{})
 	if err != nil {
 		o.logger.Error("Could not initialize Keptn Handler: " + err.Error())
 		return err

--- a/helm-service/main.go
+++ b/helm-service/main.go
@@ -35,13 +35,14 @@ func main() {
 func getKeptnDomain() (string, error) {
 	if os.Getenv("KEPTN_DOMAIN") != "" {
 		return os.Getenv("KEPTN_DOMAIN"), nil
- 	} else {
-		useInClusterConfig := false
-		if os.Getenv("ENVIRONMENT") == "production" {
-			useInClusterConfig = true
-		}
-		return keptnutils.GetKeptnDomain(useInClusterConfig)
-	}
+ 	}
+
+ 	useInClusterConfig := false
+ 	if os.Getenv("ENVIRONMENT") == "production" {
+ 		useInClusterConfig = true
+ 	}
+ 	return keptnutils.GetKeptnDomain(useInClusterConfig)
+
 }
 
 func gotEvent(ctx context.Context, event cloudevents.Event) error {

--- a/helm-service/main.go
+++ b/helm-service/main.go
@@ -33,11 +33,15 @@ func main() {
 }
 
 func getKeptnDomain() (string, error) {
-	useInClusterConfig := false
-	if os.Getenv("ENVIRONMENT") == "production" {
-		useInClusterConfig = true
+	if os.Getenv("KEPTN_DOMAIN") != "" {
+		return os.Getenv("KEPTN_DOMAIN"), nil
+ 	} else {
+		useInClusterConfig := false
+		if os.Getenv("ENVIRONMENT") == "production" {
+			useInClusterConfig = true
+		}
+		return keptnutils.GetKeptnDomain(useInClusterConfig)
 	}
-	return keptnutils.GetKeptnDomain(useInClusterConfig)
 }
 
 func gotEvent(ctx context.Context, event cloudevents.Event) error {


### PR DESCRIPTION
This PR implements #1801 

* Introduced environment variable "KEPTN_DOMAIN" in helm-service
* Use the environment variable if set
* Use configmap if environment variable is not set