### PR TITLE
Rename install flag keptn-api-service-type into endpoint-service-type

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -100,7 +100,7 @@ For more information, please follow the installation guide [Install Keptn](https
 `,
 	Example: `keptn install # install on Kubernetes
 keptn install --platform=openshift --use-case=continuous-delivery # install continuous-delivery on Openshift
-keptn install --platform=kubernetes --keptn-api-service-type=NodePort # install on a Kubernetes instance with gateway NodePort`,
+keptn install --platform=kubernetes --endpoint-service-type=NodePort # install on a Kubernetes instance with gateway NodePort`,
 	SilenceUsage: true,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 
@@ -108,7 +108,7 @@ keptn install --platform=kubernetes --keptn-api-service-type=NodePort # install 
 		if val, ok := apiServiceTypeToID[*installParams.ApiServiceTypeInput]; ok {
 			installParams.ApiServiceType = val
 		} else {
-			return errors.New("value of 'keptn-api-service-type' flag is unknown. Supported values are " +
+			return errors.New("value of 'endpoint-service-type' flag is unknown. Supported values are " +
 				"[" + ClusterIP.String() + "," + LoadBalancer.String() + "," + NodePort.String() + "]")
 		}
 
@@ -286,8 +286,8 @@ func init() {
 	installParams.UseCaseInput = installCmd.Flags().StringP("use-case", "u", "",
 		"The use case to install Keptn for ["+ContinuousDelivery.String()+","+QualityGates.String()+"]")
 
-	installParams.ApiServiceTypeInput = installCmd.Flags().StringP("keptn-api-service-type", "",
-		ClusterIP.String(), "Installation options for the api-service type ["+ClusterIP.String()+","+
+	installParams.ApiServiceTypeInput = installCmd.Flags().StringP("endpoint-service-type", "",
+		ClusterIP.String(), "Installation options for the endpoint-service type ["+ClusterIP.String()+","+
 			LoadBalancer.String()+","+NodePort.String()+"]")
 
 	installParams.ChartRepoURL = installCmd.Flags().StringP("chart-repo", "",

--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -3,7 +3,7 @@ mongodb:
 
 nats:
   nameOverride: keptn-nats-cluster
-  cluster.replicas: 1
+  nats.cluster.replicas: 3
 
   natsbox:
     enabled: false

--- a/test/test_install_gke.sh
+++ b/test/test_install_gke.sh
@@ -17,7 +17,7 @@ echo "{}" > creds.json # empty credentials file
 echo "Installing keptn on cluster"
 
 # Install keptn (using the develop version, which should point the :latest docker images)
-keptn install --chart-repo="${KEPTN_INSTALLER_REPO}" --creds=creds.json --verbose --use-case=continuous-delivery --keptn-api-service-type=LoadBalancer
+keptn install --chart-repo="${KEPTN_INSTALLER_REPO}" --creds=creds.json --verbose --use-case=continuous-delivery --endpoint-service-type=LoadBalancer
 verify_test_step $? "keptn install failed"
 
 # authenticate at Keptn API

--- a/test/test_install_kubernetes_full.sh
+++ b/test/test_install_kubernetes_full.sh
@@ -20,7 +20,7 @@ verify_deployment_in_namespace "istio-sidecar-injector" "istio-system"
 echo "Installing keptn on cluster"
 echo "{}" > creds.json # empty credentials file
 # Install keptn (using the develop version, which should point the :latest docker images)
-keptn install --chart-repo="${KEPTN_INSTALLER_REPO}" --platform=kubernetes --creds=creds.json --keptn-api-service-type=NodePort --verbose --use-case=continuous-delivery
+keptn install --chart-repo="${KEPTN_INSTALLER_REPO}" --platform=kubernetes --creds=creds.json --endpoint-service-type=NodePort --verbose --use-case=continuous-delivery
 
 verify_test_step $? "keptn install failed"
 

--- a/test/test_install_kubernetes_quality_gates.sh
+++ b/test/test_install_kubernetes_quality_gates.sh
@@ -7,7 +7,7 @@ source test/utils.sh
 echo "Installing keptn on cluster"
 echo "{}" > creds.json # empty credentials file
 # Install keptn (using the develop version, which should point the :latest docker images)
-keptn install --chart-repo="${KEPTN_INSTALLER_REPO}" --platform=kubernetes --creds=creds.json --keptn-api-service-type=NodePort --verbose
+keptn install --chart-repo="${KEPTN_INSTALLER_REPO}" --platform=kubernetes --creds=creds.json --endpoint-service-type=NodePort --verbose
 
 verify_test_step $? "keptn install failed"
 


### PR DESCRIPTION
The flag name `keptn-api-service-type` was misleading for users, because this service is also used to expose the Bridge.