### PR TITLE
#1752 added instructions to re-enable bridge access 

### DIFF
--- a/cli/cmd/configure_domain.go
+++ b/cli/cmd/configure_domain.go
@@ -194,6 +194,12 @@ Please find more information on https://keptn.sh/docs/develop/reference/troubles
 				}
 				logging.PrintLog("Successfully configured domain", logging.InfoLevel)
 			}
+			fmt.Println()
+			logging.PrintLog("NOTE: If you have exposed the Keptn's bridge via 'keptn configure bridge --action=expose', please execute the following commands to re-enable access:", logging.InfoLevel)
+			logging.PrintLog("keptn configure bridge --action=lockdown", logging.InfoLevel)
+			logging.PrintLog("keptn configure bridge --action=expose", logging.InfoLevel)
+			fmt.Println()
+			logging.PrintLog("NOTE: VirtualServices for services that have been onboarded previously have not been updated.", logging.InfoLevel)
 		}
 
 		return nil


### PR DESCRIPTION
Closes #1752 
After configuring the domain, the following output is appended:

```
NOTE: If you have exposed the Keptn's bridge via 'keptn configure bridge --action=expose', please execute the following commands to re-enable access:
keptn configure bridge --action=lockdown
keptn configure bridge --action=expose

NOTE: VirtualServices for services that have been onboarded previously have not been updated.
```

Note that updating the VirtualServices for onboarded services also requires updating the corresponding resources within the configuration service (GitOps repo for the service). If we would like to tackle this, I propose to create a follow up-issue for moving the execution of the `configure domain` command to the `api-service` (as we did with the `configure bridge` command). This would also remove the dependency of having a configured `kubectl` CLI available locally when executing this command