### PR TITLE
#2102 Re-use GKE cluster in integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -527,7 +527,7 @@ jobs:
       - docker images | grep keptn
 
   - stage: Test GKE Full with Istio - Pt. 1 (--platform=gke --use-case=continuous-delivery)
-    if: branch = feature/2102/gke-tests #branch = master AND type = cron # run for cron
+    if: branch = master AND type = cron # run for cron
     env:
       - GKE_VERSION=1.14
     <<: *gke_full_part1 # use template
@@ -539,7 +539,7 @@ jobs:
     <<: *gke_full_part1 # use template
 
   - stage: Test GKE Full with Istio - Pt. 2 (--platform=gke --use-case=continuous-delivery)
-    if: branch = feature/2102/gke-tests #branch = master AND type = cron # run for cron
+    if: branch = master AND type = cron # run for cron
     env:
       - GKE_VERSION=1.14
     <<: *gke_full_part2 # use template
@@ -551,7 +551,7 @@ jobs:
     <<: *gke_full_part2 # use template
 
   - stage: Test Minishift Standalone (--platform=openshift)
-    if: branch = feature/2102/gke-tests #(branch = master or branch =~ ^release.*$) AND (type = cron OR type = push) # run for any change on master/release-* on push as well as cron
+    if: (branch = master or branch =~ ^release.*$) AND (type = cron OR type = push) # run for any change on master/release-* on push as well as cron
     os: linux
     before_script:
       # download and install kubectl

--- a/.travis.yml
+++ b/.travis.yml
@@ -146,6 +146,7 @@ gke_full_part1: &gke_full_part1
     - test/utils/download_and_install_keptn_cli.sh
     # create gke cluster on gcloud
     - test/utils/gke_create_cluster.sh
+    - test/utils/gke_authenticate_at_cluster.sh
   script:
     # test installation on gcloud
     - test/test_install_gke.sh
@@ -160,7 +161,6 @@ gke_full_part1: &gke_full_part1
   after_success:
     # delete google kubernetes cluster only on success (in case of an error we want to be able to dig into the cluster)
     - echo "Tests were successful, cleaning up the cluster now..."
-    - test/utils/gke_delete_cluster.sh
   after_failure:
     # print some debug info
     - echo "Keptn Installation Log:"
@@ -181,8 +181,8 @@ gke_full_part2: &gke_full_part2
     - echo ${GCLOUD_SERVICE_KEY} | base64 --decode > ~/gcloud-service-key.json
     - gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
     - test/utils/download_and_install_keptn_cli.sh
-    # create gke cluster on gcloud
-    - test/utils/gke_create_cluster.sh
+    # authenticate at gke cluster
+    - test/utils/gke_authenticate_at_cluster.sh
   script:
     # test installation on gcloud
     - test/test_install_gke.sh
@@ -528,7 +528,7 @@ jobs:
       - docker images | grep keptn
 
   - stage: Test GKE Full with Istio - Pt. 1 (--platform=gke --use-case=continuous-delivery)
-    if: branch = master AND type = cron # run for cron
+    if: branch = feature/2102/gke-tests #branch = master AND type = cron # run for cron
     env:
       - GKE_VERSION=1.14
     <<: *gke_full_part1 # use template
@@ -540,7 +540,7 @@ jobs:
     <<: *gke_full_part1 # use template
 
   - stage: Test GKE Full with Istio - Pt. 2 (--platform=gke --use-case=continuous-delivery)
-    if: branch = master AND type = cron # run for cron
+    if: branch = feature/2102/gke-tests #branch = master AND type = cron # run for cron
     env:
       - GKE_VERSION=1.14
     <<: *gke_full_part2 # use template

--- a/.travis.yml
+++ b/.travis.yml
@@ -157,7 +157,6 @@ gke_full_part1: &gke_full_part1
     - test/test_new_artifact.sh
     - test/test_delete_project.sh
     - test/test_self_healing.sh
-    - test/test_keptn_uninstall.sh
   after_success:
     # delete google kubernetes cluster only on success (in case of an error we want to be able to dig into the cluster)
     - echo "Tests were successful, cleaning up the cluster now..."
@@ -184,11 +183,10 @@ gke_full_part2: &gke_full_part2
     # authenticate at gke cluster
     - test/utils/gke_authenticate_at_cluster.sh
   script:
-    # test installation on gcloud
-    - test/test_install_gke.sh
     - export PROJECT=sockshop
     - test/test_self_healing_scaling.sh
     - test/test_delivery_assistant.sh
+    - test/test_keptn_uninstall.sh
   after_success:
     # delete google kubernetes cluster only on success (in case of an error we want to be able to dig into the cluster)
     - echo "Tests were successful, cleaning up the cluster now..."

