### PR TITLE
#1607 logging refactoring

### DIFF
--- a/gatekeeper-service/go.mod
+++ b/gatekeeper-service/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/uuid v1.1.1
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.6.3-0.20200528100519-ac2805768145
+	github.com/keptn/go-utils v0.6.3-0.20200617060337-e48e5452bfe9
 	github.com/keptn/kubernetes-utils v0.0.0-20200417060634-69e3369c72d3
 )
 

--- a/gatekeeper-service/go.sum
+++ b/gatekeeper-service/go.sum
@@ -346,6 +346,8 @@ github.com/keptn/go-utils v0.6.3-0.20200511072526-085591393853 h1:eL5pxdjc/nQ3j4
 github.com/keptn/go-utils v0.6.3-0.20200511072526-085591393853/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/keptn/go-utils v0.6.3-0.20200528100519-ac2805768145 h1:4AuLaA5W35WhqnB88QpOscpg2xCnxjSwUuiSFFsQSzY=
 github.com/keptn/go-utils v0.6.3-0.20200528100519-ac2805768145/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
+github.com/keptn/go-utils v0.6.3-0.20200617060337-e48e5452bfe9 h1:K36NQ1/DwTBU/3EGJnlKVNYKLnnVcHEzhaZ4qNb2wkU=
+github.com/keptn/go-utils v0.6.3-0.20200617060337-e48e5452bfe9/go.mod h1:hf2FU6JFuOzLP5rEAlA1/XnNS28pDZbVfxDESeQsq1g=
 github.com/keptn/kubernetes-utils v0.0.0-20200401103501-ae44a5ee0656 h1:uGdzQ+DT+/KqzMJF+5F+B+/h0nOfwmmSA7ClxsI1y6Y=
 github.com/keptn/kubernetes-utils v0.0.0-20200401103501-ae44a5ee0656/go.mod h1:7MQMS/jqKM4eVZ0S1S7LWdZNcBTJn5QeERircdADWzo=
 github.com/keptn/kubernetes-utils v0.0.0-20200416114530-1f75caaf74a9 h1:9LpiWYAXnfFsV0R7xSmnLcBNLiCjFaq3dY2vNrDSjl0=

--- a/gatekeeper-service/main.go
+++ b/gatekeeper-service/main.go
@@ -70,9 +70,9 @@ func switchEvent(event cloudevents.Event) {
 		return
 	}
 
