### PR TITLE
#1942 updated dependency to kubernetes utils

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gorilla/websocket v1.4.1
 	github.com/hashicorp/go-version v1.2.0
 	github.com/keptn/go-utils v0.6.3-0.20200618144455-073e08a10aaa
-	github.com/keptn/kubernetes-utils v0.0.0-20200414115508-d18721552e01
+	github.com/keptn/kubernetes-utils v0.1.1-0.20200625070721-78fa6ab70b07
 	github.com/magiconair/properties v1.8.1
 	github.com/mattn/go-shellwords v1.0.10
 	github.com/mitchellh/go-homedir v1.1.0

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -347,6 +347,7 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/keptn/go-utils v0.6.1-0.20200330141040-86c024b3622b/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
+github.com/keptn/go-utils v0.6.1-compat.0.20200414111241-846f2becaf21/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/keptn/go-utils v0.6.3-0.20200615074910-2565441cb79d h1:VtFkwEEXBCKnp67X4Dy4y6ZVu+r2X9juDDexgtZl0Sc=
 github.com/keptn/go-utils v0.6.3-0.20200615074910-2565441cb79d/go.mod h1:hf2FU6JFuOzLP5rEAlA1/XnNS28pDZbVfxDESeQsq1g=
 github.com/keptn/go-utils v0.6.3-0.20200618092443-bcf792635866 h1:jZn62XGXqM6dJIYPsYI5xVTk5q4kBT7OJ3QD6gog93Q=
@@ -359,6 +360,8 @@ github.com/keptn/kubernetes-utils v0.0.0-20200401103501-ae44a5ee0656 h1:uGdzQ+DT
 github.com/keptn/kubernetes-utils v0.0.0-20200401103501-ae44a5ee0656/go.mod h1:7MQMS/jqKM4eVZ0S1S7LWdZNcBTJn5QeERircdADWzo=
 github.com/keptn/kubernetes-utils v0.0.0-20200414115508-d18721552e01 h1:E7VbURzJxMXDhh2p03j1Ij8DLprfnO5UOrKIJj3rhwM=
 github.com/keptn/kubernetes-utils v0.0.0-20200414115508-d18721552e01/go.mod h1:WBH8r9/3/9O/Z/L37saY9bxjfS0j1cFTudxwBysDq4c=
+github.com/keptn/kubernetes-utils v0.1.1-0.20200625070721-78fa6ab70b07 h1:a3GETG7/QG/PLYPOmiISgwCx4+pQc2KoE0MgOrKwNbI=
+github.com/keptn/kubernetes-utils v0.1.1-0.20200625070721-78fa6ab70b07/go.mod h1:YoWRuV28Guz5/mzjo9jVxtMsWAEn0MDXwxK/ScAQlZc=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=


### PR DESCRIPTION
Closes 1942
This PR updates the kubernetes-utils dependency to incorporate the latest changes regarding the retrieval of a local Kuebeconfig file. If the `KUBECONFIG` env var, this will be used to get the kube config file, otherwise it will be `~/.kube/config` per default