### PR TITLE
#1791 Patch swagger.yaml for exposing it via api

### DIFF
--- a/mongodb-datastore/Dockerfile
+++ b/mongodb-datastore/Dockerfile
@@ -41,7 +41,13 @@ RUN apk add --no-cache ca-certificates libc6-compat
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /go/src/github.com/keptn/keptn/mongodb-datastore/cmd/mongodb-datastore-server/mongodb-datastore /mongodb-datastore
 COPY --from=builder /go/src/github.com/keptn/keptn/mongodb-datastore/swagger-ui /swagger-ui
+COPY --from=builder /go/src/github.com/keptn/keptn/mongodb-datastore/swagger.yaml /swagger-ui/swagger-original.yaml
+
 COPY --from=builder /go/src/github.com/keptn/keptn/mongodb-datastore/swagger.yaml /swagger-ui/swagger.yaml
+# Replace contents for api proxy
+RUN sed -i "s|basePath: /v1|basePath: /configuration-service/v1 |g" /swagger-ui/swagger.yaml
+RUN sed -i "s|  - http|  - https |g" /swagger-ui/swagger.yaml
+RUN sed -i '/paths:/i securityDefinitions:\n  key:\n    type: apiKey\n    in: header\n    name: x-token\nsecurity:\n  - key: []\n' /swagger-ui/swagger.yaml
 
 EXPOSE 8080
 


### PR DESCRIPTION
This PR adds instructions in the Dockerfile for editing the swagger.yaml.
More precisely, the swagger.yaml is edited so that it uses https and all requests require an x-token.