### PR TITLE
wait some time after exposing oc route

### DIFF
--- a/test/test_install_minishift_quality_gates.sh
+++ b/test/test_install_minishift_quality_gates.sh
@@ -19,6 +19,8 @@ verify_test_step $? "keptn install failed"
 
 oc expose svc/api-gateway-nginx -n keptn --hostname=api.keptn.127.0.0.1.nip.io
 
+sleep 30
+
 KEPTN_API_URL=api.keptn.127.0.0.1.nip.io
 KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token} | base64 --decode)
 keptn auth --endpoint=http://$KEPTN_API_URL/api --api-token=$KEPTN_API_TOKEN


### PR DESCRIPTION
Some times the tests on minishift fail because the route to the api-service does not seem to be available right away.