### PR TITLE
#1948 Use scheme from provided endpoint

### DIFF
--- a/cli/cmd/add_resource.go
+++ b/cli/cmd/add_resource.go
@@ -75,7 +75,7 @@ keptn add-resource --project=rockshop --stage=production --service=shop --resour
 			},
 		}
 
-		resourceHandler := apiutils.NewAuthenticatedResourceHandler(endPoint.Host+"/api/configuration-service", apiToken, "x-token", nil, *scheme)
+		resourceHandler := apiutils.NewAuthenticatedResourceHandler(endPoint.Host+"/api/configuration-service", apiToken, "x-token", nil, endPoint.Scheme)
 
 		if (addResourceCmdParams.Service != nil && *addResourceCmdParams.Service != "") && (addResourceCmdParams.Stage != nil && *addResourceCmdParams.Stage != "") {
 			logging.PrintLog("Adding resource "+*addResourceCmdParams.Resource+" to service "+*addResourceCmdParams.Service+" in stage "+*addResourceCmdParams.Stage+" in project "+*addResourceCmdParams.Project, logging.InfoLevel)

--- a/cli/cmd/auth.go
+++ b/cli/cmd/auth.go
@@ -43,7 +43,7 @@ More precisely, the keptn CLI stores the endpoint and API token using *pass* in 
 			return err
 		}
 
-		authHandler := apiutils.NewAuthenticatedAuthHandler(url.String(), *apiToken, "x-token", nil, *scheme)
+		authHandler := apiutils.NewAuthenticatedAuthHandler(url.String(), *apiToken, "x-token", nil, url.Scheme)
 
 		if !mocking {
 			authenticated := false

--- a/cli/cmd/configure_monitoring.go
+++ b/cli/cmd/configure_monitoring.go
@@ -102,7 +102,7 @@ keptn configure monitoring prometheus --project=PROJECTNAME --service=SERVICENAM
 			Data: configureMonitoringEventData,
 		}
 
-		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, *scheme)
+		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)
 
 		eventByte, err := sdkEvent.MarshalJSON()
@@ -125,7 +125,7 @@ keptn configure monitoring prometheus --project=PROJECTNAME --service=SERVICENAM
 
 			// if eventContext is available, open WebSocket communication
 			if eventContext != nil && !SuppressWSCommunication {
-				return websockethelper.PrintWSContentEventContext(eventContext, endPoint, *scheme == "https")
+				return websockethelper.PrintWSContentEventContext(eventContext, endPoint)
 			}
 
 			return nil

--- a/cli/cmd/create_project.go
+++ b/cli/cmd/create_project.go
@@ -122,7 +122,7 @@ keptn create project PROJECTNAME --shipyard=FILEPATH --git-user=GIT_USER --git-t
 			project.GitRemoteURL = *createProjectParams.RemoteURL
 		}
 
