### PR TITLE
#1907 root event query tuning

### DIFF
--- a/mongodb-datastore/handlers/events.go
+++ b/mongodb-datastore/handlers/events.go
@@ -346,6 +346,9 @@ func GetEvents(params event.GetEventsParams) (*event.GetEventsOKBody, error) {
 		} else {
 		}
 	*/
+	if params.Root != nil {
+		collectionName = collectionName + rootEventCollectionSuffix
+	}
 	sortOptions = options.Find().SetSort(bson.D{{"time", -1}}).SetSkip(nextPageKey).SetLimit(pageSize)
 
 	collection := client.Database(mongoDBName).Collection(collectionName)

--- a/mongodb-datastore/handlers/events.go
+++ b/mongodb-datastore/handlers/events.go
@@ -30,7 +30,7 @@ var mutex sync.Mutex
 
 var projectLocks = map[string]*sync.Mutex{}
 
-// LockProject
+// LockProject locks the collections for a project
 func LockProject(project string) {
 	if projectLocks[project] == nil {
 		mutex.Lock()
@@ -40,6 +40,7 @@ func LockProject(project string) {
 	projectLocks[project].Lock()
 }
 
+// UnLockProject unlocks the collections for a project
 func UnlockProject(project string) {
 	if projectLocks[project] == nil {
 		mutex.Lock()

--- a/mongodb-datastore/handlers/events.go
+++ b/mongodb-datastore/handlers/events.go
@@ -194,6 +194,7 @@ func dropProjectEvents(logger *keptnutils.Logger, event *models.KeptnContextExte
 
 	collectionName := getProjectOfEvent(event)
 	collection := client.Database(mongoDBName).Collection(collectionName)
+	rootEventsCollection := client.Database(mongoDBName).Collection(collectionName + rootEventCollectionSuffix)
 
 	logger.Debug(fmt.Sprintf("Delete all events of project %s", collectionName))
 	err := collection.Drop(ctx)
@@ -202,6 +203,15 @@ func dropProjectEvents(logger *keptnutils.Logger, event *models.KeptnContextExte
 		logger.Error(err.Error())
 		return err
 	}
+
+	logger.Debug(fmt.Sprintf("Delete all root events of project %s", collectionName))
+	err = rootEventsCollection.Drop(ctx)
+	if err != nil {
+		err := fmt.Errorf("failed to drop collection %s: %v", collectionName+rootEventCollectionSuffix, err)
+		logger.Error(err.Error())
+		return err
+	}
+
 	logger.Debug(fmt.Sprintf("Delete context-to-project mappings of project %s", collectionName))
 	contextToProjectCollection := client.Database(mongoDBName).Collection(contextToProjectCollection)
 	if _, err := contextToProjectCollection.DeleteMany(ctx, bson.M{"project": collectionName}); err != nil {

--- a/mongodb-datastore/handlers/events.go
+++ b/mongodb-datastore/handlers/events.go
@@ -32,7 +32,7 @@ type ProjectEventData struct {
 	Project *string `json:"project,omitempty"`
 }
 
-type EventWithMongoDBID struct {
+type eventWithMongoDBID struct {
 	models.KeptnContextExtendedCE
 	MongoDBID string `json:"_id"`
 }
@@ -133,7 +133,7 @@ func storeRootEvent(logger *keptnutils.Logger, collectionName string, ctx contex
 		return nil
 	}
 
-	eventWithMongoDBID := &EventWithMongoDBID{
+	eventWithMongoDBID := &eventWithMongoDBID{
 		KeptnContextExtendedCE: *event,
 		MongoDBID:              event.Shkeptncontext,
 	}

--- a/mongodb-datastore/handlers/events.go
+++ b/mongodb-datastore/handlers/events.go
@@ -292,12 +292,14 @@ func GetEvents(params event.GetEventsParams) (*event.GetEventsOKBody, error) {
 	pageSize := *params.PageSize
 
 	var sortOptions *options.FindOptions
-	if params.Root != nil {
-		collectionName = collectionName + rootEventCollectionSuffix
-		sortOptions = options.Find().SetSort(bson.D{{"time", 1}}).SetSkip(nextPageKey).SetLimit(pageSize)
-	} else {
-		sortOptions = options.Find().SetSort(bson.D{{"time", -1}}).SetSkip(nextPageKey).SetLimit(pageSize)
-	}
+	/*
+		if params.Root != nil {
+			collectionName = collectionName + rootEventCollectionSuffix
+			sortOptions = options.Find().SetSort(bson.D{{"time", 1}}).SetSkip(nextPageKey).SetLimit(pageSize)
+		} else {
+		}
+	*/
+	sortOptions = options.Find().SetSort(bson.D{{"time", -1}}).SetSkip(nextPageKey).SetLimit(pageSize)
 
 	collection := client.Database(mongoDBName).Collection(collectionName)
 

--- a/upgrader/upgrade-062-070/mongodb-upgrade/main.go
+++ b/upgrader/upgrade-062-070/mongodb-upgrade/main.go
@@ -21,6 +21,8 @@ import (
 const defaultMongoDBConnectionString = "mongodb://user:password@mongodb.keptn-datastore.svc.cluster.local:27017/keptn"
 const defaultConfigurationServiceURL = "configuration-service.keptn.svc.cluster.local:8080"
 
+const rootEventCollectionSuffix = "-rootEvents"
+
 const materializedViewCollection = "keptnProjectsMV"
 
 var client *mongo.Client
@@ -154,6 +156,11 @@ func main() {
 			}
 		}
 		fmt.Printf("Inserted mapping %s -> %s\n", keptnContext, project)
+
+		err = storeRootEvent(project, ctx, doc)
+		if err != nil {
+			fmt.Println("Could not store root event: " + err.Error())
+		}
 	}
 
 	fmt.Println(fmt.Printf("Projects Materialized View:\n%v", projectsMV))
@@ -182,6 +189,50 @@ func main() {
 			}
 		}
 	}
+}
+
+func transformEventToInterface(event interface{}) (interface{}, error) {
+	data, err := json.Marshal(event)
+	if err != nil {
+		err := fmt.Errorf("failed to marshal event: %v", err)
+		return nil, err
+	}
+
+	var eventInterface interface{}
+	err = json.Unmarshal(data, &eventInterface)
+	if err != nil {
+		err := fmt.Errorf("failed to unmarshal event: %v", err)
+		return nil, err
+	}
+	return eventInterface, nil
+}
+
+func storeRootEvent(collectionName string, ctx context.Context, event bson.M) error {
+
+	keptnContext := event["shkeptncontext"].(string)
+	event["_id"] = keptnContext
+
+	rootEventsForProjectCollection := client.Database("keptn").Collection(collectionName + rootEventCollectionSuffix)
+
+	result := rootEventsForProjectCollection.FindOne(ctx, bson.M{"shkeptncontext": keptnContext})
+
+	if result.Err() != nil && result.Err() == mongo.ErrNoDocuments {
+		eventInterface, err := transformEventToInterface(event)
+		if err != nil {
+			fmt.Println("Could not transform root event to interface: " + err.Error())
+			return err
+		}
+
+		_, err = rootEventsForProjectCollection.InsertOne(ctx, eventInterface)
+		if err != nil {
+			err := fmt.Errorf("Failed to store root event for KeptnContext "+keptnContext+": %v", err.Error())
+			fmt.Println(err.Error())
+			return err
+		}
+		fmt.Println("Stored root event for KeptnContext: " + keptnContext)
+	}
+	fmt.Println("Root event for KeptnContext " + keptnContext + " already exists in collection")
+	return nil
 }
 
 func transformProjectToInterface(prj *keptnapimodels.Project) (interface{}, error) {


### PR DESCRIPTION
Closes #1907

This PR implements a more efficient way of retrieving root events for a project/service. Previously, this has been done using an expensive distinct query (to retrieve all available keptnContexts) in the events collection of a project with a subsequent query for each of the returned result.

With the new approach introduced in this PR, I have added a dedicated collection for the root events for each project (one collection per project). This makes retrieving all root events for a project easy, since we can use the same filtering logic as for other queries without using distinct queries.