### PR TITLE
#1486 Automate unit tests for Keptn Bridge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -128,7 +128,25 @@ jobs:
   ##################################################################################
   # Jobs that are always executed
   ##################################################################################
-  - stage: Unit tests
+  - stage: Unit tests # Bridge
+    os: linux
+    addons:
+      chrome: stable
+    language:
+      node_js
+    node_js:
+      - 10
+    install:
+      - npm install -g codecov # install codecov globally
+      - npm install -g libnpx@10.2.0 # install npx globally
+    script:
+      - cd bridge
+      - npm install
+      - npm run test:ci
+    after_success:
+      - bash <(curl -s https://codecov.io/bash)
+
+  - stage: Unit tests # golang
     os: linux
     script:
       - set -e # Fail the whole script whenever any command fails

--- a/.travis.yml
+++ b/.travis.yml
@@ -144,7 +144,7 @@ jobs:
       - npm install
       - npm run test:ci
     after_success:
-      - bash <(curl -s https://codecov.io/bash)
+      - bash <(curl -s https://codecov.io/bash) -F moduleA
 
   - stage: Unit tests # golang
     os: linux

--- a/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.spec.ts
+++ b/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.spec.ts
@@ -1,60 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { KtbEvaluationDetailsComponent } from './ktb-evaluation-details.component';
-import {MomentModule} from "ngx-moment";
-import {AtobPipe} from "../../_pipes/atob.pipe";
-import {AppComponent} from "../../app.component";
-import {DashboardComponent} from "../../dashboard/dashboard.component";
-import {AppHeaderComponent} from "../../app-header/app-header.component";
-import {ProjectBoardComponent} from "../../project-board/project-board.component";
-import {KtbHttpLoadingSpinnerComponent} from "../ktb-http-loading-spinner/ktb-http-loading-spinner.component";
-import {KtbHttpLoadingBarComponent} from "../ktb-http-loading-bar/ktb-http-loading-bar.component";
-import {KtbShowHttpLoadingDirective} from "../../_directives/ktb-show-http-loading/ktb-show-http-loading.directive";
-import {KtbHideHttpLoadingDirective} from "../../_directives/ktb-hide-http-loading/ktb-hide-http-loading.directive";
-import {
-  KtbExpandableTileComponent,
-  KtbExpandableTileHeader
-} from "../ktb-expandable-tile/ktb-expandable-tile.component";
-import {KtbSelectableTileComponent} from "../ktb-selectable-tile/ktb-selectable-tile.component";
-import {
-  KtbHorizontalSeparatorComponent,
-  KtbHorizontalSeparatorTitle
-} from "../ktb-horizontal-separator/ktb-horizontal-separator.component";
-import {KtbRootEventsListComponent} from "../ktb-root-events-list/ktb-root-events-list.component";
-import {KtbProjectTileComponent} from "../ktb-project-tile/ktb-project-tile.component";
-import {KtbProjectListComponent} from "../ktb-project-list/ktb-project-list.component";
-import {KtbEventsListComponent} from "../ktb-events-list/ktb-events-list.component";
-import {KtbEventItemComponent, KtbEventItemDetail} from "../ktb-event-item/ktb-event-item.component";
-import {KtbSliBreakdownComponent} from "../ktb-sli-breakdown/ktb-sli-breakdown.component";
-import {BrowserModule} from "@angular/platform-browser";
-import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
+import {AppModule} from "../../app.module";
 import {HttpClientTestingModule} from "@angular/common/http/testing";
-import {AppRouting} from "../../app.routing";
-import {FlexLayoutModule} from "@angular/flex-layout";
-import {DtThemingModule} from "@dynatrace/barista-components/theming";
-import {DtButtonModule} from "@dynatrace/barista-components/button";
-import {DtButtonGroupModule} from "@dynatrace/barista-components/button-group";
-import {DtSelectModule} from "@dynatrace/barista-components/select";
-import {DtMenuModule} from "@dynatrace/barista-components/menu";
-import {DtDrawerModule} from "@dynatrace/barista-components/drawer";
-import {DtContextDialogModule} from "@dynatrace/barista-components/context-dialog";
-import {DtInputModule} from "@dynatrace/barista-components/input";
-import {DtEmptyStateModule} from "@dynatrace/barista-components/empty-state";
-import {DtCardModule} from "@dynatrace/barista-components/card";
-import {DtTileModule} from "@dynatrace/barista-components/tile";
-import {DtInfoGroupModule} from "@dynatrace/barista-components/info-group";
-import {DtProgressBarModule} from "@dynatrace/barista-components/progress-bar";
-import {DtLoadingDistractorModule} from "@dynatrace/barista-components/loading-distractor";
-import {DtTagModule} from "@dynatrace/barista-components/tag";
-import {DtExpandableTextModule} from "@dynatrace/barista-components/expandable-text";
-import {DtExpandablePanelModule} from "@dynatrace/barista-components/expandable-panel";
-import {DtShowMoreModule} from "@dynatrace/barista-components/show-more";
-import {DtIndicatorModule} from "@dynatrace/barista-components/core";
-import {DtProgressCircleModule} from "@dynatrace/barista-components/progress-circle";
-import {DtConsumptionModule} from "@dynatrace/barista-components/consumption";
-import {DtKeyValueListModule} from "@dynatrace/barista-components/key-value-list";
-import {DtChartModule} from "@dynatrace/barista-components/chart";
-import {DtIconModule} from "@dynatrace/barista-components/icon";
 
 describe('KtbEvaluationDetailsComponent', () => {
   let component: KtbEvaluationDetailsComponent;
@@ -62,64 +10,10 @@ describe('KtbEvaluationDetailsComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [
-        AppComponent,
-        DashboardComponent,
-        AppHeaderComponent,
-        ProjectBoardComponent,
-        KtbHttpLoadingSpinnerComponent,
-        KtbHttpLoadingBarComponent,
-        KtbShowHttpLoadingDirective,
-        KtbHideHttpLoadingDirective,
-        KtbExpandableTileComponent,
-        KtbExpandableTileHeader,
-        KtbSelectableTileComponent,
-        KtbHorizontalSeparatorComponent,
-        KtbHorizontalSeparatorTitle,
-        KtbRootEventsListComponent,
-        KtbProjectTileComponent,
-        KtbProjectListComponent,
-        KtbEventsListComponent,
-        AtobPipe,
-        KtbEventItemComponent,
-        KtbEventItemDetail,
-        KtbEvaluationDetailsComponent,
-        KtbSliBreakdownComponent,
-      ],
+      declarations: [],
       imports: [
-        BrowserModule,
-        BrowserAnimationsModule,
+        AppModule,
         HttpClientTestingModule,
-        AppRouting,
-        FlexLayoutModule,
-        MomentModule,
-        DtThemingModule,
-        DtButtonModule,
-        DtButtonGroupModule,
-        DtSelectModule,
-        DtMenuModule,
-        DtDrawerModule,
-        DtContextDialogModule,
-        DtInputModule,
-        DtEmptyStateModule,
-        DtCardModule,
-        DtTileModule,
-        DtInfoGroupModule,
-        DtProgressBarModule,
-        DtLoadingDistractorModule,
-        DtTagModule,
-        DtExpandableTextModule,
-        DtExpandablePanelModule,
-        DtShowMoreModule,
-        DtIndicatorModule,
-        DtProgressCircleModule,
-        DtConsumptionModule,
-        DtKeyValueListModule,
-        DtChartModule,
-        DtIconModule.forRoot({
-          svgIconLocation: `/assets/icons/{{name}}.svg`,
-        }),
-        BrowserAnimationsModule
       ]
     })
     .compileComponents();

--- a/bridge/client/app/_components/ktb-event-item/ktb-event-item.component.spec.ts
+++ b/bridge/client/app/_components/ktb-event-item/ktb-event-item.component.spec.ts
@@ -1,60 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
-import {KtbEventItemComponent, KtbEventItemDetail} from './ktb-event-item.component';
-import {
-  KtbExpandableTileComponent,
-  KtbExpandableTileHeader
-} from "../ktb-expandable-tile/ktb-expandable-tile.component";
-import {DtTagModule} from "@dynatrace/barista-components/tag";
-import {DtIconModule} from "@dynatrace/barista-components/icon";
-import {AppComponent} from "../../app.component";
-import {DashboardComponent} from "../../dashboard/dashboard.component";
-import {AppHeaderComponent} from "../../app-header/app-header.component";
-import {ProjectBoardComponent} from "../../project-board/project-board.component";
-import {KtbHttpLoadingSpinnerComponent} from "../ktb-http-loading-spinner/ktb-http-loading-spinner.component";
-import {KtbHttpLoadingBarComponent} from "../ktb-http-loading-bar/ktb-http-loading-bar.component";
-import {KtbShowHttpLoadingDirective} from "../../_directives/ktb-show-http-loading/ktb-show-http-loading.directive";
-import {KtbHideHttpLoadingDirective} from "../../_directives/ktb-hide-http-loading/ktb-hide-http-loading.directive";
-import {KtbSelectableTileComponent} from "../ktb-selectable-tile/ktb-selectable-tile.component";
-import {
-  KtbHorizontalSeparatorComponent,
-  KtbHorizontalSeparatorTitle
-} from "../ktb-horizontal-separator/ktb-horizontal-separator.component";
-import {KtbRootEventsListComponent} from "../ktb-root-events-list/ktb-root-events-list.component";
-import {KtbProjectTileComponent} from "../ktb-project-tile/ktb-project-tile.component";
-import {KtbProjectListComponent} from "../ktb-project-list/ktb-project-list.component";
-import {KtbEventsListComponent} from "../ktb-events-list/ktb-events-list.component";
-import {AtobPipe} from "../../_pipes/atob.pipe";
-import {KtbEvaluationDetailsComponent} from "../ktb-evaluation-details/ktb-evaluation-details.component";
-import {KtbSliBreakdownComponent} from "../ktb-sli-breakdown/ktb-sli-breakdown.component";
-import {BrowserModule} from "@angular/platform-browser";
-import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
+import {KtbEventItemComponent} from './ktb-event-item.component';
+import {AppModule} from '../../app.module';
 import {HttpClientTestingModule} from "@angular/common/http/testing";
-import {AppRouting} from "../../app.routing";
-import {FlexLayoutModule} from "@angular/flex-layout";
-import {MomentModule} from "ngx-moment";
-import {DtThemingModule} from "@dynatrace/barista-components/theming";
-import {DtButtonModule} from "@dynatrace/barista-components/button";
-import {DtButtonGroupModule} from "@dynatrace/barista-components/button-group";
-import {DtSelectModule} from "@dynatrace/barista-components/select";
-import {DtMenuModule} from "@dynatrace/barista-components/menu";
-import {DtDrawerModule} from "@dynatrace/barista-components/drawer";
-import {DtContextDialogModule} from "@dynatrace/barista-components/context-dialog";
-import {DtInputModule} from "@dynatrace/barista-components/input";
-import {DtEmptyStateModule} from "@dynatrace/barista-components/empty-state";
-import {DtCardModule} from "@dynatrace/barista-components/card";
-import {DtTileModule} from "@dynatrace/barista-components/tile";
-import {DtInfoGroupModule} from "@dynatrace/barista-components/info-group";
-import {DtProgressBarModule} from "@dynatrace/barista-components/progress-bar";
-import {DtLoadingDistractorModule} from "@dynatrace/barista-components/loading-distractor";
-import {DtExpandableTextModule} from "@dynatrace/barista-components/expandable-text";
-import {DtExpandablePanelModule} from "@dynatrace/barista-components/expandable-panel";
-import {DtShowMoreModule} from "@dynatrace/barista-components/show-more";
-import {DtIndicatorModule} from "@dynatrace/barista-components/core";
-import {DtProgressCircleModule} from "@dynatrace/barista-components/progress-circle";
-import {DtConsumptionModule} from "@dynatrace/barista-components/consumption";
-import {DtKeyValueListModule} from "@dynatrace/barista-components/key-value-list";
-import {DtChartModule} from "@dynatrace/barista-components/chart";
 
 describe('KtbEventItemComponent', () => {
   let component: KtbEventItemComponent;
@@ -63,63 +11,10 @@ describe('KtbEventItemComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
-        AppComponent,
-        DashboardComponent,
-        AppHeaderComponent,
-        ProjectBoardComponent,
-        KtbHttpLoadingSpinnerComponent,
-        KtbHttpLoadingBarComponent,
-        KtbShowHttpLoadingDirective,
-        KtbHideHttpLoadingDirective,
-        KtbExpandableTileComponent,
-        KtbExpandableTileHeader,
-        KtbSelectableTileComponent,
-        KtbHorizontalSeparatorComponent,
-        KtbHorizontalSeparatorTitle,
-        KtbRootEventsListComponent,
-        KtbProjectTileComponent,
-        KtbProjectListComponent,
-        KtbEventsListComponent,
-        AtobPipe,
-        KtbEventItemComponent,
-        KtbEventItemDetail,
-        KtbEvaluationDetailsComponent,
-        KtbSliBreakdownComponent,
       ],
       imports: [
-        BrowserModule,
-        BrowserAnimationsModule,
+        AppModule,
         HttpClientTestingModule,
-        AppRouting,
-        FlexLayoutModule,
-        MomentModule,
-        DtThemingModule,
-        DtButtonModule,
-        DtButtonGroupModule,
-        DtSelectModule,
-        DtMenuModule,
-        DtDrawerModule,
-        DtContextDialogModule,
-        DtInputModule,
-        DtEmptyStateModule,
-        DtCardModule,
-        DtTileModule,
-        DtInfoGroupModule,
-        DtProgressBarModule,
-        DtLoadingDistractorModule,
-        DtTagModule,
-        DtExpandableTextModule,
-        DtExpandablePanelModule,
-        DtShowMoreModule,
-        DtIndicatorModule,
-        DtProgressCircleModule,
-        DtConsumptionModule,
-        DtKeyValueListModule,
-        DtChartModule,
-        DtIconModule.forRoot({
-          svgIconLocation: `/assets/icons/{{name}}.svg`,
-        }),
-        BrowserAnimationsModule
       ],
     })
     .compileComponents();

--- a/bridge/client/app/_components/ktb-events-list/ktb-events-list.component.spec.ts
+++ b/bridge/client/app/_components/ktb-events-list/ktb-events-list.component.spec.ts
@@ -1,60 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { KtbEventsListComponent } from './ktb-events-list.component';
-import {
-  KtbHorizontalSeparatorComponent,
-  KtbHorizontalSeparatorTitle
-} from "../ktb-horizontal-separator/ktb-horizontal-separator.component";
-import {KtbEventItemComponent, KtbEventItemDetail} from "../ktb-event-item/ktb-event-item.component";
-import {KtbEvaluationDetailsComponent} from "../ktb-evaluation-details/ktb-evaluation-details.component";
-import {KtbSelectableTileComponent} from "../ktb-selectable-tile/ktb-selectable-tile.component";
-import {AppComponent} from "../../app.component";
-import {DashboardComponent} from "../../dashboard/dashboard.component";
-import {AppHeaderComponent} from "../../app-header/app-header.component";
-import {ProjectBoardComponent} from "../../project-board/project-board.component";
-import {KtbHttpLoadingSpinnerComponent} from "../ktb-http-loading-spinner/ktb-http-loading-spinner.component";
-import {KtbHttpLoadingBarComponent} from "../ktb-http-loading-bar/ktb-http-loading-bar.component";
-import {KtbShowHttpLoadingDirective} from "../../_directives/ktb-show-http-loading/ktb-show-http-loading.directive";
-import {KtbHideHttpLoadingDirective} from "../../_directives/ktb-hide-http-loading/ktb-hide-http-loading.directive";
-import {
-  KtbExpandableTileComponent,
-  KtbExpandableTileHeader
-} from "../ktb-expandable-tile/ktb-expandable-tile.component";
-import {KtbRootEventsListComponent} from "../ktb-root-events-list/ktb-root-events-list.component";
-import {KtbProjectTileComponent} from "../ktb-project-tile/ktb-project-tile.component";
-import {KtbProjectListComponent} from "../ktb-project-list/ktb-project-list.component";
-import {AtobPipe} from "../../_pipes/atob.pipe";
-import {KtbSliBreakdownComponent} from "../ktb-sli-breakdown/ktb-sli-breakdown.component";
-import {BrowserModule} from "@angular/platform-browser";
-import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
+import { AppModule } from '../../app.module';
 import {HttpClientTestingModule} from "@angular/common/http/testing";
-import {AppRouting} from "../../app.routing";
-import {FlexLayoutModule} from "@angular/flex-layout";
-import {MomentModule} from "ngx-moment";
-import {DtThemingModule} from "@dynatrace/barista-components/theming";
-import {DtButtonModule} from "@dynatrace/barista-components/button";
-import {DtButtonGroupModule} from "@dynatrace/barista-components/button-group";
-import {DtSelectModule} from "@dynatrace/barista-components/select";
-import {DtMenuModule} from "@dynatrace/barista-components/menu";
-import {DtDrawerModule} from "@dynatrace/barista-components/drawer";
-import {DtContextDialogModule} from "@dynatrace/barista-components/context-dialog";
-import {DtInputModule} from "@dynatrace/barista-components/input";
-import {DtEmptyStateModule} from "@dynatrace/barista-components/empty-state";
-import {DtCardModule} from "@dynatrace/barista-components/card";
-import {DtTileModule} from "@dynatrace/barista-components/tile";
-import {DtInfoGroupModule} from "@dynatrace/barista-components/info-group";
-import {DtProgressBarModule} from "@dynatrace/barista-components/progress-bar";
-import {DtLoadingDistractorModule} from "@dynatrace/barista-components/loading-distractor";
-import {DtTagModule} from "@dynatrace/barista-components/tag";
-import {DtExpandableTextModule} from "@dynatrace/barista-components/expandable-text";
-import {DtExpandablePanelModule} from "@dynatrace/barista-components/expandable-panel";
-import {DtShowMoreModule} from "@dynatrace/barista-components/show-more";
-import {DtIndicatorModule} from "@dynatrace/barista-components/core";
-import {DtProgressCircleModule} from "@dynatrace/barista-components/progress-circle";
-import {DtConsumptionModule} from "@dynatrace/barista-components/consumption";
-import {DtKeyValueListModule} from "@dynatrace/barista-components/key-value-list";
-import {DtChartModule} from "@dynatrace/barista-components/chart";
-import {DtIconModule} from "@dynatrace/barista-components/icon";
 
 describe('KtbEventsListComponent', () => {
   let component: KtbEventsListComponent;
@@ -63,63 +11,10 @@ describe('KtbEventsListComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
-        AppComponent,
-        DashboardComponent,
-        AppHeaderComponent,
-        ProjectBoardComponent,
-        KtbHttpLoadingSpinnerComponent,
-        KtbHttpLoadingBarComponent,
-        KtbShowHttpLoadingDirective,
-        KtbHideHttpLoadingDirective,
-        KtbExpandableTileComponent,
-        KtbExpandableTileHeader,
-        KtbSelectableTileComponent,
-        KtbHorizontalSeparatorComponent,
-        KtbHorizontalSeparatorTitle,
-        KtbRootEventsListComponent,
-        KtbProjectTileComponent,
-        KtbProjectListComponent,
-        KtbEventsListComponent,
-        AtobPipe,
-        KtbEventItemComponent,
-        KtbEventItemDetail,
-        KtbEvaluationDetailsComponent,
-        KtbSliBreakdownComponent,
       ],
       imports: [
-        BrowserModule,
-        BrowserAnimationsModule,
+        AppModule,
         HttpClientTestingModule,
-        AppRouting,
-        FlexLayoutModule,
-        MomentModule,
-        DtThemingModule,
-        DtButtonModule,
-        DtButtonGroupModule,
-        DtSelectModule,
-        DtMenuModule,
-        DtDrawerModule,
-        DtContextDialogModule,
-        DtInputModule,
-        DtEmptyStateModule,
-        DtCardModule,
-        DtTileModule,
-        DtInfoGroupModule,
-        DtProgressBarModule,
-        DtLoadingDistractorModule,
-        DtTagModule,
-        DtExpandableTextModule,
-        DtExpandablePanelModule,
-        DtShowMoreModule,
-        DtIndicatorModule,
-        DtProgressCircleModule,
-        DtConsumptionModule,
-        DtKeyValueListModule,
-        DtChartModule,
-        DtIconModule.forRoot({
-          svgIconLocation: `/assets/icons/{{name}}.svg`,
-        }),
-        BrowserAnimationsModule
       ],
     })
     .compileComponents();

--- a/bridge/client/app/_components/ktb-expandable-tile/ktb-expandable-tile.component.spec.ts
+++ b/bridge/client/app/_components/ktb-expandable-tile/ktb-expandable-tile.component.spec.ts
@@ -1,57 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import {KtbExpandableTileComponent, KtbExpandableTileHeader} from './ktb-expandable-tile.component';
-import {DtExpandablePanelModule} from "@dynatrace/barista-components/expandable-panel";
-import {AppComponent} from "../../app.component";
-import {DashboardComponent} from "../../dashboard/dashboard.component";
-import {AppHeaderComponent} from "../../app-header/app-header.component";
-import {ProjectBoardComponent} from "../../project-board/project-board.component";
-import {KtbHttpLoadingSpinnerComponent} from "../ktb-http-loading-spinner/ktb-http-loading-spinner.component";
-import {KtbHttpLoadingBarComponent} from "../ktb-http-loading-bar/ktb-http-loading-bar.component";
-import {KtbShowHttpLoadingDirective} from "../../_directives/ktb-show-http-loading/ktb-show-http-loading.directive";
-import {KtbHideHttpLoadingDirective} from "../../_directives/ktb-hide-http-loading/ktb-hide-http-loading.directive";
-import {KtbSelectableTileComponent} from "../ktb-selectable-tile/ktb-selectable-tile.component";
-import {
-  KtbHorizontalSeparatorComponent,
-  KtbHorizontalSeparatorTitle
-} from "../ktb-horizontal-separator/ktb-horizontal-separator.component";
-import {KtbRootEventsListComponent} from "../ktb-root-events-list/ktb-root-events-list.component";
-import {KtbProjectTileComponent} from "../ktb-project-tile/ktb-project-tile.component";
-import {KtbProjectListComponent} from "../ktb-project-list/ktb-project-list.component";
-import {KtbEventsListComponent} from "../ktb-events-list/ktb-events-list.component";
-import {AtobPipe} from "../../_pipes/atob.pipe";
-import {KtbEventItemComponent, KtbEventItemDetail} from "../ktb-event-item/ktb-event-item.component";
-import {KtbEvaluationDetailsComponent} from "../ktb-evaluation-details/ktb-evaluation-details.component";
-import {KtbSliBreakdownComponent} from "../ktb-sli-breakdown/ktb-sli-breakdown.component";
-import {BrowserModule} from "@angular/platform-browser";
-import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
+import {AppModule} from '../../app.module';
 import {HttpClientTestingModule} from "@angular/common/http/testing";
-import {AppRouting} from "../../app.routing";
-import {FlexLayoutModule} from "@angular/flex-layout";
-import {MomentModule} from "ngx-moment";
-import {DtThemingModule} from "@dynatrace/barista-components/theming";
-import {DtButtonModule} from "@dynatrace/barista-components/button";
-import {DtButtonGroupModule} from "@dynatrace/barista-components/button-group";
-import {DtSelectModule} from "@dynatrace/barista-components/select";
-import {DtMenuModule} from "@dynatrace/barista-components/menu";
-import {DtDrawerModule} from "@dynatrace/barista-components/drawer";
-import {DtContextDialogModule} from "@dynatrace/barista-components/context-dialog";
-import {DtInputModule} from "@dynatrace/barista-components/input";
-import {DtEmptyStateModule} from "@dynatrace/barista-components/empty-state";
-import {DtCardModule} from "@dynatrace/barista-components/card";
-import {DtTileModule} from "@dynatrace/barista-components/tile";
-import {DtInfoGroupModule} from "@dynatrace/barista-components/info-group";
-import {DtProgressBarModule} from "@dynatrace/barista-components/progress-bar";
-import {DtLoadingDistractorModule} from "@dynatrace/barista-components/loading-distractor";
-import {DtTagModule} from "@dynatrace/barista-components/tag";
-import {DtExpandableTextModule} from "@dynatrace/barista-components/expandable-text";
-import {DtShowMoreModule} from "@dynatrace/barista-components/show-more";
-import {DtIndicatorModule} from "@dynatrace/barista-components/core";
-import {DtProgressCircleModule} from "@dynatrace/barista-components/progress-circle";
-import {DtConsumptionModule} from "@dynatrace/barista-components/consumption";
-import {DtKeyValueListModule} from "@dynatrace/barista-components/key-value-list";
-import {DtChartModule} from "@dynatrace/barista-components/chart";
-import {DtIconModule} from "@dynatrace/barista-components/icon";
 
 describe('KtbExpandableTileComponent', () => {
   let component: KtbExpandableTileComponent;
@@ -60,63 +11,10 @@ describe('KtbExpandableTileComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
-        AppComponent,
-        DashboardComponent,
-        AppHeaderComponent,
-        ProjectBoardComponent,
-        KtbHttpLoadingSpinnerComponent,
-        KtbHttpLoadingBarComponent,
-        KtbShowHttpLoadingDirective,
-        KtbHideHttpLoadingDirective,
-        KtbExpandableTileComponent,
-        KtbExpandableTileHeader,
-        KtbSelectableTileComponent,
-        KtbHorizontalSeparatorComponent,
-        KtbHorizontalSeparatorTitle,
-        KtbRootEventsListComponent,
-        KtbProjectTileComponent,
-        KtbProjectListComponent,
-        KtbEventsListComponent,
-        AtobPipe,
-        KtbEventItemComponent,
-        KtbEventItemDetail,
-        KtbEvaluationDetailsComponent,
-        KtbSliBreakdownComponent,
       ],
       imports: [
-        BrowserModule,
-        BrowserAnimationsModule,
+        AppModule,
         HttpClientTestingModule,
-        AppRouting,
-        FlexLayoutModule,
-        MomentModule,
-        DtThemingModule,
-        DtButtonModule,
-        DtButtonGroupModule,
-        DtSelectModule,
-        DtMenuModule,
-        DtDrawerModule,
-        DtContextDialogModule,
-        DtInputModule,
-        DtEmptyStateModule,
-        DtCardModule,
-        DtTileModule,
-        DtInfoGroupModule,
-        DtProgressBarModule,
-        DtLoadingDistractorModule,
-        DtTagModule,
-        DtExpandableTextModule,
-        DtExpandablePanelModule,
-        DtShowMoreModule,
-        DtIndicatorModule,
-        DtProgressCircleModule,
-        DtConsumptionModule,
-        DtKeyValueListModule,
-        DtChartModule,
-        DtIconModule.forRoot({
-          svgIconLocation: `/assets/icons/{{name}}.svg`,
-        }),
-        BrowserAnimationsModule
       ],
     })
     .compileComponents();

--- a/bridge/client/app/_components/ktb-horizontal-separator/ktb-horizontal-separator.component.spec.ts
+++ b/bridge/client/app/_components/ktb-horizontal-separator/ktb-horizontal-separator.component.spec.ts
@@ -1,57 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import {KtbHorizontalSeparatorComponent, KtbHorizontalSeparatorTitle} from './ktb-horizontal-separator.component';
-import {AppComponent} from "../../app.component";
-import {DashboardComponent} from "../../dashboard/dashboard.component";
-import {AppHeaderComponent} from "../../app-header/app-header.component";
-import {ProjectBoardComponent} from "../../project-board/project-board.component";
-import {KtbHttpLoadingSpinnerComponent} from "../ktb-http-loading-spinner/ktb-http-loading-spinner.component";
-import {KtbHttpLoadingBarComponent} from "../ktb-http-loading-bar/ktb-http-loading-bar.component";
-import {KtbShowHttpLoadingDirective} from "../../_directives/ktb-show-http-loading/ktb-show-http-loading.directive";
-import {KtbHideHttpLoadingDirective} from "../../_directives/ktb-hide-http-loading/ktb-hide-http-loading.directive";
-import {
-  KtbExpandableTileComponent,
-  KtbExpandableTileHeader
-} from "../ktb-expandable-tile/ktb-expandable-tile.component";
-import {KtbSelectableTileComponent} from "../ktb-selectable-tile/ktb-selectable-tile.component";
-import {KtbRootEventsListComponent} from "../ktb-root-events-list/ktb-root-events-list.component";
-import {KtbProjectTileComponent} from "../ktb-project-tile/ktb-project-tile.component";
-import {KtbProjectListComponent} from "../ktb-project-list/ktb-project-list.component";
-import {KtbEventsListComponent} from "../ktb-events-list/ktb-events-list.component";
-import {AtobPipe} from "../../_pipes/atob.pipe";
-import {KtbEventItemComponent, KtbEventItemDetail} from "../ktb-event-item/ktb-event-item.component";
-import {KtbEvaluationDetailsComponent} from "../ktb-evaluation-details/ktb-evaluation-details.component";
-import {KtbSliBreakdownComponent} from "../ktb-sli-breakdown/ktb-sli-breakdown.component";
-import {BrowserModule} from "@angular/platform-browser";
-import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
 import {HttpClientTestingModule} from "@angular/common/http/testing";
-import {AppRouting} from "../../app.routing";
-import {FlexLayoutModule} from "@angular/flex-layout";
-import {MomentModule} from "ngx-moment";
-import {DtThemingModule} from "@dynatrace/barista-components/theming";
-import {DtButtonModule} from "@dynatrace/barista-components/button";
-import {DtButtonGroupModule} from "@dynatrace/barista-components/button-group";
-import {DtSelectModule} from "@dynatrace/barista-components/select";
-import {DtMenuModule} from "@dynatrace/barista-components/menu";
-import {DtDrawerModule} from "@dynatrace/barista-components/drawer";
-import {DtContextDialogModule} from "@dynatrace/barista-components/context-dialog";
-import {DtInputModule} from "@dynatrace/barista-components/input";
-import {DtEmptyStateModule} from "@dynatrace/barista-components/empty-state";
-import {DtCardModule} from "@dynatrace/barista-components/card";
-import {DtTileModule} from "@dynatrace/barista-components/tile";
-import {DtInfoGroupModule} from "@dynatrace/barista-components/info-group";
-import {DtProgressBarModule} from "@dynatrace/barista-components/progress-bar";
-import {DtLoadingDistractorModule} from "@dynatrace/barista-components/loading-distractor";
-import {DtTagModule} from "@dynatrace/barista-components/tag";
-import {DtExpandableTextModule} from "@dynatrace/barista-components/expandable-text";
-import {DtExpandablePanelModule} from "@dynatrace/barista-components/expandable-panel";
-import {DtShowMoreModule} from "@dynatrace/barista-components/show-more";
-import {DtIndicatorModule} from "@dynatrace/barista-components/core";
-import {DtProgressCircleModule} from "@dynatrace/barista-components/progress-circle";
-import {DtConsumptionModule} from "@dynatrace/barista-components/consumption";
-import {DtKeyValueListModule} from "@dynatrace/barista-components/key-value-list";
-import {DtChartModule} from "@dynatrace/barista-components/chart";
-import {DtIconModule} from "@dynatrace/barista-components/icon";
+import {AppModule} from "../../app.module";
 
 describe('KtbHorizontalSeparatorComponent', () => {
   let component: KtbHorizontalSeparatorComponent;
@@ -60,63 +11,10 @@ describe('KtbHorizontalSeparatorComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
-        AppComponent,
-        DashboardComponent,
-        AppHeaderComponent,
-        ProjectBoardComponent,
-        KtbHttpLoadingSpinnerComponent,
-        KtbHttpLoadingBarComponent,
-        KtbShowHttpLoadingDirective,
-        KtbHideHttpLoadingDirective,
-        KtbExpandableTileComponent,
-        KtbExpandableTileHeader,
-        KtbSelectableTileComponent,
-        KtbHorizontalSeparatorComponent,
-        KtbHorizontalSeparatorTitle,
-        KtbRootEventsListComponent,
-        KtbProjectTileComponent,
-        KtbProjectListComponent,
-        KtbEventsListComponent,
-        AtobPipe,
-        KtbEventItemComponent,
-        KtbEventItemDetail,
-        KtbEvaluationDetailsComponent,
-        KtbSliBreakdownComponent,
       ],
       imports: [
-        BrowserModule,
-        BrowserAnimationsModule,
+        AppModule,
         HttpClientTestingModule,
-        AppRouting,
-        FlexLayoutModule,
-        MomentModule,
-        DtThemingModule,
-        DtButtonModule,
-        DtButtonGroupModule,
-        DtSelectModule,
-        DtMenuModule,
-        DtDrawerModule,
-        DtContextDialogModule,
-        DtInputModule,
-        DtEmptyStateModule,
-        DtCardModule,
-        DtTileModule,
-        DtInfoGroupModule,
-        DtProgressBarModule,
-        DtLoadingDistractorModule,
-        DtTagModule,
-        DtExpandableTextModule,
-        DtExpandablePanelModule,
-        DtShowMoreModule,
-        DtIndicatorModule,
-        DtProgressCircleModule,
-        DtConsumptionModule,
-        DtKeyValueListModule,
-        DtChartModule,
-        DtIconModule.forRoot({
-          svgIconLocation: `/assets/icons/{{name}}.svg`,
-        }),
-        BrowserAnimationsModule
       ],
     })
     .compileComponents();

--- a/bridge/client/app/_components/ktb-http-loading-bar/ktb-http-loading-bar.component.spec.ts
+++ b/bridge/client/app/_components/ktb-http-loading-bar/ktb-http-loading-bar.component.spec.ts
@@ -1,60 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { KtbHttpLoadingBarComponent } from './ktb-http-loading-bar.component';
-import {DtProgressBarModule} from "@dynatrace/barista-components/progress-bar";
-import {AppComponent} from "../../app.component";
-import {DashboardComponent} from "../../dashboard/dashboard.component";
-import {AppHeaderComponent} from "../../app-header/app-header.component";
-import {ProjectBoardComponent} from "../../project-board/project-board.component";
-import {KtbHttpLoadingSpinnerComponent} from "../ktb-http-loading-spinner/ktb-http-loading-spinner.component";
-import {KtbShowHttpLoadingDirective} from "../../_directives/ktb-show-http-loading/ktb-show-http-loading.directive";
-import {KtbHideHttpLoadingDirective} from "../../_directives/ktb-hide-http-loading/ktb-hide-http-loading.directive";
-import {
-  KtbExpandableTileComponent,
-  KtbExpandableTileHeader
-} from "../ktb-expandable-tile/ktb-expandable-tile.component";
-import {KtbSelectableTileComponent} from "../ktb-selectable-tile/ktb-selectable-tile.component";
-import {
-  KtbHorizontalSeparatorComponent,
-  KtbHorizontalSeparatorTitle
-} from "../ktb-horizontal-separator/ktb-horizontal-separator.component";
-import {KtbRootEventsListComponent} from "../ktb-root-events-list/ktb-root-events-list.component";
-import {KtbProjectTileComponent} from "../ktb-project-tile/ktb-project-tile.component";
-import {KtbProjectListComponent} from "../ktb-project-list/ktb-project-list.component";
-import {KtbEventsListComponent} from "../ktb-events-list/ktb-events-list.component";
-import {AtobPipe} from "../../_pipes/atob.pipe";
-import {KtbEventItemComponent, KtbEventItemDetail} from "../ktb-event-item/ktb-event-item.component";
-import {KtbEvaluationDetailsComponent} from "../ktb-evaluation-details/ktb-evaluation-details.component";
-import {KtbSliBreakdownComponent} from "../ktb-sli-breakdown/ktb-sli-breakdown.component";
-import {BrowserModule} from "@angular/platform-browser";
-import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
 import {HttpClientTestingModule} from "@angular/common/http/testing";
-import {AppRouting} from "../../app.routing";
-import {FlexLayoutModule} from "@angular/flex-layout";
-import {MomentModule} from "ngx-moment";
-import {DtThemingModule} from "@dynatrace/barista-components/theming";
-import {DtButtonModule} from "@dynatrace/barista-components/button";
-import {DtButtonGroupModule} from "@dynatrace/barista-components/button-group";
-import {DtSelectModule} from "@dynatrace/barista-components/select";
-import {DtMenuModule} from "@dynatrace/barista-components/menu";
-import {DtDrawerModule} from "@dynatrace/barista-components/drawer";
-import {DtContextDialogModule} from "@dynatrace/barista-components/context-dialog";
-import {DtInputModule} from "@dynatrace/barista-components/input";
-import {DtEmptyStateModule} from "@dynatrace/barista-components/empty-state";
-import {DtCardModule} from "@dynatrace/barista-components/card";
-import {DtTileModule} from "@dynatrace/barista-components/tile";
-import {DtInfoGroupModule} from "@dynatrace/barista-components/info-group";
-import {DtLoadingDistractorModule} from "@dynatrace/barista-components/loading-distractor";
-import {DtTagModule} from "@dynatrace/barista-components/tag";
-import {DtExpandableTextModule} from "@dynatrace/barista-components/expandable-text";
-import {DtExpandablePanelModule} from "@dynatrace/barista-components/expandable-panel";
-import {DtShowMoreModule} from "@dynatrace/barista-components/show-more";
-import {DtIndicatorModule} from "@dynatrace/barista-components/core";
-import {DtProgressCircleModule} from "@dynatrace/barista-components/progress-circle";
-import {DtConsumptionModule} from "@dynatrace/barista-components/consumption";
-import {DtKeyValueListModule} from "@dynatrace/barista-components/key-value-list";
-import {DtChartModule} from "@dynatrace/barista-components/chart";
-import {DtIconModule} from "@dynatrace/barista-components/icon";
+import {AppModule} from "../../app.module";
 
 describe('HttpLoadingBarComponent', () => {
   let component: KtbHttpLoadingBarComponent;
@@ -63,63 +11,10 @@ describe('HttpLoadingBarComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
-        AppComponent,
-        DashboardComponent,
-        AppHeaderComponent,
-        ProjectBoardComponent,
-        KtbHttpLoadingSpinnerComponent,
-        KtbHttpLoadingBarComponent,
-        KtbShowHttpLoadingDirective,
-        KtbHideHttpLoadingDirective,
-        KtbExpandableTileComponent,
-        KtbExpandableTileHeader,
-        KtbSelectableTileComponent,
-        KtbHorizontalSeparatorComponent,
-        KtbHorizontalSeparatorTitle,
-        KtbRootEventsListComponent,
-        KtbProjectTileComponent,
-        KtbProjectListComponent,
-        KtbEventsListComponent,
-        AtobPipe,
-        KtbEventItemComponent,
-        KtbEventItemDetail,
-        KtbEvaluationDetailsComponent,
-        KtbSliBreakdownComponent,
       ],
       imports: [
-        BrowserModule,
-        BrowserAnimationsModule,
+        AppModule,
         HttpClientTestingModule,
-        AppRouting,
-        FlexLayoutModule,
-        MomentModule,
-        DtThemingModule,
-        DtButtonModule,
-        DtButtonGroupModule,
-        DtSelectModule,
-        DtMenuModule,
-        DtDrawerModule,
-        DtContextDialogModule,
-        DtInputModule,
-        DtEmptyStateModule,
-        DtCardModule,
-        DtTileModule,
-        DtInfoGroupModule,
-        DtProgressBarModule,
-        DtLoadingDistractorModule,
-        DtTagModule,
-        DtExpandableTextModule,
-        DtExpandablePanelModule,
-        DtShowMoreModule,
-        DtIndicatorModule,
-        DtProgressCircleModule,
-        DtConsumptionModule,
-        DtKeyValueListModule,
-        DtChartModule,
-        DtIconModule.forRoot({
-          svgIconLocation: `/assets/icons/{{name}}.svg`,
-        }),
-        BrowserAnimationsModule
       ],
     })
     .compileComponents();

--- a/bridge/client/app/_components/ktb-http-loading-spinner/ktb-http-loading-spinner.component.spec.ts
+++ b/bridge/client/app/_components/ktb-http-loading-spinner/ktb-http-loading-spinner.component.spec.ts
@@ -1,60 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { KtbHttpLoadingSpinnerComponent } from './ktb-http-loading-spinner.component';
-import {DtLoadingDistractorModule} from "@dynatrace/barista-components/loading-distractor";
-import {AppComponent} from "../../app.component";
-import {DashboardComponent} from "../../dashboard/dashboard.component";
-import {AppHeaderComponent} from "../../app-header/app-header.component";
-import {ProjectBoardComponent} from "../../project-board/project-board.component";
-import {KtbHttpLoadingBarComponent} from "../ktb-http-loading-bar/ktb-http-loading-bar.component";
-import {KtbShowHttpLoadingDirective} from "../../_directives/ktb-show-http-loading/ktb-show-http-loading.directive";
-import {KtbHideHttpLoadingDirective} from "../../_directives/ktb-hide-http-loading/ktb-hide-http-loading.directive";
-import {
-  KtbExpandableTileComponent,
-  KtbExpandableTileHeader
-} from "../ktb-expandable-tile/ktb-expandable-tile.component";
-import {KtbSelectableTileComponent} from "../ktb-selectable-tile/ktb-selectable-tile.component";
-import {
-  KtbHorizontalSeparatorComponent,
-  KtbHorizontalSeparatorTitle
-} from "../ktb-horizontal-separator/ktb-horizontal-separator.component";
-import {KtbRootEventsListComponent} from "../ktb-root-events-list/ktb-root-events-list.component";
-import {KtbProjectTileComponent} from "../ktb-project-tile/ktb-project-tile.component";
-import {KtbProjectListComponent} from "../ktb-project-list/ktb-project-list.component";
-import {KtbEventsListComponent} from "../ktb-events-list/ktb-events-list.component";
-import {AtobPipe} from "../../_pipes/atob.pipe";
-import {KtbEventItemComponent, KtbEventItemDetail} from "../ktb-event-item/ktb-event-item.component";
-import {KtbEvaluationDetailsComponent} from "../ktb-evaluation-details/ktb-evaluation-details.component";
-import {KtbSliBreakdownComponent} from "../ktb-sli-breakdown/ktb-sli-breakdown.component";
-import {BrowserModule} from "@angular/platform-browser";
-import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
 import {HttpClientTestingModule} from "@angular/common/http/testing";
-import {AppRouting} from "../../app.routing";
-import {FlexLayoutModule} from "@angular/flex-layout";
-import {MomentModule} from "ngx-moment";
-import {DtThemingModule} from "@dynatrace/barista-components/theming";
-import {DtButtonModule} from "@dynatrace/barista-components/button";
-import {DtButtonGroupModule} from "@dynatrace/barista-components/button-group";
-import {DtSelectModule} from "@dynatrace/barista-components/select";
-import {DtMenuModule} from "@dynatrace/barista-components/menu";
-import {DtDrawerModule} from "@dynatrace/barista-components/drawer";
-import {DtContextDialogModule} from "@dynatrace/barista-components/context-dialog";
-import {DtInputModule} from "@dynatrace/barista-components/input";
-import {DtEmptyStateModule} from "@dynatrace/barista-components/empty-state";
-import {DtCardModule} from "@dynatrace/barista-components/card";
-import {DtTileModule} from "@dynatrace/barista-components/tile";
-import {DtInfoGroupModule} from "@dynatrace/barista-components/info-group";
-import {DtProgressBarModule} from "@dynatrace/barista-components/progress-bar";
-import {DtTagModule} from "@dynatrace/barista-components/tag";
-import {DtExpandableTextModule} from "@dynatrace/barista-components/expandable-text";
-import {DtExpandablePanelModule} from "@dynatrace/barista-components/expandable-panel";
-import {DtShowMoreModule} from "@dynatrace/barista-components/show-more";
-import {DtIndicatorModule} from "@dynatrace/barista-components/core";
-import {DtProgressCircleModule} from "@dynatrace/barista-components/progress-circle";
-import {DtConsumptionModule} from "@dynatrace/barista-components/consumption";
-import {DtKeyValueListModule} from "@dynatrace/barista-components/key-value-list";
-import {DtChartModule} from "@dynatrace/barista-components/chart";
-import {DtIconModule} from "@dynatrace/barista-components/icon";
+import {AppModule} from "../../app.module";
 
 describe('HttpLoadingSpinnerComponent', () => {
   let component: KtbHttpLoadingSpinnerComponent;
@@ -62,64 +10,10 @@ describe('HttpLoadingSpinnerComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [
-        AppComponent,
-        DashboardComponent,
-        AppHeaderComponent,
-        ProjectBoardComponent,
-        KtbHttpLoadingSpinnerComponent,
-        KtbHttpLoadingBarComponent,
-        KtbShowHttpLoadingDirective,
-        KtbHideHttpLoadingDirective,
-        KtbExpandableTileComponent,
-        KtbExpandableTileHeader,
-        KtbSelectableTileComponent,
-        KtbHorizontalSeparatorComponent,
-        KtbHorizontalSeparatorTitle,
-        KtbRootEventsListComponent,
-        KtbProjectTileComponent,
-        KtbProjectListComponent,
-        KtbEventsListComponent,
-        AtobPipe,
-        KtbEventItemComponent,
-        KtbEventItemDetail,
-        KtbEvaluationDetailsComponent,
-        KtbSliBreakdownComponent,
-      ],
+      declarations: [],
       imports: [
-        BrowserModule,
-        BrowserAnimationsModule,
+        AppModule,
         HttpClientTestingModule,
-        AppRouting,
-        FlexLayoutModule,
-        MomentModule,
-        DtThemingModule,
-        DtButtonModule,
-        DtButtonGroupModule,
-        DtSelectModule,
-        DtMenuModule,
-        DtDrawerModule,
-        DtContextDialogModule,
-        DtInputModule,
-        DtEmptyStateModule,
-        DtCardModule,
-        DtTileModule,
-        DtInfoGroupModule,
-        DtProgressBarModule,
-        DtLoadingDistractorModule,
-        DtTagModule,
-        DtExpandableTextModule,
-        DtExpandablePanelModule,
-        DtShowMoreModule,
-        DtIndicatorModule,
-        DtProgressCircleModule,
-        DtConsumptionModule,
-        DtKeyValueListModule,
-        DtChartModule,
-        DtIconModule.forRoot({
-          svgIconLocation: `/assets/icons/{{name}}.svg`,
-        }),
-        BrowserAnimationsModule
       ],
     })
     .compileComponents();

--- a/bridge/client/app/_components/ktb-project-list/ktb-project-list.component.spec.ts
+++ b/bridge/client/app/_components/ktb-project-list/ktb-project-list.component.spec.ts
@@ -1,60 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { KtbProjectListComponent } from './ktb-project-list.component';
-import {KtbProjectTileComponent} from "../ktb-project-tile/ktb-project-tile.component";
-import {AppComponent} from "../../app.component";
-import {DashboardComponent} from "../../dashboard/dashboard.component";
-import {AppHeaderComponent} from "../../app-header/app-header.component";
-import {ProjectBoardComponent} from "../../project-board/project-board.component";
-import {KtbHttpLoadingSpinnerComponent} from "../ktb-http-loading-spinner/ktb-http-loading-spinner.component";
-import {KtbHttpLoadingBarComponent} from "../ktb-http-loading-bar/ktb-http-loading-bar.component";
-import {KtbShowHttpLoadingDirective} from "../../_directives/ktb-show-http-loading/ktb-show-http-loading.directive";
-import {KtbHideHttpLoadingDirective} from "../../_directives/ktb-hide-http-loading/ktb-hide-http-loading.directive";
-import {
-  KtbExpandableTileComponent,
-  KtbExpandableTileHeader
-} from "../ktb-expandable-tile/ktb-expandable-tile.component";
-import {KtbSelectableTileComponent} from "../ktb-selectable-tile/ktb-selectable-tile.component";
-import {
-  KtbHorizontalSeparatorComponent,
-  KtbHorizontalSeparatorTitle
-} from "../ktb-horizontal-separator/ktb-horizontal-separator.component";
-import {KtbRootEventsListComponent} from "../ktb-root-events-list/ktb-root-events-list.component";
-import {KtbEventsListComponent} from "../ktb-events-list/ktb-events-list.component";
-import {AtobPipe} from "../../_pipes/atob.pipe";
-import {KtbEventItemComponent, KtbEventItemDetail} from "../ktb-event-item/ktb-event-item.component";
-import {KtbEvaluationDetailsComponent} from "../ktb-evaluation-details/ktb-evaluation-details.component";
-import {KtbSliBreakdownComponent} from "../ktb-sli-breakdown/ktb-sli-breakdown.component";
-import {BrowserModule} from "@angular/platform-browser";
-import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
 import {HttpClientTestingModule} from "@angular/common/http/testing";
-import {AppRouting} from "../../app.routing";
-import {FlexLayoutModule} from "@angular/flex-layout";
-import {MomentModule} from "ngx-moment";
-import {DtThemingModule} from "@dynatrace/barista-components/theming";
-import {DtButtonModule} from "@dynatrace/barista-components/button";
-import {DtButtonGroupModule} from "@dynatrace/barista-components/button-group";
-import {DtSelectModule} from "@dynatrace/barista-components/select";
-import {DtMenuModule} from "@dynatrace/barista-components/menu";
-import {DtDrawerModule} from "@dynatrace/barista-components/drawer";
-import {DtContextDialogModule} from "@dynatrace/barista-components/context-dialog";
-import {DtInputModule} from "@dynatrace/barista-components/input";
-import {DtEmptyStateModule} from "@dynatrace/barista-components/empty-state";
-import {DtCardModule} from "@dynatrace/barista-components/card";
-import {DtTileModule} from "@dynatrace/barista-components/tile";
-import {DtInfoGroupModule} from "@dynatrace/barista-components/info-group";
-import {DtProgressBarModule} from "@dynatrace/barista-components/progress-bar";
-import {DtLoadingDistractorModule} from "@dynatrace/barista-components/loading-distractor";
-import {DtTagModule} from "@dynatrace/barista-components/tag";
-import {DtExpandableTextModule} from "@dynatrace/barista-components/expandable-text";
-import {DtExpandablePanelModule} from "@dynatrace/barista-components/expandable-panel";
-import {DtShowMoreModule} from "@dynatrace/barista-components/show-more";
-import {DtIndicatorModule} from "@dynatrace/barista-components/core";
-import {DtProgressCircleModule} from "@dynatrace/barista-components/progress-circle";
-import {DtConsumptionModule} from "@dynatrace/barista-components/consumption";
-import {DtKeyValueListModule} from "@dynatrace/barista-components/key-value-list";
-import {DtChartModule} from "@dynatrace/barista-components/chart";
-import {DtIconModule} from "@dynatrace/barista-components/icon";
+import {AppModule} from "../../app.module";
 
 describe('KtbProjectListComponent', () => {
   let component: KtbProjectListComponent;
@@ -63,63 +11,10 @@ describe('KtbProjectListComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
-        AppComponent,
-        DashboardComponent,
-        AppHeaderComponent,
-        ProjectBoardComponent,
-        KtbHttpLoadingSpinnerComponent,
-        KtbHttpLoadingBarComponent,
-        KtbShowHttpLoadingDirective,
-        KtbHideHttpLoadingDirective,
-        KtbExpandableTileComponent,
-        KtbExpandableTileHeader,
-        KtbSelectableTileComponent,
-        KtbHorizontalSeparatorComponent,
-        KtbHorizontalSeparatorTitle,
-        KtbRootEventsListComponent,
-        KtbProjectTileComponent,
-        KtbProjectListComponent,
-        KtbEventsListComponent,
-        AtobPipe,
-        KtbEventItemComponent,
-        KtbEventItemDetail,
-        KtbEvaluationDetailsComponent,
-        KtbSliBreakdownComponent,
       ],
       imports: [
-        BrowserModule,
-        BrowserAnimationsModule,
+        AppModule,
         HttpClientTestingModule,
-        AppRouting,
-        FlexLayoutModule,
-        MomentModule,
-        DtThemingModule,
-        DtButtonModule,
-        DtButtonGroupModule,
-        DtSelectModule,
-        DtMenuModule,
-        DtDrawerModule,
-        DtContextDialogModule,
-        DtInputModule,
-        DtEmptyStateModule,
-        DtCardModule,
-        DtTileModule,
-        DtInfoGroupModule,
-        DtProgressBarModule,
-        DtLoadingDistractorModule,
-        DtTagModule,
-        DtExpandableTextModule,
-        DtExpandablePanelModule,
-        DtShowMoreModule,
-        DtIndicatorModule,
-        DtProgressCircleModule,
-        DtConsumptionModule,
-        DtKeyValueListModule,
-        DtChartModule,
-        DtIconModule.forRoot({
-          svgIconLocation: `/assets/icons/{{name}}.svg`,
-        }),
-        BrowserAnimationsModule
       ],
     })
     .compileComponents();

--- a/bridge/client/app/_components/ktb-project-tile/ktb-project-tile.component.spec.ts
+++ b/bridge/client/app/_components/ktb-project-tile/ktb-project-tile.component.spec.ts
@@ -1,60 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { KtbProjectTileComponent } from './ktb-project-tile.component';
-import {DtTileModule} from "@dynatrace/barista-components/tile";
-import {DtTagModule} from "@dynatrace/barista-components/tag";
-import {AppComponent} from "../../app.component";
-import {DashboardComponent} from "../../dashboard/dashboard.component";
-import {AppHeaderComponent} from "../../app-header/app-header.component";
-import {ProjectBoardComponent} from "../../project-board/project-board.component";
-import {KtbHttpLoadingSpinnerComponent} from "../ktb-http-loading-spinner/ktb-http-loading-spinner.component";
-import {KtbHttpLoadingBarComponent} from "../ktb-http-loading-bar/ktb-http-loading-bar.component";
-import {KtbShowHttpLoadingDirective} from "../../_directives/ktb-show-http-loading/ktb-show-http-loading.directive";
-import {KtbHideHttpLoadingDirective} from "../../_directives/ktb-hide-http-loading/ktb-hide-http-loading.directive";
-import {
-  KtbExpandableTileComponent,
-  KtbExpandableTileHeader
-} from "../ktb-expandable-tile/ktb-expandable-tile.component";
-import {KtbSelectableTileComponent} from "../ktb-selectable-tile/ktb-selectable-tile.component";
-import {
-  KtbHorizontalSeparatorComponent,
-  KtbHorizontalSeparatorTitle
-} from "../ktb-horizontal-separator/ktb-horizontal-separator.component";
-import {KtbRootEventsListComponent} from "../ktb-root-events-list/ktb-root-events-list.component";
-import {KtbProjectListComponent} from "../ktb-project-list/ktb-project-list.component";
-import {KtbEventsListComponent} from "../ktb-events-list/ktb-events-list.component";
-import {AtobPipe} from "../../_pipes/atob.pipe";
-import {KtbEventItemComponent, KtbEventItemDetail} from "../ktb-event-item/ktb-event-item.component";
-import {KtbEvaluationDetailsComponent} from "../ktb-evaluation-details/ktb-evaluation-details.component";
-import {KtbSliBreakdownComponent} from "../ktb-sli-breakdown/ktb-sli-breakdown.component";
-import {BrowserModule} from "@angular/platform-browser";
-import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
+import {AppModule} from "../../app.module";
 import {HttpClientTestingModule} from "@angular/common/http/testing";
-import {AppRouting} from "../../app.routing";
-import {FlexLayoutModule} from "@angular/flex-layout";
-import {MomentModule} from "ngx-moment";
-import {DtThemingModule} from "@dynatrace/barista-components/theming";
-import {DtButtonModule} from "@dynatrace/barista-components/button";
-import {DtButtonGroupModule} from "@dynatrace/barista-components/button-group";
-import {DtSelectModule} from "@dynatrace/barista-components/select";
-import {DtMenuModule} from "@dynatrace/barista-components/menu";
-import {DtDrawerModule} from "@dynatrace/barista-components/drawer";
-import {DtContextDialogModule} from "@dynatrace/barista-components/context-dialog";
-import {DtInputModule} from "@dynatrace/barista-components/input";
-import {DtEmptyStateModule} from "@dynatrace/barista-components/empty-state";
-import {DtCardModule} from "@dynatrace/barista-components/card";
-import {DtInfoGroupModule} from "@dynatrace/barista-components/info-group";
-import {DtProgressBarModule} from "@dynatrace/barista-components/progress-bar";
-import {DtLoadingDistractorModule} from "@dynatrace/barista-components/loading-distractor";
-import {DtExpandableTextModule} from "@dynatrace/barista-components/expandable-text";
-import {DtExpandablePanelModule} from "@dynatrace/barista-components/expandable-panel";
-import {DtShowMoreModule} from "@dynatrace/barista-components/show-more";
-import {DtIndicatorModule} from "@dynatrace/barista-components/core";
-import {DtProgressCircleModule} from "@dynatrace/barista-components/progress-circle";
-import {DtConsumptionModule} from "@dynatrace/barista-components/consumption";
-import {DtKeyValueListModule} from "@dynatrace/barista-components/key-value-list";
-import {DtChartModule} from "@dynatrace/barista-components/chart";
-import {DtIconModule} from "@dynatrace/barista-components/icon";
 
 describe('KtbProjectTileComponent', () => {
   let component: KtbProjectTileComponent;
@@ -62,64 +10,10 @@ describe('KtbProjectTileComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [
-        AppComponent,
-        DashboardComponent,
-        AppHeaderComponent,
-        ProjectBoardComponent,
-        KtbHttpLoadingSpinnerComponent,
-        KtbHttpLoadingBarComponent,
-        KtbShowHttpLoadingDirective,
-        KtbHideHttpLoadingDirective,
-        KtbExpandableTileComponent,
-        KtbExpandableTileHeader,
-        KtbSelectableTileComponent,
-        KtbHorizontalSeparatorComponent,
-        KtbHorizontalSeparatorTitle,
-        KtbRootEventsListComponent,
-        KtbProjectTileComponent,
-        KtbProjectListComponent,
-        KtbEventsListComponent,
-        AtobPipe,
-        KtbEventItemComponent,
-        KtbEventItemDetail,
-        KtbEvaluationDetailsComponent,
-        KtbSliBreakdownComponent,
-      ],
+      declarations: [],
       imports: [
-        BrowserModule,
-        BrowserAnimationsModule,
+        AppModule,
         HttpClientTestingModule,
-        AppRouting,
-        FlexLayoutModule,
-        MomentModule,
-        DtThemingModule,
-        DtButtonModule,
-        DtButtonGroupModule,
-        DtSelectModule,
-        DtMenuModule,
-        DtDrawerModule,
-        DtContextDialogModule,
-        DtInputModule,
-        DtEmptyStateModule,
-        DtCardModule,
-        DtTileModule,
-        DtInfoGroupModule,
-        DtProgressBarModule,
-        DtLoadingDistractorModule,
-        DtTagModule,
-        DtExpandableTextModule,
-        DtExpandablePanelModule,
-        DtShowMoreModule,
-        DtIndicatorModule,
-        DtProgressCircleModule,
-        DtConsumptionModule,
-        DtKeyValueListModule,
-        DtChartModule,
-        DtIconModule.forRoot({
-          svgIconLocation: `/assets/icons/{{name}}.svg`,
-        }),
-        BrowserAnimationsModule
       ],
     })
     .compileComponents();

--- a/bridge/client/app/_components/ktb-root-events-list/ktb-root-events-list.component.spec.ts
+++ b/bridge/client/app/_components/ktb-root-events-list/ktb-root-events-list.component.spec.ts
@@ -1,60 +1,9 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { KtbRootEventsListComponent } from './ktb-root-events-list.component';
-import {AppComponent} from "../../app.component";
-import {DashboardComponent} from "../../dashboard/dashboard.component";
-import {AppHeaderComponent} from "../../app-header/app-header.component";
-import {ProjectBoardComponent} from "../../project-board/project-board.component";
-import {KtbHttpLoadingSpinnerComponent} from "../ktb-http-loading-spinner/ktb-http-loading-spinner.component";
-import {KtbHttpLoadingBarComponent} from "../ktb-http-loading-bar/ktb-http-loading-bar.component";
-import {KtbShowHttpLoadingDirective} from "../../_directives/ktb-show-http-loading/ktb-show-http-loading.directive";
-import {KtbHideHttpLoadingDirective} from "../../_directives/ktb-hide-http-loading/ktb-hide-http-loading.directive";
-import {
-  KtbExpandableTileComponent,
-  KtbExpandableTileHeader
-} from "../ktb-expandable-tile/ktb-expandable-tile.component";
-import {KtbSelectableTileComponent} from "../ktb-selectable-tile/ktb-selectable-tile.component";
-import {
-  KtbHorizontalSeparatorComponent,
-  KtbHorizontalSeparatorTitle
-} from "../ktb-horizontal-separator/ktb-horizontal-separator.component";
-import {KtbProjectTileComponent} from "../ktb-project-tile/ktb-project-tile.component";
-import {KtbProjectListComponent} from "../ktb-project-list/ktb-project-list.component";
 import {KtbEventsListComponent} from "../ktb-events-list/ktb-events-list.component";
-import {AtobPipe} from "../../_pipes/atob.pipe";
-import {KtbEventItemComponent, KtbEventItemDetail} from "../ktb-event-item/ktb-event-item.component";
-import {KtbEvaluationDetailsComponent} from "../ktb-evaluation-details/ktb-evaluation-details.component";
-import {KtbSliBreakdownComponent} from "../ktb-sli-breakdown/ktb-sli-breakdown.component";
-import {BrowserModule} from "@angular/platform-browser";
-import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
 import {HttpClientTestingModule} from "@angular/common/http/testing";
-import {AppRouting} from "../../app.routing";
-import {FlexLayoutModule} from "@angular/flex-layout";
-import {MomentModule} from "ngx-moment";
-import {DtThemingModule} from "@dynatrace/barista-components/theming";
-import {DtButtonModule} from "@dynatrace/barista-components/button";
-import {DtButtonGroupModule} from "@dynatrace/barista-components/button-group";
-import {DtSelectModule} from "@dynatrace/barista-components/select";
-import {DtMenuModule} from "@dynatrace/barista-components/menu";
-import {DtDrawerModule} from "@dynatrace/barista-components/drawer";
-import {DtContextDialogModule} from "@dynatrace/barista-components/context-dialog";
-import {DtInputModule} from "@dynatrace/barista-components/input";
-import {DtEmptyStateModule} from "@dynatrace/barista-components/empty-state";
-import {DtCardModule} from "@dynatrace/barista-components/card";
-import {DtTileModule} from "@dynatrace/barista-components/tile";
-import {DtInfoGroupModule} from "@dynatrace/barista-components/info-group";
-import {DtProgressBarModule} from "@dynatrace/barista-components/progress-bar";
-import {DtLoadingDistractorModule} from "@dynatrace/barista-components/loading-distractor";
-import {DtTagModule} from "@dynatrace/barista-components/tag";
-import {DtExpandableTextModule} from "@dynatrace/barista-components/expandable-text";
-import {DtExpandablePanelModule} from "@dynatrace/barista-components/expandable-panel";
-import {DtShowMoreModule} from "@dynatrace/barista-components/show-more";
-import {DtIndicatorModule} from "@dynatrace/barista-components/core";
-import {DtProgressCircleModule} from "@dynatrace/barista-components/progress-circle";
-import {DtConsumptionModule} from "@dynatrace/barista-components/consumption";
-import {DtKeyValueListModule} from "@dynatrace/barista-components/key-value-list";
-import {DtChartModule} from "@dynatrace/barista-components/chart";
-import {DtIconModule} from "@dynatrace/barista-components/icon";
+import {AppModule} from "../../app.module";
 
 describe('KtbEventsListComponent', () => {
   let component: KtbRootEventsListComponent;
@@ -63,63 +12,10 @@ describe('KtbEventsListComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
-        AppComponent,
-        DashboardComponent,
-        AppHeaderComponent,
-        ProjectBoardComponent,
-        KtbHttpLoadingSpinnerComponent,
-        KtbHttpLoadingBarComponent,
-        KtbShowHttpLoadingDirective,
-        KtbHideHttpLoadingDirective,
-        KtbExpandableTileComponent,
-        KtbExpandableTileHeader,
-        KtbSelectableTileComponent,
-        KtbHorizontalSeparatorComponent,
-        KtbHorizontalSeparatorTitle,
-        KtbRootEventsListComponent,
-        KtbProjectTileComponent,
-        KtbProjectListComponent,
-        KtbEventsListComponent,
-        AtobPipe,
-        KtbEventItemComponent,
-        KtbEventItemDetail,
-        KtbEvaluationDetailsComponent,
-        KtbSliBreakdownComponent,
       ],
       imports: [
-        BrowserModule,
-        BrowserAnimationsModule,
+        AppModule,
         HttpClientTestingModule,
-        AppRouting,
-        FlexLayoutModule,
-        MomentModule,
-        DtThemingModule,
-        DtButtonModule,
-        DtButtonGroupModule,
-        DtSelectModule,
-        DtMenuModule,
-        DtDrawerModule,
-        DtContextDialogModule,
-        DtInputModule,
-        DtEmptyStateModule,
-        DtCardModule,
-        DtTileModule,
-        DtInfoGroupModule,
-        DtProgressBarModule,
-        DtLoadingDistractorModule,
-        DtTagModule,
-        DtExpandableTextModule,
-        DtExpandablePanelModule,
-        DtShowMoreModule,
-        DtIndicatorModule,
-        DtProgressCircleModule,
-        DtConsumptionModule,
-        DtKeyValueListModule,
-        DtChartModule,
-        DtIconModule.forRoot({
-          svgIconLocation: `/assets/icons/{{name}}.svg`,
-        }),
-        BrowserAnimationsModule
       ],
     })
     .compileComponents();

--- a/bridge/client/app/_components/ktb-selectable-tile/ktb-selectable-tile.component.spec.ts
+++ b/bridge/client/app/_components/ktb-selectable-tile/ktb-selectable-tile.component.spec.ts
@@ -1,22 +1,21 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
-import { KtbSelectableTileComponent } from './ktb-selectable-tile.component';
+import {ComponentFixture, TestBed, fakeAsync} from '@angular/core/testing';
 import {By} from "@angular/platform-browser";
 import {Component} from "@angular/core";
+
 import {AppModule} from "../../app.module";
+import {KtbSelectableTileComponent} from './ktb-selectable-tile.component';
 
 describe('KtbSelectableTileComponent', () => {
   let component: SimpleKtbSelectableTileComponent;
   let fixture: ComponentFixture<SimpleKtbSelectableTileComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
       declarations: [
-        SimpleKtbSelectableTileComponent
+        SimpleKtbSelectableTileComponent,
+        KtbSelectableTileComponent,
       ],
-      imports: [
-        AppModule,
-      ],
+      imports: [],
     })
     .compileComponents();
   }));

