### PR TITLE
Allow filtering of roots events by type

### DIFF
--- a/bridge/client/app/_models/trace.ts
+++ b/bridge/client/app/_models/trace.ts
@@ -27,7 +27,7 @@ let icons = {
   "sh.keptn.event.problem.close": "applicationhealth"
 };
 
-export class Trace {
+class Trace {
   id: string;
   shkeptncontext: string;
   source: string;
@@ -174,3 +174,5 @@ export class Trace {
     return Object.assign(new this, data, { plainEvent: JSON.parse(JSON.stringify(data)) });
   }
 }
+
+export {Trace, labels}

--- a/bridge/client/app/app.module.ts
+++ b/bridge/client/app/app.module.ts
@@ -59,6 +59,7 @@ import {DtKeyValueListModule} from "@dynatrace/barista-components/key-value-list
 import {DtButtonGroupModule} from "@dynatrace/barista-components/button-group";
 import {DtChartModule} from "@dynatrace/barista-components/chart";
 import {DtOverlayModule} from "@dynatrace/barista-components/overlay";
+import {DtCheckboxModule} from "@dynatrace/barista-components/checkbox";
 
 import {registerLocaleData} from "@angular/common";
 import localeEn from '@angular/common/locales/en';
@@ -122,6 +123,7 @@ registerLocaleData(localeEn, 'en');
     DtKeyValueListModule,
     DtChartModule,
     DtOverlayModule,
+    DtCheckboxModule,
     MatDialogModule,
     DtIconModule.forRoot({
       svgIconLocation: `/assets/icons/{{name}}.svg`,

--- a/bridge/client/app/project-board/project-board.component.html
+++ b/bridge/client/app/project-board/project-board.component.html
@@ -98,7 +98,21 @@
           <ktb-expandable-tile-header>
             <dt-info-group>
               <dt-info-group-title>
-                <h2 class="m-0" [textContent]="service.serviceName"></h2>
+                <div fxLayout="row">
+                  <div fxFlex>
+                    <h2 class="m-0" [textContent]="service.serviceName"></h2>
+                  </div>
+                  <div fxLayout="column" fxLayoutAlign="start end" *ngIf="eventTypes">
+                    <button dt-icon-button (click)="$event.stopPropagation()" [dtContextDialogTrigger]="filterEventsDialog" variant="nested" aria-label="Open context dialog">
+                      <dt-icon name="filter"></dt-icon>
+                    </button>
+                    <dt-context-dialog #filterEventsDialog aria-label="Open context dialog" ariaLabelClose="Close context dialog">
+                      <p *ngFor="let eventType of eventTypes">
+                        <dt-checkbox (change)="filterEvents($event, eventType)" [checked]="isFilteredEvent(eventType)">{{getEventLabel(eventType)}}</dt-checkbox>
+                      </p>
+                    </dt-context-dialog>
+                  </div>
+                </div>
               </dt-info-group-title>
               <p class="m-0 mb-1 mt-1" *ngIf="getLatestDeployment(project, service) as deployment">
                 <span class="bold">Last relevant artifact: </span><span [textContent]="deployment.getShortImageName()"></span>
@@ -114,7 +128,7 @@
               <dt-tag>Last time fetched: <span [textContent]="getRootsLastUpdated(project, service) | amCalendar:getCalendarFormats()"></span></dt-tag>
             </dt-tag-list>
           </div>
-          <ktb-root-events-list [events]="service.roots" [selectedEvent]="currentRoot"  (selectedEventChange)="selectRoot($event)"></ktb-root-events-list>
+          <ktb-root-events-list [events]="getFilteredRoots(service.roots)" [selectedEvent]="currentRoot"  (selectedEventChange)="selectRoot($event)"></ktb-root-events-list>
           <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="15px" *ngIf="!service.roots">
             <dt-loading-spinner></dt-loading-spinner>
             <p>Loading ...</p>

--- a/bridge/client/app/project-board/project-board.component.scss
+++ b/bridge/client/app/project-board/project-board.component.scss
@@ -22,3 +22,7 @@
 ::ng-deep .dt-menu-item:hover {
   background: $primary-color !important;
 }
+
+::ng-deep .ktb-expandable-tile .dt-show-more-icon {
+  margin-right: 5px;
+}

--- a/bridge/client/app/project-board/project-board.component.ts
+++ b/bridge/client/app/project-board/project-board.component.ts
@@ -13,8 +13,9 @@ import {DataService} from "../_services/data.service";
 import {ApiService} from "../_services/api.service";
 import DateUtil from "../_utils/date.utils";
 import {Service} from "../_models/service";
-import {Trace} from "../_models/trace";
+import {labels, Trace} from "../_models/trace";
 import {Stage} from "../_models/stage";
+import {DtCheckboxChange} from "@dynatrace/barista-components/checkbox";
 
 @Component({
   selector: 'app-project-board',
@@ -43,6 +44,9 @@ export class ProjectBoardComponent implements OnInit, OnDestroy {
 
   public view: string = 'services';
   public selectedStage: Stage = null;
+
+  public eventTypes: string[] = [];
+  public filterEventTypes: string[] = [];
 
   constructor(private _changeDetectorRef: ChangeDetectorRef, private router: Router, private location: Location, private route: ActivatedRoute, private dataService: DataService, private apiService: ApiService) { }
 
@@ -97,8 +101,11 @@ export class ProjectBoardComponent implements OnInit, OnDestroy {
 
         this._rootsSubs.unsubscribe();
         this._rootsSubs = this.dataService.roots.subscribe(roots => {
-          if(roots && !this.currentRoot)
-            this.currentRoot = roots.find(r => r.shkeptncontext == params["contextId"]);
+          if(roots) {
+            if(!this.currentRoot)
+              this.currentRoot = roots.find(r => r.shkeptncontext == params["contextId"]);
+            this.eventTypes = this.eventTypes.concat(roots.map(r => r.type)).filter((r, i, a) => a.indexOf(r) === i);
+          }
           if(this.currentRoot && !this.eventId)
             this.eventId = this.currentRoot.traces[this.currentRoot.traces.length-1].id;
         });
@@ -203,6 +210,28 @@ export class ProjectBoardComponent implements OnInit, OnDestroy {
 
   selectView(view) {
     this.view = view;
+  }
+
+  filterEvents(event: DtCheckboxChange<string>, eventType: string): void {
+    let index = this.filterEventTypes.indexOf(eventType);
+    if(index == -1) {
+      this.filterEventTypes.push(eventType);
+    } else {
+      this.filterEventTypes.splice(index, 1);
+    }
+  }
+
+  isFilteredEvent(eventType: string) {
+    return this.filterEventTypes.indexOf(eventType) == -1;
+  }
+
+  getEventLabel(key): string {
+    return labels[key] || key;
+  }
+
+  getFilteredRoots(roots: Root[]) {
+    if(roots)
+      return roots.filter(r => this.filterEventTypes.indexOf(r.type) == -1);
   }
 
   selectStage(stage) {


### PR DESCRIPTION
We added a filter button to the list of root events, which allows to filter (show/hide) the root events by type.

![image](https://user-images.githubusercontent.com/6098219/83115001-053dde00-a0ca-11ea-8a81-cfa2c1e8b918.png)

![image](https://user-images.githubusercontent.com/6098219/83114930-ee978700-a0c9-11ea-8c32-3dedb3df32a2.png)
