### PR TITLE
Fix CLI Build for master branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ repositories
 cli/vendor/*
 api/vendor/*
 
+# Avoid having the examples folder added (e.g., when running integration tests on travis-ci or locally)
+examples/
+
 # Built artifacts
 *.exe
 cli/onboarding-carts/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -257,16 +257,14 @@ jobs:
       - echo ${GCLOUD_SERVICE_KEY} | base64 --decode > ~/gcloud-service-key.json
       - gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
     script:
-      - |
-        if [[ $CHANGED_FILES == *"${CLI_FOLDER}"*  ]]; then
-          echo "Build keptn cli"
-          cd ./cli
-          go test ./...
-          TAG="latest"
-          VERSION="master+${DATE}"
-          source ../travis-scripts/build_cli.sh "${VERSION}" "${KUBE_CONSTRAINTS}"
-          cd ..
-        fi
+      - export VERSION="master+${DATE}"
+      - export TAG="latest"
+      - echo "Build keptn cli"
+      - cd ./cli
+      - go test ./...
+      - TAG="${VERSION}"
+      - source ../travis-scripts/build_cli.sh "${VERSION}" "${KUBE_CONSTRAINTS}"
+      - cd ..
 
   ##################################################################################
   # feature/bug/hotfix/patch branches build jobs


### PR DESCRIPTION
This PR fixes the CLI build on the master branch, as it was only triggered for changed files (which does not make sense for type=cron on master).

In addition, I've added the examples repo to gitignore, as it constantly pops up locally for me when I run integration tests.