--- a/bridge/client/app/_components/ktb-selectable-tile/ktb-selectable-tile.component.spec.ts
+++ b/bridge/client/app/_components/ktb-selectable-tile/ktb-selectable-tile.component.spec.ts
@@ -1,27 +1,28 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { KtbSelectableTileComponent } from './ktb-selectable-tile.component';
-import {HttpClientTestingModule} from "@angular/common/http/testing";
+import {By} from "@angular/platform-browser";
+import {Component} from "@angular/core";
 import {AppModule} from "../../app.module";
 
 describe('KtbSelectableTileComponent', () => {
-  let component: KtbSelectableTileComponent;
-  let fixture: ComponentFixture<KtbSelectableTileComponent>;
+  let component: SimpleKtbSelectableTileComponent;
+  let fixture: ComponentFixture<SimpleKtbSelectableTileComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
+        SimpleKtbSelectableTileComponent
       ],
       imports: [
         AppModule,
-        HttpClientTestingModule,
       ],
     })
     .compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(KtbSelectableTileComponent);
+    fixture = TestBed.createComponent(SimpleKtbSelectableTileComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
@@ -29,4 +30,46 @@ describe('KtbSelectableTileComponent', () => {
   it('should create an instance', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should add and remove the selected state', () => {
+    let selectableTileDebugElement = fixture.debugElement.query(By.directive(KtbSelectableTileComponent));
+    let selectableTileInstance = selectableTileDebugElement.componentInstance;
+    let selectableTileNativeElement = selectableTileDebugElement.nativeElement;
+    let testComponentInstace = fixture.debugElement.componentInstance;
+
+    expect(selectableTileInstance.selected).toBe(false);
+
+    testComponentInstace.isSelected = true;
+    fixture.detectChanges();
+
+    expect(selectableTileInstance.selected).toBe(true);
+    expect(selectableTileNativeElement.classList).toContain('ktb-tile-selected');
+
+    testComponentInstace.isSelected = false;
+    fixture.detectChanges();
+
+    expect(selectableTileInstance.selected).toBe(false);
+    expect(selectableTileNativeElement.classList).not.toContain('ktb-tile-selected');
+  });
 });
