### PR TITLE
#1896 Added integration tests for k3s

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -494,6 +494,44 @@ jobs:
       - kubectl get services --all-namespaces
       - kubectl get ingress --all-namespaces
 
+  - &K3sStandaloneTest
+    stage: Test K3s Standalone (--platform=kubernetes --use-case=quality-gates)
+    if: (branch = master or branch =~ ^release.*$) AND (type = cron OR type = push) # run for any change on master/release-* on push as well as cron
+    os: linux
+    env:
+      - K3S_VERSION=v1.16.10+k3s1 # see https://github.com/rancher/k3s/releases
+    before_script:
+      # download and install kubectl
+      - curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.17.0/bin/linux/amd64/kubectl && chmod +x ./kubectl && sudo mv ./kubectl /usr/local/bin/kubectl
+      - test/utils/download_and_install_keptn_cli.sh
+      - test/utils/k3s_create_cluster.sh
+      - export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+    script:
+      - kubectl get nodes || travis_terminate 1
+      - test/test_install_kubernetes_quality_gates.sh
+      - keptn status
+      - export PROJECT=musicshop
+      - test/test_quality_gates_standalone.sh
+    after_success:
+      # delete google kubernetes cluster only on success (in case of an error we want to be able to dig into the cluster)
+      - echo "Tests were successful, cleaning up the cluster now..."
+    after_failure:
+      # print some debug info
+      - echo "Keptn Installation Log:"
+      - cat ~/.keptn/keptn-installer.log
+      - kubectl get events --sort-by='.lastTimestamp' --all-namespaces
+      - kubectl get pods --all-namespaces
+      - kubectl get services --all-namespaces
+      - kubectl get ingress --all-namespaces
+
+  - <<: *K3sStandaloneTest
+    env:
+      - K3S_VERSION=v1.17.6+k3s1 # see https://github.com/rancher/k3s/releases
+
+  - <<: *K3sStandaloneTest
+    env:
+      - K3S_VERSION=v1.18.3+k3s1 # see https://github.com/rancher/k3s/releases
+
   - &microk8sStandaloneTest
     stage: Test MicroK8s Standalone (--platform=kubernetes --use-case=quality-gates)
     if: (branch = master or branch =~ ^release.*$) AND (type = cron OR type = push) # run for any change on master/release-* on push as well as cron

--- a/test/test_quality_gates_standalone.sh
+++ b/test/test_quality_gates_standalone.sh
@@ -72,6 +72,7 @@ response=$(curl -X GET "${KEPTN_ENDPOINT}/configuration-service/v1/project/${PRO
 
 if [[ "$response" != "${PROJECT}" ]]; then
   echo "Failed to check that the project exists via the API."
+  echo "${response}"
   exit 2
 else
   echo "Verified that Project exists via api"

--- a/test/utils/k3s_create_cluster.sh
+++ b/test/utils/k3s_create_cluster.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# install k3s version from github (see https://github.com/rancher/k3s/releases)
+K3S_VERSION=${K3S_VERSION:-"v1.18.3+k3s1"}
+
+# see https://rancher.com/docs/k3s/latest/en/installation/
+echo "Downloading and installing K3s in Version ${K3S_VERSION}"
+curl -Lo k3s "https://github.com/rancher/k3s/releases/download/${K3S_VERSION}/k3s" && chmod +x k3s && sudo mv k3s /usr/local/bin/
+
+sudo k3s server --no-deploy=traefik --write-kubeconfig-mode=644 --log /k3s.log &
+# wait a bit for the server to start
+sleep 30
+echo "Waiting until k3s is definately ready..."
+sleep 30
+echo "Still waiting..."
+sleep 30
+cat /k3s.log
+
+# Kubeconfig is written to /etc/rancher/k3s/k3s.yaml
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+
+kubectl get nodes
+kubectl get services --all-namespaces

--- a/test/utils/minikube_create_cluster.sh
+++ b/test/utils/minikube_create_cluster.sh
@@ -2,7 +2,7 @@
 
 # download and install minikube
 MINIKUBE_VERSION=${MINIKUBE_VERSION:-"v1.2.0"}
-echo "Downlaoding and installing Minikube in Version ${MINIKUBE_VERSION}"
+echo "Downloading and installing Minikube in Version ${MINIKUBE_VERSION}"
 curl -Lo minikube "https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64" && chmod +x minikube && sudo mv minikube /usr/local/bin/
 
 


### PR DESCRIPTION
Implements integration test of k3s requested in #1896 

![Screenshot from 2020-06-09 16-42-57](https://user-images.githubusercontent.com/56065213/84162214-6a9db180-aa70-11ea-9683-7f9696d685f3.png)

This PR includes:

* Travis-CI stuff to execute an integration test (quality-gates) using a specified version of k3s
* Utility Script to download k3s and create a k3s cluster
* Fixed a typo in minikube create cluster utility script
