### PR TITLE
#1792 retrieve evaluation-done events from mongodb-datastore

### DIFF
--- a/cli/cmd/get_event_evaluationDone.go
+++ b/cli/cmd/get_event_evaluationDone.go
@@ -34,10 +34,10 @@ var evaluationDone evaluationDoneStruct
 
 // evaluationDoneCmd represents the evaluation-done command
 var evaluationDoneCmd = &cobra.Command{
-	Use:   "evaluation-done",
-	Short: "Returns the latest Keptn sh.keptn.events.evaluation-done event from a specific Keptn context",
-	Long: `Returns the latest Keptn sh.keptn.events.evaluation-done event from a specific Keptn context.`,
-	Example: `keptn get event evaluation-done --keptn-context=1234-5678-90ab-cdef`,
+	Use:          "evaluation-done",
+	Short:        "Returns the latest Keptn sh.keptn.events.evaluation-done event from a specific Keptn context",
+	Long:         `Returns the latest Keptn sh.keptn.events.evaluation-done event from a specific Keptn context.`,
+	Example:      `keptn get event evaluation-done --keptn-context=1234-5678-90ab-cdef`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds()
@@ -51,19 +51,24 @@ var evaluationDoneCmd = &cobra.Command{
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)
 
 		if !mocking {
-			evaluationDoneEvt, err := eventHandler.GetEvent(*evaluationDone.KeptnContext, keptnevents.EvaluationDoneEventType)
+			evaluationDoneEvts, err := eventHandler.GetEvents(&apiutils.EventFilter{
+				KeptnContext: *evaluationDone.KeptnContext,
+				EventType:    keptnevents.EvaluationDoneEventType,
+			})
 			if err != nil {
 				logging.PrintLog("Get evaluation-done event was unsuccessful", logging.QuietLevel)
 				return fmt.Errorf("%s", *err.Message)
 			}
 
-			if evaluationDoneEvt == nil {
+			if len(evaluationDoneEvts) == 0 {
 				logging.PrintLog("No event returned", logging.QuietLevel)
 				return nil
 			}
 
-			event, _ := json.Marshal(evaluationDoneEvt)
-			fmt.Println(string(event))
+			for _, event := range evaluationDoneEvts {
+				event, _ := json.MarshalIndent(event, "", "    ")
+				fmt.Println(string(event))
+			}
 
 		} else {
 			fmt.Println("Skipping send evaluation-start due to mocking flag set to true")

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/websocket v1.4.1
 	github.com/hashicorp/go-version v1.2.0
-	github.com/keptn/go-utils v0.6.1-compat.0.20200429125908-17c6026062a1
+	github.com/keptn/go-utils v0.6.3-0.20200519062453-c1dbff59ff39
 	github.com/keptn/kubernetes-utils v0.0.0-20200414115508-d18721552e01
 	github.com/magiconair/properties v1.8.1
 	github.com/mattn/go-shellwords v1.0.10

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -346,6 +346,10 @@ github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa
 github.com/keptn/go-utils v0.6.1-0.20200330141040-86c024b3622b/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/keptn/go-utils v0.6.1-compat.0.20200429125908-17c6026062a1 h1:ioKVVxBPAUFm/kkP0dXiqeJKa2IbcE2EJhcTJFpdr6k=
 github.com/keptn/go-utils v0.6.1-compat.0.20200429125908-17c6026062a1/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
+github.com/keptn/go-utils v0.6.3-0.20200518060925-b23b872eee78 h1:NdvK0mWaRh0UqGatDrpEwPRkUUI7zd1a8kgXhlSnVTI=
+github.com/keptn/go-utils v0.6.3-0.20200518060925-b23b872eee78/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
+github.com/keptn/go-utils v0.6.3-0.20200519062453-c1dbff59ff39 h1:WXDcmy0k4KgabfTMkABGl1RC/WvbqcSwLtQgFVwikFg=
+github.com/keptn/go-utils v0.6.3-0.20200519062453-c1dbff59ff39/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/keptn/kubernetes-utils v0.0.0-20200401103501-ae44a5ee0656 h1:uGdzQ+DT+/KqzMJF+5F+B+/h0nOfwmmSA7ClxsI1y6Y=
 github.com/keptn/kubernetes-utils v0.0.0-20200401103501-ae44a5ee0656/go.mod h1:7MQMS/jqKM4eVZ0S1S7LWdZNcBTJn5QeERircdADWzo=
 github.com/keptn/kubernetes-utils v0.0.0-20200414115508-d18721552e01 h1:E7VbURzJxMXDhh2p03j1Ij8DLprfnO5UOrKIJj3rhwM=


### PR DESCRIPTION
Closes #1792 
The CLI now uses the exposed mongodb-datastore (see PR #1791) to retrieve events for the ` keptn get event evaluation-done --keptn-context=1234` command.

Additionally, the output of the `get event` command is now formatted in a more readable way. Example output:

```
$keptn get event evaluation-done --keptn-context=1234
Starting to get evaluation-done event
{
    "contenttype": "application/json",
    "data": {
        "deploymentstrategy": "direct",
        "evaluationdetails": {
            "indicatorResults": null,
            "result": "no evaluation performed by lighthouse because no test has been executed",
            "score": 0,
            "sloFileContent": "",
            "timeEnd": "2020-05-18T10:13:21Z",
            "timeStart": "2020-05-18T10:13:21Z"
        },
        "labels": null,
        "project": "sockshop",
        "result": "pass",
        "service": "carts-db",
        "stage": "production",
        "teststrategy": ""
    },
    "id": "5678",
    "shkeptncontext": "1234",
    "source": "lighthouse-service",
    "specversion": "0.2",
    "time": "2020-05-18T10:13:21.555Z",
    "type": "sh.keptn.events.evaluation-done"
}
```