### PR TITLE
Remove reference to api.keptn hostheader

### DIFF
--- a/cli/pkg/websockethelper/websocket_helper.go
+++ b/cli/pkg/websockethelper/websocket_helper.go
@@ -64,7 +64,6 @@ func openWS(connData keptnutils.ConnectionData, apiEndPoint url.URL, useWss bool
 	header := http.Header{}
 	header.Add("Token", *connData.EventContext.Token)
 	header.Add("Keptn-Ws-Channel-Id", *connData.EventContext.KeptnContext)
-	header.Add("Host", "api.keptn")
 
 	dialer := websocket.DefaultDialer
 	dialer.NetDial = apiutils.ResolveXipIo

--- a/installer/manifests/keptn/keptn-ingress.yaml
+++ b/installer/manifests/keptn/keptn-ingress.yaml
@@ -18,9 +18,3 @@ spec:
           - backend:
               serviceName: api-gateway-nginx
               servicePort: 80
-    - host: api.keptn
-      http:
-        paths:
-          - backend:
-              serviceName: api-gateway-nginx
-              servicePort: 80

--- a/installer/scripts/openshift/installOnOpenshift.sh
+++ b/installer/scripts/openshift/installOnOpenshift.sh
@@ -31,7 +31,6 @@ elif [ "$INGRESS" = "nginx" ]; then
     oc delete route api -n keptn
 
     oc create route edge api --service=api-gateway-nginx --port=http --insecure-policy='None' -n keptn --hostname="api.keptn.$BASE_URL"
-    oc create route edge api2 --service=api-gateway-nginx --port=http --insecure-policy='None' -n keptn --hostname="api.keptn"
 fi
 
 # Add config map in keptn namespace that contains the domain - this will be used by other services as well


### PR DESCRIPTION
Fixes #1797.

This PR removes the reference to the api.keptn host header and updates to the latest version of go-utils.