### PR TITLE
#1585 include comprehensive error message in lighthouse result

### DIFF
--- a/lighthouse-service/event_handler/evaluate_sli_handler.go
+++ b/lighthouse-service/event_handler/evaluate_sli_handler.go
@@ -113,7 +113,7 @@ func (eh *EvaluateSLIHandler) HandleEvent() error {
 		if testsFinishedEvent.Result == "fail" {
 			eh.KeptnHandler.Logger.Debug("Setting evaluation result to 'fail' because of failed preceding test execution")
 			evaluationResult.Result = "fail"
-			evaluationResult.EvaluationDetails.Result = "fail"
+			evaluationResult.EvaluationDetails.Result = "Setting evaluation result to 'fail' because of failed preceding test execution"
 		}
 	}
 


### PR DESCRIPTION
Closes #1585
With this PR, a message to indicate that the preceding test execution has failed is included in the `evaluationResults.result` property.