### PR TITLE
#1777 enable GKE 1.16; configure domain to nip.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -408,20 +408,19 @@ jobs:
       - KEPTN_INSTALLATION_TYPE=FULL
     <<: *gke_full # use template
 
-  - stage: Test GKE Full (--platform=gke)
-    if: branch = master AND type = cron # run for cron
-    env:
-      - GKE_VERSION=1.15
-      - KEPTN_INSTALLATION_TYPE=FULL
-    <<: *gke_full # use template
-
-  # Test GKE with 1.16 (not available yet)
 #  - stage: Test GKE Full (--platform=gke)
 #    if: branch = master AND type = cron # run for cron
 #    env:
-#      - GKE_VERSION=1.16
+#      - GKE_VERSION=1.15
 #      - KEPTN_INSTALLATION_TYPE=FULL
 #    <<: *gke_full # use template
+
+  - stage: Test GKE Full (--platform=gke)
+    if: branch = master AND type = cron # run for cron
+    env:
+      - GKE_VERSION=1.16
+      - KEPTN_INSTALLATION_TYPE=FULL
+    <<: *gke_full # use template
 
   # Test GKE with 1.17 (not available yet)
 #  - stage: Test GKE Full (--platform=gke)
@@ -438,20 +437,19 @@ jobs:
       - GKE_VERSION=1.14
     <<: *gke_full # use template
 
-  - stage: Test GKE Full with Istio (--platform=gke --ingress-install-option=Reuse)
-    if: branch = master AND type = cron # run for cron
-    env:
-      - KEPTN_INSTALLATION_TYPE=REUSE-ISTIO
-      - GKE_VERSION=1.15
-    <<: *gke_full # use template
-
-  # Test GKE with 1.16 (not available yet)
 #  - stage: Test GKE Full with Istio (--platform=gke --ingress-install-option=Reuse)
 #    if: branch = master AND type = cron # run for cron
 #    env:
 #      - KEPTN_INSTALLATION_TYPE=REUSE-ISTIO
-#      - GKE_VERSION=1.16
+#      - GKE_VERSION=1.15
 #    <<: *gke_full # use template
+
+  - stage: Test GKE Full with Istio (--platform=gke --ingress-install-option=Reuse)
+    if: branch = master AND type = cron # run for cron
+    env:
+      - KEPTN_INSTALLATION_TYPE=REUSE-ISTIO
+      - GKE_VERSION=1.16
+    <<: *gke_full # use template
 
   # Test GKE with 1.17 (not available yet)
 #  - stage: Test GKE Full with Istio (--platform=gke --ingress-install-option=Reuse)

--- a/test/test_install_gke.sh
+++ b/test/test_install_gke.sh
@@ -30,6 +30,15 @@ fi
 keptn install ${INGRESS_CONFIG} --keptn-installer-image="${KEPTN_INSTALLER_IMAGE}" --creds=creds.json --verbose
 verify_test_step $? "keptn install failed"
 
+# change domain
+CURRENT_DOMAIN=$(kubectl get cm -n keptn keptn-domain -ojsonpath={.data.app_domain})
+# replace xip.io with nip.io
+NEW_DOMAIN=${CURRENT_DOMAIN//xip/nip}
+
+echo "Changing Keptn domain to ${NEW_DOMAIN}"
+echo "y" | keptn configure domain "${NEW_DOMAIN}" --keptn-version=master
+verify_test_step $? "Could not change Keptn Domain to ${NEW_DOMAIN}"
+
 # verify that the keptn CLI has successfully authenticated
 echo "Checking that keptn is authenticated..."
 ls -la ~/.keptn/.keptn


### PR DESCRIPTION
This PR adapts travis ci yaml to use GKE 1.16, as it is now available as a regular version. As we know that 1.15 is similar to 1.14, but 1.16 is not, I've disabled the tests for 1.15 to avoid creating too many clusters on GKE.

In addition, as xip.io is failing a lot of times now, I've switched it over to nip.io using a `keptn configure domain` command. This way, we do not only test `keptn configure bridge` but also `keptn configure domain`