-		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, *scheme)
+		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)
 
 		if !mocking {
@@ -134,7 +134,7 @@ keptn create project PROJECTNAME --shipyard=FILEPATH --git-user=GIT_USER --git-t
 
 			// if eventContext is available, open WebSocket communication
 			if eventContext != nil && !SuppressWSCommunication {
-				return websockethelper.PrintWSContentEventContext(eventContext, endPoint, *scheme == "https")
+				return websockethelper.PrintWSContentEventContext(eventContext, endPoint)
 			}
 
 			return nil

--- a/cli/cmd/create_service.go
+++ b/cli/cmd/create_service.go
@@ -60,7 +60,7 @@ Please note: This command is different from keptn onboard service (which require
 			ServiceName: &args[0],
 		}
 
-		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, *scheme)
+		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)
 
 		if !mocking {
@@ -72,7 +72,7 @@ Please note: This command is different from keptn onboard service (which require
 
 			// if eventContext is available, open WebSocket communication
 			if eventContext != nil && !SuppressWSCommunication {
-				return websockethelper.PrintWSContentEventContext(eventContext, endPoint, *scheme == "https")
+				return websockethelper.PrintWSContentEventContext(eventContext, endPoint)
 			}
 
 			return nil

--- a/cli/cmd/delete_project.go
+++ b/cli/cmd/delete_project.go
@@ -54,7 +54,7 @@ var delProjectCmd = &cobra.Command{
 			ProjectName: args[0],
 		}
 
-		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, *scheme)
+		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)
 
 		if !mocking {
@@ -66,7 +66,7 @@ var delProjectCmd = &cobra.Command{
 
 			// if eventContext is available, open WebSocket communication
 			if eventContext != nil && !SuppressWSCommunication {
-				return websockethelper.PrintWSContentEventContext(eventContext, endPoint, *scheme == "https")
+				return websockethelper.PrintWSContentEventContext(eventContext, endPoint)
 			}
 
 			return nil

--- a/cli/cmd/generate_support_archive.go
+++ b/cli/cmd/generate_support_archive.go
@@ -525,7 +525,7 @@ func getProjects() *errorableProjectResult {
 	if err != nil {
 		return newErrorableProjectResult(nil, err)
 	}
-	projectHandler := apiutils.NewAuthenticatedProjectHandler(endPoint.String(), apiToken, "x-token", nil, *scheme)
+	projectHandler := apiutils.NewAuthenticatedProjectHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 	return newErrorableProjectResult(projectHandler.GetAllProjects())
 }
 
@@ -547,7 +547,7 @@ func getKeptnMetadata() *errorableMetadataResult {
 	if err != nil {
 		return newErrorableMetadataResult(nil, err)
 	}
-	metadataHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, *scheme)
+	metadataHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 	metadataData, errMetadata := metadataHandler.GetMetadata()
 	if errMetadata != nil {
 		err = errors.New("Error occured with response code " + string(errMetadata.Code) + " with message " + *errMetadata.Message)

--- a/cli/cmd/get_event_approvalTriggered.go
+++ b/cli/cmd/get_event_approvalTriggered.go
@@ -65,8 +65,8 @@ func getApprovalTriggeredEvents(approvalTriggered approvalTriggeredStruct) error
 
 	logging.PrintLog("Starting to get approval.triggered events", logging.InfoLevel)
 
-	serviceHandler := apiutils.NewAuthenticatedServiceHandler(endPoint.String(), apiToken, "x-token", nil, *scheme)
-	eventHandler := apiutils.NewAuthenticatedEventHandler(endPoint.String(), apiToken, "x-token", nil, *scheme)
+	serviceHandler := apiutils.NewAuthenticatedServiceHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
+	eventHandler := apiutils.NewAuthenticatedEventHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 
 	logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)
 

--- a/cli/cmd/get_event_approvalTriggered_test.go
+++ b/cli/cmd/get_event_approvalTriggered_test.go
@@ -131,7 +131,6 @@ func Test_getApprovalTriggeredEvents(t *testing.T) {
 			w.Write([]byte(`{}`))
 		}),
 	)
-	scheme = stringp("http")
 	defer ts.Close()
 
 	os.Setenv("MOCK_SERVER", ts.URL)

