### PR TITLE
#1872 fix installer checks for helm-service distributor

### DIFF
--- a/installer/scripts/common/setupKeptn.sh
+++ b/installer/scripts/common/setupKeptn.sh
@@ -102,7 +102,7 @@ case $USE_CASE in
     wait_for_deployment_in_namespace "wait-service" "keptn"
     wait_for_deployment_in_namespace "lighthouse-service-distributor" "keptn"
     wait_for_deployment_in_namespace "gatekeeper-service-evaluation-done-distributor" "keptn"
-    wait_for_deployment_in_namespace "helm-service-configuration-change-distributor" "keptn"
+    wait_for_deployment_in_namespace "helm-service-distributor" "keptn"
     wait_for_deployment_in_namespace "jmeter-service-deployment-distributor" "keptn"
     wait_for_deployment_in_namespace "remediation-service-problem-distributor" "keptn"
     wait_for_deployment_in_namespace "wait-service-deployment-distributor" "keptn"

--- a/installer/scripts/openshift/setupKeptn.sh
+++ b/installer/scripts/openshift/setupKeptn.sh
@@ -108,7 +108,7 @@ case $USE_CASE in
     wait_for_deployment_in_namespace "wait-service" "keptn"
     wait_for_deployment_in_namespace "lighthouse-service-distributor" "keptn"
     wait_for_deployment_in_namespace "gatekeeper-service-evaluation-done-distributor" "keptn"
-    wait_for_deployment_in_namespace "helm-service-configuration-change-distributor" "keptn"
+    wait_for_deployment_in_namespace "helm-service-distributor" "keptn"
     wait_for_deployment_in_namespace "jmeter-service-deployment-distributor" "keptn"
     wait_for_deployment_in_namespace "remediation-service-problem-distributor" "keptn"
     wait_for_deployment_in_namespace "wait-service-deployment-distributor" "keptn"


### PR DESCRIPTION
This partially fixes #1872.

In PR #1867 the distributor was renamed, but the installer was not adapted. Within this PR I am also fixing this in the installer.