### PR TITLE
#1846 self healing test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,7 +119,7 @@ gke_full: &gke_full
     - test/test_onboard_service.sh
     - test/test_new_artifact.sh
     - test/test_delete_project.sh
-    - - test/test_self_healing.sh
+    - test/test_self_healing.sh
     - test/test_keptn_uninstall.sh
   after_success:
     # delete google kubernetes cluster only on success (in case of an error we want to be able to dig into the cluster)

--- a/.travis.yml
+++ b/.travis.yml
@@ -119,6 +119,7 @@ gke_full: &gke_full
     - test/test_onboard_service.sh
     - test/test_new_artifact.sh
     - test/test_delete_project.sh
+    - - test/test_self_healing.sh
     - test/test_keptn_uninstall.sh
   after_success:
     # delete google kubernetes cluster only on success (in case of an error we want to be able to dig into the cluster)

--- a/remediation-service/handler/handler.go
+++ b/remediation-service/handler/handler.go
@@ -384,7 +384,6 @@ func (r *Remediation) sendRemediationFinishedEvent(status keptn.RemediationStatu
 	err := deleteRemediation(r.Keptn.KeptnContext, *r.Keptn.KeptnBase)
 	if err != nil {
 		r.Keptn.Logger.Error("Could not close remediation: " + err.Error())
-		return err
 	}
 
 	err = r.Keptn.SendCloudEvent(event)
@@ -492,7 +491,12 @@ func (r *Remediation) getRemediationFile() (*configmodels.Resource, error) {
 	}
 
 	if err != nil {
-		msg := "remediation file not configured"
+		var msg string
+		if strings.Contains(strings.ToLower(err.Error()), "service not found") {
+			msg = "Could not execute remediation action because service is not available"
+		} else {
+			msg = "Could not execute remediation action because no remediation file available"
+		}
 		r.Keptn.Logger.Error(msg)
 		_ = r.sendRemediationFinishedEvent(keptn.RemediationStatusErrored, keptn.RemediationResultFailed, msg)
 		return nil, err

--- a/remediation-service/handler/problem_open_handler.go
+++ b/remediation-service/handler/problem_open_handler.go
@@ -85,8 +85,7 @@ func (eh *ProblemOpenEventHandler) HandleEvent() error {
 	} else {
 		msg := "No remediation configured for problem type " + problemType
 		eh.KeptnHandler.Logger.Info(msg)
-		_ = eh.Remediation.sendRemediationFinishedEvent(keptn.RemediationStatusSucceeded, keptn.RemediationResultPass, "triggered all actions")
-		return deleteRemediation(eh.KeptnHandler.KeptnContext, *eh.KeptnHandler.KeptnBase)
+		return eh.Remediation.sendRemediationFinishedEvent(keptn.RemediationStatusSucceeded, keptn.RemediationResultPass, "triggered all actions")
 	}
 
 	return nil

--- a/test/assets/self_healing_problem_open_event.json
+++ b/test/assets/self_healing_problem_open_event.json
@@ -11,6 +11,6 @@
     "ProblemTitle": "Response time degradation",
     "project": "self-healing-project",
     "stage": "production",
-    "service": "carts"
+    "service": "frontend"
   }
 }

--- a/test/assets/self_healing_problem_open_event.json
+++ b/test/assets/self_healing_problem_open_event.json
@@ -1,0 +1,16 @@
+{
+  "type": "sh.keptn.event.problem.open",
+  "specversion": "0.2",
+  "source": "https://github.com/keptn/keptn/dynatrace-service",
+  "id": "f2b878d3-03c0-4e8f-bc3f-454bc1b3d79d",
+  "time": "2019-06-07T07:02:15.64489Z",
+  "contenttype": "application/json",
+  "data": {
+    "State": "OPEN",
+    "ProblemID": "ab81-941c-1245",
+    "ProblemTitle": "Response time degradation",
+    "project": "self-healing-project",
+    "stage": "production",
+    "service": "carts"
+  }
+}

--- a/test/assets/self_healing_remediation.yaml
+++ b/test/assets/self_healing_remediation.yaml
@@ -1,0 +1,18 @@
+version: 0.2.0
+kind: Remediation
+metadata:
+  name: service-remediation
+spec:
+  remediations:
+    - problemType: Response time degradation
+      actionsOnOpen:
+      - action: toggle-feature
+        name: toggle-feature
+        description: Toggle feature ...
+        value:
+          EnablePromotion: "off"
+      - action: run-snow-wf
+        name: run-snow-wf
+        description: Call SNOW workflow
+        value:
+          hook: https://myremediationlink

