### PR TITLE
Use localhost for pub-sub-recipient in distributors

### DIFF
--- a/configuration-service/deploy/service.yaml
+++ b/configuration-service/deploy/service.yaml
@@ -67,7 +67,7 @@ spec:
           - name: PUBSUB_TOPIC
             value: 'sh.keptn.>'
           - name: PUBSUB_RECIPIENT
-            value: 'configuration-service'
+            value: '127.0.0.1'
           - name: PUBSUB_RECIPIENT_PATH
             value: '/v1/event'
       volumes:

--- a/gatekeeper-service/deploy/service.yaml
+++ b/gatekeeper-service/deploy/service.yaml
@@ -63,7 +63,7 @@ spec:
           - name: PUBSUB_TOPIC
             value: 'sh.keptn.events.evaluation-done,sh.keptn.event.approval.>'
           - name: PUBSUB_RECIPIENT
-            value: 'gatekeeper-service'
+            value: '127.0.0.1'
 ---
 apiVersion: v1
 kind: Service

--- a/helm-service/deploy/service.yaml
+++ b/helm-service/deploy/service.yaml
@@ -87,7 +87,7 @@ spec:
           - name: PUBSUB_TOPIC
             value: 'sh.keptn.internal.event.service.create'
           - name: PUBSUB_RECIPIENT
-            value: 'helm-service'
+            value: '127.0.0.1'
 ---
 apiVersion: v1
 kind: Service

--- a/installer/manifests/keptn/charts/continuous-delivery/charts/openshift/templates/route-service-openshift.yaml
+++ b/installer/manifests/keptn/charts/continuous-delivery/charts/openshift/templates/route-service-openshift.yaml
@@ -157,7 +157,7 @@ spec:
           - name: PUBSUB_TOPIC
             value: 'sh.keptn.internal.event.project.create'
           - name: PUBSUB_RECIPIENT
-            value: 'openshift-route-service'
+            value: '127.0.0.1'
       serviceAccountName: keptn-openshift-route-service
 ---
 apiVersion: v1

--- a/installer/manifests/keptn/charts/continuous-delivery/templates/continuous-deployment.yaml
+++ b/installer/manifests/keptn/charts/continuous-delivery/templates/continuous-deployment.yaml
@@ -98,7 +98,7 @@ spec:
             - name: PUBSUB_TOPIC
               value: 'sh.keptn.events.evaluation-done,sh.keptn.event.approval.>'
             - name: PUBSUB_RECIPIENT
-              value: 'gatekeeper-service'
+              value: '127.0.0.1'
 ---
 apiVersion: v1
 kind: Service
@@ -198,7 +198,7 @@ spec:
             - name: PUBSUB_TOPIC
               value: 'sh.keptn.events.deployment-finished'
             - name: PUBSUB_RECIPIENT
-              value: 'jmeter-service'
+              value: '127.0.0.1'
 ---
 apiVersion: v1
 kind: Service

--- a/installer/manifests/keptn/charts/control-plane/templates/continuous-operations.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/continuous-operations.yaml
@@ -58,7 +58,7 @@ spec:
           - name: PUBSUB_TOPIC
             value: 'sh.keptn.>'
           - name: PUBSUB_RECIPIENT
-            value: 'remediation-service'
+            value: '127.0.0.1'
       serviceAccountName: keptn-default
 ---
 apiVersion: v1

--- a/installer/manifests/keptn/charts/control-plane/templates/core.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/core.yaml
@@ -266,7 +266,7 @@ spec:
             - name: PUBSUB_TOPIC
               value: 'sh.keptn.internal.event.service.create'
             - name: PUBSUB_RECIPIENT
-              value: 'helm-service'
+              value: '127.0.0.1'
       serviceAccountName: keptn-helm-service
 ---
 apiVersion: v1
@@ -337,7 +337,7 @@ spec:
             - name: PUBSUB_TOPIC
               value: 'sh.keptn.internal.event.project.create,sh.keptn.internal.event.project.delete'
             - name: PUBSUB_RECIPIENT
-              value: 'shipyard-service'
+              value: '127.0.0.1'
       serviceAccountName: keptn-default
 ---
 apiVersion: v1
