### PR TITLE
#1836 Cleanup Keptn on GKE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,6 +109,7 @@ gke_full: &gke_full
     - test/test_onboard_service.sh
     - test/test_new_artifact.sh
     - test/test_delete_project.sh
+    - test/test_keptn_uninstall.sh
   after_success:
     # delete google kubernetes cluster only on success (in case of an error we want to be able to dig into the cluster)
     - echo "Tests were successful, cleaning up the cluster now..."

--- a/test/test_keptn_uninstall.sh
+++ b/test/test_keptn_uninstall.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+source test/utils.sh
+
+echo "y" | keptn uninstall
+
+verify_test_step $? "keptn uninstall failed"
+
+# verify namespace keptn has been removed
+kubectl -n keptn get namespace keptn
+
+if [[ $? -eq 0 ]]; then
+  echo "Found namespace keptn - uninstall failed"
+  exit 1
+fi
+
+# delete the namespaces for projects that we onboarded (if they exist)
+echo "Deleting namespaces $PROJECT-dev $PROJECT-staging $PROJECT-production"
+kubectl delete namespace $PROJECT-dev $PROJECT-staging $PROJECT-production || true
+
+# let's wait a bit for their actual deletion...
+sleep 60
+
+echo "Okay, Keptn seems to have been uninstalled. This is what is left on the cluster:"
+kubectl get all --all-namespaces

--- a/test/utils/gke_create_cluster.sh
+++ b/test/utils/gke_create_cluster.sh
@@ -25,9 +25,9 @@ fi
 
 echo "Creating nightly cluster ${CLUSTER_NAME_NIGHTLY}"
 
-# create a new cluster
+# create a new cluster (Note: disk-size reduced to 25 GB to save resources; pre-emptible nodes used as well)
 gcloud beta container --project $PROJECT_NAME clusters create $CLUSTER_NAME_NIGHTLY --zone $CLOUDSDK_COMPUTE_ZONE --username "admin" --cluster-version $GKE_VERSION \
- --machine-type "n1-standard-8" --image-type "UBUNTU" --disk-type "pd-standard" --disk-size "100" \
+ --machine-type "n1-standard-8" --image-type "UBUNTU" --preemptible --disk-type "pd-standard" --disk-size "25" \
  --scopes "https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" --num-nodes "1" --enable-cloud-logging --enable-cloud-monitoring --enable-ip-alias --network "projects/sai-research/global/networks/default" --subnetwork "projects/sai-research/regions/$CLOUDSDK_REGION/subnetworks/default" \
  --addons $ADDONS $ISTIO_CONFIG --no-enable-autoupgrade --no-enable-autorepair \
  --labels owner=travis,expiry=auto-delete


### PR DESCRIPTION
Fixes #1836 (orphaned resources on GKE for integration tests)

This PR executes and adds a test for `keptn uninstall`.
It also cleans up our default examples namespaces (sockshop-dev, sockshop-staging and sockshop-production). 

I verified that these two actions will lead to no GCE disks left orphaned after a cluster deletion.

Still open: Verify no IP addresses / load balancers / ... are still in use.

In addition, I've modified the create cluster command for GKE to only use 25 GB of persistant storage (instead of 100), and to use [pre-emptible nodes](https://cloud.google.com/compute/docs/instances/preemptible) (those nodes can be removed by google any time) which [cost only 1/5 of a normal node](https://cloud.google.com/compute/all-pricing#n1_machine_types).