### PR TITLE
#1737 Request approval for the next stage

### DIFF
--- a/gatekeeper-service/pkg/handler/approval_finished_event_handler.go
+++ b/gatekeeper-service/pkg/handler/approval_finished_event_handler.go
@@ -75,8 +75,8 @@ func (a *ApprovalFinishedEventHandler) handleApprovalFinishedEvent(inputEvent ke
 			if inputEvent.Tag != "" {
 				image += ":" + inputEvent.Tag
 			}
-			if event := getPromotionEvent(inputEvent.Project, inputEvent.Stage, inputEvent.Service, image,
-				shkeptncontext, inputEvent.Labels, shipyard, a.logger); event != nil {
+			if event := getConfigurationChangeEventForCanary(
+				inputEvent.Project, inputEvent.Service, inputEvent.Stage, image, shkeptncontext, inputEvent.Labels); event != nil {
 				outgoingEvents = append(outgoingEvents, *event)
 			}
 			if err := closeOpenApproval(inputEvent); err != nil {

--- a/gatekeeper-service/pkg/handler/approval_finished_event_handler_test.go
+++ b/gatekeeper-service/pkg/handler/approval_finished_event_handler_test.go
@@ -25,7 +25,7 @@ var approvalFinishedTests = []struct {
 		shipyard:   getShipyardWithApproval(keptnevents.Automatic, keptnevents.Automatic),
 		inputEvent: getApprovalFinishedTestData("pass", "succeeded"),
 		outputEvent: []cloudevents.Event{
-			getConfigurationChangeTestEventForNextStage("docker.io/keptnexamples/carts:0.11.1", "production"),
+			getConfigurationChangeTestEvent("docker.io/keptnexamples/carts:0.11.1", "production"),
 		},
 	},
 	{

--- a/gatekeeper-service/pkg/handler/evaluation_done_event_handler_test.go
+++ b/gatekeeper-service/pkg/handler/evaluation_done_event_handler_test.go
@@ -22,7 +22,7 @@ var evaluationDoneTests = []struct {
 		inputEvent: getEvaluationDoneTestData(true),
 		outputEvent: []cloudevents.Event{
 			getConfigurationChangeTestEventForCanaryAction(keptnevents.Promote),
-			getConfigurationChangeTestEventForNextStage("docker.io/keptnexamples/carts:0.11.1", "production"),
+			getConfigurationChangeTestEvent("docker.io/keptnexamples/carts:0.11.1", "production"),
 		},
 	},
 	{
@@ -136,12 +136,12 @@ func getConfigurationChangeTestEventForCanaryAction(action keptnevents.CanaryAct
 	return *getCloudEvent(configurationChangeEvent, keptnevents.ConfigurationChangeEventType, shkeptncontext)
 }
 
-func getConfigurationChangeTestEventForNextStage(image, nextStage string) cloudevents.Event {
+func getConfigurationChangeTestEvent(image, stage string) cloudevents.Event {
 
 	configurationChangeEvent := keptnevents.ConfigurationChangeEventData{
 		Project: "sockshop",
 		Service: "carts",
-		Stage:   nextStage,
+		Stage:   stage,
 		ValuesCanary: map[string]interface{}{
 			"image": image,
 		},

--- a/gatekeeper-service/pkg/handler/handler.go
+++ b/gatekeeper-service/pkg/handler/handler.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"fmt"
 	"net/url"
 	"time"
 
@@ -52,34 +51,7 @@ func getCloudEvent(data interface{}, ceType string, shkeptncontext string) *clou
 	}
 }
 
-func getPromotionEvent(project, currentStage, service, image, shkeptncontext string, labels map[string]string,
-	shipyard keptnevents.Shipyard, logger *keptnevents.Logger) *cloudevents.Event {
-
-	if nextStage := getNextStage(shipyard, currentStage); nextStage != "" {
-		logger.Info(fmt.Sprintf("Promote service %s of project %s to stage %s",
-			service, project, nextStage))
-		return getConfigurationChangeEventForNextStage(project, service, nextStage, image, shkeptncontext, labels)
-	}
-	logger.Info(fmt.Sprintf("No further stage available to promote the service %s of project %s",
-		service, project))
-	return nil
-}
-
-func getNextStage(shipyard keptnevents.Shipyard, currentStage string) string {
-	currentFound := false
-	for _, stage := range shipyard.Stages {
-		if currentFound {
-			// Here, we return the next stage
-			return stage.Name
-		}
-		if stage.Name == currentStage {
-			currentFound = true
-		}
-	}
-	return ""
-}
-
-func getConfigurationChangeEventForNextStage(project, service, nextStage, image, shkeptncontext string, labels map[string]string) *cloudevents.Event {
+func getConfigurationChangeEventForCanary(project, service, nextStage, image, shkeptncontext string, labels map[string]string) *cloudevents.Event {
 
 	valuesCanary := make(map[string]interface{})
 	valuesCanary["image"] = image

--- a/gatekeeper-service/pkg/handler/handler_test.go
+++ b/gatekeeper-service/pkg/handler/handler_test.go
@@ -80,17 +80,17 @@ func getShipyardWithApproval(approvalStrategyForPass keptnevents.ApprovalStrateg
 				DeploymentStrategy:  "blue_green_service",
 				TestStrategy:        "performance",
 				RemediationStrategy: "",
+				ApprovalStrategy:    nil,
+			},
+			{
+				Name: "production",
 				ApprovalStrategy: &keptnevents.ApprovalStrategyStruct{
 					Pass:    approvalStrategyForPass,
 					Warning: approvalStrategyForWarning,
 				},
-			},
-			{
-				Name:                "production",
 				DeploymentStrategy:  "blue_green_service",
 				TestStrategy:        "",
 				RemediationStrategy: "",
-				ApprovalStrategy:    nil,
 			},
 		},
 	}
@@ -140,7 +140,7 @@ func getApprovalTriggeredTestData(evaluationResult string) keptnevents.ApprovalT
 	return keptnevents.ApprovalTriggeredEventData{
 		Project:            "sockshop",
 		Service:            "carts",
-		Stage:              "hardening",
+		Stage:              "production",
 		TestStrategy:       getPtr("performance"),
 		DeploymentStrategy: getPtr("blue_green_service"),
 		Tag:                "0.11.1",
@@ -157,7 +157,7 @@ func getApprovalFinishedTestData(result, status string) keptnevents.ApprovalFini
 	return keptnevents.ApprovalFinishedEventData{
 		Project:            "sockshop",
 		Service:            "carts",
-		Stage:              "hardening",
+		Stage:              "production",
 		TestStrategy:       getPtr("performance"),
 		DeploymentStrategy: getPtr("blue_green_service"),
 		Tag:                "0.11.1",


### PR DESCRIPTION
This PR corrects that the gatekeeper requests the approval for the next stage as described in the spec https://github.com/keptn/spec/blob/master/shipyard.md. 

In the following, an example event flow is shown:

**Shipyard**
```
stages:
  - name: "dev"
    deployment_strategy: "direct"
    test_strategy: "functional"
  - name: "staging"
    approval_strategy: 
      pass: "manual"
      warning: "manual"
    deployment_strategy: "blue_green_service"
    test_strategy: "performance"
  - name: "production"
    deployment_strategy: "blue_green_service"
    remediation_strategy: "automated"
```
**Desired event stream**
<img width="1114" alt="Screen Shot 2020-06-04 at 13 50 40" src="https://user-images.githubusercontent.com/10980861/83753445-97b22480-a66a-11ea-8739-00c15451ddc3.png">
