### PR TITLE
Show stage details in environments screen

### DIFF
--- a/bridge/client/app/app-header/app-header.component.html
+++ b/bridge/client/app/app-header/app-header.component.html
@@ -2,10 +2,10 @@
   <div fxFlex fxLayout="row" fxLayoutGap="10px" fxLayoutAlign="flex-start center">
     <a routerLink="/" class="brand" fxLayout="row" fxLayoutGap="10px" fxLayoutAlign="space-between center">
       <img src="/assets/logo.png" />
-      <p>keptn</p>
+      <p class="mt-1 mb-1">keptn</p>
     </a>
-    <p>/</p>
-    <p>
+    <p class="mt-1 mb-1">/</p>
+    <p class="mt-1 mb-1">
       <dt-select id="projectSelect" placeholder="Choose project" aria-label="Choose project" [value]="(project | async)?.projectName">
         <dt-option *ngFor="let project of projects | async" [routerLink]="['/project', project.projectName]" [value]="project.projectName" [textContent]="project.projectName"></dt-option>
       </dt-select>

--- a/bridge/client/app/project-board/project-board.component.html
+++ b/bridge/client/app/project-board/project-board.component.html
@@ -37,9 +37,8 @@
       <a (click)="selectView('services')" [class.active]="view == 'services'" dtMenuItem>Services</a>
     </dt-menu-group>
   </dt-menu>
-
   <ng-container *ngIf="view == 'environment'">
-    <div class="container" fxFlex fxLayout="column" fxLayoutGap="15px">
+    <div class="container" fxFlex="66" fxLayout="row" fxLayoutGap="15px">
       <div fxFlex fxLayout="column" fxLayoutGap="15px">
         <div>
           <dt-info-group>
@@ -47,9 +46,11 @@
               <p><span [textContent]="project.stages.length"></span> Stages</p>
             </dt-info-group-title>
             <div class="mr-minus-15" fxLayout="row wrap" fxLayout.lt-sm="column" fxLayoutGap="15px" fxLayoutAlign="start">
-              <dt-tile *ngFor="let stage of project.stages; trackBy:trackStage"
-                       fxFlex="0 1 calc(33.3% - 15px)" fxFlex.lt-md="0 1 calc(50% - 15px)" fxFlex.lt-sm="100%">
-                <dt-tile-title [textContent]="stage.stageName"></dt-tile-title>
+              <ktb-selectable-tile *ngFor="let stage of project.stages; trackBy:trackStage"
+                                   fxFlex="0 1 calc(33.3% - 15px)" fxFlex.lt-md="0 1 calc(50% - 15px)" fxFlex.lt-sm="100%"
+                                   (click)="selectStage(stage)" [selected]="_selectedStage == stage">
+                <h2 class="m-0 mt-1 mb-1" [textContent]="stage.stageName"></h2>
+                <hr/>
                 <ng-container *ngIf="stage.services">
                   <dt-tag-list aria-label="services">
                     <dt-tag *ngFor="let service of getDeployedServices(project, stage)">
@@ -57,11 +58,32 @@
                     </dt-tag>
                   </dt-tag-list>
                 </ng-container>
-              </dt-tile>
+              </ktb-selectable-tile>
             </div>
           </dt-info-group>
         </div>
       </div>
+    </div>
+    <div class="container dark" fxFlex="34" fxLayout="column" fxLayoutGap="15px" *ngIf="_selectedStage">
+      <h2 [textContent]="_selectedStage.stageName"></h2>
+      <ng-container *ngFor="let service of getDeployedServices(project, _selectedStage)">
+        <ktb-expandable-tile *ngIf="getLatestDeployment(project, service, _selectedStage) as deployment">
+          <ktb-expandable-tile-header>
+            <dt-info-group>
+              <dt-info-group-title>
+                <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px">
+                  <h2 class="m-0" [textContent]="deployment.getService()"></h2>
+                  <a *ngIf="deployment.data.deploymentURIPublic" [href]="deployment.data.deploymentURIPublic" target="_blank"><button dt-icon-button variant="nested"><dt-icon name="externallink"></dt-icon></button></a>
+                </div>
+              </dt-info-group-title>
+              <p class="m-0 mb-1"><span [textContent]="deployment.data.image"></span>:<span [textContent]="deployment.data.tag"></span></p>
+              <div *ngIf="deployment.time">
+                <p class="m-0 mb-1"><span class="bold">Deployed at: </span><span [textContent]="deployment.time | amCalendar:getCalendarFormats()"></span></p>
+              </div>
+            </dt-info-group>
+          </ktb-expandable-tile-header>
+        </ktb-expandable-tile>
+      </ng-container>
     </div>
   </ng-container>
   <ng-container *ngIf="view == 'services'">

--- a/bridge/client/app/project-board/project-board.component.html
+++ b/bridge/client/app/project-board/project-board.component.html
@@ -76,10 +76,8 @@
                   <a *ngIf="deployment.data.deploymentURIPublic" [href]="deployment.data.deploymentURIPublic" target="_blank"><button dt-icon-button variant="nested"><dt-icon name="externallink"></dt-icon></button></a>
                 </div>
               </dt-info-group-title>
