### PR TITLE
#1841 Increase SLO criteria for response_time_p95 for integration tests

### DIFF
--- a/test/assets/quality_gates_standalone_slo_step1.yaml
+++ b/test/assets/quality_gates_standalone_slo_step1.yaml
@@ -11,11 +11,12 @@ objectives:
     key_sli: false
     pass:             # pass if (relative change <= 10% AND absolute value is < 600ms)
       - criteria:
-          - "<=+10%"  # relative values require a prefixed sign (plus or minus)
+          - "<=+20%"  # relative values require a prefixed sign (plus or minus)
           - "<75"    # absolute values only require a logical operator
     warning:          # if the response time is below 800ms, the result should be a warning
       - criteria:
           - "<=200"
+          - "<=+50%"
     weight: 1
   - sli: "throughput"
     pass:

--- a/test/assets/quality_gates_standalone_slo_step2.yaml
+++ b/test/assets/quality_gates_standalone_slo_step2.yaml
@@ -11,11 +11,12 @@ objectives:
     key_sli: false
     pass:             # pass if (relative change <= 10% AND absolute value is < 600ms)
       - criteria:
-          - "<=+10%"  # relative values require a prefixed sign (plus or minus)
+          - "<=+20%"  # relative values require a prefixed sign (plus or minus)
           - "<75"    # absolute values only require a logical operator
     warning:          # if the response time is below 800ms, the result should be a warning
       - criteria:
           - "<=200"
+          - "<=+50%"
     weight: 1
   - sli: "throughput"
     pass:

--- a/test/assets/quality_gates_standalone_slo_step3.yaml
+++ b/test/assets/quality_gates_standalone_slo_step3.yaml
@@ -11,11 +11,12 @@ objectives:
     key_sli: false
     pass:             # pass if (relative change <= 10% AND absolute value is < 600ms)
       - criteria:
-          - "<=+10%"  # relative values require a prefixed sign (plus or minus)
+          - "<=+20%"  # relative values require a prefixed sign (plus or minus)
           - "<75"    # absolute values only require a logical operator
     warning:          # if the response time is below 800ms, the result should be a warning
       - criteria:
           - "<=200"
+          - "<=+50%"
     weight: 1
   - sli: "throughput"
     pass:


### PR DESCRIPTION
This fixes #1841.

Sometimes the integration test for quality gates has failed as the criteria for the response_time_p95 SLOs with `<=+10%` was violated.

I increased the SLO and also added another SLO of type warning, just in case.

