### PR TITLE
#1808 Update go-utils

### DIFF
--- a/helm-service/go.mod
+++ b/helm-service/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/websocket v1.4.1
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.6.3-0.20200617060337-e48e5452bfe9
+	github.com/keptn/go-utils v0.6.3-0.20200701140917-da1f9cdf8804
 	github.com/keptn/kubernetes-utils v0.0.0-20200417060634-69e3369c72d3
 	github.com/kinbiko/jsonassert v1.0.1
 	github.com/stretchr/testify v1.4.0

--- a/helm-service/go.sum
+++ b/helm-service/go.sum
@@ -448,6 +448,8 @@ github.com/keptn/go-utils v0.6.3-0.20200608064908-52b9e92e5c8f h1:tyjFprH1RrixG5
 github.com/keptn/go-utils v0.6.3-0.20200608064908-52b9e92e5c8f/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/keptn/go-utils v0.6.3-0.20200617060337-e48e5452bfe9 h1:K36NQ1/DwTBU/3EGJnlKVNYKLnnVcHEzhaZ4qNb2wkU=
 github.com/keptn/go-utils v0.6.3-0.20200617060337-e48e5452bfe9/go.mod h1:hf2FU6JFuOzLP5rEAlA1/XnNS28pDZbVfxDESeQsq1g=
+github.com/keptn/go-utils v0.6.3-0.20200701140917-da1f9cdf8804 h1:rqpWdzhLyjWkMppmkX8xwP5E15Ub86hF4UFm8ZRFxIM=
+github.com/keptn/go-utils v0.6.3-0.20200701140917-da1f9cdf8804/go.mod h1:hf2FU6JFuOzLP5rEAlA1/XnNS28pDZbVfxDESeQsq1g=
 github.com/keptn/kubernetes-utils v0.0.0-20200401103501-ae44a5ee0656 h1:uGdzQ+DT+/KqzMJF+5F+B+/h0nOfwmmSA7ClxsI1y6Y=
 github.com/keptn/kubernetes-utils v0.0.0-20200401103501-ae44a5ee0656/go.mod h1:7MQMS/jqKM4eVZ0S1S7LWdZNcBTJn5QeERircdADWzo=
 github.com/keptn/kubernetes-utils v0.0.0-20200414093719-126698f19c3e h1:9/7mjIDhpvlezvYKB6JjEBE7HXb0Fh4BAlg5aPKE+N0=

--- a/helm-service/main.go
+++ b/helm-service/main.go
@@ -83,6 +83,7 @@ func gotEvent(ctx context.Context, event cloudevents.Event) error {
 	url, err := serviceutils.GetConfigServiceURL()
 	if err != nil {
 		keptnHandler.Logger.Error(fmt.Sprintf("Error when getting config service url: %s", err.Error()))
+		loggingDone <- true
 		return err
 	}
 


### PR DESCRIPTION
Fixes #1808 

The helm-service now properly uses the `CONFIGURATION_SERVICE` environment variable. Furthermore, the go-utils now check whether this variable is not empty.

If no `CONFIGURATION_SERVICE` environment variable is specified, the error message is now 
`Error when getting config service url: Provided environment variable CONFIGURATION_SERVICE has no valid value`

If the configuration-service cannot be accessed using the `CONFIGURATION_SERVICE` environment variable, the error message is now
`Error when reading chart carts-generated from project sockshop: Get http://configuratio-service.keptn.svc.cluster.local:8080/v1/project/sockshop/stage/dev/service/carts/resource/helm%2Fcarts-generated.tgz: dial tcp: lookup configuratio-service.keptn.svc.cluster.local: no such host`