--- a/cli/cmd/get_event_evaluationDone.go
+++ b/cli/cmd/get_event_evaluationDone.go
@@ -47,7 +47,7 @@ var evaluationDoneCmd = &cobra.Command{
 
 		logging.PrintLog("Starting to get evaluation-done event", logging.InfoLevel)
 
-		eventHandler := apiutils.NewAuthenticatedEventHandler(endPoint.String(), apiToken, "x-token", nil, *scheme)
+		eventHandler := apiutils.NewAuthenticatedEventHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)
 
 		if !mocking {

--- a/cli/cmd/get_projects.go
+++ b/cli/cmd/get_projects.go
@@ -91,7 +91,7 @@ keptn get project sockshop -output=json
 		var projectName string
 		projectName = strings.Join(args, " ")
 
-		projectsHandler := apiutils.NewAuthenticatedProjectHandler(endPoint.String(), apiToken, "x-token", nil, *scheme)
+		projectsHandler := apiutils.NewAuthenticatedProjectHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 
 		if !mocking {
 

--- a/cli/cmd/get_services.go
+++ b/cli/cmd/get_services.go
@@ -88,8 +88,8 @@ keptn get services carts --project=sockshop -o=json
 			return errors.New(authErrorMsg)
 		}
 
-		projectsHandler := apiutils.NewAuthenticatedProjectHandler(endPoint.String(), apiToken, "x-token", nil, *scheme)
-		servicesHandler := apiutils.NewAuthenticatedServiceHandler(endPoint.String(), apiToken, "x-token", nil, *scheme)
+		projectsHandler := apiutils.NewAuthenticatedProjectHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
+		servicesHandler := apiutils.NewAuthenticatedServiceHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 
 		if !mocking {
 

--- a/cli/cmd/get_stages.go
+++ b/cli/cmd/get_stages.go
@@ -66,7 +66,7 @@ staging        2020-04-06T14:37:45.210Z
 			return errors.New(authErrorMsg)
 		}
 
-		stagesHandler := apiutils.NewAuthenticatedStageHandler(endPoint.String(), apiToken, "x-token", nil, *scheme)
+		stagesHandler := apiutils.NewAuthenticatedStageHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 		if !mocking {
 			stages, err := stagesHandler.GetAllStages(*stageParameter.project)
 			if err != nil {

--- a/cli/cmd/onboard_service.go
+++ b/cli/cmd/onboard_service.go
@@ -119,7 +119,7 @@ keptn onboard service SERVICENAME --project=PROJECTNAME --chart=HELM_CHART.tgz`,
 			service.DeploymentStrategies = deplStrategies
 		}
 
-		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, *scheme)
+		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)
 
 		if !mocking {
@@ -131,7 +131,7 @@ keptn onboard service SERVICENAME --project=PROJECTNAME --chart=HELM_CHART.tgz`,
 
 			// if eventContext is available, open WebSocket communication
 			if eventContext != nil && !SuppressWSCommunication {
-				return websockethelper.PrintWSContentEventContext(eventContext, endPoint, *scheme == "https")
+				return websockethelper.PrintWSContentEventContext(eventContext, endPoint)
 			}
 
 			return nil

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -23,8 +23,6 @@ var SuppressWSCommunication bool
 var insecureSkipTLSVerify bool
 var kubectlOptions string
 
-var scheme *string
-
 const authErrorMsg = "This command requires to be authenticated. See \"keptn auth\" for details"
 
 // rootCmd represents the base command when called without any subcommands
@@ -64,9 +62,6 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&mocking, "mock", "", false, "mocking of server communication - ATTENTION: your commands will not be sent to the keptn server")
 	rootCmd.PersistentFlags().BoolVarP(&SuppressWSCommunication, "suppress-websocket", "", false,
 		"disables websocket communication - use the ID of Keptn context (if provided) for checking the result of your command")
-
-	scheme = rootCmd.PersistentFlags().StringP("scheme", "", "https", "The used scheme for the Keptn API")
-	rootCmd.PersistentFlags().MarkHidden("scheme")
 	cobra.OnInitialize(initConfig)
 
 }

--- a/cli/cmd/send_event.go
+++ b/cli/cmd/send_event.go
@@ -69,7 +69,7 @@ For convenience, this command offers the *--stream-websocket* flag to open a web
 			return fmt.Errorf("Failed to map event to API event model. %s", err.Error())
 		}
 
-		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, *scheme)
+		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)
 
 		if !mocking {

--- a/cli/cmd/send_event_approvalFinished.go
+++ b/cli/cmd/send_event_approvalFinished.go
@@ -76,8 +76,8 @@ func sendApprovalFinishedEvent(sendApprovalFinishedOptions sendApprovalFinishedS
 
 	logging.PrintLog("Starting to send approval.finished event", logging.InfoLevel)
 
-	apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, *scheme)
-	eventHandler := apiutils.NewAuthenticatedEventHandler(endPoint.String(), apiToken, "x-token", nil, *scheme)
+	apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
+	eventHandler := apiutils.NewAuthenticatedEventHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 
 	logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)
 
@@ -88,7 +88,7 @@ func sendApprovalFinishedEvent(sendApprovalFinishedOptions sendApprovalFinishedS
 	if *sendApprovalFinishedOptions.ID != "" {
 		keptnContext, triggeredID, approvalFinishedEvent, err = getApprovalFinishedForID(eventHandler, sendApprovalFinishedOptions)
 	} else if *sendApprovalFinishedOptions.Service != "" {
-		serviceHandler := apiutils.NewAuthenticatedServiceHandler(endPoint.String(), apiToken, "x-token", nil, *scheme)
+		serviceHandler := apiutils.NewAuthenticatedServiceHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 		keptnContext, triggeredID, approvalFinishedEvent, err = getApprovalFinishedForService(eventHandler,
 			serviceHandler, sendApprovalFinishedOptions)
 	}

--- a/cli/cmd/send_event_approvalFinished_test.go
+++ b/cli/cmd/send_event_approvalFinished_test.go
@@ -111,7 +111,6 @@ func Test_sendApprovalFinishedEvent(t *testing.T) {
 			return
 		}),
 	)
