### PR TITLE
#1856 #1928 Keptn Install log output

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -391,12 +391,14 @@ func doInstallation() error {
 
 	o := options{"apply", "-f", "-"}
 	o.appendIfNotEmpty(kubectlOptions)
+	logging.PrintLog("Executing: kubectl "+strings.Join(o, " "), logging.VerboseLevel)
 	cmd := exec.Command("kubectl", o...)
 	cmd.Stdin = strings.NewReader(prepareInstallerManifest())
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("Error while applying installer job: %s \n%s\nAborting installation", err.Error(), string(out))
 	}
+	logging.PrintLog("Result: "+string(out), logging.VerboseLevel)
 
 	logging.PrintLog("Waiting for installer pod to be started ...", logging.InfoLevel)
 	installerPodName, err := waitForInstallerPod()
@@ -412,10 +414,13 @@ func doInstallation() error {
 
 	o = options{"delete", "job", "installer", "-n", "keptn"}
 	o.appendIfNotEmpty(kubectlOptions)
-	_, err = keptnutils.ExecuteCommand("kubectl", o)
+	logging.PrintLog("Executing: kubectl "+strings.Join(o, " "), logging.VerboseLevel)
+	result, err := keptnutils.ExecuteCommand("kubectl", o)
 	if err != nil {
+		logging.PrintLog("Error deleting installer job : kubectl "+err.Error(), logging.QuietLevel)
 		return err
 	}
+	logging.PrintLog("Result: "+result, logging.VerboseLevel)
 
 	if _, eks := p.(*eksPlatform); eks {
 		var hostname string
@@ -423,18 +428,24 @@ func doInstallation() error {
 			o = options{"get", "svc", "istio-ingressgateway", "-n", "istio-system",
 				"-ojsonpath={.status.loadBalancer.ingress[0].hostname}"}
 			o.appendIfNotEmpty(kubectlOptions)
+			logging.PrintLog("Executing: kubectl"+strings.Join(o, " "), logging.VerboseLevel)
 			hostname, err = keptnutils.ExecuteCommand("kubectl", o)
 			if err != nil {
+				logging.PrintLog("Error retrieving istio-ingress: "+hostname+"\n"+err.Error(), logging.QuietLevel)
 				return err
 			}
+			logging.PrintLog("Result:"+hostname, logging.VerboseLevel)
 		} else if getIngress() == nginx {
 			o = options{"get", "svc", "ingress-nginx", "-n", "ingress-nginx",
 				"-ojsonpath={.status.loadBalancer.ingress[0].hostname}"}
 			o.appendIfNotEmpty(kubectlOptions)
+			logging.PrintLog("Executing: kubectl"+strings.Join(o, " "), logging.VerboseLevel)
 			hostname, err = keptnutils.ExecuteCommand("kubectl", o)
 			if err != nil {
+				logging.PrintLog("Error retrieving nginx-ingress: "+hostname+"\n"+err.Error(), logging.QuietLevel)
 				return err
 			}
+			logging.PrintLog("Result:"+hostname, logging.VerboseLevel)
 		}
 
 		fmt.Println()
@@ -452,23 +463,26 @@ func doInstallation() error {
 }
 
 func applyRbac(rbac map[string]bool) error {
+	logging.PrintLog("Applying RBAC rules for installer", logging.VerboseLevel)
 	var merged string
 	for k := range rbac {
 		merged += k
 	}
 	o := options{"apply", "-f", "-"}
 	o.appendIfNotEmpty(kubectlOptions)
-
+	logging.PrintLog("Executing: kubectl "+strings.Join(o, " "), logging.VerboseLevel)
 	cmd := exec.Command("kubectl", o...)
 	cmd.Stdin = strings.NewReader(merged)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("Error while applying RBAC: %s \n%s\nAborting installation", err.Error(), string(out))
 	}
+	logging.PrintLog("Result: "+string(out), logging.VerboseLevel)
 	return nil
 }
 
 func deleteRbac(rbac map[string]bool) error {
+	logging.PrintLog("Deleting RBAC rules for installer", logging.VerboseLevel)
 	var merged string
 	for k := range rbac {
 		merged += k
@@ -476,12 +490,14 @@ func deleteRbac(rbac map[string]bool) error {
 	o := options{"delete", "-f", "-"}
 	o.appendIfNotEmpty(kubectlOptions)
 
+	logging.PrintLog("Executing: kubectl "+strings.Join(o, " "), logging.VerboseLevel)
 	cmd := exec.Command("kubectl", o...)
 	cmd.Stdin = strings.NewReader(merged)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("Error while deleting RBAC: %s \n%s\nAborting installation", err.Error(), string(out))
 	}
+	logging.PrintLog("Result: "+string(out), logging.VerboseLevel)
 	return nil
 }
 
@@ -569,11 +585,13 @@ func waitForInstallerPod() (string, error) {
 			"keptn",
 			"-ojson"}
 		options.appendIfNotEmpty(kubectlOptions)
+		logging.PrintLog("Executing: kubectl "+strings.Join(options, " "), logging.VerboseLevel)
 		out, err := keptnutils.ExecuteCommand("kubectl", options)
 
 		if err != nil {
 			return "", fmt.Errorf("Error while retrieving installer pod: %s\n. Aborting installation", err)
 		}
+		logging.PrintLog("Result: "+out, logging.VerboseLevel)
 
 		var podInfo map[string]interface{}
 		err = json.Unmarshal([]byte(out), &podInfo)
@@ -612,6 +630,7 @@ func getInstallerLogs(podName string) error {
 		"-f"}
 	options.appendIfNotEmpty(kubectlOptions)
 
+	logging.PrintLog("Executing: kubectl"+strings.Join(options, " "), logging.VerboseLevel)
 	execCmd := exec.Command(
 		"kubectl", options...,
 	)

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -428,7 +428,7 @@ func doInstallation() error {
 			o = options{"get", "svc", "istio-ingressgateway", "-n", "istio-system",
 				"-ojsonpath={.status.loadBalancer.ingress[0].hostname}"}
 			o.appendIfNotEmpty(kubectlOptions)
-			logging.PrintLog("Executing: kubectl"+strings.Join(o, " "), logging.VerboseLevel)
+			logging.PrintLog("Executing: kubectl "+strings.Join(o, " "), logging.VerboseLevel)
 			hostname, err = keptnutils.ExecuteCommand("kubectl", o)
 			if err != nil {
 				logging.PrintLog("Error retrieving istio-ingress: "+hostname+"\n"+err.Error(), logging.QuietLevel)
@@ -439,7 +439,7 @@ func doInstallation() error {
 			o = options{"get", "svc", "ingress-nginx", "-n", "ingress-nginx",
 				"-ojsonpath={.status.loadBalancer.ingress[0].hostname}"}
 			o.appendIfNotEmpty(kubectlOptions)
-			logging.PrintLog("Executing: kubectl"+strings.Join(o, " "), logging.VerboseLevel)
+			logging.PrintLog("Executing: kubectl "+strings.Join(o, " "), logging.VerboseLevel)
 			hostname, err = keptnutils.ExecuteCommand("kubectl", o)
 			if err != nil {
 				logging.PrintLog("Error retrieving nginx-ingress: "+hostname+"\n"+err.Error(), logging.QuietLevel)
@@ -630,7 +630,7 @@ func getInstallerLogs(podName string) error {
 		"-f"}
 	options.appendIfNotEmpty(kubectlOptions)
 
-	logging.PrintLog("Executing: kubectl"+strings.Join(options, " "), logging.VerboseLevel)
+	logging.PrintLog("Executing: kubectl "+strings.Join(options, " "), logging.VerboseLevel)
 	execCmd := exec.Command(
 		"kubectl", options...,
 	)

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -201,7 +201,7 @@ Please see https://kubernetes.io/docs/tasks/tools/install-kubectl/`)
 			if *installParams.PlatformIdentifier != "openshift" {
 				if err := kube.CheckKubeServerVersion(KubeServerVersionConstraints); err != nil {
 					logging.PrintLog(err.Error(), logging.VerboseLevel)
-					logging.PrintLog("See https://keptn.sh/docs/0.6.0/installation/k8s-support/ for details.", logging.VerboseLevel)
+					logging.PrintLog("See https://keptn.sh/docs/0.7.0/installation/k8s-support/ for details.", logging.VerboseLevel)
 					return errors.New(`Keptn requires Kubernetes server version: ` + KubeServerVersionConstraints)
 				}
 			}

--- a/cli/cmd/installAKS.go
+++ b/cli/cmd/installAKS.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"github.com/keptn/keptn/cli/pkg/logging"
 	"strings"
 
 	keptnutils "github.com/keptn/kubernetes-utils/pkg"
@@ -102,7 +103,8 @@ func (p aksPlatform) readAzureSubscription() {
 }
 
 func (p aksPlatform) authenticateAtCluster() (bool, error) {
-	_, err := keptnutils.ExecuteCommand("az", []string{
+	logging.PrintLog("Authenticating at AKS cluster: aks get-credentials --resource-group "+p.creds.AzureResourceGroup+" --name "+p.creds.ClusterName+" --subscription "+p.creds.AzureSubscription+" --overwrite-existing", logging.VerboseLevel)
+	out, err := keptnutils.ExecuteCommand("az", []string{
 		"aks",
 		"get-credentials",
 		"--resource-group",
@@ -113,6 +115,8 @@ func (p aksPlatform) authenticateAtCluster() (bool, error) {
 		p.creds.AzureSubscription,
 		"--overwrite-existing",
 	})
+
+	logging.PrintLog("Result: "+out, logging.VerboseLevel)
 
 	if err != nil {
 		fmt.Println("Could not connect to cluster. " +

--- a/cli/cmd/installEKS.go
+++ b/cli/cmd/installEKS.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/keptn/keptn/cli/pkg/logging"
 	"regexp"
 	"strconv"
 	"strings"
@@ -98,7 +99,8 @@ func (p eksPlatform) readAwsRegion() {
 }
 
 func (p eksPlatform) authenticateAtCluster() (bool, error) {
-	_, err := keptnutils.ExecuteCommand("aws", []string{
+	logging.PrintLog("Authenticating at EKS cluster: aws eks --region "+p.creds.AwsRegion+" update-kubeconfig --name "+p.creds.ClusterName, logging.VerboseLevel)
+	out, err := keptnutils.ExecuteCommand("aws", []string{
 		"eks",
 		"--region",
 		p.creds.AwsRegion,
@@ -106,6 +108,8 @@ func (p eksPlatform) authenticateAtCluster() (bool, error) {
 		"--name",
 		p.creds.ClusterName,
 	})
+
+	logging.PrintLog("Result: "+out, logging.VerboseLevel)
 
 	if err != nil {
 		fmt.Println("Could not connect to cluster. " +

--- a/cli/cmd/installGKE.go
+++ b/cli/cmd/installGKE.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"github.com/keptn/keptn/cli/pkg/logging"
 	"strings"
 
 	keptnutils "github.com/keptn/kubernetes-utils/pkg"
@@ -102,7 +103,8 @@ func (p gkePlatform) readGkeProject() {
 }
 
 func (p gkePlatform) authenticateAtCluster() (bool, error) {
-	_, err := keptnutils.ExecuteCommand("gcloud", []string{
+	logging.PrintLog("Authenticating at GKE cluster: gcloud container clusters get-credentials "+p.creds.ClusterName+" -- zone "+p.creds.ClusterZone+" --project "+p.creds.GkeProject, logging.VerboseLevel)
+	out, err := keptnutils.ExecuteCommand("gcloud", []string{
 		"container",
 		"clusters",
 		"get-credentials",
@@ -112,6 +114,8 @@ func (p gkePlatform) authenticateAtCluster() (bool, error) {
 		"--project",
 		p.creds.GkeProject,
 	})
+
+	logging.PrintLog("Result: "+out, logging.VerboseLevel)
 
 	if err != nil {
 		fmt.Println("Could not connect to cluster. " +

--- a/cli/cmd/installKubernetes.go
+++ b/cli/cmd/installKubernetes.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"github.com/keptn/keptn/cli/pkg/logging"
 	"strings"
 
 	keptnutils "github.com/keptn/kubernetes-utils/pkg"
@@ -62,10 +63,13 @@ func (p kubernetesPlatform) checkCreds() error {
 }
 
 func getKubeContext() (string, error) {
-	return keptnutils.ExecuteCommand("kubectl", []string{
+	logging.PrintLog("Checking current kubernetes context: kubectl config current-context", logging.VerboseLevel)
+	out, err := keptnutils.ExecuteCommand("kubectl", []string{
 		"config",
 		"current-context",
 	})
+	logging.PrintLog("Result: "+out, logging.VerboseLevel)
+	return out, err
 }
 
 func (p kubernetesPlatform) printCreds() {

--- a/cli/cmd/installOpenShift.go
+++ b/cli/cmd/installOpenShift.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"github.com/keptn/keptn/cli/pkg/logging"
 
 	keptnutils "github.com/keptn/kubernetes-utils/pkg"
 )
@@ -55,7 +56,7 @@ func (p openShiftPlatform) checkCreds() error {
 		return err
 	}
 	if !authenticated {
-		return errors.New("Cannot authenticate at cluster " + p.creds.OpenshiftURL)
+		return errors.New("Cannot authenticate at cluster " + p.creds.OpenshiftURL + ": " + err.Error())
 	}
 	return nil
 }
@@ -96,13 +97,16 @@ func (p openShiftPlatform) readOpenshiftPassword() {
 }
 
 func (p openShiftPlatform) authenticateAtCluster() (bool, error) {
-	_, err := keptnutils.ExecuteCommand("oc", []string{
+	logging.PrintLog("Authenticating at Openshift cluster: oc login "+p.creds.OpenshiftURL, logging.VerboseLevel)
+	out, err := keptnutils.ExecuteCommand("oc", []string{
 		"login",
 		p.creds.OpenshiftURL,
 		"-u=" + p.creds.OpenshiftUser,
 		"-p=" + p.creds.OpenshiftPassword,
 		"--insecure-skip-tls-verify=true",
 	})
+
+	logging.PrintLog("Result: "+out, logging.VerboseLevel)
 
 	if err != nil {
 		fmt.Println("Could not connect to cluster. Please verify that you have entered the correct information.")

--- a/installer/scripts/common/install.sh
+++ b/installer/scripts/common/install.sh
@@ -42,3 +42,6 @@ fi
 
 # Install done
 print_info "Installation of Keptn complete."
+
+# wait a few seconds to make sure the last log output is captured by the CLI before the pod is deleted
+sleep 10


### PR DESCRIPTION
Closes #1856 #1928 

This PR adds additional log output to the `install` command of the CLI that will be displayed.

The error described in #1856 might be caused by the automatic deletion of the installer pod after the installer job has been finished - my guess is that caused the CLI to not retrieve the `installation complete` command and thus run into an error. That's why I have added a short sleep of 10s to the end of the installer job. In any case, I was not able to reproduce this Issue locally, so we will have to keep an eye on that to see if that resolved the issue.

For #1928, I have added several log outputs with logLevel=Verbose, to log all kubectl commands that are executed by the CLI, and their outputs. Also attempted connections to the K8s cluster are logged more thoroughly to avoid confusions caused by being connected to a different cluster than intended.