### PR TITLE
Better parameter/flag checking of the keptn add-resource command.

### DIFF
--- a/cli/cmd/add_resource.go
+++ b/cli/cmd/add_resource.go
@@ -47,6 +47,7 @@ keptn add-resource --project=musicshop --stage=hardening --service=catalogue --r
 keptn add-resource --project=sockshop --stage=dev --service=carts --resource=./jmeter.jmx --resourceUri=jmeter/functional.jmx
 keptn add-resource --project=rockshop --stage=production --service=shop --resource=./basiccheck.jmx --resourceUri=jmeter/basiccheck.jmx`,
 	SilenceUsage: true,
+	Args: cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds()
 		if err != nil {

--- a/cli/cmd/add_resource_test.go
+++ b/cli/cmd/add_resource_test.go
@@ -97,3 +97,24 @@ func TestAddResourceToProjectService(t *testing.T) {
 		t.Errorf(unexpectedErrMsg, err)
 	}
 }
+
+// TestAddResourceWhenArgsArePresent
+func TestAddResourceWhenArgsArePresent(t *testing.T) {
+
+	credentialmanager.MockAuthCreds = true
+
+	resourceFileName := "testResource.txt"
+	defer testResource(t, resourceFileName, "")()
+
+	cmd := fmt.Sprintf("add-resource --project=%s --stage=%s --service=%s --resource=%s "+
+		"-- resourceUri=%s --mock", "sockshop", "dev", "carts", resourceFileName, "resource/"+resourceFileName)
+	_, err := executeActionCommandC(cmd)	
+	if err == nil {
+		t.Errorf("Expected an error")	
+	}
+	got := err.Error()
+	expected := "accepts 0 arg(s), received 2"
+	if got != expected {
+		t.Errorf("Expected %q, got %q", expected, got)	
+	}
+}


### PR DESCRIPTION
For add-resource command,
If len(args) > 0 -> then abort this command.

Resolving [#1735 ](https://github.com/keptn/keptn/issues/1735l)