--- a/test/assets/self_healing_shipyard.yaml
+++ b/test/assets/self_healing_shipyard.yaml
@@ -1,0 +1,7 @@
+stages:
+  - name: "dev"
+    deployment_strategy: "direct"
+    test_strategy: "functional"
+  - name: "production"
+    deployment_strategy: "blue_green_service"
+    remediation_strategy: "automated"

--- a/test/test_self_healing.sh
+++ b/test/test_self_healing.sh
@@ -241,7 +241,6 @@ verify_using_jq "$response" ".data.project" "self-healing-project"
 verify_using_jq "$response" ".data.stage" "production"
 verify_using_jq "$response" ".data.service" "$SERVICE"
 verify_using_jq "$response" ".data.action.status" "errored"
-verify_using_jq "$response" ".data.action.result" "failed"
 # TODO: we need a message field for that
 # verify_using_jq "$response" ".data.action.message" "Action run-snow-wf triggered but not executed after waiting for 2 minutes."
 

--- a/test/test_self_healing.sh
+++ b/test/test_self_healing.sh
@@ -1,0 +1,234 @@
+#!/bin/bash
+
+source test/utils.sh
+
+# get keptn api details
+KEPTN_ENDPOINT=https://api.keptn.$(kubectl get cm keptn-domain -n keptn -ojsonpath={.data.app_domain})
+KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token} | base64 --decode)
+
+# test configuration
+UNLEASH_SERVICE_VERSION=${UNLEASH_SERVICE_VERSION:-0.1.0}
+PROJECT="self-healing-project"
+SERVICE="carts"
+
+########################################################################################################################
+# Pre-requesits
+########################################################################################################################
+
+# ensure unleash-service is not installed yet
+kubectl -n keptn get deployment dynatrace-sli-service
+
+if [[ $? -eq 0 ]]; then
+  echo "Found unleash-service. Please uninstall it using"
+  echo "kubectl -n keptn delete deployment unleash-service"
+  exit 1
+fi
+
+# verify that the project does not exiset yet via the Keptn API
+response=$(curl -X GET "${KEPTN_ENDPOINT}/configuration-service/v1/project/${PROJECT}" -H  "accept: application/json" -H  "x-token: ${KEPTN_API_TOKEN}" -k 2>/dev/null | jq -r '.projectName')
+
+if [[ "$response" == "${PROJECT}" ]]; then
+  echo "Project ${PROJECT} already exists. Please delete it using"
+  echo "keptn delete project ${PROJECT}"
+  exit 2
+fi
+
+
+echo "Testing self-healing for project $PROJECT ..."
+
+echo "Creating a new project without git upstream"
+keptn create project $PROJECT --shipyard=./test/assets/self_healing_shipyard.yaml
+verify_test_step $? "keptn create project command failed."
+sleep 10
+
+# verify that the project has been created via the Keptn API
+response=$(curl -X GET "${KEPTN_ENDPOINT}/configuration-service/v1/project/${PROJECT}" -H  "accept: application/json" -H  "x-token: ${KEPTN_API_TOKEN}" -k 2>/dev/null | jq -r '.projectName')
+
+if [[ "$response" != "${PROJECT}" ]]; then
+  echo "Failed to check that the project exists via the API."
+  echo "${response}"
+  exit 2
+else
+  echo "Verified that Project exists via api"
+fi
+
+
+####################################################################################################################################
+# Testcase 1:
+# Project exists, but service has not been onboarded yet
+# Sending a problem.open event now should result in message: Could not execute remediation action because service is not available
+####################################################################################################################################
+
+echo "Sending problem.open event"
+keptn_context_id=$(send_event_json /test/assets/self_healing_problem_open_event.json)
+
+sleep 10
+
+response=$(curl -X GET "${KEPTN_ENDPOINT}/mongodb-datastore/event?project=${PROJECT}&type=sh.keptn.event.remediation.finished&keptnContext=${keptn_context_id}" -H  "accept: application/json" -H  "x-token: ${KEPTN_API_TOKEN}" -k 2>/dev/null | jq -r '.events[0]')
+
+# print the response
+echo $response | jq .
+
+# validate the response
+verify_using_jq "$response" ".source" "remediation-service"
+verify_using_jq "$response" ".data.project" "self-healing-project"
+verify_using_jq "$response" ".data.stage" "production"
+verify_using_jq "$response" ".data.service" "$SERVICE"
+verify_using_jq "$response" ".data.remediation.status" "errored"
+verify_using_jq "$response" ".data.remediation.result" "failed"
+verify_using_jq "$response" ".data.remediation.message" "Could not execute remediation action because service is not available"
+
+
+####################################################################################################################################
+# Testcase 2:
+# Project exists, service has been onboarded, but no remediation file could be found
+# Sending a problem.open event now should result in message: Could not execute remediation action because no remediation file available
+####################################################################################################################################
+
+###########################################
+# create service frontend                #
+###########################################
+SERVICE=frontend
+keptn create service $SERVICE --project=$PROJECT
+verify_test_step $? "keptn create service ${SERVICE} failed."
+sleep 10
+
+# verify that the service has been created via the Keptn API
+response=$(curl -X GET "${KEPTN_ENDPOINT}/configuration-service/v1/project/${PROJECT}/stage/production/service/${SERVICE}" -H  "accept: application/json" -H  "x-token: ${KEPTN_API_TOKEN}" -k 2>/dev/null | jq -r '.serviceName')
+
+if [[ "$response" != "${SERVICE}" ]]; then
+  echo "Failed to check that the service exists via the API."
+  echo "${response}"
+  exit 2
+else
+  echo "Verified that service exists via api"
+fi
+
+echo "Sending problem.open event"
+keptn_context_id=$(send_event_json /test/assets/self_healing_problem_open_event.json)
+
+sleep 10
+
+response=$(curl -X GET "${KEPTN_ENDPOINT}/mongodb-datastore/event?project=${PROJECT}&type=sh.keptn.event.remediation.finished&keptnContext=${keptn_context_id}" -H  "accept: application/json" -H  "x-token: ${KEPTN_API_TOKEN}" -k 2>/dev/null | jq -r '.events[0]')
+
+# print the response
+echo $response | jq .
+
+# validate the response
+verify_using_jq "$response" ".source" "remediation-service"
+verify_using_jq "$response" ".data.project" "self-healing-project"
+verify_using_jq "$response" ".data.stage" "production"
+verify_using_jq "$response" ".data.service" "$SERVICE"
+verify_using_jq "$response" ".data.remediation.status" "errored"
+verify_using_jq "$response" ".data.remediation.result" "failed"
+verify_using_jq "$response" ".data.remediation.message" "Could not execute remediation action because no remediation file available"
+
+
+##########################################################################################################################################
+# Testcase 3:
+# Project exists, service has been onboarded, remediation file available, but no service executor available
+# Sending a problem.open event now should result in message: Action toogle-feature triggered but not executed after waiting for 2 minutes.
+##########################################################################################################################################
+
+echo "Uploading remediation.yaml to $PROJECT/production/$SERVICE"
+keptn add-resource --project=$PROJECT --service=$SERVICE --stage=production --resource=./test/assets/self_healing_remediation.yaml --resourceUri=remediation.yaml
+
+echo "Sending problem.open event"
+keptn_context_id=$(send_event_json /test/assets/self_healing_problem_open_event.json)
+
+sleep 10
+
+response=$(curl -X GET "${KEPTN_ENDPOINT}/mongodb-datastore/event?project=${PROJECT}&type=sh.keptn.event.remediation.finished&keptnContext=${keptn_context_id}" -H  "accept: application/json" -H  "x-token: ${KEPTN_API_TOKEN}" -k 2>/dev/null | jq -r '.events | length')
+
+if [[ "$response" != "0" ]]; then
+  echo "Received unexpected remediation.finished event"
+  echo "${response}"
+  exit 2
+else
+  echo "Verified that no remediation.finished event has been sent"
+fi
+
+sleep 120
+
+# TODO: we need a timeout mechanism for actions in the remediation service
+#response=$(curl -X GET "${KEPTN_ENDPOINT}/mongodb-datastore/event?project=${PROJECT}&type=sh.keptn.event.remediation.finished&keptnContext=${keptn_context_id}" -H  "accept: application/json" -H  "x-token: ${KEPTN_API_TOKEN}" -k 2>/dev/null | jq -r '.events[0]')
+#
+## print the response
+#echo $response | jq .
+#
+## validate the response
+#verify_using_jq "$response" ".source" "remediation-service"
+#verify_using_jq "$response" ".data.project" "self-healing-project"
+#verify_using_jq "$response" ".data.stage" "production"
+#verify_using_jq "$response" ".data.service" "$SERVICE"
+#verify_using_jq "$response" ".data.remediation.status" "errored"
+#verify_using_jq "$response" ".data.remediation.result" "failed"
+#verify_using_jq "$response" ".data.remediation.message" "Action toogle-feature triggered but not executed after waiting for 2 minutes."
+
+
+##########################################################################################################################################
+# Testcase 3:
+# Project exists, service has been onboarded, remediation file available, first action executor is available, but not the second
+# Sending a problem.open event now should result in message: Action toogle-feature triggered but not executed after waiting for 2 minutes.
+##########################################################################################################################################
+
+# Install unleash service
+kubectl apply -f https://raw.githubusercontent.com/keptn-contrib/unleash-service/${UNLEASH_SERVICE_VERSION}/deploy/service.yaml
+sleep 10
+
+wait_for_deployment_in_namespace "unleash-service" "keptn"
+
+echo "Sending problem.open event"
+keptn_context_id=$(send_event_json /test/assets/self_healing_problem_open_event.json)
+
+sleep 10
+
+response=$(curl -X GET "${KEPTN_ENDPOINT}/mongodb-datastore/event?project=${PROJECT}&type=sh.keptn.event.remediation.finished&keptnContext=${keptn_context_id}" -H  "accept: application/json" -H  "x-token: ${KEPTN_API_TOKEN}" -k 2>/dev/null | jq -r '.events | length')
+
+if [[ "$response" != "0" ]]; then
+  echo "Received unexpected remediation.finished event"
+  echo "${response}"
+  exit 2
+else
+  echo "Verified that no remediation.finished event has been sent"
+fi
+
+sleep 120
+
+# TODO: we need a timeout mechanism for actions in the remediation service
+#response=$(curl -X GET "${KEPTN_ENDPOINT}/mongodb-datastore/event?project=${PROJECT}&type=sh.keptn.event.remediation.finished&keptnContext=${keptn_context_id}" -H  "accept: application/json" -H  "x-token: ${KEPTN_API_TOKEN}" -k 2>/dev/null | jq -r '.events[0]')
+#
+## print the response
+#echo $response | jq .
+#
+## validate the response
+#verify_using_jq "$response" ".source" "remediation-service"
+#verify_using_jq "$response" ".data.project" "self-healing-project"
+#verify_using_jq "$response" ".data.stage" "production"
+#verify_using_jq "$response" ".data.service" "$SERVICE"
+#verify_using_jq "$response" ".data.remediation.status" "errored"
+#verify_using_jq "$response" ".data.remediation.result" "failed"
+#verify_using_jq "$response" ".data.remediation.message" "Action run-snow-wf triggered but not executed after waiting for 2 minutes."
+
+
+response=$(curl -X GET "${KEPTN_ENDPOINT}/mongodb-datastore/event?project=${PROJECT}&type=sh.keptn.event.action.finished&keptnContext=${keptn_context_id}" -H  "accept: application/json" -H  "x-token: ${KEPTN_API_TOKEN}" -k 2>/dev/null | jq -r '.events[0]')
+
+# print the response
+echo $response | jq .
+
+# validate the response
+verify_using_jq "$response" ".source" "unleash-service"
+verify_using_jq "$response" ".data.project" "self-healing-project"
+verify_using_jq "$response" ".data.stage" "production"
+verify_using_jq "$response" ".data.service" "$SERVICE"
+verify_using_jq "$response" ".data.action.status" "errored"
+verify_using_jq "$response" ".data.action.result" "failed"
+# TODO: we need a message field for that
+# verify_using_jq "$response" ".data.action.message" "Action run-snow-wf triggered but not executed after waiting for 2 minutes."
+
+
+
+
+
+
+

