### PR TITLE
Remove wait service from installer

### DIFF
--- a/installer/scripts/common/setupKeptn.sh
+++ b/installer/scripts/common/setupKeptn.sh
@@ -88,7 +88,6 @@ case $USE_CASE in
     wait_for_deployment_in_namespace "lighthouse-service" "keptn"
     wait_for_deployment_in_namespace "lighthouse-service-distributor" "keptn"
     wait_for_deployment_in_namespace "remediation-service-distributor" "keptn"
-    wait_for_deployment_in_namespace "wait-service-deployment-distributor" "keptn"
     ;;
   continuous-delivery)
     print_debug "Deploying Keptn continuous deployment"

--- a/installer/scripts/openshift/setupKeptn.sh
+++ b/installer/scripts/openshift/setupKeptn.sh
@@ -94,9 +94,7 @@ case $USE_CASE in
     wait_for_deployment_in_namespace "lighthouse-service" "keptn"
     wait_for_deployment_in_namespace "lighthouse-service-distributor" "keptn"
     wait_for_deployment_in_namespace "remediation-service" "keptn"
-    wait_for_deployment_in_namespace "wait-service" "keptn"
     wait_for_deployment_in_namespace "remediation-service-distributor" "keptn"
-    wait_for_deployment_in_namespace "wait-service-deployment-distributor" "keptn"
     ;;
   continuous-delivery)
     print_debug "Deploying Keptn continuous deployment"

--- a/lighthouse-service/event_handler/start_evaluation_handler.go
+++ b/lighthouse-service/event_handler/start_evaluation_handler.go
@@ -92,9 +92,12 @@ func (eh *StartEvaluationHandler) HandleEvent() error {
 	deployment := ""
 	if e.DeploymentStrategy != "" {
 		if e.DeploymentStrategy == "blue_green_service" {
-			if e.TestStrategy == "real-user" { // e.g., remediation use case -> wait-service
+			// blue-green deployed services should be evaluated based on data of either the primary or canary deployment
+			if e.TestStrategy == "real-user" {
+				// remediation use case will be tested by real users, therefore the evaluation needs to take place on the on the primary deployment
 				deployment = "primary"
 			} else {
+				// while load-tests are running on the canary deployment
 				deployment = "canary"
 			}
 		} else {


### PR DESCRIPTION
There might have been a merge conflict in the past, as we removed wait-service, but re-introduced it in one of the scripts again.

This PR fixes it.