### PR TITLE
mock image availability check responses

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -197,7 +197,7 @@ keptn install --platform=kubernetes --gateway=NodePort # install on a Kubernetes
 			*installParams.InstallerImage = image + ":" + tag
 		}
 
-		err = docker.CheckImageAvailability(image, tag)
+		err = docker.CheckImageAvailability(image, tag, nil)
 		if err != nil {
 			return fmt.Errorf("Installer image not found under: %v", err)
 		}

--- a/cli/cmd/send_event_newArtifact.go
+++ b/cli/cmd/send_event_newArtifact.go
@@ -63,7 +63,7 @@ Furthermore, please note that the value provided in the *image* flag has to cont
 **Note:** This command does not send the actual Docker image to Keptn, just the image name and tag. Instead, Keptn uses Kubernetes functionalities for pulling this image.
 For pulling an image from a private registry, we would like to refer to the Kubernetes documentation (https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
 `,
-	Example: `keptn send event new-artifact --project=sockshop --service=carts --image=docker.io/keptnexamples/carts --tag=0.7.0`,
+	Example:      `keptn send event new-artifact --project=sockshop --service=carts --image=docker.io/keptnexamples/carts --tag=0.7.0`,
 	SilenceUsage: true,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		trimmedImage := strings.TrimSuffix(*newArtifact.Image, "/")
@@ -72,7 +72,7 @@ For pulling an image from a private registry, we would like to refer to the Kube
 		if newArtifact.Tag == nil || *newArtifact.Tag == "" {
 			*newArtifact.Image, *newArtifact.Tag = docker.SplitImageName(*newArtifact.Image)
 		}
-		return docker.CheckImageAvailability(*newArtifact.Image, *newArtifact.Tag)
+		return docker.CheckImageAvailability(*newArtifact.Image, *newArtifact.Tag, nil)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds()

--- a/cli/pkg/docker/docker_utils.go
+++ b/cli/pkg/docker/docker_utils.go
@@ -28,10 +28,13 @@ func SplitImageName(imageWithTag string) (string, string) {
 }
 
 // CheckImageAvailability checks the availability of a image which is hosted on Docker or on Quay
-func CheckImageAvailability(image, tag string) error {
+func CheckImageAvailability(image, tag string, client *http.Client) error {
 
+	if client == nil {
+		client = http.DefaultClient
+	}
 	if strings.HasPrefix(image, "docker.io/") {
-		resp, err := http.Get("https://index.docker.io/v1/repositories/" +
+		resp, err := client.Get("https://index.docker.io/v1/repositories/" +
 			strings.TrimPrefix(image, "docker.io/") + "/tags/" + tag)
 		if err != nil {
 			return err
@@ -45,7 +48,7 @@ func CheckImageAvailability(image, tag string) error {
 		}
 		return errors.New("Provided image not found: " + string(body))
 	} else if strings.HasPrefix(image, "quay.io/") {
-		resp, err := http.Get("https://quay.io/api/v1/repository/" +
+		resp, err := client.Get("https://quay.io/api/v1/repository/" +
 			strings.TrimPrefix(image, "quay.io/") + "/tag/" + tag + "/images")
 		if err != nil {
 			return err


### PR DESCRIPTION
previously, we called external services such as docker.io or quay.io in the `TestCheckImageAvailablity` unit test. These endpoints have now been mocked to ensure our unit tests are not impacted by potential downtimes of those services