### PR TITLE
#1480 handle configuration service errors in jmeter-service

### DIFF
--- a/jmeter-service/go.mod
+++ b/jmeter-service/go.mod
@@ -7,5 +7,5 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/uuid v1.1.1
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.6.3-0.20200618144455-073e08a10aaa
+	github.com/keptn/go-utils v0.6.3-0.20200701140917-da1f9cdf8804
 )

--- a/jmeter-service/go.sum
+++ b/jmeter-service/go.sum
@@ -151,6 +151,8 @@ github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dv
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/keptn/go-utils v0.6.3-0.20200618144455-073e08a10aaa h1:r0S3xDRh6QKyyrz4EwxSpAD8V12SFUvlVlHX28B4ySE=
 github.com/keptn/go-utils v0.6.3-0.20200618144455-073e08a10aaa/go.mod h1:hf2FU6JFuOzLP5rEAlA1/XnNS28pDZbVfxDESeQsq1g=
+github.com/keptn/go-utils v0.6.3-0.20200701140917-da1f9cdf8804 h1:rqpWdzhLyjWkMppmkX8xwP5E15Ub86hF4UFm8ZRFxIM=
+github.com/keptn/go-utils v0.6.3-0.20200701140917-da1f9cdf8804/go.mod h1:hf2FU6JFuOzLP5rEAlA1/XnNS28pDZbVfxDESeQsq1g=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=

--- a/jmeter-service/jmeterUtils_test.go
+++ b/jmeter-service/jmeterUtils_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	keptnutils "github.com/keptn/go-utils/pkg/lib"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+)
+
+func Test_executeJMeter(t *testing.T) {
+	var returnedStatus int
+	ts := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(returnedStatus)
+			w.Write([]byte(`{}`))
+		}),
+	)
+	defer ts.Close()
+
+	os.Setenv("CONFIGURATION_SERVICE_URL", ts.URL)
+	os.Setenv("env", "production")
+
+	type args struct {
+		testInfo       *TestInfo
+		workload       *Workload
+		resultsDir     string
+		url            *url.URL
+		LTN            string
+		funcValidation bool
+		logger         *keptnutils.Logger
+	}
+	tests := []struct {
+		name           string
+		args           args
+		returnedStatus int
+		want           bool
+		wantErr        bool
+	}{
+		{
+			name: "Skip tests if 404 is returned by configuration service and mark as success",
+			args: args{
+				testInfo: &TestInfo{
+					Project:      "sockshop",
+					Stage:        "dev",
+					Service:      "carts",
+					TestStrategy: "functional",
+				},
+				workload: &Workload{
+					TestStrategy:      "",
+					VUser:             0,
+					LoopCount:         0,
+					ThinkTime:         0,
+					Script:            "test.jmx",
+					AcceptedErrorRate: 0,
+					AvgRtValidation:   0,
+					Properties:        nil,
+				},
+				resultsDir:     "",
+				url:            nil,
+				LTN:            "",
+				funcValidation: false,
+				logger:         nil,
+			},
+			want:           true,
+			wantErr:        false,
+			returnedStatus: 404,
+		},
+		{
+			name: "Skip tests if error code is returned by configuration service and return error",
+			args: args{
+				testInfo: &TestInfo{
+					Project:      "sockshop",
+					Stage:        "dev",
+					Service:      "carts",
+					TestStrategy: "functional",
+				},
+				workload: &Workload{
+					TestStrategy:      "",
+					VUser:             0,
+					LoopCount:         0,
+					ThinkTime:         0,
+					Script:            "test.jmx",
+					AcceptedErrorRate: 0,
+					AvgRtValidation:   0,
+					Properties:        nil,
+				},
+				resultsDir:     "",
+				url:            nil,
+				LTN:            "",
+				funcValidation: false,
+				logger:         nil,
+			},
+			want:           false,
+			wantErr:        true,
+			returnedStatus: 500,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			returnedStatus = tt.returnedStatus
+			got, err := executeJMeter(tt.args.testInfo, tt.args.workload, tt.args.resultsDir, tt.args.url, tt.args.LTN, tt.args.funcValidation, tt.args.logger)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("executeJMeter() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("executeJMeter() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #1480 
In this PR, the jmeter-service marks a test as failed if an error is returned by the configuration-service when retrieving the test script. The only exception is when the configuration-service returns a 404 - which means that no test has been specified and can therefore be skipped.