### PR TITLE
#1797 removed another occurance of api.keptn in the hosts section

### DIFF
--- a/installer/manifests/keptn/keptn-api-virtualservice.yaml
+++ b/installer/manifests/keptn/keptn-api-virtualservice.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   hosts:
     - "api.keptn.DOMAIN_PLACEHOLDER"
-    - "api.keptn"
   gateways:
     - public-gateway.istio-system
   http:


### PR DESCRIPTION
In PR #1854 I forgot to remove `api.keptn` in the hosts section of this manifest.

This PR fixes my oversight.