--- a/.travis.yml
+++ b/.travis.yml
@@ -182,6 +182,7 @@ gke_full_part2: &gke_full_part2
     - test/utils/download_and_install_keptn_cli.sh
     # authenticate at gke cluster
     - test/utils/gke_authenticate_at_cluster.sh
+    - test/utils/gke_authenticate_at_keptn.sh
   script:
     - export PROJECT=sockshop
     - test/test_self_healing_scaling.sh
@@ -526,7 +527,7 @@ jobs:
       - docker images | grep keptn
 
   - stage: Test GKE Full with Istio - Pt. 1 (--platform=gke --use-case=continuous-delivery)
-    if: branch = master AND type = cron # run for cron
+    if: branch = feature/2102/gke-tests #branch = master AND type = cron # run for cron
     env:
       - GKE_VERSION=1.14
     <<: *gke_full_part1 # use template
@@ -538,7 +539,7 @@ jobs:
     <<: *gke_full_part1 # use template
 
   - stage: Test GKE Full with Istio - Pt. 2 (--platform=gke --use-case=continuous-delivery)
-    if: branch = master AND type = cron # run for cron
+    if: branch = feature/2102/gke-tests #branch = master AND type = cron # run for cron
     env:
       - GKE_VERSION=1.14
     <<: *gke_full_part2 # use template
@@ -550,7 +551,7 @@ jobs:
     <<: *gke_full_part2 # use template
 
   - stage: Test Minishift Standalone (--platform=openshift)
-    if: (branch = master or branch =~ ^release.*$) AND (type = cron OR type = push) # run for any change on master/release-* on push as well as cron
+    if: branch = feature/2102/gke-tests #(branch = master or branch =~ ^release.*$) AND (type = cron OR type = push) # run for any change on master/release-* on push as well as cron
     os: linux
     before_script:
       # download and install kubectl

--- a/.travis.yml
+++ b/.travis.yml
@@ -526,7 +526,7 @@ jobs:
       - docker images | grep keptn
 
   - stage: Test GKE Full with Istio - Pt. 1 (--platform=gke --use-case=continuous-delivery)
-    if: branch = feature/2102/gke-tests #branch = master AND type = cron # run for cron
+    if: branch = master AND type = cron # run for cron
     env:
       - GKE_VERSION=1.14
     <<: *gke_full_part1 # use template
@@ -538,7 +538,7 @@ jobs:
     <<: *gke_full_part1 # use template
 
   - stage: Test GKE Full with Istio - Pt. 2 (--platform=gke --use-case=continuous-delivery)
-    if: branch = feature/2102/gke-tests #branch = master AND type = cron # run for cron
+    if: branch = master AND type = cron # run for cron
     env:
       - GKE_VERSION=1.14
     <<: *gke_full_part2 # use template

--- a/test/test_install_gke.sh
+++ b/test/test_install_gke.sh
@@ -23,9 +23,9 @@ verify_test_step $? "keptn install failed"
 # authenticate at Keptn API
 KEPTN_API_URL=$(kubectl -n keptn get service api-gateway-nginx -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token} | base64 --decode)
-keptn auth --endpoint=http://$KEPTN_API_URL/api --api-token=$KEPTN_API_TOKEN
 
-verify_test_step $? "Could not authenticate at Keptn API"
+auth_at_keptn $KEPTN_API_URL $KEPTN_API_TOKEN
+
 
 # install public-gateway.istio-system
 kubectl apply -f - <<EOF

--- a/test/test_install_kubernetes_full.sh
+++ b/test/test_install_kubernetes_full.sh
@@ -47,7 +47,8 @@ API_PORT=$(kubectl get svc api-gateway-nginx -n keptn -o jsonpath='{.spec.ports[
 INTERNAL_NODE_IP=$(kubectl get nodes -o jsonpath='{ $.items[0].status.addresses[?(@.type=="InternalIP")].address }')
 KEPTN_ENDPOINT=http://${INTERNAL_NODE_IP}:${API_PORT}/api
 KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token} | base64 --decode)
-keptn auth --endpoint=$KEPTN_ENDPOINT --api-token=$KEPTN_API_TOKEN
+auth_at_keptn $KEPTN_ENDPOINT $KEPTN_API_TOKEN
+#keptn auth --endpoint=$KEPTN_ENDPOINT --api-token=$KEPTN_API_TOKEN
 
 verify_test_step $? "Could not authenticate at Keptn API"
 