+
+/** Simple component for testing the KtbSelectableTileComponent */
+@Component({
+  template: `
+    <div>
+      <ktb-selectable-tile
+        [error]="isError"
+        [success]="isSuccess"
+        [selected]="isSelected"
+        (click)="onTileClicked($event)">
+      </ktb-selectable-tile>
+    </div>
+  `,
+})
+class SimpleKtbSelectableTileComponent {
+  isError = false;
+  isSuccess = false;
+  isSelected = false;
+
+  onTileClicked: (event?: Event) => void = () => { this.isSelected = !this.isSelected; };
+}

--- a/bridge/client/app/_components/ktb-selectable-tile/ktb-selectable-tile.component.spec.ts
+++ b/bridge/client/app/_components/ktb-selectable-tile/ktb-selectable-tile.component.spec.ts
@@ -2,7 +2,6 @@ import {ComponentFixture, TestBed, fakeAsync} from '@angular/core/testing';
 import {By} from "@angular/platform-browser";
 import {Component} from "@angular/core";
 
-import {AppModule} from "../../app.module";
 import {KtbSelectableTileComponent} from './ktb-selectable-tile.component';
 
 describe('KtbSelectableTileComponent', () => {

--- a/bridge/client/app/_components/ktb-selectable-tile/ktb-selectable-tile.component.spec.ts
+++ b/bridge/client/app/_components/ktb-selectable-tile/ktb-selectable-tile.component.spec.ts
@@ -1,60 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { KtbSelectableTileComponent } from './ktb-selectable-tile.component';
-import {AppComponent} from "../../app.component";
-import {DashboardComponent} from "../../dashboard/dashboard.component";
-import {AppHeaderComponent} from "../../app-header/app-header.component";
-import {ProjectBoardComponent} from "../../project-board/project-board.component";
-import {KtbHttpLoadingSpinnerComponent} from "../ktb-http-loading-spinner/ktb-http-loading-spinner.component";
-import {KtbHttpLoadingBarComponent} from "../ktb-http-loading-bar/ktb-http-loading-bar.component";
-import {KtbShowHttpLoadingDirective} from "../../_directives/ktb-show-http-loading/ktb-show-http-loading.directive";
-import {KtbHideHttpLoadingDirective} from "../../_directives/ktb-hide-http-loading/ktb-hide-http-loading.directive";
-import {
-  KtbExpandableTileComponent,
-  KtbExpandableTileHeader
-} from "../ktb-expandable-tile/ktb-expandable-tile.component";
-import {
-  KtbHorizontalSeparatorComponent,
-  KtbHorizontalSeparatorTitle
-} from "../ktb-horizontal-separator/ktb-horizontal-separator.component";
-import {KtbRootEventsListComponent} from "../ktb-root-events-list/ktb-root-events-list.component";
-import {KtbProjectTileComponent} from "../ktb-project-tile/ktb-project-tile.component";
-import {KtbProjectListComponent} from "../ktb-project-list/ktb-project-list.component";
-import {KtbEventsListComponent} from "../ktb-events-list/ktb-events-list.component";
-import {AtobPipe} from "../../_pipes/atob.pipe";
-import {KtbEventItemComponent, KtbEventItemDetail} from "../ktb-event-item/ktb-event-item.component";
-import {KtbEvaluationDetailsComponent} from "../ktb-evaluation-details/ktb-evaluation-details.component";
-import {KtbSliBreakdownComponent} from "../ktb-sli-breakdown/ktb-sli-breakdown.component";
-import {BrowserModule} from "@angular/platform-browser";
-import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
 import {HttpClientTestingModule} from "@angular/common/http/testing";
-import {AppRouting} from "../../app.routing";
-import {FlexLayoutModule} from "@angular/flex-layout";
-import {MomentModule} from "ngx-moment";
-import {DtThemingModule} from "@dynatrace/barista-components/theming";
-import {DtButtonModule} from "@dynatrace/barista-components/button";
-import {DtButtonGroupModule} from "@dynatrace/barista-components/button-group";
-import {DtSelectModule} from "@dynatrace/barista-components/select";
-import {DtMenuModule} from "@dynatrace/barista-components/menu";
-import {DtDrawerModule} from "@dynatrace/barista-components/drawer";
-import {DtContextDialogModule} from "@dynatrace/barista-components/context-dialog";
-import {DtInputModule} from "@dynatrace/barista-components/input";
-import {DtEmptyStateModule} from "@dynatrace/barista-components/empty-state";
-import {DtCardModule} from "@dynatrace/barista-components/card";
-import {DtTileModule} from "@dynatrace/barista-components/tile";
-import {DtInfoGroupModule} from "@dynatrace/barista-components/info-group";
-import {DtProgressBarModule} from "@dynatrace/barista-components/progress-bar";
-import {DtLoadingDistractorModule} from "@dynatrace/barista-components/loading-distractor";
-import {DtTagModule} from "@dynatrace/barista-components/tag";
-import {DtExpandableTextModule} from "@dynatrace/barista-components/expandable-text";
-import {DtExpandablePanelModule} from "@dynatrace/barista-components/expandable-panel";
-import {DtShowMoreModule} from "@dynatrace/barista-components/show-more";
-import {DtIndicatorModule} from "@dynatrace/barista-components/core";
-import {DtProgressCircleModule} from "@dynatrace/barista-components/progress-circle";
-import {DtConsumptionModule} from "@dynatrace/barista-components/consumption";
-import {DtKeyValueListModule} from "@dynatrace/barista-components/key-value-list";
-import {DtChartModule} from "@dynatrace/barista-components/chart";
-import {DtIconModule} from "@dynatrace/barista-components/icon";
+import {AppModule} from "../../app.module";
 
 describe('KtbSelectableTileComponent', () => {
   let component: KtbSelectableTileComponent;
@@ -63,63 +11,10 @@ describe('KtbSelectableTileComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
-        AppComponent,
-        DashboardComponent,
-        AppHeaderComponent,
-        ProjectBoardComponent,
-        KtbHttpLoadingSpinnerComponent,
-        KtbHttpLoadingBarComponent,
-        KtbShowHttpLoadingDirective,
-        KtbHideHttpLoadingDirective,
-        KtbExpandableTileComponent,
-        KtbExpandableTileHeader,
-        KtbSelectableTileComponent,
-        KtbHorizontalSeparatorComponent,
-        KtbHorizontalSeparatorTitle,
-        KtbRootEventsListComponent,
-        KtbProjectTileComponent,
-        KtbProjectListComponent,
-        KtbEventsListComponent,
-        AtobPipe,
-        KtbEventItemComponent,
-        KtbEventItemDetail,
-        KtbEvaluationDetailsComponent,
-        KtbSliBreakdownComponent,
       ],
       imports: [
-        BrowserModule,
-        BrowserAnimationsModule,
+        AppModule,
         HttpClientTestingModule,
-        AppRouting,
-        FlexLayoutModule,
-        MomentModule,
-        DtThemingModule,
-        DtButtonModule,
-        DtButtonGroupModule,
-        DtSelectModule,
-        DtMenuModule,
-        DtDrawerModule,
-        DtContextDialogModule,
-        DtInputModule,
-        DtEmptyStateModule,
-        DtCardModule,
-        DtTileModule,
-        DtInfoGroupModule,
-        DtProgressBarModule,
-        DtLoadingDistractorModule,
-        DtTagModule,
-        DtExpandableTextModule,
-        DtExpandablePanelModule,
-        DtShowMoreModule,
-        DtIndicatorModule,
-        DtProgressCircleModule,
-        DtConsumptionModule,
-        DtKeyValueListModule,
-        DtChartModule,
-        DtIconModule.forRoot({
-          svgIconLocation: `/assets/icons/{{name}}.svg`,
-        }),
-        BrowserAnimationsModule
       ],
     })
     .compileComponents();

--- a/bridge/client/app/_components/ktb-sli-breakdown/ktb-sli-breakdown.component.spec.ts
+++ b/bridge/client/app/_components/ktb-sli-breakdown/ktb-sli-breakdown.component.spec.ts
@@ -1,60 +1,9 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { KtbSliBreakdownComponent } from './ktb-sli-breakdown.component';
-import {AppComponent} from "../../app.component";
-import {DashboardComponent} from "../../dashboard/dashboard.component";
-import {AppHeaderComponent} from "../../app-header/app-header.component";
-import {ProjectBoardComponent} from "../../project-board/project-board.component";
-import {KtbHttpLoadingSpinnerComponent} from "../ktb-http-loading-spinner/ktb-http-loading-spinner.component";
-import {KtbHttpLoadingBarComponent} from "../ktb-http-loading-bar/ktb-http-loading-bar.component";
-import {KtbShowHttpLoadingDirective} from "../../_directives/ktb-show-http-loading/ktb-show-http-loading.directive";
-import {KtbHideHttpLoadingDirective} from "../../_directives/ktb-hide-http-loading/ktb-hide-http-loading.directive";
-import {
-  KtbExpandableTileComponent,
-  KtbExpandableTileHeader
-} from "../ktb-expandable-tile/ktb-expandable-tile.component";
-import {KtbSelectableTileComponent} from "../ktb-selectable-tile/ktb-selectable-tile.component";
-import {
-  KtbHorizontalSeparatorComponent,
-  KtbHorizontalSeparatorTitle
-} from "../ktb-horizontal-separator/ktb-horizontal-separator.component";
-import {KtbRootEventsListComponent} from "../ktb-root-events-list/ktb-root-events-list.component";
-import {KtbProjectTileComponent} from "../ktb-project-tile/ktb-project-tile.component";
-import {KtbProjectListComponent} from "../ktb-project-list/ktb-project-list.component";
-import {KtbEventsListComponent} from "../ktb-events-list/ktb-events-list.component";
-import {AtobPipe} from "../../_pipes/atob.pipe";
-import {KtbEventItemComponent, KtbEventItemDetail} from "../ktb-event-item/ktb-event-item.component";
 import {KtbEvaluationDetailsComponent} from "../ktb-evaluation-details/ktb-evaluation-details.component";
-import {BrowserModule} from "@angular/platform-browser";
-import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
 import {HttpClientTestingModule} from "@angular/common/http/testing";
-import {AppRouting} from "../../app.routing";
-import {FlexLayoutModule} from "@angular/flex-layout";
-import {MomentModule} from "ngx-moment";
-import {DtThemingModule} from "@dynatrace/barista-components/theming";
-import {DtButtonModule} from "@dynatrace/barista-components/button";
-import {DtButtonGroupModule} from "@dynatrace/barista-components/button-group";
-import {DtSelectModule} from "@dynatrace/barista-components/select";
-import {DtMenuModule} from "@dynatrace/barista-components/menu";
-import {DtDrawerModule} from "@dynatrace/barista-components/drawer";
-import {DtContextDialogModule} from "@dynatrace/barista-components/context-dialog";
-import {DtInputModule} from "@dynatrace/barista-components/input";
-import {DtEmptyStateModule} from "@dynatrace/barista-components/empty-state";
-import {DtCardModule} from "@dynatrace/barista-components/card";
-import {DtTileModule} from "@dynatrace/barista-components/tile";
-import {DtInfoGroupModule} from "@dynatrace/barista-components/info-group";
-import {DtProgressBarModule} from "@dynatrace/barista-components/progress-bar";
-import {DtLoadingDistractorModule} from "@dynatrace/barista-components/loading-distractor";
-import {DtTagModule} from "@dynatrace/barista-components/tag";
-import {DtExpandableTextModule} from "@dynatrace/barista-components/expandable-text";
-import {DtExpandablePanelModule} from "@dynatrace/barista-components/expandable-panel";
-import {DtShowMoreModule} from "@dynatrace/barista-components/show-more";
-import {DtIndicatorModule} from "@dynatrace/barista-components/core";
-import {DtProgressCircleModule} from "@dynatrace/barista-components/progress-circle";
-import {DtConsumptionModule} from "@dynatrace/barista-components/consumption";
-import {DtKeyValueListModule} from "@dynatrace/barista-components/key-value-list";
-import {DtChartModule} from "@dynatrace/barista-components/chart";
-import {DtIconModule} from "@dynatrace/barista-components/icon";
+import {AppModule} from "../../app.module";
 
 describe('KtbEvaluationDetailsComponent', () => {
   let component: KtbSliBreakdownComponent;
@@ -63,63 +12,10 @@ describe('KtbEvaluationDetailsComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
-        AppComponent,
-        DashboardComponent,
-        AppHeaderComponent,
-        ProjectBoardComponent,
-        KtbHttpLoadingSpinnerComponent,
-        KtbHttpLoadingBarComponent,
-        KtbShowHttpLoadingDirective,
-        KtbHideHttpLoadingDirective,
-        KtbExpandableTileComponent,
-        KtbExpandableTileHeader,
-        KtbSelectableTileComponent,
-        KtbHorizontalSeparatorComponent,
-        KtbHorizontalSeparatorTitle,
-        KtbRootEventsListComponent,
-        KtbProjectTileComponent,
-        KtbProjectListComponent,
-        KtbEventsListComponent,
-        AtobPipe,
-        KtbEventItemComponent,
-        KtbEventItemDetail,
-        KtbEvaluationDetailsComponent,
-        KtbSliBreakdownComponent,
       ],
       imports: [
-        BrowserModule,
-        BrowserAnimationsModule,
+        AppModule,
         HttpClientTestingModule,
-        AppRouting,
-        FlexLayoutModule,
-        MomentModule,
-        DtThemingModule,
-        DtButtonModule,
-        DtButtonGroupModule,
-        DtSelectModule,
-        DtMenuModule,
-        DtDrawerModule,
-        DtContextDialogModule,
-        DtInputModule,
-        DtEmptyStateModule,
-        DtCardModule,
-        DtTileModule,
-        DtInfoGroupModule,
-        DtProgressBarModule,
-        DtLoadingDistractorModule,
-        DtTagModule,
-        DtExpandableTextModule,
-        DtExpandablePanelModule,
-        DtShowMoreModule,
-        DtIndicatorModule,
-        DtProgressCircleModule,
-        DtConsumptionModule,
-        DtKeyValueListModule,
-        DtChartModule,
-        DtIconModule.forRoot({
-          svgIconLocation: `/assets/icons/{{name}}.svg`,
-        }),
-        BrowserAnimationsModule
       ],
     })
     .compileComponents();

--- a/bridge/client/app/_services/api.service.spec.ts
+++ b/bridge/client/app/_services/api.service.spec.ts
@@ -2,121 +2,13 @@ import { TestBed } from '@angular/core/testing';
 
 import { ApiService } from './api.service';
 import {HttpClientTestingModule} from "@angular/common/http/testing"
-import {AppComponent} from "../app.component";
-import {DashboardComponent} from "../dashboard/dashboard.component";
-import {AppHeaderComponent} from "../app-header/app-header.component";
-import {ProjectBoardComponent} from "../project-board/project-board.component";
-import {KtbHttpLoadingSpinnerComponent} from "../_components/ktb-http-loading-spinner/ktb-http-loading-spinner.component";
-import {KtbHttpLoadingBarComponent} from "../_components/ktb-http-loading-bar/ktb-http-loading-bar.component";
-import {KtbShowHttpLoadingDirective} from "../_directives/ktb-show-http-loading/ktb-show-http-loading.directive";
-import {KtbHideHttpLoadingDirective} from "../_directives/ktb-hide-http-loading/ktb-hide-http-loading.directive";
-import {
-  KtbExpandableTileComponent,
-  KtbExpandableTileHeader
-} from "../_components/ktb-expandable-tile/ktb-expandable-tile.component";
-import {KtbSelectableTileComponent} from "../_components/ktb-selectable-tile/ktb-selectable-tile.component";
-import {
-  KtbHorizontalSeparatorComponent,
-  KtbHorizontalSeparatorTitle
-} from "../_components/ktb-horizontal-separator/ktb-horizontal-separator.component";
-import {KtbRootEventsListComponent} from "../_components/ktb-root-events-list/ktb-root-events-list.component";
-import {KtbProjectTileComponent} from "../_components/ktb-project-tile/ktb-project-tile.component";
-import {KtbProjectListComponent} from "../_components/ktb-project-list/ktb-project-list.component";
-import {KtbEventsListComponent} from "../_components/ktb-events-list/ktb-events-list.component";
-import {AtobPipe} from "../_pipes/atob.pipe";
-import {KtbEventItemComponent, KtbEventItemDetail} from "../_components/ktb-event-item/ktb-event-item.component";
-import {KtbEvaluationDetailsComponent} from "../_components/ktb-evaluation-details/ktb-evaluation-details.component";
-import {KtbSliBreakdownComponent} from "../_components/ktb-sli-breakdown/ktb-sli-breakdown.component";
-import {BrowserModule} from "@angular/platform-browser";
-import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
-import {AppRouting} from "../app.routing";
-import {FlexLayoutModule} from "@angular/flex-layout";
-import {MomentModule} from "ngx-moment";
-import {DtThemingModule} from "@dynatrace/barista-components/theming";
-import {DtButtonModule} from "@dynatrace/barista-components/button";
-import {DtButtonGroupModule} from "@dynatrace/barista-components/button-group";
-import {DtSelectModule} from "@dynatrace/barista-components/select";
-import {DtMenuModule} from "@dynatrace/barista-components/menu";
-import {DtDrawerModule} from "@dynatrace/barista-components/drawer";
-import {DtContextDialogModule} from "@dynatrace/barista-components/context-dialog";
-import {DtInputModule} from "@dynatrace/barista-components/input";
-import {DtEmptyStateModule} from "@dynatrace/barista-components/empty-state";
-import {DtCardModule} from "@dynatrace/barista-components/card";
-import {DtTileModule} from "@dynatrace/barista-components/tile";
-import {DtInfoGroupModule} from "@dynatrace/barista-components/info-group";
-import {DtProgressBarModule} from "@dynatrace/barista-components/progress-bar";
-import {DtLoadingDistractorModule} from "@dynatrace/barista-components/loading-distractor";
-import {DtTagModule} from "@dynatrace/barista-components/tag";
-import {DtExpandableTextModule} from "@dynatrace/barista-components/expandable-text";
-import {DtExpandablePanelModule} from "@dynatrace/barista-components/expandable-panel";
-import {DtShowMoreModule} from "@dynatrace/barista-components/show-more";
-import {DtIndicatorModule} from "@dynatrace/barista-components/core";
-import {DtProgressCircleModule} from "@dynatrace/barista-components/progress-circle";
-import {DtConsumptionModule} from "@dynatrace/barista-components/consumption";
-import {DtKeyValueListModule} from "@dynatrace/barista-components/key-value-list";
-import {DtChartModule} from "@dynatrace/barista-components/chart";
-import {DtIconModule} from "@dynatrace/barista-components/icon";
 
 describe('ApiService', () => {
   beforeEach(() => TestBed.configureTestingModule({
     declarations: [
-      AppComponent,
-      DashboardComponent,
-      AppHeaderComponent,
-      ProjectBoardComponent,
-      KtbHttpLoadingSpinnerComponent,
-      KtbHttpLoadingBarComponent,
-      KtbShowHttpLoadingDirective,
-      KtbHideHttpLoadingDirective,
-      KtbExpandableTileComponent,
-      KtbExpandableTileHeader,
-      KtbSelectableTileComponent,
-      KtbHorizontalSeparatorComponent,
-      KtbHorizontalSeparatorTitle,
-      KtbRootEventsListComponent,
-      KtbProjectTileComponent,
-      KtbProjectListComponent,
-      KtbEventsListComponent,
-      AtobPipe,
-      KtbEventItemComponent,
-      KtbEventItemDetail,
-      KtbEvaluationDetailsComponent,
-      KtbSliBreakdownComponent,
     ],
     imports: [
-      BrowserModule,
-      BrowserAnimationsModule,
       HttpClientTestingModule,
-      AppRouting,
-      FlexLayoutModule,
-      MomentModule,
-      DtThemingModule,
-      DtButtonModule,
-      DtButtonGroupModule,
-      DtSelectModule,
-      DtMenuModule,
-      DtDrawerModule,
-      DtContextDialogModule,
-      DtInputModule,
-      DtEmptyStateModule,
-      DtCardModule,
-      DtTileModule,
-      DtInfoGroupModule,
-      DtProgressBarModule,
-      DtLoadingDistractorModule,
-      DtTagModule,
-      DtExpandableTextModule,
-      DtExpandablePanelModule,
-      DtShowMoreModule,
-      DtIndicatorModule,
-      DtProgressCircleModule,
-      DtConsumptionModule,
-      DtKeyValueListModule,
-      DtChartModule,
-      DtIconModule.forRoot({
-        svgIconLocation: `/assets/icons/{{name}}.svg`,
-      }),
-      BrowserAnimationsModule
     ],
   }));
 

--- a/bridge/client/app/_services/data.service.spec.ts
+++ b/bridge/client/app/_services/data.service.spec.ts
@@ -2,121 +2,13 @@ import { TestBed } from '@angular/core/testing';
 
 import { DataService } from './data.service';
 import {HttpClientTestingModule} from "@angular/common/http/testing"
-import {AppComponent} from "../app.component";
-import {DashboardComponent} from "../dashboard/dashboard.component";
-import {AppHeaderComponent} from "../app-header/app-header.component";
-import {ProjectBoardComponent} from "../project-board/project-board.component";
-import {KtbHttpLoadingSpinnerComponent} from "../_components/ktb-http-loading-spinner/ktb-http-loading-spinner.component";
-import {KtbHttpLoadingBarComponent} from "../_components/ktb-http-loading-bar/ktb-http-loading-bar.component";
-import {KtbShowHttpLoadingDirective} from "../_directives/ktb-show-http-loading/ktb-show-http-loading.directive";
-import {KtbHideHttpLoadingDirective} from "../_directives/ktb-hide-http-loading/ktb-hide-http-loading.directive";
-import {
-  KtbExpandableTileComponent,
-  KtbExpandableTileHeader
-} from "../_components/ktb-expandable-tile/ktb-expandable-tile.component";
-import {KtbSelectableTileComponent} from "../_components/ktb-selectable-tile/ktb-selectable-tile.component";
-import {
-  KtbHorizontalSeparatorComponent,
-  KtbHorizontalSeparatorTitle
-} from "../_components/ktb-horizontal-separator/ktb-horizontal-separator.component";
-import {KtbRootEventsListComponent} from "../_components/ktb-root-events-list/ktb-root-events-list.component";
-import {KtbProjectTileComponent} from "../_components/ktb-project-tile/ktb-project-tile.component";
-import {KtbProjectListComponent} from "../_components/ktb-project-list/ktb-project-list.component";
-import {KtbEventsListComponent} from "../_components/ktb-events-list/ktb-events-list.component";
-import {AtobPipe} from "../_pipes/atob.pipe";
-import {KtbEventItemComponent, KtbEventItemDetail} from "../_components/ktb-event-item/ktb-event-item.component";
-import {KtbEvaluationDetailsComponent} from "../_components/ktb-evaluation-details/ktb-evaluation-details.component";
-import {KtbSliBreakdownComponent} from "../_components/ktb-sli-breakdown/ktb-sli-breakdown.component";
-import {BrowserModule} from "@angular/platform-browser";
-import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
-import {AppRouting} from "../app.routing";
-import {FlexLayoutModule} from "@angular/flex-layout";
-import {MomentModule} from "ngx-moment";
-import {DtThemingModule} from "@dynatrace/barista-components/theming";
-import {DtButtonModule} from "@dynatrace/barista-components/button";
-import {DtButtonGroupModule} from "@dynatrace/barista-components/button-group";
-import {DtSelectModule} from "@dynatrace/barista-components/select";
-import {DtMenuModule} from "@dynatrace/barista-components/menu";
-import {DtDrawerModule} from "@dynatrace/barista-components/drawer";
-import {DtContextDialogModule} from "@dynatrace/barista-components/context-dialog";
-import {DtInputModule} from "@dynatrace/barista-components/input";
-import {DtEmptyStateModule} from "@dynatrace/barista-components/empty-state";
-import {DtCardModule} from "@dynatrace/barista-components/card";
-import {DtTileModule} from "@dynatrace/barista-components/tile";
-import {DtInfoGroupModule} from "@dynatrace/barista-components/info-group";
-import {DtProgressBarModule} from "@dynatrace/barista-components/progress-bar";
-import {DtLoadingDistractorModule} from "@dynatrace/barista-components/loading-distractor";
-import {DtTagModule} from "@dynatrace/barista-components/tag";
-import {DtExpandableTextModule} from "@dynatrace/barista-components/expandable-text";
-import {DtExpandablePanelModule} from "@dynatrace/barista-components/expandable-panel";
-import {DtShowMoreModule} from "@dynatrace/barista-components/show-more";
-import {DtIndicatorModule} from "@dynatrace/barista-components/core";
-import {DtProgressCircleModule} from "@dynatrace/barista-components/progress-circle";
-import {DtConsumptionModule} from "@dynatrace/barista-components/consumption";
-import {DtKeyValueListModule} from "@dynatrace/barista-components/key-value-list";
-import {DtChartModule} from "@dynatrace/barista-components/chart";
-import {DtIconModule} from "@dynatrace/barista-components/icon";
 
 describe('DataService', () => {
   beforeEach(() => TestBed.configureTestingModule({
     declarations: [
-      AppComponent,
-      DashboardComponent,
-      AppHeaderComponent,
-      ProjectBoardComponent,
-      KtbHttpLoadingSpinnerComponent,
-      KtbHttpLoadingBarComponent,
-      KtbShowHttpLoadingDirective,
-      KtbHideHttpLoadingDirective,
-      KtbExpandableTileComponent,
-      KtbExpandableTileHeader,
-      KtbSelectableTileComponent,
-      KtbHorizontalSeparatorComponent,
-      KtbHorizontalSeparatorTitle,
-      KtbRootEventsListComponent,
-      KtbProjectTileComponent,
-      KtbProjectListComponent,
-      KtbEventsListComponent,
-      AtobPipe,
-      KtbEventItemComponent,
-      KtbEventItemDetail,
-      KtbEvaluationDetailsComponent,
-      KtbSliBreakdownComponent,
     ],
     imports: [
-      BrowserModule,
-      BrowserAnimationsModule,
       HttpClientTestingModule,
-      AppRouting,
-      FlexLayoutModule,
-      MomentModule,
-      DtThemingModule,
-      DtButtonModule,
-      DtButtonGroupModule,
-      DtSelectModule,
-      DtMenuModule,
-      DtDrawerModule,
-      DtContextDialogModule,
-      DtInputModule,
-      DtEmptyStateModule,
-      DtCardModule,
-      DtTileModule,
-      DtInfoGroupModule,
-      DtProgressBarModule,
-      DtLoadingDistractorModule,
-      DtTagModule,
-      DtExpandableTextModule,
-      DtExpandablePanelModule,
-      DtShowMoreModule,
-      DtIndicatorModule,
-      DtProgressCircleModule,
-      DtConsumptionModule,
-      DtKeyValueListModule,
-      DtChartModule,
-      DtIconModule.forRoot({
-        svgIconLocation: `/assets/icons/{{name}}.svg`,
-      }),
-      BrowserAnimationsModule
     ],
   }));
 

--- a/bridge/client/app/app-header/app-header.component.spec.ts
+++ b/bridge/client/app/app-header/app-header.component.spec.ts
@@ -1,60 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AppHeaderComponent } from './app-header.component';
-import {AppComponent} from "../app.component";
-import {DashboardComponent} from "../dashboard/dashboard.component";
-import {ProjectBoardComponent} from "../project-board/project-board.component";
-import {KtbHttpLoadingSpinnerComponent} from "../_components/ktb-http-loading-spinner/ktb-http-loading-spinner.component";
-import {KtbHttpLoadingBarComponent} from "../_components/ktb-http-loading-bar/ktb-http-loading-bar.component";
-import {KtbShowHttpLoadingDirective} from "../_directives/ktb-show-http-loading/ktb-show-http-loading.directive";
-import {KtbHideHttpLoadingDirective} from "../_directives/ktb-hide-http-loading/ktb-hide-http-loading.directive";
-import {
-  KtbExpandableTileComponent,
-  KtbExpandableTileHeader
-} from "../_components/ktb-expandable-tile/ktb-expandable-tile.component";
-import {KtbSelectableTileComponent} from "../_components/ktb-selectable-tile/ktb-selectable-tile.component";
-import {
-  KtbHorizontalSeparatorComponent,
-  KtbHorizontalSeparatorTitle
-} from "../_components/ktb-horizontal-separator/ktb-horizontal-separator.component";
-import {KtbRootEventsListComponent} from "../_components/ktb-root-events-list/ktb-root-events-list.component";
-import {KtbProjectTileComponent} from "../_components/ktb-project-tile/ktb-project-tile.component";
-import {KtbProjectListComponent} from "../_components/ktb-project-list/ktb-project-list.component";
-import {KtbEventsListComponent} from "../_components/ktb-events-list/ktb-events-list.component";
-import {AtobPipe} from "../_pipes/atob.pipe";
-import {KtbEventItemComponent, KtbEventItemDetail} from "../_components/ktb-event-item/ktb-event-item.component";
-import {KtbEvaluationDetailsComponent} from "../_components/ktb-evaluation-details/ktb-evaluation-details.component";
-import {KtbSliBreakdownComponent} from "../_components/ktb-sli-breakdown/ktb-sli-breakdown.component";
-import {BrowserModule} from "@angular/platform-browser";
-import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
 import {HttpClientTestingModule} from "@angular/common/http/testing";
-import {AppRouting} from "../app.routing";
-import {FlexLayoutModule} from "@angular/flex-layout";
-import {MomentModule} from "ngx-moment";
-import {DtThemingModule} from "@dynatrace/barista-components/theming";
-import {DtButtonModule} from "@dynatrace/barista-components/button";
-import {DtButtonGroupModule} from "@dynatrace/barista-components/button-group";
-import {DtSelectModule} from "@dynatrace/barista-components/select";
-import {DtMenuModule} from "@dynatrace/barista-components/menu";
-import {DtDrawerModule} from "@dynatrace/barista-components/drawer";
-import {DtContextDialogModule} from "@dynatrace/barista-components/context-dialog";
-import {DtInputModule} from "@dynatrace/barista-components/input";
-import {DtEmptyStateModule} from "@dynatrace/barista-components/empty-state";
-import {DtCardModule} from "@dynatrace/barista-components/card";
-import {DtTileModule} from "@dynatrace/barista-components/tile";
-import {DtInfoGroupModule} from "@dynatrace/barista-components/info-group";
-import {DtProgressBarModule} from "@dynatrace/barista-components/progress-bar";
-import {DtLoadingDistractorModule} from "@dynatrace/barista-components/loading-distractor";
-import {DtTagModule} from "@dynatrace/barista-components/tag";
-import {DtExpandableTextModule} from "@dynatrace/barista-components/expandable-text";
-import {DtExpandablePanelModule} from "@dynatrace/barista-components/expandable-panel";
-import {DtShowMoreModule} from "@dynatrace/barista-components/show-more";
-import {DtIndicatorModule} from "@dynatrace/barista-components/core";
-import {DtProgressCircleModule} from "@dynatrace/barista-components/progress-circle";
-import {DtConsumptionModule} from "@dynatrace/barista-components/consumption";
-import {DtKeyValueListModule} from "@dynatrace/barista-components/key-value-list";
-import {DtChartModule} from "@dynatrace/barista-components/chart";
-import {DtIconModule} from "@dynatrace/barista-components/icon";
+import {AppModule} from "../app.module";
 
 describe('AppHeaderComponent', () => {
   let component: AppHeaderComponent;
@@ -63,63 +11,10 @@ describe('AppHeaderComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
-        AppComponent,
-        DashboardComponent,
-        AppHeaderComponent,
-        ProjectBoardComponent,
-        KtbHttpLoadingSpinnerComponent,
-        KtbHttpLoadingBarComponent,
-        KtbShowHttpLoadingDirective,
-        KtbHideHttpLoadingDirective,
-        KtbExpandableTileComponent,
-        KtbExpandableTileHeader,
-        KtbSelectableTileComponent,
-        KtbHorizontalSeparatorComponent,
-        KtbHorizontalSeparatorTitle,
-        KtbRootEventsListComponent,
-        KtbProjectTileComponent,
-        KtbProjectListComponent,
-        KtbEventsListComponent,
-        AtobPipe,
-        KtbEventItemComponent,
-        KtbEventItemDetail,
-        KtbEvaluationDetailsComponent,
-        KtbSliBreakdownComponent,
       ],
       imports: [
-        BrowserModule,
-        BrowserAnimationsModule,
+        AppModule,
         HttpClientTestingModule,
-        AppRouting,
-        FlexLayoutModule,
-        MomentModule,
-        DtThemingModule,
-        DtButtonModule,
-        DtButtonGroupModule,
-        DtSelectModule,
-        DtMenuModule,
-        DtDrawerModule,
-        DtContextDialogModule,
-        DtInputModule,
-        DtEmptyStateModule,
-        DtCardModule,
-        DtTileModule,
-        DtInfoGroupModule,
-        DtProgressBarModule,
-        DtLoadingDistractorModule,
-        DtTagModule,
-        DtExpandableTextModule,
-        DtExpandablePanelModule,
-        DtShowMoreModule,
-        DtIndicatorModule,
-        DtProgressCircleModule,
-        DtConsumptionModule,
-        DtKeyValueListModule,
-        DtChartModule,
-        DtIconModule.forRoot({
-          svgIconLocation: `/assets/icons/{{name}}.svg`,
-        }),
-        BrowserAnimationsModule
       ],
     })
     .compileComponents();

--- a/bridge/client/app/app.component.spec.ts
+++ b/bridge/client/app/app.component.spec.ts
@@ -1,64 +1,14 @@
 import {TestBed, async, ComponentFixture, fakeAsync, tick} from '@angular/core/testing';
 import { AppComponent } from './app.component';
-import {AppHeaderComponent} from "./app-header/app-header.component";
-import {KtbHttpLoadingBarComponent} from "./_components/ktb-http-loading-bar/ktb-http-loading-bar.component";
-import {DashboardComponent} from "./dashboard/dashboard.component";
-import {ProjectBoardComponent} from "./project-board/project-board.component";
-import {KtbHttpLoadingSpinnerComponent} from "./_components/ktb-http-loading-spinner/ktb-http-loading-spinner.component";
-import {KtbShowHttpLoadingDirective} from "./_directives/ktb-show-http-loading/ktb-show-http-loading.directive";
-import {KtbHideHttpLoadingDirective} from "./_directives/ktb-hide-http-loading/ktb-hide-http-loading.directive";
-import {
-  KtbExpandableTileComponent,
-  KtbExpandableTileHeader
-} from "./_components/ktb-expandable-tile/ktb-expandable-tile.component";
-import {KtbSelectableTileComponent} from "./_components/ktb-selectable-tile/ktb-selectable-tile.component";
-import {
-  KtbHorizontalSeparatorComponent,
-  KtbHorizontalSeparatorTitle
-} from "./_components/ktb-horizontal-separator/ktb-horizontal-separator.component";
-import {KtbRootEventsListComponent} from "./_components/ktb-root-events-list/ktb-root-events-list.component";
-import {KtbProjectTileComponent} from "./_components/ktb-project-tile/ktb-project-tile.component";
-import {KtbProjectListComponent} from "./_components/ktb-project-list/ktb-project-list.component";
-import {KtbEventsListComponent} from "./_components/ktb-events-list/ktb-events-list.component";
-import {AtobPipe} from "./_pipes/atob.pipe";
-import {KtbEventItemComponent, KtbEventItemDetail} from "./_components/ktb-event-item/ktb-event-item.component";
-import {KtbEvaluationDetailsComponent} from "./_components/ktb-evaluation-details/ktb-evaluation-details.component";
-import {KtbSliBreakdownComponent} from "./_components/ktb-sli-breakdown/ktb-sli-breakdown.component";
 import {BrowserModule, By} from "@angular/platform-browser";
-import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
 import {HttpClientTestingModule} from "@angular/common/http/testing";
 import {Location} from '@angular/common';
-import {AppRouting, routes} from "./app.routing";
-import {FlexLayoutModule} from "@angular/flex-layout";
-import {MomentModule} from "ngx-moment";
-import {DtThemingModule} from "@dynatrace/barista-components/theming";
-import {DtButtonModule} from "@dynatrace/barista-components/button";
-import {DtButtonGroupModule} from "@dynatrace/barista-components/button-group";
-import {DtSelectModule} from "@dynatrace/barista-components/select";
-import {DtMenuModule} from "@dynatrace/barista-components/menu";
-import {DtDrawerModule} from "@dynatrace/barista-components/drawer";
-import {DtContextDialogModule} from "@dynatrace/barista-components/context-dialog";
-import {DtInputModule} from "@dynatrace/barista-components/input";
-import {DtEmptyStateModule} from "@dynatrace/barista-components/empty-state";
-import {DtCardModule} from "@dynatrace/barista-components/card";
-import {DtTileModule} from "@dynatrace/barista-components/tile";
-import {DtInfoGroupModule} from "@dynatrace/barista-components/info-group";
-import {DtProgressBarModule} from "@dynatrace/barista-components/progress-bar";
-import {DtLoadingDistractorModule} from "@dynatrace/barista-components/loading-distractor";
-import {DtTagModule} from "@dynatrace/barista-components/tag";
-import {DtExpandableTextModule} from "@dynatrace/barista-components/expandable-text";
-import {DtExpandablePanelModule} from "@dynatrace/barista-components/expandable-panel";
-import {DtShowMoreModule} from "@dynatrace/barista-components/show-more";
-import {DtIndicatorModule} from "@dynatrace/barista-components/core";
-import {DtProgressCircleModule} from "@dynatrace/barista-components/progress-circle";
-import {DtConsumptionModule} from "@dynatrace/barista-components/consumption";
-import {DtKeyValueListModule} from "@dynatrace/barista-components/key-value-list";
-import {DtChartModule} from "@dynatrace/barista-components/chart";
-import {DtIconModule} from "@dynatrace/barista-components/icon";
 import {DataService} from "./_services/data.service";
 import {MockDataService} from "./_services/mock-data.service";
 import {Router} from "@angular/router";
+import {AppModule} from "./app.module";
 import {RouterTestingModule} from "@angular/router/testing";
+import {routes} from "./app.routing";
 
 describe('AppComponent', () => {
   let router: Router;
@@ -69,63 +19,11 @@ describe('AppComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
-        AppComponent,
-        DashboardComponent,
-        AppHeaderComponent,
-        ProjectBoardComponent,
-        KtbHttpLoadingSpinnerComponent,
-        KtbHttpLoadingBarComponent,
-        KtbShowHttpLoadingDirective,
-        KtbHideHttpLoadingDirective,
-        KtbExpandableTileComponent,
-        KtbExpandableTileHeader,
-        KtbSelectableTileComponent,
-        KtbHorizontalSeparatorComponent,
-        KtbHorizontalSeparatorTitle,
-        KtbRootEventsListComponent,
-        KtbProjectTileComponent,
-        KtbProjectListComponent,
-        KtbEventsListComponent,
-        AtobPipe,
-        KtbEventItemComponent,
-        KtbEventItemDetail,
-        KtbEvaluationDetailsComponent,
-        KtbSliBreakdownComponent,
       ],
       imports: [
-        BrowserModule,
-        BrowserAnimationsModule,
+        AppModule,
         HttpClientTestingModule,
-        AppRouting,
-        FlexLayoutModule,
-        MomentModule,
-        DtThemingModule,
-        DtButtonModule,
-        DtButtonGroupModule,
-        DtSelectModule,
-        DtMenuModule,
-        DtDrawerModule,
-        DtContextDialogModule,
-        DtInputModule,
-        DtEmptyStateModule,
-        DtCardModule,
-        DtTileModule,
-        DtInfoGroupModule,
-        DtProgressBarModule,
-        DtLoadingDistractorModule,
-        DtTagModule,
-        DtExpandableTextModule,
-        DtExpandablePanelModule,
-        DtShowMoreModule,
-        DtIndicatorModule,
-        DtProgressCircleModule,
-        DtConsumptionModule,
-        DtKeyValueListModule,
-        DtChartModule,
-        DtIconModule.forRoot({
-          svgIconLocation: `/assets/icons/{{name}}.svg`,
-        }),
-        RouterTestingModule.withRoutes(routes)
+        RouterTestingModule.withRoutes(routes),
       ],
       providers: [
         {provide: DataService, useClass: MockDataService}

--- a/bridge/client/app/dashboard/dashboard.component.spec.ts
+++ b/bridge/client/app/dashboard/dashboard.component.spec.ts
@@ -1,60 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { DashboardComponent } from './dashboard.component';
-import {AppComponent} from "../app.component";
-import {AppHeaderComponent} from "../app-header/app-header.component";
-import {ProjectBoardComponent} from "../project-board/project-board.component";
-import {KtbHttpLoadingSpinnerComponent} from "../_components/ktb-http-loading-spinner/ktb-http-loading-spinner.component";
-import {KtbHttpLoadingBarComponent} from "../_components/ktb-http-loading-bar/ktb-http-loading-bar.component";
-import {KtbShowHttpLoadingDirective} from "../_directives/ktb-show-http-loading/ktb-show-http-loading.directive";
-import {KtbHideHttpLoadingDirective} from "../_directives/ktb-hide-http-loading/ktb-hide-http-loading.directive";
-import {
-  KtbExpandableTileComponent,
-  KtbExpandableTileHeader
-} from "../_components/ktb-expandable-tile/ktb-expandable-tile.component";
-import {KtbSelectableTileComponent} from "../_components/ktb-selectable-tile/ktb-selectable-tile.component";
-import {
-  KtbHorizontalSeparatorComponent,
-  KtbHorizontalSeparatorTitle
-} from "../_components/ktb-horizontal-separator/ktb-horizontal-separator.component";
-import {KtbRootEventsListComponent} from "../_components/ktb-root-events-list/ktb-root-events-list.component";
-import {KtbProjectTileComponent} from "../_components/ktb-project-tile/ktb-project-tile.component";
-import {KtbProjectListComponent} from "../_components/ktb-project-list/ktb-project-list.component";
-import {KtbEventsListComponent} from "../_components/ktb-events-list/ktb-events-list.component";
-import {AtobPipe} from "../_pipes/atob.pipe";
-import {KtbEventItemComponent, KtbEventItemDetail} from "../_components/ktb-event-item/ktb-event-item.component";
-import {KtbEvaluationDetailsComponent} from "../_components/ktb-evaluation-details/ktb-evaluation-details.component";
-import {KtbSliBreakdownComponent} from "../_components/ktb-sli-breakdown/ktb-sli-breakdown.component";
-import {BrowserModule} from "@angular/platform-browser";
-import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
+import { AppModule } from '../app.module';
 import {HttpClientTestingModule} from "@angular/common/http/testing";
-import {AppRouting} from "../app.routing";
-import {FlexLayoutModule} from "@angular/flex-layout";
-import {MomentModule} from "ngx-moment";
-import {DtThemingModule} from "@dynatrace/barista-components/theming";
-import {DtButtonModule} from "@dynatrace/barista-components/button";
-import {DtButtonGroupModule} from "@dynatrace/barista-components/button-group";
-import {DtSelectModule} from "@dynatrace/barista-components/select";
-import {DtMenuModule} from "@dynatrace/barista-components/menu";
-import {DtDrawerModule} from "@dynatrace/barista-components/drawer";
-import {DtContextDialogModule} from "@dynatrace/barista-components/context-dialog";
-import {DtInputModule} from "@dynatrace/barista-components/input";
-import {DtEmptyStateModule} from "@dynatrace/barista-components/empty-state";
-import {DtCardModule} from "@dynatrace/barista-components/card";
-import {DtTileModule} from "@dynatrace/barista-components/tile";
-import {DtInfoGroupModule} from "@dynatrace/barista-components/info-group";
-import {DtProgressBarModule} from "@dynatrace/barista-components/progress-bar";
-import {DtLoadingDistractorModule} from "@dynatrace/barista-components/loading-distractor";
-import {DtTagModule} from "@dynatrace/barista-components/tag";
-import {DtExpandableTextModule} from "@dynatrace/barista-components/expandable-text";
-import {DtExpandablePanelModule} from "@dynatrace/barista-components/expandable-panel";
-import {DtShowMoreModule} from "@dynatrace/barista-components/show-more";
-import {DtIndicatorModule} from "@dynatrace/barista-components/core";
-import {DtProgressCircleModule} from "@dynatrace/barista-components/progress-circle";
-import {DtConsumptionModule} from "@dynatrace/barista-components/consumption";
-import {DtKeyValueListModule} from "@dynatrace/barista-components/key-value-list";
-import {DtChartModule} from "@dynatrace/barista-components/chart";
-import {DtIconModule} from "@dynatrace/barista-components/icon";
 
 describe('DashboardComponent', () => {
   let component: DashboardComponent;
@@ -62,64 +10,10 @@ describe('DashboardComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [
-        AppComponent,
-        DashboardComponent,
-        AppHeaderComponent,
-        ProjectBoardComponent,
-        KtbHttpLoadingSpinnerComponent,
-        KtbHttpLoadingBarComponent,
-        KtbShowHttpLoadingDirective,
-        KtbHideHttpLoadingDirective,
-        KtbExpandableTileComponent,
-        KtbExpandableTileHeader,
-        KtbSelectableTileComponent,
-        KtbHorizontalSeparatorComponent,
-        KtbHorizontalSeparatorTitle,
-        KtbRootEventsListComponent,
-        KtbProjectTileComponent,
-        KtbProjectListComponent,
-        KtbEventsListComponent,
-        AtobPipe,
-        KtbEventItemComponent,
-        KtbEventItemDetail,
-        KtbEvaluationDetailsComponent,
-        KtbSliBreakdownComponent,
-      ],
+      declarations: [],
       imports: [
-        BrowserModule,
-        BrowserAnimationsModule,
+        AppModule,
         HttpClientTestingModule,
-        AppRouting,
-        FlexLayoutModule,
-        MomentModule,
-        DtThemingModule,
-        DtButtonModule,
-        DtButtonGroupModule,
-        DtSelectModule,
-        DtMenuModule,
-        DtDrawerModule,
-        DtContextDialogModule,
-        DtInputModule,
-        DtEmptyStateModule,
-        DtCardModule,
-        DtTileModule,
-        DtInfoGroupModule,
-        DtProgressBarModule,
-        DtLoadingDistractorModule,
-        DtTagModule,
-        DtExpandableTextModule,
-        DtExpandablePanelModule,
-        DtShowMoreModule,
-        DtIndicatorModule,
-        DtProgressCircleModule,
-        DtConsumptionModule,
-        DtKeyValueListModule,
-        DtChartModule,
-        DtIconModule.forRoot({
-          svgIconLocation: `/assets/icons/{{name}}.svg`,
-        }),
-        BrowserAnimationsModule
       ],
     })
     .compileComponents();

--- a/bridge/client/app/project-board/project-board.component.html
+++ b/bridge/client/app/project-board/project-board.component.html
@@ -108,7 +108,7 @@
                     </button>
                     <dt-context-dialog #filterEventsDialog aria-label="Open context dialog" ariaLabelClose="Close context dialog">
                       <p *ngFor="let eventType of eventTypes">
-                        <dt-checkbox (change)="filterEvents($event, eventType)" [checked]="isFilteredEvent(eventType)">{{getEventLabel(eventType)}}</dt-checkbox>
+                        <dt-checkbox (change)="filterEvents($event, eventType)" [checked]="true || isFilteredEvent(eventType)">{{getEventLabel(eventType)}}</dt-checkbox>
                       </p>
                     </dt-context-dialog>
                   </div>

--- a/bridge/client/app/project-board/project-board.component.spec.ts
+++ b/bridge/client/app/project-board/project-board.component.spec.ts
@@ -1,60 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import {ProjectBoardComponent} from './project-board.component';
-import {DtTagModule} from '@dynatrace/barista-components/tag';
-import {DtLoadingDistractorModule} from "@dynatrace/barista-components/loading-distractor";
-import {DtInfoGroupModule} from "@dynatrace/barista-components/info-group";
-import {DtEmptyStateModule} from "@dynatrace/barista-components/empty-state";
-import {AppComponent} from "../app.component";
-import {DashboardComponent} from "../dashboard/dashboard.component";
-import {AppHeaderComponent} from "../app-header/app-header.component";
-import {KtbHttpLoadingSpinnerComponent} from "../_components/ktb-http-loading-spinner/ktb-http-loading-spinner.component";
-import {KtbHttpLoadingBarComponent} from "../_components/ktb-http-loading-bar/ktb-http-loading-bar.component";
-import {KtbShowHttpLoadingDirective} from "../_directives/ktb-show-http-loading/ktb-show-http-loading.directive";
-import {KtbHideHttpLoadingDirective} from "../_directives/ktb-hide-http-loading/ktb-hide-http-loading.directive";
-import {
-  KtbExpandableTileComponent,
-  KtbExpandableTileHeader
-} from "../_components/ktb-expandable-tile/ktb-expandable-tile.component";
-import {KtbSelectableTileComponent} from "../_components/ktb-selectable-tile/ktb-selectable-tile.component";
-import {
-  KtbHorizontalSeparatorComponent,
-  KtbHorizontalSeparatorTitle
-} from "../_components/ktb-horizontal-separator/ktb-horizontal-separator.component";
-import {KtbRootEventsListComponent} from "../_components/ktb-root-events-list/ktb-root-events-list.component";
-import {KtbProjectTileComponent} from "../_components/ktb-project-tile/ktb-project-tile.component";
-import {KtbProjectListComponent} from "../_components/ktb-project-list/ktb-project-list.component";
-import {KtbEventsListComponent} from "../_components/ktb-events-list/ktb-events-list.component";
-import {AtobPipe} from "../_pipes/atob.pipe";
-import {KtbEventItemComponent, KtbEventItemDetail} from "../_components/ktb-event-item/ktb-event-item.component";
-import {KtbEvaluationDetailsComponent} from "../_components/ktb-evaluation-details/ktb-evaluation-details.component";
-import {KtbSliBreakdownComponent} from "../_components/ktb-sli-breakdown/ktb-sli-breakdown.component";
-import {BrowserModule} from "@angular/platform-browser";
-import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
+import {AppModule} from '../app.module';
 import {HttpClientTestingModule} from "@angular/common/http/testing";
-import {AppRouting} from "../app.routing";
-import {FlexLayoutModule} from "@angular/flex-layout";
-import {MomentModule} from "ngx-moment";
-import {DtThemingModule} from "@dynatrace/barista-components/theming";
-import {DtButtonModule} from "@dynatrace/barista-components/button";
-import {DtButtonGroupModule} from "@dynatrace/barista-components/button-group";
-import {DtSelectModule} from "@dynatrace/barista-components/select";
-import {DtMenuModule} from "@dynatrace/barista-components/menu";
-import {DtDrawerModule} from "@dynatrace/barista-components/drawer";
-import {DtContextDialogModule} from "@dynatrace/barista-components/context-dialog";
-import {DtInputModule} from "@dynatrace/barista-components/input";
-import {DtCardModule} from "@dynatrace/barista-components/card";
-import {DtTileModule} from "@dynatrace/barista-components/tile";
-import {DtProgressBarModule} from "@dynatrace/barista-components/progress-bar";
-import {DtExpandableTextModule} from "@dynatrace/barista-components/expandable-text";
-import {DtExpandablePanelModule} from "@dynatrace/barista-components/expandable-panel";
-import {DtShowMoreModule} from "@dynatrace/barista-components/show-more";
-import {DtIndicatorModule} from "@dynatrace/barista-components/core";
-import {DtProgressCircleModule} from "@dynatrace/barista-components/progress-circle";
-import {DtConsumptionModule} from "@dynatrace/barista-components/consumption";
-import {DtKeyValueListModule} from "@dynatrace/barista-components/key-value-list";
-import {DtChartModule} from "@dynatrace/barista-components/chart";
-import {DtIconModule} from "@dynatrace/barista-components/icon";
 
 describe('ProjectBoardComponent', () => {
   let component: ProjectBoardComponent;
@@ -63,64 +11,10 @@ describe('ProjectBoardComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
 
-      declarations: [
-        AppComponent,
-        DashboardComponent,
-        AppHeaderComponent,
-        ProjectBoardComponent,
-        KtbHttpLoadingSpinnerComponent,
-        KtbHttpLoadingBarComponent,
-        KtbShowHttpLoadingDirective,
-        KtbHideHttpLoadingDirective,
-        KtbExpandableTileComponent,
-        KtbExpandableTileHeader,
-        KtbSelectableTileComponent,
-        KtbHorizontalSeparatorComponent,
-        KtbHorizontalSeparatorTitle,
-        KtbRootEventsListComponent,
-        KtbProjectTileComponent,
-        KtbProjectListComponent,
-        KtbEventsListComponent,
-        AtobPipe,
-        KtbEventItemComponent,
-        KtbEventItemDetail,
-        KtbEvaluationDetailsComponent,
-        KtbSliBreakdownComponent,
-      ],
+      declarations: [],
       imports: [
-        BrowserModule,
-        BrowserAnimationsModule,
+        AppModule,
         HttpClientTestingModule,
-        AppRouting,
-        FlexLayoutModule,
-        MomentModule,
-        DtThemingModule,
-        DtButtonModule,
-        DtButtonGroupModule,
-        DtSelectModule,
-        DtMenuModule,
-        DtDrawerModule,
-        DtContextDialogModule,
-        DtInputModule,
-        DtEmptyStateModule,
-        DtCardModule,
-        DtTileModule,
-        DtInfoGroupModule,
-        DtProgressBarModule,
-        DtLoadingDistractorModule,
-        DtTagModule,
-        DtExpandableTextModule,
-        DtExpandablePanelModule,
-        DtShowMoreModule,
-        DtIndicatorModule,
-        DtProgressCircleModule,
-        DtConsumptionModule,
-        DtKeyValueListModule,
-        DtChartModule,
-        DtIconModule.forRoot({
-          svgIconLocation: `/assets/icons/{{name}}.svg`,
-        }),
-        BrowserAnimationsModule
       ],
     })
     .compileComponents();

--- a/bridge/karma.conf.js
+++ b/bridge/karma.conf.js
@@ -25,7 +25,7 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome'],
+    browsers: ['Chrome', 'Chromium'],
     singleRun: false,
     restartOnFileChange: true
   });

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -10,6 +10,7 @@
     "ng": "ng",
     "build": "ng build --prod",
     "test": "ng test --code-coverage",
+    "test:ci": "ng test --code-coverage --browsers=ChromeHeadless",
     "lint": "ng lint",
     "e2e": "ng e2e",
     "connect:bridge": "kubectl port-forward -n keptn svc/bridge 9000:8080",

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -10,7 +10,7 @@
     "ng": "ng",
     "build": "ng build --prod",
     "test": "ng test --code-coverage",
-    "test:ci": "ng test --code-coverage --browsers=ChromeHeadless",
+    "test:ci": "ng test --watch=false --code-coverage --browsers=ChromeHeadless",
     "lint": "ng lint",
     "e2e": "ng e2e",
     "connect:bridge": "kubectl port-forward -n keptn svc/bridge 9000:8080",

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,6 +5,9 @@ coverage:
         # basic
         target: auto
         threshold: 2% # allow cov to drop by 2% (just in case)
+      bridge:
+        target: auto
+        threshold: 2% # allow cov to drop by 2% (just in case)
     patch:
       default:
         threshold: 1% # allow patch


### PR DESCRIPTION
This PR enhances travis-ci with the unit tests implemented in #1873 

In addition, I noticed that several import statements in the spec files were creating troubles, therefore I tried to reduce the imports to `AppModule` where possible.

@ermin-muratovic please take a look at my changes, and as discussed via Slack, adapt the imports if you believe that it is necessary (e.g., http loading spinner should not need the full appmodule)