### PR TITLE
fixed wait command for remediation-service-distributor

### DIFF
--- a/installer/scripts/common/setupKeptn.sh
+++ b/installer/scripts/common/setupKeptn.sh
@@ -106,7 +106,7 @@ case $USE_CASE in
     wait_for_deployment_in_namespace "gatekeeper-service-evaluation-done-distributor" "keptn"
     wait_for_deployment_in_namespace "helm-service-distributor" "keptn"
     wait_for_deployment_in_namespace "jmeter-service-deployment-distributor" "keptn"
-    wait_for_deployment_in_namespace "remediation-service-problem-distributor" "keptn"
+    wait_for_deployment_in_namespace "remediation-service-distributor" "keptn"
     wait_for_deployment_in_namespace "wait-service-deployment-distributor" "keptn"
     ;;
   *)

--- a/installer/scripts/openshift/setupKeptn.sh
+++ b/installer/scripts/openshift/setupKeptn.sh
@@ -114,7 +114,7 @@ case $USE_CASE in
     wait_for_deployment_in_namespace "gatekeeper-service-evaluation-done-distributor" "keptn"
     wait_for_deployment_in_namespace "helm-service-distributor" "keptn"
     wait_for_deployment_in_namespace "jmeter-service-deployment-distributor" "keptn"
-    wait_for_deployment_in_namespace "remediation-service-problem-distributor" "keptn"
+    wait_for_deployment_in_namespace "remediation-service-distributor" "keptn"
     wait_for_deployment_in_namespace "wait-service-deployment-distributor" "keptn"
     ;;
   *)


### PR DESCRIPTION
Since the `remediation-service-problem-distributor` has been replaced by the `remediation-service-distributor` the instruction to wait for the deployment had to be changed