### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,7 +4,7 @@
 # These owners will be the default owners for everything in the repo.
 #################################################################################
 # Learn about CODEOWNERS file format:
-#  https://help.github.com/en/articles/about-code-owners
+# https://help.github.com/en/articles/about-code-owners
 #################################################################################
 # FYI: Owners will be auto-assigned for code reviews as well
 #################################################################################
@@ -16,23 +16,23 @@ CODEOWNERS @AloisReitbauer @grabnerandi @jetzlstorfer @christian-kreuzberger-dtx
 ADOPTERS.md @AloisReitbauer @grabnerandi @jetzlstorfer
 
 # Keptn Bridge (includes reviewers without write-access)
-bridge/* @ermin-muratovic @SaraDavilaMendez @mpfosi @sandroschmid @GustavAT
+bridge/ @ermin-muratovic @SaraDavilaMendez @mpfosi @sandroschmid @GustavAT
 
 # Installer
-installer/* @bacherfl @agrimmer @christian-kreuzberger-dtx
+installer/ @bacherfl @agrimmer @christian-kreuzberger-dtx
 
 # Upgrader
-upgrader/* @bacherfl
+upgrader/ @bacherfl
 
 # JMeter service
-jmeter-service/* @grabnerandi
+jmeter-service/ @grabnerandi
 
 # Release Notes
-releasenotes/* @johannes-b
+releasenotes/ @johannes-b
 
 # Docs, etc...
 *.md @christian-kreuzberger-dtx @johannes-b @jetzlstorfer
-docs/* @christian-kreuzberger-dtx @johannes-b @jetzlstorfer
+docs/ @christian-kreuzberger-dtx @johannes-b @jetzlstorfer
 
 # Dockerfiles
 */Dockerfile @christian-kreuzberger-dtx

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,22 +16,22 @@ CODEOWNERS @AloisReitbauer @grabnerandi @jetzlstorfer @christian-kreuzberger-dtx
 ADOPTERS.md @AloisReitbauer @grabnerandi @jetzlstorfer
 
 # api
-api/ @agrimmer
+api/ @agrimmer @bacherfl
 
 # Keptn Bridge (includes reviewers without write-access)
 bridge/ @ermin-muratovic @SaraDavilaMendez @mpfosi @sandroschmid @GustavAT
 
 # cli
-cli/ @agrimmer
+cli/ @agrimmer @bacherfl
 
 # gatekeeper-service
-gatekeeper-service/ @agrimmer
+gatekeeper-service/ @agrimmer @bacherfl
 
 # helm-service
-helm-service/ @agrimmer
+helm-service/ @agrimmer @bacherfl
 
 # Installer
-installer/ @bacherfl @agrimmer @christian-kreuzberger-dtx
+installer/ @bacherfl @agrimmer @christian-kreuzberger-dtx @bacherfl
 
 # Upgrader
 upgrader/ @bacherfl
@@ -40,10 +40,10 @@ upgrader/ @bacherfl
 jmeter-service/ @grabnerandi
 
 # mongodb-datastore
-mongodb-datastore/ @agrimmer
+mongodb-datastore/ @agrimmer @bacherfl
 
 # shipyard-service
-shipyard-service/ @agrimmer
+shipyard-service/ @agrimmer @bacherfl
 
 # Release Notes
 releasenotes/ @johannes-b
@@ -53,7 +53,7 @@ releasenotes/ @johannes-b
 docs/ @christian-kreuzberger-dtx @johannes-b @jetzlstorfer
 
 # Dockerfiles
-*/Dockerfile @christian-kreuzberger-dtx
+*/Dockerfile @christian-kreuzberger-dtx @bacherfl
 
 # dot files are usually config files
 .* @christian-kreuzberger-dtx

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -31,7 +31,7 @@ gatekeeper-service/ @agrimmer @bacherfl
 helm-service/ @agrimmer @bacherfl
 
 # Installer
-installer/ @bacherfl @agrimmer @christian-kreuzberger-dtx @bacherfl
+installer/ @bacherfl @agrimmer @christian-kreuzberger-dtx
 
 # Upgrader
 upgrader/ @bacherfl

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,8 +15,20 @@ CODEOWNERS @AloisReitbauer @grabnerandi @jetzlstorfer @christian-kreuzberger-dtx
 # Adopters file
 ADOPTERS.md @AloisReitbauer @grabnerandi @jetzlstorfer
 
+# api
+api/ @agrimmer
+
 # Keptn Bridge (includes reviewers without write-access)
 bridge/ @ermin-muratovic @SaraDavilaMendez @mpfosi @sandroschmid @GustavAT
+
+# cli
+cli/ @agrimmer
+
+# gatekeeper-service
+gatekeeper-service/ @agrimmer
+
+# helm-service
+helm-service/ @agrimmer
 
 # Installer
 installer/ @bacherfl @agrimmer @christian-kreuzberger-dtx
@@ -26,6 +38,12 @@ upgrader/ @bacherfl
 
 # JMeter service
 jmeter-service/ @grabnerandi
+
+# mongodb-datastore
+mongodb-datastore/ @agrimmer
+
+# shipyard-service
+shipyard-service/ @agrimmer
 
 # Release Notes
 releasenotes/ @johannes-b

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,13 @@
+#################################################################################
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
-
 # These owners will be the default owners for everything in the repo.
-
-* @christian-kreuzberger-dtx @johannes-b
+#################################################################################
+# Learn about CODEOWNERS file format:
+#  https://help.github.com/en/articles/about-code-owners
+#################################################################################
+# FYI: Owners will be auto-assigned for code reviews as well
+#################################################################################
 
 # Codeowners file
 CODEOWNERS @AloisReitbauer @grabnerandi @jetzlstorfer @christian-kreuzberger-dtx @johannes-b @danielkhan
@@ -11,8 +15,31 @@ CODEOWNERS @AloisReitbauer @grabnerandi @jetzlstorfer @christian-kreuzberger-dtx
 # Adopters file
 ADOPTERS.md @AloisReitbauer @grabnerandi @jetzlstorfer
 
+# Keptn Bridge (includes reviewers without write-access)
+bridge/* @ermin-muratovic @SaraDavilaMendez @mpfosi @sandroschmid @GustavAT
+
+# Installer
+installer/* @bacherfl @agrimmer @christian-kreuzberger-dtx
+
+# Upgrader
+upgrader/* @bacherfl
+
+# JMeter service
+jmeter-service/* @grabnerandi
+
+# Release Notes
+releasenotes/* @johannes-b
+
+# Docs, etc...
+*.md @christian-kreuzberger-dtx @johannes-b @jetzlstorfer
+docs/* @christian-kreuzberger-dtx @johannes-b @jetzlstorfer
+
+# Dockerfiles
+*/Dockerfile @christian-kreuzberger-dtx
+
 # dot files are usually config files
 .* @christian-kreuzberger-dtx
 
-# Keptn Bridge
-bridge/* @ermin-muratovic @SaraDavilaMendez @mpfosi @sandroschmid
+# all other files
+* @christian-kreuzberger-dtx @johannes-b
+


### PR DESCRIPTION
This introduces a more fine-grained codeowners for certain files. Removing the `*` for subdirectories, as `bridge/*` has a different meaning than just `bridge/` (includes nested directories and files).

Also, added another reviewer for Keptn Bridge