### PR TITLE
added permission to read keptn-domain configmap for helm-service

### DIFF
--- a/installer/manifests/keptn/continuous-deployment.yaml
+++ b/installer/manifests/keptn/continuous-deployment.yaml
@@ -28,22 +28,6 @@ subjects:
     name: keptn-helm-service
     namespace: keptn
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: keptn-helm-service
-  namespace: keptn
-  labels:
-    "app": "keptn"
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: keptn-read-keptndomain
-subjects:
-  - kind: ServiceAccount
-    name: keptn-helm-service
-    namespace: keptn
----
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:

--- a/installer/manifests/keptn/rbac.yaml
+++ b/installer/manifests/keptn/rbac.yaml
@@ -231,3 +231,19 @@ subjects:
   - kind: ServiceAccount
     name: keptn-configuration-service
     namespace: keptn
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: keptn-helm-service
+  namespace: keptn
+  labels:
+    "app": "keptn"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: keptn-read-keptndomain
+subjects:
+  - kind: ServiceAccount
+    name: keptn-helm-service
+    namespace: keptn


### PR DESCRIPTION
When creating a service, the helm service needs to read the configMap. The required RoleBinding has been moved from installer/.../continuous-deployment.yaml to installer/.../rbac.yaml