### PR TITLE
#1695 Don't send out an event if no deployment_strategy is defined

### DIFF
--- a/gatekeeper-service/pkg/handler/evaluation_done_event_handler.go
+++ b/gatekeeper-service/pkg/handler/evaluation_done_event_handler.go
@@ -32,6 +32,17 @@ func (e *EvaluationDoneEventHandler) Handle(event cloudevents.Event, keptnHandle
 		return
 	}
 
+	nextStage := getNextStage(*shipyard, data.Stage)
+
+	for _, stage := range shipyard.Stages {
+		if stage.Name == nextStage {
+			if stage.DeploymentStrategy == "" {
+				e.logger.Info("No deployment strategy defined for next stage. exiting.")
+				return
+			}
+		}
+	}
+
 	image, err := e.getImage(data.Project, data.Stage, data.Service)
 	if err != nil {
 		e.logger.Error(err.Error())

--- a/gatekeeper-service/pkg/handler/evaluation_done_event_handler.go
+++ b/gatekeeper-service/pkg/handler/evaluation_done_event_handler.go
@@ -32,17 +32,6 @@ func (e *EvaluationDoneEventHandler) Handle(event cloudevents.Event, keptnHandle
 		return
 	}
 
-	nextStage := getNextStage(*shipyard, data.Stage)
-
-	for _, stage := range shipyard.Stages {
-		if stage.Name == nextStage {
-			if stage.DeploymentStrategy == "" {
-				e.logger.Info("No deployment strategy defined for next stage. exiting.")
-				return
-			}
-		}
-	}
-
 	image, err := e.getImage(data.Project, data.Stage, data.Service)
 	if err != nil {
 		e.logger.Error(err.Error())
@@ -75,6 +64,16 @@ func (EvaluationDoneEventHandler) getImage(project string, currentStage string, 
 func (e *EvaluationDoneEventHandler) handleEvaluationDoneEvent(inputEvent keptnevents.EvaluationDoneEventData, shkeptncontext string, image string,
 	shipyard keptnevents.Shipyard) []cloudevents.Event {
 
+	nextStage := getNextStage(shipyard, inputEvent.Stage)
+
+	for _, stage := range shipyard.Stages {
+		if stage.Name == nextStage {
+			if stage.DeploymentStrategy == "" {
+				e.logger.Info("No deployment strategy defined for next stage. exiting.")
+				return nil
+			}
+		}
+	}
 	// Evaluation has passed if we have result = pass or result = warning
 
 	if inputEvent.TestStrategy == TestStrategyRealUser {

--- a/gatekeeper-service/pkg/handler/evaluation_done_event_handler_test.go
+++ b/gatekeeper-service/pkg/handler/evaluation_done_event_handler_test.go
@@ -54,6 +54,13 @@ var evaluationDoneTests = []struct {
 			getConfigurationChangeTestEventForCanaryAction(keptnevents.Discard),
 		},
 	},
+	{
+		name:        "pass-no-deployment-strategy",
+		image:       "docker.io/keptnexamples/carts:0.11.1",
+		shipyard:    getShipyardWithoutDeploymentStrategy(keptnevents.Automatic, keptnevents.Automatic),
+		inputEvent:  getEvaluationDoneTestData(true),
+		outputEvent: nil,
+	},
 }
 
 func TestHandleEvaluationDoneEvent(t *testing.T) {

--- a/gatekeeper-service/pkg/handler/handler_test.go
+++ b/gatekeeper-service/pkg/handler/handler_test.go
@@ -96,6 +96,45 @@ func getShipyardWithApproval(approvalStrategyForPass keptnevents.ApprovalStrateg
 	}
 }
 
+func getShipyardWithoutDeploymentStrategy(approvalStrategyForPass keptnevents.ApprovalStrategy,
+	approvalStrategyForWarning keptnevents.ApprovalStrategy) keptnevents.Shipyard {
+
+	return keptnevents.Shipyard{
+		Stages: []struct {
+			Name                string                              `json:"name" yaml:"name"`
+			DeploymentStrategy  string                              `json:"deployment_strategy" yaml:"deployment_strategy"`
+			TestStrategy        string                              `json:"test_strategy,omitempty" yaml:"test_strategy"`
+			RemediationStrategy string                              `json:"remediation_strategy,omitempty" yaml:"remediation_strategy"`
+			ApprovalStrategy    *keptnevents.ApprovalStrategyStruct `json:"approval_strategy,omitempty" yaml:"approval_strategy"`
+		}{
+			{
+				Name:                "dev",
+				DeploymentStrategy:  "direct",
+				TestStrategy:        "functional",
+				RemediationStrategy: "",
+				ApprovalStrategy:    nil,
+			},
+			{
+				Name:                "hardening",
+				DeploymentStrategy:  "blue_green_service",
+				TestStrategy:        "performance",
+				RemediationStrategy: "",
+				ApprovalStrategy: &keptnevents.ApprovalStrategyStruct{
+					Pass:    approvalStrategyForPass,
+					Warning: approvalStrategyForWarning,
+				},
+			},
+			{
+				Name:                "production",
+				DeploymentStrategy:  "",
+				TestStrategy:        "",
+				RemediationStrategy: "",
+				ApprovalStrategy:    nil,
+			},
+		},
+	}
+}
+
 func getApprovalTriggeredTestData(evaluationResult string) keptnevents.ApprovalTriggeredEventData {
 
 	return keptnevents.ApprovalTriggeredEventData{


### PR DESCRIPTION
Closes #1695 

With this PR, the gatekeeper-service checks wether the `deployment_strategy` for next stage is defined. If not, no further event is sent out.