### PR TITLE
updated go-utils dependency

### DIFF
--- a/helm-service/go.mod
+++ b/helm-service/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/websocket v1.4.1
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.6.3-0.20200709130352-6dacb8130dc0
+	github.com/keptn/go-utils v0.6.3-0.20200714120809-ab94889d31e3
 	github.com/keptn/kubernetes-utils v0.0.0-20200417060634-69e3369c72d3
 	github.com/kinbiko/jsonassert v1.0.1
 	github.com/stretchr/testify v1.4.0

--- a/helm-service/go.sum
+++ b/helm-service/go.sum
@@ -459,6 +459,8 @@ github.com/keptn/go-utils v0.6.3-0.20200702115825-f6d5f793dcc7 h1:hV8kot6G05FABX
 github.com/keptn/go-utils v0.6.3-0.20200702115825-f6d5f793dcc7/go.mod h1:hf2FU6JFuOzLP5rEAlA1/XnNS28pDZbVfxDESeQsq1g=
 github.com/keptn/go-utils v0.6.3-0.20200709130352-6dacb8130dc0 h1:g13cMMcTimnXdDY9ATMMFq3ph28eR0wylqz0byXp3HM=
 github.com/keptn/go-utils v0.6.3-0.20200709130352-6dacb8130dc0/go.mod h1:hf2FU6JFuOzLP5rEAlA1/XnNS28pDZbVfxDESeQsq1g=
+github.com/keptn/go-utils v0.6.3-0.20200714120809-ab94889d31e3 h1:f47ITlk40aLoX3Wb9Irpra2ccwlpF5/eCZVc5z6Khas=
+github.com/keptn/go-utils v0.6.3-0.20200714120809-ab94889d31e3/go.mod h1:hf2FU6JFuOzLP5rEAlA1/XnNS28pDZbVfxDESeQsq1g=
 github.com/keptn/kubernetes-utils v0.0.0-20200401103501-ae44a5ee0656 h1:uGdzQ+DT+/KqzMJF+5F+B+/h0nOfwmmSA7ClxsI1y6Y=
 github.com/keptn/kubernetes-utils v0.0.0-20200401103501-ae44a5ee0656/go.mod h1:7MQMS/jqKM4eVZ0S1S7LWdZNcBTJn5QeERircdADWzo=
 github.com/keptn/kubernetes-utils v0.0.0-20200414093719-126698f19c3e h1:9/7mjIDhpvlezvYKB6JjEBE7HXb0Fh4BAlg5aPKE+N0=


### PR DESCRIPTION
The helm service was not able to create websocket connections due to a wrong URL used in a previous version of `keptn/go-utils`. This has been fixed by updating the dependency