-	handlers := []handler.Handler{handler.NewEvaluationDoneEventHandler(l),
-		handler.NewApprovalTriggeredEventHandler(l),
-		handler.NewApprovalFinishedEventHandler(l)}
+	handlers := []handler.Handler{handler.NewEvaluationDoneEventHandler(keptnHandler),
+		handler.NewApprovalTriggeredEventHandler(keptnHandler),
+		handler.NewApprovalFinishedEventHandler(keptnHandler)}
 
 	unhandled := true
 	for _, handler := range handlers {

--- a/gatekeeper-service/main.go
+++ b/gatekeeper-service/main.go
@@ -57,7 +57,10 @@ func gotEvent(ctx context.Context, event cloudevents.Event) error {
 }
 
 func switchEvent(event cloudevents.Event) {
-	keptnHandler, err := keptnevents.NewKeptn(&event, keptnevents.KeptnOpts{})
+	serviceName := "gatekeeper-service"
+	keptnHandler, err := keptnevents.NewKeptn(&event, keptnevents.KeptnOpts{
+		LoggingOptions: &keptnevents.LoggingOpts{ServiceName: &serviceName},
+	})
 	if err != nil {
 		l := keptnevents.NewLogger("", event.Context.GetID(), "gatekeeper-service")
 		l.Error("failed to initialize Keptn handler: " + err.Error())

--- a/gatekeeper-service/pkg/handler/approval_finished_event_handler.go
+++ b/gatekeeper-service/pkg/handler/approval_finished_event_handler.go
@@ -27,6 +27,7 @@ type ApprovalFinishedEventHandler struct {
 	keptn *keptnevents.Keptn
 }
 
+// NewApprovalFinishedEventHandler returns a new approval.finished event handler
 func NewApprovalFinishedEventHandler(keptn *keptnevents.Keptn) *ApprovalFinishedEventHandler {
 	return &ApprovalFinishedEventHandler{keptn: keptn}
 }

--- a/gatekeeper-service/pkg/handler/approval_finished_event_handler_test.go
+++ b/gatekeeper-service/pkg/handler/approval_finished_event_handler_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -111,7 +112,14 @@ func TestHandleApprovalFinishedEvent(t *testing.T) {
 
 	for _, tt := range approvalFinishedTests {
 		t.Run(tt.name, func(t *testing.T) {
-			e := NewApprovalFinishedEventHandler(keptnevents.NewLogger(shkeptncontext, eventID, "gatekeeper-service"))
+			ce := cloudevents.New("0.2")
+			dataBytes, err := json.Marshal(tt.inputEvent)
+			if err != nil {
+				t.Error(err)
+			}
+			ce.Data = dataBytes
+			keptnHandler, _ := keptnevents.NewKeptn(&ce, keptnevents.KeptnOpts{})
+			e := NewApprovalFinishedEventHandler(keptnHandler)
 			res := e.handleApprovalFinishedEvent(tt.inputEvent, shkeptncontext, tt.shipyard)
 			if len(res) != len(tt.outputEvent) {
 				t.Errorf("got %d output event, want %v output events for %s",

--- a/gatekeeper-service/pkg/handler/approval_triggered_event_handler.go
+++ b/gatekeeper-service/pkg/handler/approval_triggered_event_handler.go
@@ -16,6 +16,7 @@ type ApprovalTriggeredEventHandler struct {
 	keptn *keptnevents.Keptn
 }
 
+// NewApprovalTriggeredEventHandler returns a new approal.triggered event handler
 func NewApprovalTriggeredEventHandler(keptn *keptnevents.Keptn) *ApprovalTriggeredEventHandler {
 	return &ApprovalTriggeredEventHandler{keptn: keptn}
 }

--- a/gatekeeper-service/pkg/handler/approval_triggered_event_handler_test.go
+++ b/gatekeeper-service/pkg/handler/approval_triggered_event_handler_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -130,7 +131,14 @@ var approvalTriggeredTests = []struct {
 func TestHandleApprovalTriggeredEvent(t *testing.T) {
 	for _, tt := range approvalTriggeredTests {
 		t.Run(tt.name, func(t *testing.T) {
-			e := NewApprovalTriggeredEventHandler(keptnevents.NewLogger(shkeptncontext, eventID, "gatekeeper-service"))
+			ce := cloudevents.New("0.2")
+			dataBytes, err := json.Marshal(tt.inputEvent)
+			if err != nil {
+				t.Error(err)
+			}
+			ce.Data = dataBytes
+			keptnHandler, _ := keptnevents.NewKeptn(&ce, keptnevents.KeptnOpts{})
+			e := NewApprovalTriggeredEventHandler(keptnHandler)
 			res := e.handleApprovalTriggeredEvent(tt.inputEvent, eventID, shkeptncontext, tt.shipyard)
 			if len(res) != len(tt.outputEvent) {
 				t.Errorf("got %d output event, want %v output events for %s",

--- a/gatekeeper-service/pkg/handler/evaluation_done_event_handler.go
+++ b/gatekeeper-service/pkg/handler/evaluation_done_event_handler.go
@@ -17,6 +17,7 @@ type EvaluationDoneEventHandler struct {
 	keptn *keptnevents.Keptn
 }
 
+// NewEvaluationDoneEventHandler returns a new evaluation-done handler
 func NewEvaluationDoneEventHandler(keptn *keptnevents.Keptn) *EvaluationDoneEventHandler {
 	return &EvaluationDoneEventHandler{keptn: keptn}
 }

--- a/gatekeeper-service/pkg/handler/evaluation_done_event_handler_test.go
+++ b/gatekeeper-service/pkg/handler/evaluation_done_event_handler_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -66,7 +67,14 @@ var evaluationDoneTests = []struct {
 func TestHandleEvaluationDoneEvent(t *testing.T) {
 	for _, tt := range evaluationDoneTests {
 		t.Run(tt.name, func(t *testing.T) {
-			e := NewEvaluationDoneEventHandler(keptnevents.NewLogger(shkeptncontext, eventID, "gatekeeper-service"))
+			ce := cloudevents.New("0.2")
+			dataBytes, err := json.Marshal(tt.inputEvent)
+			if err != nil {
+				t.Error(err)
+			}
+			ce.Data = dataBytes
+			keptnHandler, _ := keptnevents.NewKeptn(&ce, keptnevents.KeptnOpts{})
+			e := NewEvaluationDoneEventHandler(keptnHandler)
 			res := e.handleEvaluationDoneEvent(tt.inputEvent, shkeptncontext, tt.image, tt.shipyard)
 			if len(res) != len(tt.outputEvent) {
 				t.Errorf("got %d output event, want %v output events for %s",

--- a/gatekeeper-service/pkg/handler/handler.go
+++ b/gatekeeper-service/pkg/handler/handler.go
@@ -24,7 +24,7 @@ type Handler interface {
 		shipyard *keptnevents.Shipyard)
 }
 
-func sendEvents(keptnHandler *keptnevents.Keptn, events []cloudevents.Event, l *keptnevents.Logger) {
+func sendEvents(keptnHandler *keptnevents.Keptn, events []cloudevents.Event, l keptnevents.LoggerInterface) {
 	for _, outgoingEvent := range events {
 		err := keptnHandler.SendCloudEvent(outgoingEvent)
 		if err != nil {

--- a/helm-service/controller/configuration_changer.go
+++ b/helm-service/controller/configuration_changer.go
@@ -194,7 +194,7 @@ func (c *ConfigurationChanger) applyValuesCanary(e *keptnevents.ConfigurationCha
 	if err := c.upgradeChart(ch, *e, deploymentStrategy); err != nil {
 		return err
 	}
-	onboarder := NewOnboarder(c.mesh, c.keptnHandler.Logger, c.keptnDomain, c.configServiceURL)
+	onboarder := NewOnboarder(c.mesh, c.keptnHandler, c.keptnDomain, c.configServiceURL)
 	if onboarder.IsGeneratedChartEmpty(genChart) {
 		userChartManifest, err := c.helmExecutor.GetManifest(helm.GetReleaseName(e.Project, e.Stage, e.Service, false),
 			e.Project+"-"+e.Stage)

--- a/helm-service/controller/onboarder_test.go
+++ b/helm-service/controller/onboarder_test.go
@@ -10,14 +10,12 @@ import (
 	"testing"
 
 	"github.com/cloudevents/sdk-go/pkg/cloudevents"
-	"github.com/google/uuid"
 	"github.com/keptn/keptn/helm-service/controller/mesh"
 	"github.com/keptn/keptn/helm-service/pkg/helmtest"
 
 	configmodels "github.com/keptn/go-utils/pkg/api/models"
 	configutils "github.com/keptn/go-utils/pkg/api/utils"
 	keptnevents "github.com/keptn/go-utils/pkg/lib"
-	keptnutils "github.com/keptn/go-utils/pkg/lib"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -84,9 +82,10 @@ func TestDoOnboard(t *testing.T) {
 	}
 	ce.Data = dataBytes
 
-	id := uuid.New().String()
+	keptnHandler, _ := keptnevents.NewKeptn(&ce, keptnevents.KeptnOpts{})
+
 	onboarder := NewOnboarder(mesh.NewIstioMesh(),
-		keptnutils.NewLogger(id, "service.create", "helm-service"), "test.keptn.sh", "")
+		keptnHandler, "test.keptn.sh", "")
 	loggingDone := make(chan bool)
 	err = onboarder.DoOnboard(ce, loggingDone)
 	if err != nil {

--- a/helm-service/go.mod
+++ b/helm-service/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/websocket v1.4.1
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.6.3-0.20200603110000-ac6bdc5ce42b
+	github.com/keptn/go-utils v0.6.3-0.20200617060337-e48e5452bfe9
 	github.com/keptn/kubernetes-utils v0.0.0-20200417060634-69e3369c72d3
 	github.com/kinbiko/jsonassert v1.0.1
 	github.com/stretchr/testify v1.4.0

--- a/helm-service/go.mod
+++ b/helm-service/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/websocket v1.4.1
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.6.3-0.20200608064908-52b9e92e5c8f
+	github.com/keptn/go-utils v0.6.3-0.20200603110000-ac6bdc5ce42b
 	github.com/keptn/kubernetes-utils v0.0.0-20200417060634-69e3369c72d3
 	github.com/kinbiko/jsonassert v1.0.1
 	github.com/stretchr/testify v1.4.0

--- a/helm-service/go.sum
+++ b/helm-service/go.sum
@@ -440,6 +440,8 @@ github.com/keptn/go-utils v0.6.3-0.20200528130847-06ffb9763e83 h1:DbyMq5ELazflrY
 github.com/keptn/go-utils v0.6.3-0.20200528130847-06ffb9763e83/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/keptn/go-utils v0.6.3-0.20200603095703-4d6be09d1378 h1:PiSYoB7jCLO94LAoxLYfW+xgni5eD6oZPGFZzm/MxFg=
 github.com/keptn/go-utils v0.6.3-0.20200603095703-4d6be09d1378/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
+github.com/keptn/go-utils v0.6.3-0.20200603110000-ac6bdc5ce42b h1:k+PHrrY9QoBOexREsj+DaAjhJDRnpjUlOH+hZsyLB70=
+github.com/keptn/go-utils v0.6.3-0.20200603110000-ac6bdc5ce42b/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/keptn/go-utils v0.6.3-0.20200606091645-e86010a153ad h1:ATFHDviVxtygscdB7oI2WRyAskDqz3Ul8B1Xy/++D2o=
 github.com/keptn/go-utils v0.6.3-0.20200606091645-e86010a153ad/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/keptn/go-utils v0.6.3-0.20200608064908-52b9e92e5c8f h1:tyjFprH1RrixG5oHtLXe6ttP3j8vSR+nEAgazewx8eI=

--- a/helm-service/go.sum
+++ b/helm-service/go.sum
@@ -446,6 +446,8 @@ github.com/keptn/go-utils v0.6.3-0.20200606091645-e86010a153ad h1:ATFHDviVxtygsc
 github.com/keptn/go-utils v0.6.3-0.20200606091645-e86010a153ad/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/keptn/go-utils v0.6.3-0.20200608064908-52b9e92e5c8f h1:tyjFprH1RrixG5oHtLXe6ttP3j8vSR+nEAgazewx8eI=
 github.com/keptn/go-utils v0.6.3-0.20200608064908-52b9e92e5c8f/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
+github.com/keptn/go-utils v0.6.3-0.20200617060337-e48e5452bfe9 h1:K36NQ1/DwTBU/3EGJnlKVNYKLnnVcHEzhaZ4qNb2wkU=
+github.com/keptn/go-utils v0.6.3-0.20200617060337-e48e5452bfe9/go.mod h1:hf2FU6JFuOzLP5rEAlA1/XnNS28pDZbVfxDESeQsq1g=
 github.com/keptn/kubernetes-utils v0.0.0-20200401103501-ae44a5ee0656 h1:uGdzQ+DT+/KqzMJF+5F+B+/h0nOfwmmSA7ClxsI1y6Y=
 github.com/keptn/kubernetes-utils v0.0.0-20200401103501-ae44a5ee0656/go.mod h1:7MQMS/jqKM4eVZ0S1S7LWdZNcBTJn5QeERircdADWzo=
 github.com/keptn/kubernetes-utils v0.0.0-20200414093719-126698f19c3e h1:9/7mjIDhpvlezvYKB6JjEBE7HXb0Fh4BAlg5aPKE+N0=

--- a/lighthouse-service/event_handler/configure_monitoring_handler.go
+++ b/lighthouse-service/event_handler/configure_monitoring_handler.go
@@ -11,7 +11,6 @@ import (
 )
 
 type ConfigureMonitoringHandler struct {
-	Logger       *keptnutils.Logger
 	Event        cloudevents.Event
 	KeptnHandler *keptnutils.Keptn
 }
@@ -24,7 +23,7 @@ func (eh *ConfigureMonitoringHandler) HandleEvent() error {
 	e := &keptnevents.ConfigureMonitoringEventData{}
 	err := eh.Event.DataAs(e)
 	if err != nil {
-		eh.Logger.Error("Could not parse event payload: " + err.Error())
+		eh.KeptnHandler.Logger.Error("Could not parse event payload: " + err.Error())
 		return err
 	}
 
@@ -36,7 +35,7 @@ func (eh *ConfigureMonitoringHandler) HandleEvent() error {
 	}
 
 	if err != nil {
-		eh.Logger.Error("Could not create Kube API")
+		eh.KeptnHandler.Logger.Error("Could not create Kube API")
 		return err
 	}
 	_, err = kubeAPI.CoreV1().ConfigMaps("keptn").Create(configMap)

--- a/lighthouse-service/event_handler/configure_monitoring_handler_test.go
+++ b/lighthouse-service/event_handler/configure_monitoring_handler_test.go
@@ -73,8 +73,8 @@ func TestConfigureMonitoringHandler_getSLISourceConfigMap(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			eh := &ConfigureMonitoringHandler{
-				Logger: tt.fields.Logger,
-				Event:  tt.fields.Event,
+				KeptnHandler: nil,
+				Event:        tt.fields.Event,
 			}
 			if got := eh.getSLISourceConfigMap(tt.args.e); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getSLISourceConfigMap() = %v, want %v", got, tt.want)

--- a/lighthouse-service/event_handler/evaluate_sli_handler_test.go
+++ b/lighthouse-service/event_handler/evaluate_sli_handler_test.go
@@ -2468,10 +2468,12 @@ func TestEvaluateSLIHandler_getPreviousTestExecutionResult(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 
 			returnedResult = tt.resultFromDatastore
+
+			//keptnHandler, _ := keptnevents.NewKeptn(&tt.fields.Event, keptnevents.KeptnOpts{})
 			eh := &EvaluateSLIHandler{
-				Logger:     tt.fields.Logger,
-				Event:      tt.fields.Event,
-				HTTPClient: tt.fields.HTTPClient,
+				KeptnHandler: nil,
+				Event:        tt.fields.Event,
+				HTTPClient:   tt.fields.HTTPClient,
 			}
 			got, err := eh.getPreviousTestExecutionResult(tt.args.e, tt.args.keptnContext)
 			if (err != nil) != tt.wantErr {
@@ -2578,10 +2580,13 @@ func TestEvaluateSLIHandler_getPreviousEvaluations(t *testing.T) {
 	for _, tt := range tests {
 		returnedResult = tt.resultFromDatastore
 		t.Run(tt.name, func(t *testing.T) {
+
+			//keptnHandler, _ := keptnevents.NewKeptn(&tt.fields.Event, keptnevents.KeptnOpts{})
+
 			eh := &EvaluateSLIHandler{
-				Logger:     tt.fields.Logger,
-				Event:      tt.fields.Event,
-				HTTPClient: tt.fields.HTTPClient,
+				KeptnHandler: nil,
+				Event:        tt.fields.Event,
+				HTTPClient:   tt.fields.HTTPClient,
 			}
 			got, err := eh.getPreviousEvaluations(tt.args.e, tt.args.numberOfPreviousResults)
 			if (err != nil) != tt.wantErr {

--- a/lighthouse-service/event_handler/handler.go
+++ b/lighthouse-service/event_handler/handler.go
@@ -14,19 +14,22 @@ type EvaluationEventHandler interface {
 
 func NewEventHandler(event cloudevents.Event, logger *keptn.Logger) (EvaluationEventHandler, error) {
 	logger.Debug("Received event: " + event.Type())
-	keptnHandler, err := keptn.NewKeptn(&event, keptn.KeptnOpts{})
+	serviceName := "lighthouse-service"
+	keptnHandler, err := keptn.NewKeptn(&event, keptn.KeptnOpts{
+		LoggingOptions: &keptn.LoggingOpts{ServiceName: &serviceName},
+	})
 	if err != nil {
 		return nil, err
 	}
 	switch event.Type() {
 	case keptn.TestsFinishedEventType:
-		return &StartEvaluationHandler{Logger: logger, Event: event, KeptnHandler: keptnHandler}, nil
+		return &StartEvaluationHandler{Event: event, KeptnHandler: keptnHandler}, nil
 	case keptn.StartEvaluationEventType:
-		return &StartEvaluationHandler{Logger: logger, Event: event, KeptnHandler: keptnHandler}, nil // new event type in Keptn versions >= 0.6
+		return &StartEvaluationHandler{Event: event, KeptnHandler: keptnHandler}, nil // new event type in Keptn versions >= 0.6
 	case keptn.InternalGetSLIDoneEventType:
-		return &EvaluateSLIHandler{Logger: logger, Event: event, HTTPClient: &http.Client{}, KeptnHandler: keptnHandler}, nil
+		return &EvaluateSLIHandler{Event: event, HTTPClient: &http.Client{}, KeptnHandler: keptnHandler}, nil
 	case keptn.ConfigureMonitoringEventType:
-		return &ConfigureMonitoringHandler{Logger: logger, Event: event, KeptnHandler: keptnHandler}, nil
+		return &ConfigureMonitoringHandler{Event: event, KeptnHandler: keptnHandler}, nil
 	default:
 		return nil, errors.New("received unknown event type")
 	}

--- a/lighthouse-service/event_handler/handler_test.go
+++ b/lighthouse-service/event_handler/handler_test.go
@@ -30,7 +30,10 @@ func TestNewEventHandler(t *testing.T) {
 		DataEncoded: false,
 	}
 
-	keptnHandler, _ := keptn.NewKeptn(&incomingEvent, keptn.KeptnOpts{})
+	serviceName := "lighthouse-service"
+	keptnHandler, _ := keptn.NewKeptn(&incomingEvent, keptn.KeptnOpts{
+		LoggingOptions: &keptn.LoggingOpts{ServiceName: &serviceName},
+	})
 
 	type args struct {
 		event  cloudevents.Event
@@ -51,7 +54,6 @@ func TestNewEventHandler(t *testing.T) {
 			},
 			eventType: keptn.TestsFinishedEventType,
 			want: &StartEvaluationHandler{
-				Logger:       nil,
 				Event:        incomingEvent,
 				KeptnHandler: keptnHandler,
 			},
@@ -65,7 +67,6 @@ func TestNewEventHandler(t *testing.T) {
 			},
 			eventType: keptn.StartEvaluationEventType,
 			want: &StartEvaluationHandler{
-				Logger:       nil,
 				Event:        incomingEvent,
 				KeptnHandler: keptnHandler,
 			},
@@ -79,7 +80,6 @@ func TestNewEventHandler(t *testing.T) {
 			},
 			eventType: keptn.InternalGetSLIDoneEventType,
 			want: &EvaluateSLIHandler{
-				Logger:       nil,
 				Event:        incomingEvent,
 				KeptnHandler: keptnHandler,
 				HTTPClient:   &http.Client{},
@@ -94,7 +94,6 @@ func TestNewEventHandler(t *testing.T) {
 			},
 			eventType: keptn.ConfigureMonitoringEventType,
 			want: &ConfigureMonitoringHandler{
-				Logger:       nil,
 				Event:        incomingEvent,
 				KeptnHandler: keptnHandler,
 			},

--- a/lighthouse-service/event_handler/start_evaluation_handler_test.go
+++ b/lighthouse-service/event_handler/start_evaluation_handler_test.go
@@ -168,7 +168,6 @@ func TestStartEvaluationHandler_HandleEvent(t *testing.T) {
 			})
 			returnSlo = tt.sloAvailable
 			eh := &StartEvaluationHandler{
-				Logger:       tt.fields.Logger,
 				Event:        tt.fields.Event,
 				KeptnHandler: keptnHandler,
 			}

--- a/lighthouse-service/go.mod
+++ b/lighthouse-service/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/json-iterator/go v1.1.9 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.6.3-0.20200528100519-ac2805768145
+	github.com/keptn/go-utils v0.6.3-0.20200617060337-e48e5452bfe9
 	github.com/nats-io/nats-server/v2 v2.1.6
 	github.com/stretchr/testify v1.4.0
 	k8s.io/api v0.17.0

--- a/lighthouse-service/go.sum
+++ b/lighthouse-service/go.sum
@@ -190,6 +190,8 @@ github.com/keptn/go-utils v0.6.1-compat.0.20200406125548-5337a2e806c4 h1:D6m0Bxm
 github.com/keptn/go-utils v0.6.1-compat.0.20200406125548-5337a2e806c4/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/keptn/go-utils v0.6.3-0.20200528100519-ac2805768145 h1:4AuLaA5W35WhqnB88QpOscpg2xCnxjSwUuiSFFsQSzY=
 github.com/keptn/go-utils v0.6.3-0.20200528100519-ac2805768145/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
+github.com/keptn/go-utils v0.6.3-0.20200617060337-e48e5452bfe9 h1:K36NQ1/DwTBU/3EGJnlKVNYKLnnVcHEzhaZ4qNb2wkU=
+github.com/keptn/go-utils v0.6.3-0.20200617060337-e48e5452bfe9/go.mod h1:hf2FU6JFuOzLP5rEAlA1/XnNS28pDZbVfxDESeQsq1g=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/remediation-service/go.mod
+++ b/remediation-service/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/gophercloud/gophercloud v0.9.0 // indirect
 	github.com/json-iterator/go v1.1.9 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.6.3-0.20200615074910-2565441cb79d
+	github.com/keptn/go-utils v0.6.3-0.20200617060337-e48e5452bfe9
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect

--- a/remediation-service/go.sum
+++ b/remediation-service/go.sum
@@ -171,6 +171,8 @@ github.com/keptn/go-utils v0.6.3-0.20200608094732-36510e13b56d h1:5Fl3nm48xjBlHF
 github.com/keptn/go-utils v0.6.3-0.20200608094732-36510e13b56d/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/keptn/go-utils v0.6.3-0.20200615074910-2565441cb79d h1:VtFkwEEXBCKnp67X4Dy4y6ZVu+r2X9juDDexgtZl0Sc=
 github.com/keptn/go-utils v0.6.3-0.20200615074910-2565441cb79d/go.mod h1:hf2FU6JFuOzLP5rEAlA1/XnNS28pDZbVfxDESeQsq1g=
+github.com/keptn/go-utils v0.6.3-0.20200617060337-e48e5452bfe9 h1:K36NQ1/DwTBU/3EGJnlKVNYKLnnVcHEzhaZ4qNb2wkU=
+github.com/keptn/go-utils v0.6.3-0.20200617060337-e48e5452bfe9/go.mod h1:hf2FU6JFuOzLP5rEAlA1/XnNS28pDZbVfxDESeQsq1g=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/remediation-service/handler/action_finished_handler.go
+++ b/remediation-service/handler/action_finished_handler.go
@@ -12,7 +12,6 @@ const waitTimeInMinutes = 10
 // ActionFinishedEventHandler handles action.finished events
 type ActionFinishedEventHandler struct {
 	KeptnHandler *keptn.Keptn
-	Logger       keptn.LoggerInterface
 	Event        cloudevents.Event
 	Remediation  *Remediation
 	WaitFunction waitFunction
@@ -26,11 +25,11 @@ func (eh *ActionFinishedEventHandler) HandleEvent() error {
 
 	err := eh.Event.DataAs(actionFinishedEvent)
 	if err != nil {
-		eh.Logger.Error("Could not parse incoming action.finished event: " + err.Error())
+		eh.KeptnHandler.Logger.Error("Could not parse incoming action.finished event: " + err.Error())
 		return err
 	}
-	eh.Logger.Info(fmt.Sprintf("Received action.finished event for remediationStatus action. result = %v", actionFinishedEvent.Action.Result))
-	eh.Logger.Info(fmt.Sprintf("Waiting for %d minutes for action to take effect", waitTimeInMinutes))
+	eh.KeptnHandler.Logger.Info(fmt.Sprintf("Received action.finished event for remediationStatus action. result = %v", actionFinishedEvent.Action.Result))
+	eh.KeptnHandler.Logger.Info(fmt.Sprintf("Waiting for %d minutes for action to take effect", waitTimeInMinutes))
 
 	if eh.WaitFunction == nil {
 		eh.WaitFunction = func() {
@@ -38,11 +37,11 @@ func (eh *ActionFinishedEventHandler) HandleEvent() error {
 		}
 	}
 	eh.WaitFunction()
-	eh.Logger.Info("Wait time is over. Sending start-evaluation event.")
+	eh.KeptnHandler.Logger.Info("Wait time is over. Sending start-evaluation event.")
 
 	err = eh.Remediation.sendStartEvaluationEvent()
 	if err != nil {
-		eh.Logger.Error("Could not send start-evaluation event: " + err.Error())
+		eh.KeptnHandler.Logger.Error("Could not send start-evaluation event: " + err.Error())
 		eh.Remediation.sendRemediationFinishedEvent(keptn.RemediationStatusErrored, keptn.RemediationResultFailed, "could not send start-evaluation event")
 		return err
 	}

--- a/remediation-service/handler/action_finished_handler_test.go
+++ b/remediation-service/handler/action_finished_handler_test.go
@@ -67,15 +67,12 @@ func TestActionFinishedEventHandler_HandleEvent(t *testing.T) {
 				EventBrokerURL: mockEV.Server.URL,
 			})
 
-			logger := keptn.NewLogger("", "", "")
 			remediation := &Remediation{
-				Keptn:  testKeptnHandler,
-				Logger: logger,
+				Keptn: testKeptnHandler,
 			}
 
 			eh := &ActionFinishedEventHandler{
 				KeptnHandler: testKeptnHandler,
-				Logger:       logger,
 				Event:        tt.fields.Event,
 				Remediation:  remediation,
 				WaitFunction: func() {},

--- a/remediation-service/handler/evaluation_done_handler_test.go
+++ b/remediation-service/handler/evaluation_done_handler_test.go
@@ -343,15 +343,12 @@ func TestEvaluationDoneEventHandler_HandleEvent(t *testing.T) {
 				ConfigurationServiceURL: mockCS.Server.URL,
 			})
 
-			logger := keptn.NewLogger("", "", "")
 			remediation := &Remediation{
-				Keptn:  testKeptnHandler,
-				Logger: logger,
+				Keptn: testKeptnHandler,
 			}
 
 			eh := &EvaluationDoneEventHandler{
 				KeptnHandler: testKeptnHandler,
-				Logger:       logger,
 				Event:        tt.fields.Event,
 				Remediation:  remediation,
 			}

--- a/remediation-service/handler/problem_open_handler_test.go
+++ b/remediation-service/handler/problem_open_handler_test.go
@@ -443,15 +443,12 @@ func TestProblemOpenEventHandler_HandleEvent(t *testing.T) {
 				ConfigurationServiceURL: mockCS.Server.URL,
 			})
 
-			logger := keptn.NewLogger("", "", "")
 			remediation := &Remediation{
-				Keptn:  testKeptnHandler,
-				Logger: logger,
+				Keptn: testKeptnHandler,
 			}
 
 			eh := &ProblemOpenEventHandler{
 				KeptnHandler: testKeptnHandler,
-				Logger:       logger,
 				Event:        tt.fields.Event,
 				Remediation:  remediation,
 			}


### PR DESCRIPTION
Closes #1607 
In this PR, the Keptn core services use the logger provided by the `Keptn` struct of the [go-utils](https://github.com/keptn/go-utils/blob/e48e5452bfe91590fa49de2a475a0c0b90cc50a7/pkg/lib/keptn.go#L31). This way, services that already use the `Keptn` struct do not have to initialize a seperate logger. This especially comes in handy when a WebSocket communication (e.g. in the helm-service) should be established since this required a lot of code previously.