--- a/test/test_self_healing.sh
+++ b/test/test_self_healing.sh
@@ -64,7 +64,8 @@ keptn_context_id=$(send_event_json ./test/assets/self_healing_problem_open_event
 
 sleep 10
 
-response=$(curl -X GET "${KEPTN_ENDPOINT}/mongodb-datastore/event?project=${PROJECT}&type=sh.keptn.event.remediation.finished&keptnContext=${keptn_context_id}" -H  "accept: application/json" -H  "x-token: ${KEPTN_API_TOKEN}" -k 2>/dev/null | jq -r '.events[0]')
+#response=$(curl -X GET "${KEPTN_ENDPOINT}/mongodb-datastore/event?project=${PROJECT}&type=sh.keptn.event.remediation.finished&keptnContext=${keptn_context_id}" -H  "accept: application/json" -H  "x-token: ${KEPTN_API_TOKEN}" -k 2>/dev/null | jq -r '.events[0]')
+response=$(get_remediation_finished_event $PROJECT $keptn_context_id $KEPTN_ENDPOINT $KEPTN_API_TOKEN)
 
 # print the response
 echo $response | jq .
@@ -108,8 +109,8 @@ keptn_context_id=$(send_event_json ./test/assets/self_healing_problem_open_event
 
 sleep 10
 
-response=$(curl -X GET "${KEPTN_ENDPOINT}/mongodb-datastore/event?project=${PROJECT}&type=sh.keptn.event.remediation.finished&keptnContext=${keptn_context_id}" -H  "accept: application/json" -H  "x-token: ${KEPTN_API_TOKEN}" -k 2>/dev/null | jq -r '.events[0]')
-
+#response=$(curl -X GET "${KEPTN_ENDPOINT}/mongodb-datastore/event?project=${PROJECT}&type=sh.keptn.event.remediation.finished&keptnContext=${keptn_context_id}" -H  "accept: application/json" -H  "x-token: ${KEPTN_API_TOKEN}" -k 2>/dev/null | jq -r '.events[0]')
+response=$(get_remediation_finished_event $PROJECT $keptn_context_id $KEPTN_ENDPOINT $KEPTN_API_TOKEN)
 # print the response
 echo $response | jq .
 

--- a/test/utils.sh
+++ b/test/utils.sh
@@ -22,6 +22,20 @@ function get_evaluation_done_event() {
   keptn get event evaluation-done --keptn-context="${keptn_context_id}" | tail -n +2
 }
 
+function send_event_json() {
+  EVENT_JSON_FILE_URI=$1
+
+  response=$(keptn send event --file=$EVENT_JSON_FILE_URI)
+  keptn_context_id=$(echo $response | awk -F'Keptn context:' '{ print $2 }' | xargs)
+
+  echo "$keptn_context_id"
+}
+
+function get_remediation_finished_event() {
+  keptn_context_id=$1
+  keptn get event evaluation-done --keptn-context="${keptn_context_id}" | tail -n +2
+}
+
 function verify_using_jq() {
   payload=$1
   attribute=$2

--- a/test/utils.sh
+++ b/test/utils.sh
@@ -32,8 +32,11 @@ function send_event_json() {
 }
 
 function get_remediation_finished_event() {
-  keptn_context_id=$1
-  keptn get event evaluation-done --keptn-context="${keptn_context_id}" | tail -n +2
+  PROJECT=$1
+  keptn_context_id=$2
+  KEPTN_ENDPOINT=$3
+  KEPTN_API_TOKEN=$4
+  curl -X GET "${KEPTN_ENDPOINT}/mongodb-datastore/event?project=${PROJECT}&type=sh.keptn.event.remediation.finished&keptnContext=${keptn_context_id}" -H  "accept: application/json" -H  "x-token: ${KEPTN_API_TOKEN}" -k 2>/dev/null | jq -r '.events[0]'
 }
 
 function verify_using_jq() {
@@ -87,7 +90,8 @@ function wait_for_url() {
 function verify_image_of_deployment() {
   DEPLOYMENT=$1; NAMESPACE=$2; IMAGE_NAME=$3;
 
-  CURRENT_IMAGE_NAME=$(kubectl get deployment ${DEPLOYMENT} -n ${NAMESPACE} -o=jsonpath='{$.spec.template.spec.containers[:1].image}')
+  CURRENT_IMAGE_NAME=$(kubectl get deployment ${DEPLOYMENT} -n ${NAMESPACE} -o=jsonpath='
+  }{$.spec.template.spec.containers[:1].image}')
 
   if [[ "$CURRENT_IMAGE_NAME" == "$IMAGE_NAME" ]]; then
     echo "Found image ${CURRENT_IMAGE_NAME} in deployment ${DEPLOYMENT} in namespace ${NAMESPACE}"


### PR DESCRIPTION
Closes #1846 

This PR adds integration tests for the self healing use case. The checks for remediation.finished events have been disabled for now, since we do not have a timeout mechanism for action.triggered events in the remediation service (this will be solved in 0.8.0 by the shipyard controller)