### PR TITLE
increase thresholds for response time SLOs

### DIFF
--- a/test/assets/quality_gates_standalone_slo_step1.yaml
+++ b/test/assets/quality_gates_standalone_slo_step1.yaml
@@ -11,12 +11,12 @@ objectives:
     key_sli: false
     pass:             # pass if (relative change <= 10% AND absolute value is < 600ms)
       - criteria:
-          - "<=+20%"  # relative values require a prefixed sign (plus or minus)
+          - "<=+75%"  # relative values require a prefixed sign (plus or minus)
           - "<75"    # absolute values only require a logical operator
     warning:          # if the response time is below 800ms, the result should be a warning
       - criteria:
           - "<=200"
-          - "<=+50%"
+          - "<=+100%"
     weight: 1
   - sli: "throughput"
     pass:

--- a/test/assets/quality_gates_standalone_slo_step2.yaml
+++ b/test/assets/quality_gates_standalone_slo_step2.yaml
@@ -11,12 +11,12 @@ objectives:
     key_sli: false
     pass:             # pass if (relative change <= 10% AND absolute value is < 600ms)
       - criteria:
-          - "<=+20%"  # relative values require a prefixed sign (plus or minus)
+          - "<=+75%"  # relative values require a prefixed sign (plus or minus)
           - "<75"    # absolute values only require a logical operator
     warning:          # if the response time is below 800ms, the result should be a warning
       - criteria:
           - "<=200"
-          - "<=+50%"
+          - "<=+100%"
     weight: 1
   - sli: "throughput"
     pass:

--- a/test/assets/quality_gates_standalone_slo_step3.yaml
+++ b/test/assets/quality_gates_standalone_slo_step3.yaml
@@ -11,12 +11,12 @@ objectives:
     key_sli: false
     pass:             # pass if (relative change <= 10% AND absolute value is < 600ms)
       - criteria:
-          - "<=+20%"  # relative values require a prefixed sign (plus or minus)
+          - "<=+75%"  # relative values require a prefixed sign (plus or minus)
           - "<75"    # absolute values only require a logical operator
     warning:          # if the response time is below 800ms, the result should be a warning
       - criteria:
           - "<=200"
-          - "<=+50%"
+          - "<=+100%"
     weight: 1
   - sli: "throughput"
     pass:


### PR DESCRIPTION
Sometimes the quality gates standalone tests were failing because the example service we are using to retrieve values for takes slightly longer than the defined threshold. This should not lead to a failed test as long as the mechanics of retrieving and evaluating SLIs are working