### PR TITLE
Implement evaluation board to show Heatmap with deep link

### DIFF
--- a/bridge/client/app/_components/ktb-event-item/ktb-event-item.component.html
+++ b/bridge/client/app/_components/ktb-event-item/ktb-event-item.component.html
@@ -19,7 +19,10 @@
     </div>
     <div fxLayout="column" fxLayoutAlign="start end">
       <p class="m-0 mt-1 mb-1" [textContent]="_event.time | amDateFormat:getCalendarFormat()"></p>
-      <button dt-icon-button variant="nested" (click)="showEventPayloadDialog()"><dt-icon name="coding"></dt-icon></button>
+      <div fxLayout="row" fxLayoutAlign="start start">
+        <button dt-icon-button variant="nested" [routerLink]="['/evaluation', _event.shkeptncontext]" *ngIf="_event.data.evaluationdetails"><dt-icon name="chart-bar"></dt-icon></button>
+        <button dt-icon-button variant="nested" (click)="showEventPayloadDialog()"><dt-icon name="coding"></dt-icon></button>
+      </div>
     </div>
   </div>
   <div *ngIf="_event.data.ProblemDetails">

--- a/bridge/client/app/_components/ktb-event-item/ktb-event-item.component.html
+++ b/bridge/client/app/_components/ktb-event-item/ktb-event-item.component.html
@@ -20,7 +20,7 @@
     <div fxLayout="column" fxLayoutAlign="start end">
       <p class="m-0 mt-1 mb-1" [textContent]="_event.time | amDateFormat:getCalendarFormat()"></p>
       <div fxLayout="row" fxLayoutAlign="start start">
-        <button dt-icon-button variant="nested" [routerLink]="['/evaluation', _event.shkeptncontext]" *ngIf="_event.data.evaluationdetails"><dt-icon name="chart-bar"></dt-icon></button>
+        <button dt-icon-button variant="nested" [routerLink]="['/evaluation', _event.shkeptncontext, _event.data.stage]" *ngIf="_event.data.evaluationdetails"><dt-icon name="chart-bar"></dt-icon></button>
         <button dt-icon-button variant="nested" (click)="showEventPayloadDialog()"><dt-icon name="coding"></dt-icon></button>
       </div>
     </div>

--- a/bridge/client/app/app.component.ts
+++ b/bridge/client/app/app.component.ts
@@ -1,8 +1,5 @@
 import {HttpClient, HttpHeaders} from "@angular/common/http";
 import {Component, OnInit} from '@angular/core';
-import {ApiService} from "./_services/api.service";
-import {NotificationsService} from "./_services/notifications.service";
-import {NotificationType} from "./_models/notification";
 
 declare var dT_;
 

--- a/bridge/client/app/app.module.ts
+++ b/bridge/client/app/app.module.ts
@@ -69,6 +69,7 @@ import { AppRouting } from './app.routing';
 
 import { DashboardComponent } from './dashboard/dashboard.component';
 import { ProjectBoardComponent } from './project-board/project-board.component';
+import { EvaluationBoardComponent } from "./evaluation-board/evaluation-board.component";
 
 registerLocaleData(localeEn, 'en');
 
@@ -78,6 +79,7 @@ registerLocaleData(localeEn, 'en');
     DashboardComponent,
     AppHeaderComponent,
     ProjectBoardComponent,
+    EvaluationBoardComponent,
     KtbHttpLoadingSpinnerComponent,
     KtbHttpLoadingBarComponent,
     KtbShowHttpLoadingDirective,

--- a/bridge/client/app/app.routing.ts
+++ b/bridge/client/app/app.routing.ts
@@ -2,6 +2,7 @@ import {NgModule} from '@angular/core';
 import {Routes, RouterModule} from '@angular/router';
 import {DashboardComponent} from "./dashboard/dashboard.component";
 import {ProjectBoardComponent} from "./project-board/project-board.component";