-              <p class="m-0 mb-1"><span [textContent]="deployment.data.image"></span>:<span [textContent]="deployment.data.tag"></span></p>
-              <div *ngIf="deployment.time">
-                <p class="m-0 mb-1"><span class="bold">Deployed at: </span><span [textContent]="deployment.time | amCalendar:getCalendarFormats()"></span></p>
-              </div>
+              <p class="m-0 mt-1"><span [textContent]="deployment.data.image"></span>:<span [textContent]="deployment.data.tag"></span></p>
+              <p class="m-0 mb-1"><span class="bold">Deployed at: </span><span [textContent]="deployment.time | amCalendar:getCalendarFormats()"></span></p>
             </dt-info-group>
           </ktb-expandable-tile-header>
         </ktb-expandable-tile>

--- a/bridge/client/app/project-board/project-board.component.html
+++ b/bridge/client/app/project-board/project-board.component.html
@@ -48,7 +48,7 @@
             <div class="mr-minus-15" fxLayout="row wrap" fxLayout.lt-sm="column" fxLayoutGap="15px" fxLayoutAlign="start">
               <ktb-selectable-tile *ngFor="let stage of project.stages; trackBy:trackStage"
                                    fxFlex="0 1 calc(33.3% - 15px)" fxFlex.lt-md="0 1 calc(50% - 15px)" fxFlex.lt-sm="100%"
-                                   (click)="selectStage(stage)" [selected]="_selectedStage == stage">
+                                   (click)="selectStage(stage)" [selected]="selectedStage == stage">
                 <h2 class="m-0 mt-1 mb-1" [textContent]="stage.stageName"></h2>
                 <hr/>
                 <ng-container *ngIf="stage.services">
@@ -64,10 +64,10 @@
         </div>
       </div>
     </div>
-    <div class="container dark" fxFlex="34" fxLayout="column" fxLayoutGap="15px" *ngIf="_selectedStage">
-      <h2 [textContent]="_selectedStage.stageName"></h2>
-      <ng-container *ngFor="let service of getDeployedServices(project, _selectedStage)">
-        <ktb-expandable-tile *ngIf="getLatestDeployment(project, service, _selectedStage) as deployment">
+    <div class="container dark" fxFlex="34" fxLayout="column" fxLayoutGap="15px" *ngIf="selectedStage">
+      <h2 [textContent]="selectedStage.stageName"></h2>
+      <ng-container *ngFor="let service of getDeployedServices(project, selectedStage)">
+        <ktb-expandable-tile *ngIf="getLatestDeployment(project, service, selectedStage) as deployment">
           <ktb-expandable-tile-header>
             <dt-info-group>
               <dt-info-group-title>

--- a/bridge/client/app/project-board/project-board.component.scss
+++ b/bridge/client/app/project-board/project-board.component.scss
@@ -5,6 +5,10 @@
   height: 100%;
 }
 
+.stage-overview {
+
+}
+
 ::ng-deep .dt-menu,
 ::ng-deep .dt-menu-group-header {
   background-color: lighten($primary-color, 5%) !important;

--- a/bridge/client/app/project-board/project-board.component.ts
+++ b/bridge/client/app/project-board/project-board.component.ts
@@ -36,6 +36,8 @@ export class ProjectBoardComponent implements OnInit, OnDestroy {
   private _tracesTimer: Subscription = Subscription.EMPTY;
   private _tracesTimerInterval = 10;
 
+  private _selectedStage: Stage = null;
+
   public projectName: string;
   public serviceName: string;
   public contextId: string;
@@ -202,6 +204,10 @@ export class ProjectBoardComponent implements OnInit, OnDestroy {
 
   selectView(view) {
     this.view = view;
+  }
+
+  selectStage(stage) {
+    this._selectedStage = stage;
   }
 
   ngOnDestroy(): void {

--- a/bridge/client/app/project-board/project-board.component.ts
+++ b/bridge/client/app/project-board/project-board.component.ts
@@ -36,14 +36,13 @@ export class ProjectBoardComponent implements OnInit, OnDestroy {
   private _tracesTimer: Subscription = Subscription.EMPTY;
   private _tracesTimerInterval = 10;
 
-  private _selectedStage: Stage = null;
-
   public projectName: string;
   public serviceName: string;
   public contextId: string;
   public eventId: string;
 
   public view: string = 'services';
+  public selectedStage: Stage = null;
 
   constructor(private _changeDetectorRef: ChangeDetectorRef, private router: Router, private location: Location, private route: ActivatedRoute, private dataService: DataService, private apiService: ApiService) { }
 
@@ -207,7 +206,7 @@ export class ProjectBoardComponent implements OnInit, OnDestroy {
   }
 
   selectStage(stage) {
-    this._selectedStage = stage;
+    this.selectedStage = stage;
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
When clicking on a stage, you now see the deployed services with details like the public deployment URI and the deployment time.

Unfortunately at the moment we can't display more details about the stage in general, like the deployment strategy or the test strategy. This needs to be considered in a separate issue, once we can read those information via the api.

![image](https://user-images.githubusercontent.com/6098219/82452739-f5157580-9aaf-11ea-9c74-b8e84f108355.png)