### PR TITLE
#1830 do not include port in host for VirtualService and Ingress rules

### DIFF
--- a/api/go.sum
+++ b/api/go.sum
@@ -510,6 +510,7 @@ google.golang.org/api v0.6.0/go.mod h1:btoxGiFvQNVUZQ8W08zLtrVS08CNpINPEfxXxgJL1
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+google.golang.org/appengine v1.5.0 h1:KxkO13IPW4Lslp2bz+KHP2E3gtFlrIGNThxkZQ3g+4c=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19 h1:Lj2SnHtxkRGJDqnGaSjo+CCdIieEnwVazbOXILwQemk=

--- a/api/handlers/configure.go
+++ b/api/handlers/configure.go
@@ -379,5 +379,10 @@ func removeBridgeFromIngress(ingress *networking.Ingress) {
 }
 
 func getHostForBridge(keptnDomain string) string {
+	// check if the domain contains a port. If yes, only the first part without the port will be used
+	split := strings.Split(keptnDomain, ":")
+	if len(split) > 1 {
+		keptnDomain = split[0]
+	}
 	return "bridge.keptn." + keptnDomain
 }

--- a/api/handlers/configure.go
+++ b/api/handlers/configure.go
@@ -381,8 +381,5 @@ func removeBridgeFromIngress(ingress *networking.Ingress) {
 func getHostForBridge(keptnDomain string) string {
 	// check if the domain contains a port. If yes, only the first part without the port will be used
 	split := strings.Split(keptnDomain, ":")
-	if len(split) > 1 {
-		keptnDomain = split[0]
-	}
-	return "bridge.keptn." + keptnDomain
+	return "bridge.keptn." + split[0]
 }

--- a/api/handlers/configure_test.go
+++ b/api/handlers/configure_test.go
@@ -135,3 +135,36 @@ func TestDisposeBridgeFromIngressWithNoHost(t *testing.T) {
 		t.Error("Unexpected name of host")
 	}
 }
+
+func Test_getHostForBridge(t *testing.T) {
+	type args struct {
+		keptnDomain string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "get bridge hostname",
+			args: args{
+				keptnDomain: "my-domain.com",
+			},
+			want: "bridge.keptn.my-domain.com",
+		},
+		{
+			name: "get bridge hostname from domain containing a port",
+			args: args{
+				keptnDomain: "my-domain.com:1234",
+			},
+			want: "bridge.keptn.my-domain.com",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getHostForBridge(tt.args.keptnDomain); got != tt.want {
+				t.Errorf("getHostForBridge() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #1830 

The api-service will now check if the keptn-domain ConfigMap contains a Port in the baseURL. To avoid generating invalid Ingress/VirtualService rules, the port is excluded from the host property of those rules.