### PR TITLE
Show categories on xAxis in BarChart instead of timeline

### DIFF
--- a/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
+++ b/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
@@ -51,7 +51,10 @@ export class KtbEvaluationDetailsComponent implements OnInit {
 
   public _chartOptions: Highcharts.Options = {
     xAxis: {
-      type: 'datetime',
+      type: 'category',
+      labels: {
+        rotation: 90
+      }
     },
     yAxis: [
       {
@@ -173,10 +176,10 @@ export class KtbEvaluationDetailsComponent implements OnInit {
 
     evaluationHistory.forEach((evaluation) => {
       let scoreData = {
-        x: moment(evaluation.time).unix()*1000,
         y: evaluation.data.evaluationdetails ? evaluation.data.evaluationdetails.score : 0,
         evaluationData: evaluation,
-        color: this._evaluationColor[evaluation.data.evaluationdetails.result]
+        color: this._evaluationColor[evaluation.data.evaluationdetails.result],
+        name: evaluation.getChartLabel()
       };
 
       let indicatorScoreSeriesColumn = chartSeries.find(series => series.name == 'Score' && series.type == 'column');

--- a/bridge/client/app/_models/trace.ts
+++ b/bridge/client/app/_models/trace.ts
@@ -170,6 +170,15 @@ class Trace {
     return this.data.service;
   }
 
+  getChartLabel(): string {
+    let label;
+    if(this.data.labels)
+      label = this.data.labels.get("buildId");
+    if(!label)
+      label = this.time;
+    return label;
+  }
+
   static fromJSON(data: any) {
     return Object.assign(new this, data, { plainEvent: JSON.parse(JSON.stringify(data)) });
   }

--- a/bridge/client/app/_models/trace.ts
+++ b/bridge/client/app/_models/trace.ts
@@ -172,11 +172,6 @@ class Trace {
 
   getChartLabel(): string {
     return this.data.labels?.get("buildId") ?? this.time;
-    if(this.data.labels)
-      label = this.data.labels.get("buildId");
-    if(!label)
-      label = this.time;
-    return label;
   }
 
   static fromJSON(data: any) {

--- a/bridge/client/app/_models/trace.ts
+++ b/bridge/client/app/_models/trace.ts
@@ -171,7 +171,7 @@ class Trace {
   }
 
   getChartLabel(): string {
-    let label;
+    return this.data.labels?.get("buildId") ?? this.time;
     if(this.data.labels)
       label = this.data.labels.get("buildId");
     if(!label)


### PR DESCRIPTION
The bar chart for evaluation results now shows categories on the xAxis instead of timeline

![chart-labels-time](https://user-images.githubusercontent.com/6098219/86373982-52424080-bc84-11ea-8659-634ddae3c602.jpg)

If the event has labels and a label with the key `buildId` is provided, that label will be used as category. Otherwise the time will be used as category.

![chart-labels](https://user-images.githubusercontent.com/6098219/86374079-7140d280-bc84-11ea-9a56-3dff140f1ac2.jpg)
