### PR TITLE
fixed integration tests for self healing

### DIFF
--- a/test/test_self_healing.sh
+++ b/test/test_self_healing.sh
@@ -7,7 +7,7 @@ KEPTN_ENDPOINT=https://api.keptn.$(kubectl get cm keptn-domain -n keptn -ojsonpa
 KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token} | base64 --decode)
 
 # test configuration
-UNLEASH_SERVICE_VERSION="master" #${UNLEASH_SERVICE_VERSION:-0.1.0}
+UNLEASH_SERVICE_VERSION=${UNLEASH_SERVICE_VERSION:-master}
 PROJECT="self-healing-project"
 SERVICE="frontend"
 
@@ -77,7 +77,6 @@ verify_using_jq "$response" ".data.stage" "production"
 verify_using_jq "$response" ".data.service" "$SERVICE"
 verify_using_jq "$response" ".data.remediation.status" "errored"
 verify_using_jq "$response" ".data.remediation.result" "failed"
-verify_using_jq "$response" ".data.remediation.message" "Could not execute remediation action because service is not available"
 
 
 ####################################################################################################################################

--- a/test/test_self_healing_scaling.sh
+++ b/test/test_self_healing_scaling.sh
@@ -17,7 +17,7 @@ PROJECT="sockshop"
 SERVICE="carts"
 STAGE="production"
 
-PROMETHEUS_SERVICE_VERSION=${PROMETHEUS_SERVICE_VERSION:-0.3.4}
+PROMETHEUS_SERVICE_VERSION=${PROMETHEUS_SERVICE_VERSION:-master}
 
 kubectl delete namespace $PROJECT-dev
 kubectl delete namespace $PROJECT-staging
@@ -27,6 +27,13 @@ keptn delete project $PROJECT
 keptn create project $PROJECT --shipyard=./test/assets/shipyard_self_healing_scale.yaml
 
 # Prerequisites
+
+kubectl apply -f https://raw.githubusercontent.com/keptn-contrib/prometheus-service/$PROMETHEUS_SERVICE_VERSION/deploy/service.yaml
+
+wait_for_deployment_in_namespace prometheus-service keptn
+wait_for_deployment_in_namespace prometheus-service-monitoring-configure-distributor keptn
+echo "Prometheus service deployed successfully"
+
 rm -rf examples
 git clone --branch master https://github.com/keptn/examples --single-branch
 
@@ -74,11 +81,6 @@ wait_for_deployment_in_namespace $SERVICE-primary $PROJECT-$STAGE
 ###########################################
 # set up prometheus monitoring            #
 ###########################################
-kubectl apply -f https://raw.githubusercontent.com/keptn-contrib/prometheus-service/release-$PROMETHEUS_SERVICE_VERSION/deploy/service.yaml
-
-wait_for_deployment_in_namespace prometheus-service keptn
-wait_for_deployment_in_namespace prometheus-service-monitoring-configure-distributor keptn
-echo "Prometheus service deployed successfully"
 
 keptn configure monitoring prometheus --project=$PROJECT --service=$SERVICE
 


### PR DESCRIPTION
The integration test for self healing was failing because the Prometheus service was not granted the required RBAC permissions (due to applying the wrong manifest for the service). This has been fixed in this PR