### PR TITLE
#1871 Moved K8s version check after entering cluster info

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -216,15 +216,6 @@ keptn install --platform=kubernetes --gateway=NodePort # install on a Kubernetes
 				return errors.New(`Keptn requires 'kubectl' but it is not available.
 Please see https://kubernetes.io/docs/tasks/tools/install-kubectl/`)
 			}
-
-			// check that the Kubernetse Server version is compatible (except for when using OpenShift)
-			if *installParams.PlatformIdentifier != "openshift" {
-				if err := kube.CheckKubeServerVersion(KubeServerVersionConstraints); err != nil {
-					logging.PrintLog(err.Error(), logging.VerboseLevel)
-					logging.PrintLog("See https://keptn.sh/docs/0.6.0/installation/k8s-support/ for details.", logging.VerboseLevel)
-					return errors.New(`Keptn requires Kubernetes Server Version: ` + KubeServerVersionConstraints)
-				}
-			}
 		}
 
 		if installParams.ConfigFilePath != nil && *installParams.ConfigFilePath != "" {
@@ -255,6 +246,16 @@ Please see https://kubernetes.io/docs/tasks/tools/install-kubectl/`)
 					return err
 				}
 			}
+
+			// check if Kubernetes server version is compatible (except OpenShift)
+			if *installParams.PlatformIdentifier != "openshift" {
+				if err := kube.CheckKubeServerVersion(KubeServerVersionConstraints); err != nil {
+					logging.PrintLog(err.Error(), logging.VerboseLevel)
+					logging.PrintLog("See https://keptn.sh/docs/0.6.0/installation/k8s-support/ for details.", logging.VerboseLevel)
+					return errors.New(`Keptn requires Kubernetes server version: ` + KubeServerVersionConstraints)
+				}
+			}
+
 			return doInstallation()
 		}
 		fmt.Println("Skipping installation due to mocking flag")


### PR DESCRIPTION
To test the implementation, I set the constraint to >=1.15 and <=1.18 and connected to a K8s cluster version 1.14:

Now, the CLI first asks for the cluster-info and then checks the version: 

![image](https://user-images.githubusercontent.com/729071/84305167-e0317c80-ab59-11ea-9a1d-4ec6562c623f.png)
