### PR TITLE
build_cli on master needs to build latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -262,7 +262,6 @@ jobs:
       - echo "Build keptn cli"
       - cd ./cli
       - go test ./...
-      - TAG="${VERSION}"
       - source ../travis-scripts/build_cli.sh "${VERSION}" "${KUBE_CONSTRAINTS}"
       - cd ..
 


### PR DESCRIPTION
While fixing this in PR #1980, I made a mistake and introduced the wrong `TAG=` statement.
This lead to the latest cli being built not being uploaded to our google cloud storage under the directory `latest`, but `master+YYYYMMDD`.

Please note:
```
 export TAG="latest"
```
is set in line 261, therefore overwriting it with `TAG=${VERSION}` was deleted.