### PR TITLE
Added notifications to slack for travis-ci failed builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,16 @@ env:
     - GO111MODULE=on
     - GOPROXY=https://proxy.golang.org
 
+# configure notifications for failed builds
+notifications:
+  slack:
+    rooms:
+      # token generated using travis encrypt "..." --add notifications.slack -r keptn/keptn --org
+      - secure: NjL/yh3BkTig19hV7nH0q+XxNOxCGTuhdn69WV8tsR0TXp8gqQxD8pnyPX7/nNdkc9PPAUCLGdFlU+vsa3SFt1cdZCgi44lvqHPHBZCa1Sh2+CxqCPRe9NQzU8JJBwDO9OEezbL7Pbfoi7m56MVU6JfkX5RPwN7RLcyCUane/STu3NDBeJLvn0qhjXMFlfKibdwdWom+TZxMiWaZ3oX1omtE88fiHaEGDjTobO3GNR6er9Rd0peAf7LXyHPrJDC0Ss8bz6OVNPQQFtFVwHG/0zVGwZPDbDUw2U+C8DsBVofhPRKhK2g2o0VAESKgrREdDPyVtAsbOnxGnudyPv94whhNjv3aVLeNilNiujXBgeC5R8aWNc2FthDUdB1clKDRFpwiXi0F1J+3bYN498p7QI+Yrr9XSJA62ZCeUjm3Sg2zFs7VtILgCTSbPKzAL4XjSnzefAS8MnG137TnYbwyi9Z/5+XgmLwSguLRMnMlktOH4JxUvD4ImVO7OI/QYYLtUjqqSyjywEa4v+MsyuuqaiT2m4GFpIRKxB4C3c/kONn2kUAd9LM1eIcHonPNmvH36k41nTf+XLOOICy2i1+m1aB18q5yj8qeaQZenpf2WheflM9zDgZc3cku6ZnyZCMdlhLnKfMiCgf8sYvL8qnq1XY2yikeZt4SuMCKLl5wdlI=
+    if: (branch = master or branch =~ ^release.*$) AND (type = cron OR type = push)
+    on_success: never
+    on_failure: always
+
 before_install:
 # determine OS type (either osx for linux) - will be used for downloading dependencies
 - |


### PR DESCRIPTION
This PR adds notifications to slack in case of travis-ci failed builds on the master or release branch.

Please note: The token is required to be in .travis.yml in an [encrypted form as per their documentation](https://docs.travis-ci.com/user/notifications/#configuring-slack-notifications):

![image](https://user-images.githubusercontent.com/56065213/84891798-bff34780-b09c-11ea-8ab8-b4af391b5dca.png)