--- a/test/test_install_kubernetes_quality_gates.sh
+++ b/test/test_install_kubernetes_quality_gates.sh
@@ -31,7 +31,8 @@ KEPTN_ENDPOINT="http://${INTERNAL_NODE_IP}:${API_PORT}"/api
 KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token} | base64 --decode)
 
 echo "Trying to authenticate at ${KEPTN_ENDPOINT}/api"
-keptn auth --endpoint=${KEPTN_ENDPOINT} --api-token=$KEPTN_API_TOKEN
+auth_at_keptn $KEPTN_ENDPOINT $KEPTN_API_TOKEN
+#keptn auth --endpoint=${KEPTN_ENDPOINT} --api-token=$KEPTN_API_TOKEN
 
 verify_test_step $? "Could not authenticate at Keptn API"
 

--- a/test/test_install_minishift_quality_gates.sh
+++ b/test/test_install_minishift_quality_gates.sh
@@ -23,7 +23,8 @@ sleep 30
 
 KEPTN_API_URL=api.keptn.127.0.0.1.nip.io
 KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token} | base64 --decode)
-keptn auth --endpoint=http://$KEPTN_API_URL/api --api-token=$KEPTN_API_TOKEN
+auth_at_keptn $KEPTN_API_URL $KEPTN_API_TOKEN
+#keptn auth --endpoint=http://$KEPTN_API_URL/api --api-token=$KEPTN_API_TOKEN
 
 # verify that the keptn CLI has successfully authenticated
 echo "Checking that keptn is authenticated..."

--- a/test/utils.sh
+++ b/test/utils.sh
@@ -6,6 +6,32 @@ function print_error() {
   echo "[keptn|ERROR] $(timestamp) $1"
 }
 
+function auth_at_keptn() {
+  ENDPOINT=$1
+  API_TOKEN=$2
+  RETRY=0
+  RETRY_MAX=5
+
+  echo "Authenticating at http://$ENDPOINT"
+  while [[ $RETRY -lt $RETRY_MAX ]]; do
+    keptn auth --endpoint=http://$ENDPOINT --api-token=$API_TOKEN
+
+    if [[ $? -eq 0 ]]; then
+      echo "Successfully authenticated at Keptn API!"
+      break
+    else
+      RETRY=$[$RETRY+1]
+      echo "Retry: ${RETRY}/${RETRY_MAX} - Wait 10s ..."
+      sleep 10
+    fi
+  done
+
+  if [[ $RETRY == $RETRY_MAX ]]; then
+    print_error "Authentication at http://$ENDPOINT unsuccessful"
+    exit 1
+  fi
+}
+
 function send_start_evaluation_event() {
   PROJECT=$1
   STAGE=$2

--- a/test/utils/gke_authenticate_at_cluster.sh
+++ b/test/utils/gke_authenticate_at_cluster.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# configure gcloud
+gcloud --quiet config set project $PROJECT_NAME
+gcloud --quiet config set container/cluster $CLUSTER_NAME_NIGHTLY
+gcloud --quiet config set compute/zone ${CLOUDSDK_COMPUTE_ZONE}
+
+# get cluster credentials (this will set kubectl context)
+gcloud container clusters get-credentials $CLUSTER_NAME_NIGHTLY --zone $CLOUDSDK_COMPUTE_ZONE --project $PROJECT_NAME
+if [[ $? != '0' ]]; then
+    echo "gcloud get credentials failed."
+    exit 1
+fi

--- a/test/utils/gke_authenticate_at_keptn.sh
+++ b/test/utils/gke_authenticate_at_keptn.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+source test/utils.sh
+
+# authenticate at Keptn API
+KEPTN_API_URL=$(kubectl -n keptn get service api-gateway-nginx -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token} | base64 --decode)
+
+auth_at_keptn $KEPTN_API_URL $KEPTN_API_TOKEN

--- a/test/utils/gke_create_cluster.sh
+++ b/test/utils/gke_create_cluster.sh
@@ -31,10 +31,3 @@ if [[ $? != '0' ]]; then
     echo "gcloud cluster create failed."
     exit 1
 fi
-
-# get cluster credentials (this will set kubectl context)
-gcloud container clusters get-credentials $CLUSTER_NAME_NIGHTLY --zone $CLOUDSDK_COMPUTE_ZONE --project $PROJECT_NAME
-if [[ $? != '0' ]]; then
-    echo "gcloud get credentials failed."
-    exit 1
-fi


### PR DESCRIPTION
Closes #2102 
In this PR, the GKE clusters created in part 1 of the integration tests of the full installation are reused in the seconds part. 
Additionally, I have added a retry mechanism to the authentication in the integration test scripts because some builds were failing because of networking issues