### PR TITLE
#1986 added ingress gateway env var

### DIFF
--- a/helm-service/controller/configuration_changer.go
+++ b/helm-service/controller/configuration_changer.go
@@ -21,24 +21,18 @@ type ConfigurationChanger struct {
 	generatedChartHandler *helm.GeneratedChartHandler
 	keptnHandler          *keptnevents.Keptn
 	helmExecutor          helm.HelmExecutor
-	ingressHostnameSuffix string
-	ingressProtocol       string
-	ingressPort           string
 	configServiceURL      string
 }
 
 // NewConfigurationChanger creates a new ConfigurationChanger
-func NewConfigurationChanger(mesh mesh.Mesh, keptnHandler *keptnevents.Keptn, ingressHostnameSuffix string, configServiceURL string, ingressProtocol string, ingressPort string) *ConfigurationChanger {
-	generatedChartHandler := helm.NewGeneratedChartHandler(mesh, ingressHostnameSuffix, ingressProtocol, ingressPort, keptnHandler.Logger)
+func NewConfigurationChanger(mesh mesh.Mesh, keptnHandler *keptnevents.Keptn, configServiceURL string) *ConfigurationChanger {
+	generatedChartHandler := helm.NewGeneratedChartHandler(mesh, keptnHandler.Logger)
 	helmExecutor := helm.NewHelmV3Executor(keptnHandler.Logger)
 	return &ConfigurationChanger{
 		mesh:                  mesh,
 		generatedChartHandler: generatedChartHandler,
 		keptnHandler:          keptnHandler,
 		helmExecutor:          helmExecutor,
-		ingressHostnameSuffix: ingressHostnameSuffix,
-		ingressProtocol:       ingressProtocol,
-		ingressPort:           ingressPort,
 		configServiceURL:      configServiceURL,
 	}
 }
@@ -166,7 +160,7 @@ func (c *ConfigurationChanger) ChangeAndApplyConfiguration(ce cloudevents.Event,
 		}
 		var shkeptncontext string
 		ce.Context.ExtensionAs("shkeptncontext", &shkeptncontext)
-		if err := sendDeploymentFinishedEvent(keptnHandler, testStrategy, deploymentStrategy, image, tag, c.ingressHostnameSuffix, c.ingressProtocol, c.ingressPort); err != nil {
+		if err := sendDeploymentFinishedEvent(keptnHandler, testStrategy, deploymentStrategy, image, tag, mesh.GetIngressHostnameSuffix(), mesh.GetIngressProtocol(), mesh.GetIngressPort()); err != nil {
 			c.keptnHandler.Logger.Error(fmt.Sprintf("Cannot send deployment finished event: %s", err.Error()))
 			return err
 		}
@@ -203,7 +197,7 @@ func (c *ConfigurationChanger) applyValuesCanary(e *keptnevents.ConfigurationCha
 	if err := c.upgradeChart(ch, *e, deploymentStrategy); err != nil {
 		return err
 	}
-	onboarder := NewOnboarder(c.mesh, c.keptnHandler, c.ingressHostnameSuffix, c.configServiceURL, c.ingressProtocol, c.ingressPort)
+	onboarder := NewOnboarder(c.mesh, c.keptnHandler, c.configServiceURL)
 	if onboarder.IsGeneratedChartEmpty(genChart) {
 		userChartManifest, err := c.helmExecutor.GetManifest(helm.GetReleaseName(e.Project, e.Stage, e.Service, false),
 			e.Project+"-"+e.Stage)
@@ -408,7 +402,7 @@ func (c *ConfigurationChanger) changeCanary(e *keptnevents.ConfigurationChangeEv
 			return err
 		}
 
-		chartGenerator := helm.NewGeneratedChartHandler(c.mesh, c.ingressHostnameSuffix, c.ingressProtocol, c.ingressPort, c.keptnHandler.Logger)
+		chartGenerator := helm.NewGeneratedChartHandler(c.mesh, c.keptnHandler.Logger)
 		userChartManifest, err := c.helmExecutor.GetManifest(helm.GetReleaseName(e.Project, e.Stage, e.Service, false),
 			e.Project+"-"+e.Stage)
 		if err != nil {

--- a/helm-service/controller/mesh/ingress_config.go
+++ b/helm-service/controller/mesh/ingress_config.go
@@ -31,8 +31,8 @@ func GetIngressPort() string {
 
 // GetIngressGateway returns the ingress gateway
 func GetIngressGateway() string {
-	if os.Getenv("INGRESS_GATEWAY") != "" {
-		return os.Getenv("INGRESS_GATEWAY")
+	if os.Getenv("ISTIO_GATEWAY") != "" {
+		return os.Getenv("ISTIO_GATEWAY")
 	}
 	return "public-gateway.istio-system"
 }

--- a/helm-service/controller/mesh/ingress_config.go
+++ b/helm-service/controller/mesh/ingress_config.go
@@ -1,0 +1,38 @@
+package mesh
+
+import (
+	"os"
+	"strings"
+)
+
+// GetIngressHostnameSuffix returns the ingress hostname suffix
+func GetIngressHostnameSuffix() string {
+	if os.Getenv("INGRESS_HOSTNAME_SUFFIX") != "" {
+		return os.Getenv("INGRESS_HOSTNAME_SUFFIX")
+	}
+	return "svc.cluster.local"
+}
+
+// GetIngressProtocol returns the ingress protocol
+func GetIngressProtocol() string {
+	if os.Getenv("INGRESS_PROTOCOL") != "" {
+		return strings.ToLower(os.Getenv("INGRESS_PROTOCOL"))
+	}
+	return "http"
+}
+
+// GetIngressPort returns the ingress port
+func GetIngressPort() string {
+	if os.Getenv("INGRESS_PORT") != "" {
+		return os.Getenv("INGRESS_PORT")
+	}
+	return "80"
+}
+
+// GetIngressGateway returns the ingress gateway
+func GetIngressGateway() string {
+	if os.Getenv("INGRESS_GATEWAY") != "" {
+		return os.Getenv("INGRESS_GATEWAY")
+	}
+	return "public-gateway.istio-system"
+}

--- a/helm-service/controller/onboarder.go
+++ b/helm-service/controller/onboarder.go
@@ -20,23 +20,17 @@ import (
 
 // Onboarder is a container of variables required for onboarding a new service
 type Onboarder struct {
-	mesh                  mesh.Mesh
-	keptnHandler          *keptnevents.Keptn
-	ingressHostnameSuffix string
-	ingressProtocol       string
-	ingressPort           string
-	configServiceURL      string
+	mesh             mesh.Mesh
+	keptnHandler     *keptnevents.Keptn
+	configServiceURL string
 }
 
 // NewOnboarder creates a new Onboarder
-func NewOnboarder(mesh mesh.Mesh, keptnHandler *keptnevents.Keptn, ingressHostnameSuffix string, configServiceURL string, ingressProtocol string, ingressPort string) *Onboarder {
+func NewOnboarder(mesh mesh.Mesh, keptnHandler *keptnevents.Keptn, configServiceURL string) *Onboarder {
 	return &Onboarder{
-		mesh:                  mesh,
-		keptnHandler:          keptnHandler,
-		ingressHostnameSuffix: ingressHostnameSuffix,
-		configServiceURL:      configServiceURL,
-		ingressProtocol:       ingressProtocol,
-		ingressPort:           ingressPort,
+		mesh:             mesh,
+		keptnHandler:     keptnHandler,
+		configServiceURL: configServiceURL,
 	}
 }
 
@@ -208,7 +202,7 @@ func (o *Onboarder) onboardService(stageName string, event *keptnevents.ServiceC
 			return err
 		}
 
-		chartGenerator := helm.NewGeneratedChartHandler(o.mesh, o.ingressHostnameSuffix, o.ingressProtocol, o.ingressPort, o.keptnHandler.Logger)
+		chartGenerator := helm.NewGeneratedChartHandler(o.mesh, o.keptnHandler.Logger)
 		o.keptnHandler.Logger.Debug(fmt.Sprintf("For stage %s with deployment strategy %s, an empty chart is generated", stageName, event.DeploymentStrategies[stageName].String()))
 		generatedChart := chartGenerator.GenerateEmptyChart(event.Service, event.DeploymentStrategies[stageName])
 
@@ -241,7 +235,7 @@ func (c *Onboarder) IsGeneratedChartEmpty(chart *chart.Chart) bool {
 func (o *Onboarder) OnboardGeneratedService(helmManifest string, project string, stageName string,
 	service string, strategy keptnevents.DeploymentStrategy) (*chart.Chart, error) {
 
-	chartGenerator := helm.NewGeneratedChartHandler(o.mesh, o.ingressHostnameSuffix, o.ingressProtocol, o.ingressPort, o.keptnHandler.Logger)
+	chartGenerator := helm.NewGeneratedChartHandler(o.mesh, o.keptnHandler.Logger)
 
 	helmChartName := helm.GetChartName(service, true)
 	o.keptnHandler.Logger.Debug(fmt.Sprintf("Generating the keptn-managed Helm chart %s for stage %s", helmChartName, stageName))

--- a/helm-service/controller/onboarder_test.go
+++ b/helm-service/controller/onboarder_test.go
@@ -84,7 +84,7 @@ func TestDoOnboard(t *testing.T) {
 
 	keptnHandler, _ := keptnevents.NewKeptn(&ce, keptnevents.KeptnOpts{})
 
-	onboarder := NewOnboarder(mesh.NewIstioMesh(), keptnHandler, "test.keptn.sh", "", "http", "80")
+	onboarder := NewOnboarder(mesh.NewIstioMesh(), keptnHandler, configBaseURL)
 	loggingDone := make(chan bool)
 	err = onboarder.DoOnboard(ce, loggingDone)
 	if err != nil {
@@ -98,7 +98,7 @@ func TestCheckAndSetServiceName(t *testing.T) {
 		"The service name has to be a valid Unix directory name. For details see " +
 		"https://www.cyberciti.biz/faq/linuxunix-rules-for-naming-file-and-directory-names/"
 
-	o := NewOnboarder(nil, nil, "test.keptn.sh", "", "http", "80")
+	o := NewOnboarder(nil, nil, configBaseURL)
 	data := helmtest.CreateHelmChartData(t)
 
 	testCases := []struct {

--- a/helm-service/deploy/service.yaml
+++ b/helm-service/deploy/service.yaml
@@ -52,11 +52,11 @@ spec:
             configMapKeyRef:
               name: ingress-config
               key: ingress_port
-        - name: INGRESS_GATEWAY
+        - name: ISTIO_GATEWAY
           valueFrom:
             configMapKeyRef:
               name: ingress-config
-              key: ingress_gateway
+              key: istio_gateway
 ---
 apiVersion: v1
 kind: Service

--- a/helm-service/deploy/service.yaml
+++ b/helm-service/deploy/service.yaml
@@ -52,6 +52,11 @@ spec:
             configMapKeyRef:
               name: ingress-config
               key: ingress_port
+        - name: INGRESS_GATEWAY
+          valueFrom:
+            configMapKeyRef:
+              name: ingress-config
+              key: ingress_gateway
 ---
 apiVersion: v1
 kind: Service

--- a/helm-service/go.sum
+++ b/helm-service/go.sum
@@ -8,6 +8,7 @@ contrib.go.opencensus.io/exporter/ocagent v0.4.12/go.mod h1:450APlNTSR6FrvC3CTRq
 contrib.go.opencensus.io/exporter/prometheus v0.1.0/go.mod h1:cGFniUXGZlKRjzOyuZJ6mgB+PgBcCIa79kEKR8YCW+A=
 github.com/Azure/azure-sdk-for-go v16.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v30.1.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-autorest v10.8.1+incompatible h1:u0jVQf+a6k6x8A+sT60l6EY9XZu+kHdnZVPAYqpVRo0=
 github.com/Azure/go-autorest v10.8.1+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
@@ -50,7 +51,9 @@ github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuN
 github.com/Masterminds/sprig/v3 v3.0.2 h1:wz22D0CiSctrliXiI9ZO3HoNApweeRGftyDN+BQa3B8=
 github.com/Masterminds/sprig/v3 v3.0.2/go.mod h1:oesJ8kPONMONaZgtiHNzUShJbksypC5kWczhZAf6+aU=
 github.com/Masterminds/vcs v1.13.1/go.mod h1:N09YCmOQr6RLxC6UNHzuVwAdodYbbnycGHSmwVJjcKA=
+github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5 h1:ygIc8M6trr62pF5DucadTWGdEB4mEyvzi0e2nbcmcyA=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
+github.com/Microsoft/hcsshim v0.8.7 h1:ptnOoufxGSzauVTsdE+wMYnCWA301PdoN4xg5oRdZpg=
 github.com/Microsoft/hcsshim v0.8.7/go.mod h1:OHd7sQqRFrYd3RmSgbgji+ctCwkbq2wbEYNSzOYtcBQ=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
@@ -118,6 +121,7 @@ github.com/cloudevents/sdk-go v0.10.0 h1:j/0Gwiyc0aamxaPx2aLsRhbGUcwIcE/lb5s00OO
 github.com/cloudevents/sdk-go v0.10.0/go.mod h1:PW8UwWI6tD2Ry5kFpZfV1qlrADFkfaDCZXLiJ1dC1Ks=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
+github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f h1:tSNMc+rJDfmYntojat8lljbt1mgKNpTxUZJsSzJ9Y1s=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.3.0-beta.2.0.20190828155532-0293cbd26c69/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
@@ -405,6 +409,7 @@ github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
@@ -465,6 +470,7 @@ github.com/kinbiko/jsonassert v1.0.1/go.mod h1:QRwBwiAsrcJpjw+L+Q4WS8psLxuUY+Hyl
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=

--- a/helm-service/main.go
+++ b/helm-service/main.go
@@ -3,10 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
-	"os"
-	"strings"
-
 	"github.com/cloudevents/sdk-go/pkg/cloudevents"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/client"
 	cloudeventshttp "github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http"
@@ -15,6 +11,8 @@ import (
 	"github.com/keptn/keptn/helm-service/controller"
 	"github.com/keptn/keptn/helm-service/controller/mesh"
 	"github.com/keptn/keptn/helm-service/pkg/serviceutils"
+	"log"
+	"os"
 )
 
 type envConfig struct {
@@ -31,27 +29,6 @@ func main() {
 		log.Fatalf("Failed to process env var: %s", err)
 	}
 	os.Exit(_main(os.Args[1:], env))
-}
-
-func getIngressHostnameSuffix() string {
-	if os.Getenv("INGRESS_HOSTNAME_SUFFIX") != "" {
-		return os.Getenv("INGRESS_HOSTNAME_SUFFIX")
-	}
-	return "svc.cluster.local"
-}
-
-func getIngressProtocol() string {
-	if os.Getenv("INGRESS_PROTOCOL") != "" {
-		return strings.ToLower(os.Getenv("INGRESS_PROTOCOL"))
-	}
-	return "http"
-}
-
-func getIngressPort() string {
-	if os.Getenv("INGRESS_PORT") != "" {
-		return os.Getenv("INGRESS_PORT")
-	}
-	return "80"
 }
 
 func gotEvent(ctx context.Context, event cloudevents.Event) error {
@@ -76,10 +53,6 @@ func gotEvent(ctx context.Context, event cloudevents.Event) error {
 
 	mesh := mesh.NewIstioMesh()
 
-	ingressHostnameSuffix := getIngressHostnameSuffix()
-	ingressProtocol := getIngressProtocol()
-	ingressPort := getIngressPort()
-
 	url, err := serviceutils.GetConfigServiceURL()
 	if err != nil {
 		keptnHandler.Logger.Error(fmt.Sprintf("Error when getting config service url: %s", err.Error()))
@@ -90,10 +63,10 @@ func gotEvent(ctx context.Context, event cloudevents.Event) error {
 	keptnHandler.Logger.Debug("Got event of type " + event.Type())
 
 	if event.Type() == keptnevents.ConfigurationChangeEventType {
-		configChanger := controller.NewConfigurationChanger(mesh, keptnHandler, ingressHostnameSuffix, url.String(), ingressProtocol, ingressPort)
+		configChanger := controller.NewConfigurationChanger(mesh, keptnHandler, url.String())
 		go configChanger.ChangeAndApplyConfiguration(event, loggingDone)
 	} else if event.Type() == keptnevents.InternalServiceCreateEventType {
-		onboarder := controller.NewOnboarder(mesh, keptnHandler, ingressHostnameSuffix, url.String(), ingressProtocol, ingressPort)
+		onboarder := controller.NewOnboarder(mesh, keptnHandler, url.String())
 		go onboarder.DoOnboard(event, loggingDone)
 	} else if event.Type() == keptnevents.ActionTriggeredEventType {
 		actionHandler := controller.NewActionTriggeredHandler(keptnHandler, url.String())

--- a/installer/manifests/keptn/core.yaml
+++ b/installer/manifests/keptn/core.yaml
@@ -221,6 +221,11 @@ spec:
                 configMapKeyRef:
                   name: ingress-config
                   key: ingress_port
+            - name: INGRESS_GATEWAY
+              valueFrom:
+                configMapKeyRef:
+                  name: ingress-config
+                  key: ingress_gateway
       serviceAccountName: keptn-helm-service
 ---
 apiVersion: v1

--- a/installer/manifests/keptn/core.yaml
+++ b/installer/manifests/keptn/core.yaml
@@ -221,11 +221,11 @@ spec:
                 configMapKeyRef:
                   name: ingress-config
                   key: ingress_port
-            - name: INGRESS_GATEWAY
+            - name: ISTIO_GATEWAY
               valueFrom:
                 configMapKeyRef:
                   name: ingress-config
-                  key: ingress_gateway
+                  key: istio_gateway
       serviceAccountName: keptn-helm-service
 ---
 apiVersion: v1

--- a/installer/manifests/keptn/ingress-config.yaml
+++ b/installer/manifests/keptn/ingress-config.yaml
@@ -8,3 +8,4 @@ data:
   ingress_hostname_suffix: ""
   ingress_protocol: ""
   ingress_port: ""
+  ingress_gateway: ""

--- a/installer/manifests/keptn/ingress-config.yaml
+++ b/installer/manifests/keptn/ingress-config.yaml
@@ -8,4 +8,4 @@ data:
   ingress_hostname_suffix: ""
   ingress_protocol: ""
   ingress_port: ""
-  ingress_gateway: ""
+  istio_gateway: ""


### PR DESCRIPTION
Closes #1986 

This PR makes the name of the ingress gateway configurable in the helm-service. To set the value for the gateway, the `ingress-config` ConfigMap is used. This ConfigMap now has the following format:

```
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: ingress-config
  namespace: keptn
data:
  ingress_hostname_suffix: ""
  ingress_protocol: ""
  ingress_port: ""
  istio_gateway: ""

```