### PR TITLE
Increase SLO thresholds for integration tests for quality-gates

### DIFF
--- a/test/assets/quality_gates_standalone_slo_step1.yaml
+++ b/test/assets/quality_gates_standalone_slo_step1.yaml
@@ -21,8 +21,8 @@ objectives:
   - sli: "throughput"
     pass:
       - criteria:
-          - "<=+10%"
-          - ">=-10%"
+          - "<=+20%"
+          - ">=-20%"
   - sli: "error_rate"
 total_score:
   pass: "90%"

--- a/test/assets/quality_gates_standalone_slo_step2.yaml
+++ b/test/assets/quality_gates_standalone_slo_step2.yaml
@@ -21,8 +21,8 @@ objectives:
   - sli: "throughput"
     pass:
       - criteria:
-          - "<=+10%"
-          - ">=-10%"
+          - "<=+20%"
+          - ">=-20%"
   - sli: "error_rate"
   - sli: "number_calls_other_services"
   - sli: "number_of_time_calls_other_services"

--- a/test/assets/quality_gates_standalone_slo_step3.yaml
+++ b/test/assets/quality_gates_standalone_slo_step3.yaml
@@ -21,8 +21,8 @@ objectives:
   - sli: "throughput"
     pass:
       - criteria:
-          - "<=+10%"
-          - ">=-10%"
+          - "<=+20%"
+          - ">=-20%"
   - sli: "error_rate"
   - sli: "number_calls_other_services"
     pass:


### PR DESCRIPTION
This PR tweaks our integration tests for quality-gates, as the thresholds defined in the SLO throughput with +- 10 % was violated sometimes (but not always).

```
        {
          "score": 0,
          "status": "fail",
          "targets": [
            {
              "criteria": "<=+10%",
              "targetValue": 28387.7,
              "violated": true
            },
            {
              "criteria": ">=-10%",
              "targetValue": 23226.3,
              "violated": false
            }
          ],
          "value": {
            "metric": "throughput",
            "success": true,
            "value": 30748
          }
        },
```