### PR TITLE
#1849 remediation workflow fixes

### DIFF
--- a/configuration-service/common/projects_materialized_view.go
+++ b/configuration-service/common/projects_materialized_view.go
@@ -343,9 +343,10 @@ func (mv *projectsMaterializedView) CloseOpenApproval(project, stage, service, a
 func (mv *projectsMaterializedView) CreateRemediation(project, stage, service string, remediation *models.Remediation) error {
 	existingProject, err := mv.GetProject(project)
 	if err != nil {
-		mv.Logger.Error("Could create remediation for service " + service + " in stage " + stage + " in project " + project + ". Could not load project: " + err.Error())
+		mv.Logger.Error("Could not create remediation for service " + service + " in stage " + stage + " in project " + project + ". Could not load project: " + err.Error())
 		return ErrProjectNotFound
 	}
+
 	err = updateServiceInStage(existingProject, stage, service, func(service *models.ExpandedService) error {
 		if service.OpenRemediations == nil {
 			service.OpenRemediations = []*models.Remediation{}

--- a/configuration-service/handlers/event.go
+++ b/configuration-service/handlers/event.go
@@ -30,6 +30,8 @@ func HandleEventHandlerFunc(params event.HandleEventParams) middleware.Responder
 			return event.NewHandleEventDefault(400).WithPayload(&models.Error{Message: swag.String("Service must not be empty"), Code: 400})
 		}
 
+		common.LockProject(keptnBase.Project)
+		defer common.UnlockProject(keptnBase.Project)
 		mv := common.GetProjectsMaterializedView()
 		err = mv.UpdateEventOfService(params.Body.Data, *params.Body.Type, params.Body.Shkeptncontext, params.Body.ID)
 		if err != nil {

--- a/configuration-service/handlers/remediation.go
+++ b/configuration-service/handlers/remediation.go
@@ -11,8 +11,9 @@ import (
 
 // CreateRemediation creates a remediation
 func CreateRemediation(params remediation.CreateRemediationParams) middleware.Responder {
+	common.LockProject(params.ProjectName)
+	defer common.UnlockProject(params.ProjectName)
 	mv := common.GetProjectsMaterializedView()
-
 	err := mv.CreateRemediation(params.ProjectName, params.StageName, params.ServiceName, params.Remediation)
 
 	if err != nil {
@@ -21,7 +22,7 @@ func CreateRemediation(params remediation.CreateRemediationParams) middleware.Re
 	return service_approval.NewCreateRemediationOK()
 }
 
-// GetRemediations retriees all remediations of the service
+// GetRemediations retrieves all remediations of the service
 func GetRemediations(params remediation.GetRemediationsParams) middleware.Responder {
 	mv := common.GetProjectsMaterializedView()
 
@@ -107,8 +108,9 @@ func GetRemediationsForContext(params remediation.GetRemediationsForContextParam
 
 // CloseRemediations closes all remediations with a given keptnContext of a service
 func CloseRemediations(params remediation.CloseRemediationsParams) middleware.Responder {
+	common.LockProject(params.ProjectName)
+	defer common.UnlockProject(params.ProjectName)
 	mv := common.GetProjectsMaterializedView()
-
 	err := mv.CloseOpenRemediations(params.ProjectName, params.StageName, params.ServiceName, params.KeptnContext)
 
 	if err != nil {

--- a/configuration-service/handlers/service_approval.go
+++ b/configuration-service/handlers/service_approval.go
@@ -10,8 +10,9 @@ import (
 
 // CreateServiceApproval creates a service approval
 func CreateServiceApproval(params service_approval.CreateServiceApprovalParams) middleware.Responder {
+	common.LockProject(params.ProjectName)
+	defer common.UnlockProject(params.ProjectName)
 	mv := common.GetProjectsMaterializedView()
-
 	err := mv.CreateOpenApproval(params.ProjectName, params.StageName, params.ServiceName, params.Approval)
 
 	if err != nil {
@@ -90,6 +91,8 @@ func GetServiceApproval(params service_approval.GetServiceApprovalParams) middle
 
 // CloseServiceApproval closes a service approval
 func CloseServiceApproval(params service_approval.CloseServiceApprovalParams) middleware.Responder {
+	common.LockProject(params.ProjectName)
+	defer common.UnlockProject(params.ProjectName)
 	mv := common.GetProjectsMaterializedView()
 
 	err := mv.CloseOpenApproval(params.ProjectName, params.StageName, params.ServiceName, params.ApprovalID)

--- a/installer/manifests/keptn/continuous-operations.yaml
+++ b/installer/manifests/keptn/continuous-operations.yaml
@@ -123,6 +123,8 @@ spec:
             value: 'http://mongodb-datastore.keptn-datastore.svc.cluster.local:8080'
           - name: ENVIRONMENT
             value: 'production'
+          - name: WAIT_TIME_MINUTES
+            value: '10m'
       serviceAccountName: keptn-default
 ---
 apiVersion: v1

--- a/remediation-service/deploy/service.yaml
+++ b/remediation-service/deploy/service.yaml
@@ -37,6 +37,8 @@ spec:
             value: 'http://mongodb-datastore.keptn-datastore.svc.cluster.local:8080'
           - name: ENVIRONMENT
             value: 'production'
+          - name: WAIT_TIME_MINUTES
+            value: '10m'
 ---
 apiVersion: v1
 kind: Service

--- a/remediation-service/handler/action_finished_handler.go
+++ b/remediation-service/handler/action_finished_handler.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	cloudevents "github.com/cloudevents/sdk-go"
 	keptn "github.com/keptn/go-utils/pkg/lib"
+	"os"
 	"time"
 )
 
@@ -29,11 +30,16 @@ func (eh *ActionFinishedEventHandler) HandleEvent() error {
 		return err
 	}
 	eh.KeptnHandler.Logger.Info(fmt.Sprintf("Received action.finished event for remediationStatus action. result = %v", actionFinishedEvent.Action.Result))
-	eh.KeptnHandler.Logger.Info(fmt.Sprintf("Waiting for %d minutes for action to take effect", waitTimeInMinutes))
 
 	if eh.WaitFunction == nil {
 		eh.WaitFunction = func() {
-			<-time.After(waitTimeInMinutes * time.Minute)
+
+			waitTime, err := time.ParseDuration(os.Getenv("WAIT_TIME_MINUTES"))
+			if err != nil {
+				waitTime = waitTimeInMinutes * time.Minute
+			}
+			eh.KeptnHandler.Logger.Info(fmt.Sprintf("Waiting for %s for action to take effect", waitTime.String()))
+			<-time.After(waitTime)
 		}
 	}
 	eh.WaitFunction()

--- a/remediation-service/handler/evaluation_done_handler.go
+++ b/remediation-service/handler/evaluation_done_handler.go
@@ -119,6 +119,7 @@ func (eh *EvaluationDoneEventHandler) getLastRemediationStatusChangedEvent(remed
 
 	events, errorObj := eventHandler.GetEvents(&keptnapi.EventFilter{
 		EventID: lastRemediationStatusChanged.EventID,
+		Project: eh.KeptnHandler.KeptnBase.Project,
 	})
 
 	if errorObj != nil {
@@ -165,6 +166,7 @@ func (eh *EvaluationDoneEventHandler) getRemediationTriggeredEvent(remediations 
 
 	events, errorObj := eventHandler.GetEvents(&keptnapi.EventFilter{
 		EventID: remediationTriggered.EventID,
+		Project: eh.KeptnHandler.KeptnBase.Project,
 	})
 
 	if errorObj != nil || len(events) == 0 {

--- a/remediation-service/handler/evaluation_done_handler.go
+++ b/remediation-service/handler/evaluation_done_handler.go
@@ -35,13 +35,7 @@ func (eh *EvaluationDoneEventHandler) HandleEvent() error {
 	if evaluationDoneEventData.Result == "pass" || evaluationDoneEventData.Result == "warning" {
 		msg := "Remediation successful. Remediation actions resulted in evaluation result: " + evaluationDoneEventData.Result
 		eh.KeptnHandler.Logger.Info(msg)
-		eh.Remediation.sendRemediationFinishedEvent(keptn.RemediationStatusSucceeded, keptn.RemediationResultPass, msg)
-		err := deleteRemediation(eh.KeptnHandler.KeptnContext, *eh.KeptnHandler.KeptnBase)
-		if err != nil {
-			eh.KeptnHandler.Logger.Error("Could not close remediation: " + err.Error())
-			return err
-		}
-		return nil
+		return eh.Remediation.sendRemediationFinishedEvent(keptn.RemediationStatusSucceeded, keptn.RemediationResultPass, msg)
 	}
 
 	// get remediation.yaml
@@ -99,12 +93,7 @@ func (eh *EvaluationDoneEventHandler) HandleEvent() error {
 	} else {
 		msg := "No further remediation action configured for problem type " + remediationTriggeredEvent.Problem.ProblemTitle
 		eh.KeptnHandler.Logger.Info(msg)
-		_ = eh.Remediation.sendRemediationFinishedEvent(keptn.RemediationStatusSucceeded, keptn.RemediationResultFailed, msg)
-		err = deleteRemediation(eh.KeptnHandler.KeptnContext, *eh.KeptnHandler.KeptnBase)
-		if err != nil {
-			eh.KeptnHandler.Logger.Error("Could not close remediation: " + err.Error())
-			return err
-		}
+		return eh.Remediation.sendRemediationFinishedEvent(keptn.RemediationStatusSucceeded, keptn.RemediationResultFailed, msg)
 	}
 	return nil
 }

--- a/remediation-service/handler/evaluation_done_handler.go
+++ b/remediation-service/handler/evaluation_done_handler.go
@@ -121,11 +121,17 @@ func (eh *EvaluationDoneEventHandler) getLastRemediationStatusChangedEvent(remed
 		EventID: lastRemediationStatusChanged.EventID,
 	})
 
-	if errorObj != nil || len(events) == 0 {
+	if errorObj != nil {
 		msg := "could not retrieve remediation action with ID " + lastRemediationStatusChanged.EventID
 		eh.KeptnHandler.Logger.Error(msg + ": " + *errorObj.Message)
 		eh.Remediation.sendRemediationFinishedEvent(keptn.RemediationStatusErrored, keptn.RemediationResultFailed, msg)
 		return nil, errors.New(*errorObj.Message)
+	}
+	if len(events) == 0 {
+		msg := "could not retrieve remediation action with ID" + lastRemediationStatusChanged.EventID + ": no event found."
+		eh.KeptnHandler.Logger.Error(msg)
+		eh.Remediation.sendRemediationFinishedEvent(keptn.RemediationStatusErrored, keptn.RemediationResultFailed, msg)
+		return nil, errors.New(msg)
 	}
 	remediationStatusChangedEvent := &keptn.RemediationStatusChangedEventData{}
 

--- a/remediation-service/handler/handler.go
+++ b/remediation-service/handler/handler.go
@@ -381,7 +381,13 @@ func (r *Remediation) sendRemediationFinishedEvent(status keptn.RemediationStatu
 		Data: remediationFinishedEventData,
 	}
 
-	err := r.Keptn.SendCloudEvent(event)
+	err := deleteRemediation(r.Keptn.KeptnContext, *r.Keptn.KeptnBase)
+	if err != nil {
+		r.Keptn.Logger.Error("Could not close remediation: " + err.Error())
+		return err
+	}
+
+	err = r.Keptn.SendCloudEvent(event)
 	if err != nil {
 		r.Keptn.Logger.Error("Could not send action.finished event: " + err.Error())
 		return err

--- a/remediation-service/handler/problem_event_handler.go
+++ b/remediation-service/handler/problem_event_handler.go
@@ -30,13 +30,7 @@ func (eh *ProblemEventHandler) HandleEvent() error {
 	if problemEvent.State == "CLOSED" {
 		msg := "Problem " + problemEvent.PID + " of type " + problemEvent.ProblemTitle + " has been closed."
 		eh.Logger.Info(msg)
-		_ = eh.Remediation.sendRemediationFinishedEvent(keptn.RemediationStatusSucceeded, keptn.RemediationResultFailed, msg)
-		err := deleteRemediation(eh.KeptnHandler.KeptnContext, *eh.KeptnHandler.KeptnBase)
-		if err != nil {
-			eh.Logger.Error("Could not close remediation: " + err.Error())
-			return err
-		}
-		return nil
+		return eh.Remediation.sendRemediationFinishedEvent(keptn.RemediationStatusSucceeded, keptn.RemediationResultFailed, msg)
 	}
 	return nil
 }

--- a/remediation-service/handler/problem_open_handler.go
+++ b/remediation-service/handler/problem_open_handler.go
@@ -86,11 +86,7 @@ func (eh *ProblemOpenEventHandler) HandleEvent() error {
 		msg := "No remediation configured for problem type " + problemType
 		eh.KeptnHandler.Logger.Info(msg)
 		_ = eh.Remediation.sendRemediationFinishedEvent(keptn.RemediationStatusSucceeded, keptn.RemediationResultPass, "triggered all actions")
-		err = deleteRemediation(eh.KeptnHandler.KeptnContext, *eh.KeptnHandler.KeptnBase)
-		if err != nil {
-			eh.KeptnHandler.Logger.Error("Could not close remediation: " + err.Error())
-			return err
-		}
+		return deleteRemediation(eh.KeptnHandler.KeptnContext, *eh.KeptnHandler.KeptnBase)
 	}
 
 	return nil

--- a/remediation-service/main.go
+++ b/remediation-service/main.go
@@ -59,10 +59,13 @@ func gotEvent(ctx context.Context, event cloudevents.Event) error {
 		return err
 	}
 	if handler != nil {
-		err := handler.HandleEvent()
-		if err != nil {
-			return err
-		}
+		go func() error {
+			err := handler.HandleEvent()
+			if err != nil {
+				return err
+			}
+			return nil
+		}()
 	}
 
 	return nil


### PR DESCRIPTION
Closes #1848 #1849
This PR fixes a couple of problems that were caused by race conditions in the configuration-service that caused remediation status updates sent by the remediation service to be lost.
Further, the cleanup of completed remediations by the remediation-service has been fixed.
Finally, the wait time for the remediation-service has been made configurable via an environment variable