@@ -425,7 +425,7 @@ spec:
             - name: PUBSUB_TOPIC
               value: 'sh.keptn.>'
             - name: PUBSUB_RECIPIENT
-              value: 'configuration-service'
+              value: '127.0.0.1'
             - name: PUBSUB_RECIPIENT_PATH
               value: '/v1/event'
       volumes:

--- a/installer/manifests/keptn/charts/control-plane/templates/mongodb-datastore.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/mongodb-datastore.yaml
@@ -66,7 +66,7 @@ spec:
           - name: PUBSUB_TOPIC
             value: 'sh.keptn.>'
           - name: PUBSUB_RECIPIENT
-            value: 'mongodb-datastore'
+            value: '127.0.0.1'
           - name: PUBSUB_RECIPIENT_PATH
             value: '/event'
 ---

--- a/installer/manifests/keptn/charts/control-plane/templates/quality-gates.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/quality-gates.yaml
@@ -56,7 +56,7 @@ spec:
             - name: PUBSUB_TOPIC
               value: 'sh.keptn.>'
             - name: PUBSUB_RECIPIENT
-              value: 'lighthouse-service'
+              value: '127.0.0.1'
       serviceAccountName: keptn-lighthouse-service
 ---
 apiVersion: v1

--- a/jmeter-service/deploy/service.yaml
+++ b/jmeter-service/deploy/service.yaml
@@ -50,7 +50,7 @@ spec:
           - name: PUBSUB_TOPIC
             value: 'sh.keptn.events.deployment-finished'
           - name: PUBSUB_RECIPIENT
-            value: 'jmeter-service'
+            value: '127.0.0.1'
 ---
 apiVersion: v1
 kind: Service

--- a/lighthouse-service/deploy/service.yaml
+++ b/lighthouse-service/deploy/service.yaml
@@ -64,7 +64,7 @@ spec:
             - name: PUBSUB_TOPIC
               value: 'sh.keptn.>'
             - name: PUBSUB_RECIPIENT
-              value: 'lighthouse-service'
+              value: '127.0.0.1'
 ---
 apiVersion: v1
 kind: Service

--- a/mongodb-datastore/deploy/mongodb-datastore.yaml
+++ b/mongodb-datastore/deploy/mongodb-datastore.yaml
@@ -76,7 +76,7 @@ spec:
           - name: PUBSUB_TOPIC
             value: 'sh.keptn.>'
           - name: PUBSUB_RECIPIENT
-            value: 'mongodb-datastore'
+            value: '127.0.0.1'
           - name: PUBSUB_RECIPIENT_PATH
             value: '/event'
 ---

--- a/platform-support/openshift-route-service/deploy/service.yaml
+++ b/platform-support/openshift-route-service/deploy/service.yaml
@@ -163,7 +163,7 @@ spec:
           - name: PUBSUB_TOPIC
             value: 'sh.keptn.internal.event.project.create'
           - name: PUBSUB_RECIPIENT
-            value: 'openshift-route-service'
+            value: '127.0.0.1'
 ---
 apiVersion: v1
 kind: Service

--- a/remediation-service/deploy/service.yaml
+++ b/remediation-service/deploy/service.yaml
@@ -57,7 +57,7 @@ spec:
           - name: PUBSUB_TOPIC
             value: 'sh.keptn.>'
           - name: PUBSUB_RECIPIENT
-            value: 'remediation-service'
+            value: '127.0.0.1'
 ---
 apiVersion: v1
 kind: Service

--- a/shipyard-service/deploy/service.yaml
+++ b/shipyard-service/deploy/service.yaml
@@ -64,7 +64,7 @@ spec:
           - name: PUBSUB_TOPIC
             value: 'sh.keptn.internal.event.project.create,sh.keptn.internal.event.project.delete'
           - name: PUBSUB_RECIPIENT
-            value: 'shipyard-service'
+            value: '127.0.0.1'
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
As the distributors now run as a sidecar next to the respective service, we can forward the events using `127.0.0.1`. By this, we don't leave the networking boundary of the pod. This was a problem in Openshift.

Furthermore, I intentionally did not remove the unused services of e.g. the `shipyard-service` because the `helm-service` still requires a distributor which cannot run as a sidecar.