### PR TITLE
added some log messages during wait for problem event

### DIFF
--- a/test/test_self_healing_scaling.sh
+++ b/test/test_self_healing_scaling.sh
@@ -99,6 +99,12 @@ wait_for_deployment_in_namespace cartsloadgen loadgen
 
 echo "loadgen deployed successfully waiting for problem notification"
 
+sleep 120
+echo "Still waiting..."
+sleep 120
+echo "Still waiting..."
+sleep 120
+
 event=$(wait_for_problem_open_event ${PROJECT} ${SERVICE} ${STAGE})
 
 echo $event


### PR DESCRIPTION
To avoid a timeout on travis (which occurs after 10m of no console output), I've added some echoes during the waiting period until the problem.open event occurs