### PR TITLE
Reduce compatibility checks for ingress when ingress_install_option reuse is active

### DIFF
--- a/installer/scripts/common/setupIstio.sh
+++ b/installer/scripts/common/setupIstio.sh
@@ -7,11 +7,9 @@ ISTIO_AVAILABLE=$?
 
 if [[ "$ISTIO_AVAILABLE" == 0 ]] && [[ "$INGRESS_INSTALL_OPTION" == "Reuse" ]]; then
     # An istio-version is already installed
-    print_info "Istio installation is reused but its compatibility is not checked"
+    print_info "Istio installation is reused but its full compatibility is not checked"
+    print_info "Checking if istio-ingressgateway is available in namespace istio-system"
     wait_for_deployment_in_namespace "istio-ingressgateway" "istio-system"
-    wait_for_deployment_in_namespace "istio-pilot" "istio-system"
-    wait_for_deployment_in_namespace "istio-citadel" "istio-system"
-    wait_for_deployment_in_namespace "istio-sidecar-injector" "istio-system"
     wait_for_all_pods_in_namespace "istio-system"
 
 elif [[ "$ISTIO_AVAILABLE" == 0 ]] && ([[ "$INGRESS_INSTALL_OPTION" == "StopIfInstalled" ]] || [[ "$INGRESS_INSTALL_OPTION" == "" ]] || [[ "$INGRESS_INSTALL_OPTION" == "INGRESS_INSTALL_PLACEHOLDER" ]]); then

--- a/installer/scripts/common/setupNginx.sh
+++ b/installer/scripts/common/setupNginx.sh
@@ -5,7 +5,8 @@ kubectl get ns ingress-nginx
 NGINX_AVAILABLE=$?
 
 if [[ "$NGINX_AVAILABLE" == 0 ]] && [[ "$INGRESS_INSTALL_OPTION" == "Reuse" ]]; then
-    print_info "NGINX ingress controller is reused but its compatibility is not checked"
+    print_info "NGINX ingress controller is reused but its full compatibility is not checked"
+    print_info "Checking if nginx-ingress-controller is available in namespace ingress-nginx"
     wait_for_deployment_in_namespace "nginx-ingress-controller" "ingress-nginx"
     wait_for_all_pods_in_namespace "ingress-nginx"
 


### PR DESCRIPTION
Fixes #1824.

This PR addresses a problem with newer Istio Versions (1.5 and newer) that don't have istio-pilot.

In addition, the only thing we really need to make sure people can reach API and Bridge right now is the ingress controller, therefore I streamlined the checks for nginx and istio.