+import {EvaluationBoardComponent} from "./evaluation-board/evaluation-board.component";
 
 
 const routes: Routes = [
@@ -13,6 +14,8 @@ const routes: Routes = [
   {path: 'project/:projectName/:serviceName/:contextId/:eventId', component: ProjectBoardComponent},
   {path: 'trace/:shkeptncontext', component: ProjectBoardComponent},
   {path: 'trace/:shkeptncontext/:eventselector', component: ProjectBoardComponent},
+  {path: 'evaluation/:shkeptncontext', component: EvaluationBoardComponent},
+  {path: 'evaluation/:shkeptncontext/:eventselector', component: EvaluationBoardComponent},
   {path: '**', redirectTo: ''}
 ];
 

--- a/bridge/client/app/evaluation-board/evaluation-board.component.html
+++ b/bridge/client/app/evaluation-board/evaluation-board.component.html
@@ -1,0 +1,48 @@
+<div class="container" *ngIf="error">
+  <dt-empty-state>
+    <dt-empty-state-item>
+      <dt-empty-state-item-img>
+        <img class="mt-2" src="/assets/keptn_logo.png" />
+      </dt-empty-state-item-img>
+      <ng-container [ngSwitch]="error">
+        <ng-container *ngSwitchCase="'contextError'">
+          <dt-empty-state-item-title class="mt-2" aria-level="2">Traces for <span class="italic" [textContent]="contextId"></span> not found</dt-empty-state-item-title>
+          <p>Sorry, we couldn't load any traces with that shkeptncontext. Check our <a href="https://keptn.sh/docs/quickstart/" target="_blank">Quick Start</a> instructions on how to <a href="https://keptn.sh/docs/0.6.0/manage/project/" target="_blank">setup a project</a> or go back to <a [routerLink]="['/dashboard']">your dashboard</a>.</p>
+        </ng-container>
+        <ng-container *ngSwitchDefault>
+          <dt-empty-state-item-title class="mt-2" aria-level="2">Some error occured</dt-empty-state-item-title>
+          <p>Sorry, some error occured. Check our <a href="https://keptn.sh/docs/quickstart/" target="_blank">Quick Start</a> instructions on how to <a href="https://keptn.sh/docs/0.6.0/manage/project/" target="_blank">setup a project</a> or go back to <a [routerLink]="['/dashboard']">your dashboard</a>.</p>
+        </ng-container>
+      </ng-container>
+    </dt-empty-state-item>
+  </dt-empty-state>
+</div>
+<div class="container" *ngIf="!error && !evaluations">
+  <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="15px">
+    <dt-loading-spinner></dt-loading-spinner>
+    <p>Loading ...</p>
+  </div>
+</div>
+<div class="evaluation-board pr-4 pl-4" fxLayout="column" *ngIf="evaluations">
+  <dt-info-group>
+    <dt-info-group-title>
+      <div fxFlex fxLayout="row" fxLayoutAlign="flex-start center" fxLayoutGap="15px">
+        <div fxLayout="row" fxLayoutAlign="start center">
+          <button dt-icon-button disabled variant="nested" *ngIf="root.isFaulty()"><dt-icon name="criticalevent"></dt-icon></button>
+          <p *ngIf="root.getShortImageName()" [textContent]="root.getShortImageName()"></p>
+          <p *ngIf="!root.getShortImageName()" [textContent]="root.getService()"></p>
+        </div>
+      </div>
+    </dt-info-group-title>
+    <p class="m-0" *ngIf="root.data.valuesCanary"><span class="bold">Artifact: </span><span [textContent]="root.data.valuesCanary.image"></span></p>
+    <p class="m-0 mb-3"><span class="bold">Keptn ID: </span><span [textContent]="root.shkeptncontext"></span></p>
+  </dt-info-group>
+  <div *ngFor="let evaluation of evaluations;">
+    <p><span class="bold">Stage: </span><span [textContent]="evaluation.data.stage"></span></p>
+    <ktb-event-item [event]="evaluation">
+      <ktb-event-item-detail>
+        <ktb-evaluation-details *ngIf="evaluation.data.evaluationdetails" [evaluationData]="evaluation"></ktb-evaluation-details>
+      </ktb-event-item-detail>
+    </ktb-event-item>
+  </div>
+</div>

--- a/bridge/client/app/evaluation-board/evaluation-board.component.scss
+++ b/bridge/client/app/evaluation-board/evaluation-board.component.scss
@@ -1,4 +1,3 @@
-@import "../../variables";
 
 .evaluation-board {
   width: 100%;

--- a/bridge/client/app/evaluation-board/evaluation-board.component.scss
+++ b/bridge/client/app/evaluation-board/evaluation-board.component.scss
@@ -1,0 +1,6 @@
+@import "../../variables";
+
+.evaluation-board {
+  width: 100%;
+  height: 100%;
+}

--- a/bridge/client/app/evaluation-board/evaluation-board.component.spec.ts
+++ b/bridge/client/app/evaluation-board/evaluation-board.component.spec.ts
@@ -1,0 +1,32 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import {EvaluationBoardComponent} from './evaluation-board.component';
+import {AppModule} from '../app.module';
+import {HttpClientTestingModule} from "@angular/common/http/testing";
+
+describe('ProjectBoardComponent', () => {
+  let component: EvaluationBoardComponent;
+  let fixture: ComponentFixture<EvaluationBoardComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+
+      declarations: [],
+      imports: [
+        AppModule,
+        HttpClientTestingModule,
+      ],
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(EvaluationBoardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create an instance', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/bridge/client/app/evaluation-board/evaluation-board.component.ts
+++ b/bridge/client/app/evaluation-board/evaluation-board.component.ts
@@ -1,0 +1,74 @@
+import {ChangeDetectorRef, Component, OnDestroy, OnInit} from '@angular/core';
+import {filter, map, startWith, switchMap} from "rxjs/operators";
+import {Observable, Subscription, timer} from "rxjs";
+import {ActivatedRoute, Router} from "@angular/router";
+import {Location} from "@angular/common";
+
+import * as moment from 'moment';
+
+import {Root} from "../_models/root";
+import {Project} from "../_models/project";
+
+import {DataService} from "../_services/data.service";
+import {ApiService} from "../_services/api.service";
+import DateUtil from "../_utils/date.utils";
+import {Service} from "../_models/service";
+import {labels, Trace} from "../_models/trace";
+import {Stage} from "../_models/stage";
+import {DtCheckboxChange} from "@dynatrace/barista-components/checkbox";
+
+@Component({
+  selector: 'app-project-board',
+  templateUrl: './evaluation-board.component.html',
+  styleUrls: ['./evaluation-board.component.scss']
+})
+export class EvaluationBoardComponent implements OnInit, OnDestroy {
+
+  public _routeSubs: Subscription = Subscription.EMPTY;
+  public error: string = null;
+
+  public contextId: string;
+  public root: Root;
+  public evaluations: Trace[];
+
+  constructor(private _changeDetectorRef: ChangeDetectorRef, private router: Router, private location: Location, private route: ActivatedRoute, private dataService: DataService, private apiService: ApiService) { }
+
+  ngOnInit() {
+    this._routeSubs = this.route.params.subscribe(params => {
+      if(params["shkeptncontext"]) {
+        this.contextId = params["shkeptncontext"];
+        this.apiService.getTraces(this.contextId)
+          .pipe(
+            map(response => response.body),
+            map(result => result.events||[]),
+            map(traces => traces.map(trace => Trace.fromJSON(trace)).sort((a, b) => new Date(a.time).getTime() - new Date(b.time).getTime()))
+          )
+          .subscribe((traces: Trace[]) => {
+            if(traces.length > 0) {
+              console.log("traces", traces);
+              this.root = Root.fromJSON(traces[0]);
+              this.root.traces = traces;
+              this.evaluations = traces.filter(t => t.type == 'sh.keptn.events.evaluation-done' && (!params["eventselector"] || t.id == params["eventselector"] || t.data.stage == params["eventselector"])) ;
+            } else {
+              this.error = "contextError";
+            }
+          }, (err) => {
+            this.error = "error";
+          });
+      }
+    });
+  }
+
+  getCalendarFormats() {
+    return DateUtil.getCalendarFormats(true);
+  }
+
+  getEventLabel(key): string {
+    return labels[key] || key;
+  }
+
+  ngOnDestroy(): void {
+    this._routeSubs.unsubscribe();
+  }
+
+}

--- a/bridge/client/app/evaluation-board/evaluation-board.component.ts
+++ b/bridge/client/app/evaluation-board/evaluation-board.component.ts
@@ -42,7 +42,6 @@ export class EvaluationBoardComponent implements OnInit, OnDestroy {
             .pipe(takeUntil(this.unsubscribe$))
             .subscribe((traces: Trace[]) => {
               if(traces.length > 0) {
-                console.log("traces", traces);
                 this.root = Root.fromJSON(traces[0]);
                 this.root.traces = traces;
                 this.evaluations = traces.filter(t => t.type == 'sh.keptn.events.evaluation-done' && (!params["eventselector"] || t.id == params["eventselector"] || t.data.stage == params["eventselector"])) ;

--- a/bridge/client/app/evaluation-board/evaluation-board.component.ts
+++ b/bridge/client/app/evaluation-board/evaluation-board.component.ts
@@ -9,7 +9,9 @@ import {Root} from "../_models/root";
 import {DataService} from "../_services/data.service";
 import {ApiService} from "../_services/api.service";
 import DateUtil from "../_utils/date.utils";
-import {labels, Trace} from "../_models/trace";
+import {Trace} from "../_models/trace";
+import {EventTypes} from "../_models/event-types";
+import {EVENT_LABELS} from "../_models/event-labels";
 
 @Component({
   selector: 'app-project-board',
@@ -44,7 +46,7 @@ export class EvaluationBoardComponent implements OnInit, OnDestroy {
               if(traces.length > 0) {
                 this.root = Root.fromJSON(traces[0]);
                 this.root.traces = traces;
-                this.evaluations = traces.filter(t => t.type == 'sh.keptn.events.evaluation-done' && (!params["eventselector"] || t.id == params["eventselector"] || t.data.stage == params["eventselector"])) ;
+                this.evaluations = traces.filter(t => t.type == EventTypes.EVALUATION_DONE && (!params["eventselector"] || t.id == params["eventselector"] || t.data.stage == params["eventselector"])) ;
               } else {
                 this.error = "contextError";
               }
@@ -60,7 +62,7 @@ export class EvaluationBoardComponent implements OnInit, OnDestroy {
   }
 
   getEventLabel(key): string {
-    return labels[key] || key;
+    return EVENT_LABELS[key] || key;
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
The Bridge now provides a new view showing only the evaluation result as Heatmap/Chart.
With this view there are also to new deep links introduced:

`bridge.keptn.mykeptndomain/evaluation/{keptnContext}`: this shows all evaluations with the provided `keptnContext`

`bridge.keptn.mykeptndomain/evaluation/{keptnContext}/{stage}` or `bridge.keptn.mykeptndomain/evaluation/{keptnContext}/{eventId}`: this shows the evaluation with the provided `keptnContext `on the specified `stage `or with the specified `eventId`

![image](https://user-images.githubusercontent.com/6098219/86367269-068b9900-bc7c-11ea-910e-b3ffb55d36b4.png)
