### PR TITLE
close declined approvals

### DIFF
--- a/gatekeeper-service/pkg/handler/approval_finished_event_handler.go
+++ b/gatekeeper-service/pkg/handler/approval_finished_event_handler.go
@@ -93,6 +93,10 @@ func (a *ApprovalFinishedEventHandler) handleApprovalFinishedEvent(inputEvent ke
 		} else {
 			a.keptn.Logger.Info(fmt.Sprintf("Rejection for image %s for service %s of project %s and current stage %s received",
 				inputEvent.Image, inputEvent.Service, inputEvent.Project, inputEvent.Stage))
+			if err := closeOpenApproval(inputEvent, triggeredID); err != nil {
+				a.keptn.Logger.Error(fmt.Sprintf("failed to close open approvals in materialized view: %v", err))
+				return outgoingEvents
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR ensures that the gatekeeper service closes an open approval when it has been declined (previously, only approved approvals have been closed)