-	scheme = stringp("http")
 	defer ts.Close()
 
 	os.Setenv("MOCK_SERVER", ts.URL)

--- a/cli/cmd/send_event_evaluationStart.go
+++ b/cli/cmd/send_event_evaluationStart.go
@@ -120,7 +120,7 @@ point, the flag *--start* flag can be used. In this case, the specified time fra
 			return fmt.Errorf("Failed to map cloud event to API event model. %s", err.Error())
 		}
 
-		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, *scheme)
+		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)
 
 		if !mocking {

--- a/cli/cmd/send_event_newArtifact.go
+++ b/cli/cmd/send_event_newArtifact.go
@@ -117,7 +117,7 @@ For pulling an image from a private registry, we would like to refer to the Kube
 			return fmt.Errorf("Failed to map cloud event to API event model. %s", err.Error())
 		}
 
-		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, *scheme)
+		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)
 
 		if !mocking {
@@ -129,7 +129,7 @@ For pulling an image from a private registry, we would like to refer to the Kube
 
 			// if eventContext is available, open WebSocket communication
 			if eventContext != nil && !SuppressWSCommunication {
-				return websockethelper.PrintWSContentEventContext(eventContext, endPoint, *scheme == "https")
+				return websockethelper.PrintWSContentEventContext(eventContext, endPoint)
 			}
 
 			return nil

--- a/cli/cmd/update_project.go
+++ b/cli/cmd/update_project.go
@@ -73,7 +73,7 @@ For more information about updating projects or upstream repositories visit http
 			project.GitRemoteURI = *updateProjectParams.RemoteURL
 		}
 
-		projectHandler := apiutils.NewAuthenticatedProjectHandler(endPoint.String(), apiToken, "x-token", nil, *scheme)
+		projectHandler := apiutils.NewAuthenticatedProjectHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)
 
 		if !mocking {
@@ -85,7 +85,7 @@ For more information about updating projects or upstream repositories visit http
 
 			// if eventContext is available, open WebSocket communication
 			if eventContext != nil && !SuppressWSCommunication {
-				return websockethelper.PrintWSContentEventContext(eventContext, endPoint, *scheme == "https")
+				return websockethelper.PrintWSContentEventContext(eventContext, endPoint)
 			}
 			logging.PrintLog("Project updated successful", logging.InfoLevel)
 			return nil

--- a/cli/pkg/websockethelper/websocket_helper.go
+++ b/cli/pkg/websockethelper/websocket_helper.go
@@ -22,19 +22,19 @@ import (
 
 // PrintWSContentEventContext opens a websocket using the passed
 // connection data and prints status data
-func PrintWSContentEventContext(eventContext *apimodels.EventContext, apiEndPoint url.URL, useWss bool) error {
+func PrintWSContentEventContext(eventContext *apimodels.EventContext, apiEndPoint url.URL) error {
 	connectionData := &keptnutils.ConnectionData{EventContext: *eventContext}
-	return printWSContent(*connectionData, apiEndPoint, useWss)
+	return printWSContent(*connectionData, apiEndPoint)
 }
 
-func printWSContent(connData keptnutils.ConnectionData, apiEndPoint url.URL, useWss bool) error {
+func printWSContent(connData keptnutils.ConnectionData, apiEndPoint url.URL) error {
 
 	err := validateConnectionData(connData)
 	if err != nil {
 		return err
 	}
 
-	ws, _, err := openWS(connData, apiEndPoint, useWss)
+	ws, _, err := openWS(connData, apiEndPoint)
 	if err != nil {
 		fmt.Println("Opening websocket failed")
 		return err
@@ -53,10 +53,10 @@ func validateConnectionData(connData keptnutils.ConnectionData) error {
 }
 
 // openWS opens a websocket
-func openWS(connData keptnutils.ConnectionData, apiEndPoint url.URL, useWss bool) (*websocket.Conn, *http.Response, error) {
+func openWS(connData keptnutils.ConnectionData, apiEndPoint url.URL) (*websocket.Conn, *http.Response, error) {
 
 	wsEndPoint := apiEndPoint
-	if useWss {
+	if apiEndPoint.Scheme == "https" {
 		wsEndPoint.Scheme = "wss"
 	} else {
 		wsEndPoint.Scheme = "ws"


### PR DESCRIPTION
Closes #1948 

This PR removes the hidden flag --scheme, which allowed to override the used scheme.
With this PR, the scheme can be specified in the endpoint URL provided with `keptn auth`.