### PR TITLE
#1718 Review of the description of all Keptn CLI commands

### DIFF
--- a/cli/cmd/add_resource.go
+++ b/cli/cmd/add_resource.go
@@ -28,7 +28,7 @@ var addResourceCmdParams *addResourceCommandParameters
 var addResourceCmd = &cobra.Command{
 	Use:   "add-resource --project=PROJECT --stage=STAGE --service=SERVICE --resource=FILEPATH --resourceUri=FILEPATH",
 	Short: "Adds a local resource to a service within your project in the specified stage",
-	Long: `Adds a local resource to a service within your project in the specified stage. The resource is then stored within the Git Repo.
+	Long: `Adds a local resource to a service within your project in the specified stage. The resource is then stored within the Git repository.
 
 This command allows adding, for example, *test files* to a service, which will then be used by a test service (e.g., jmeter-service) during the continuous delivery.
 
@@ -47,7 +47,7 @@ keptn add-resource --project=musicshop --stage=hardening --service=catalogue --r
 keptn add-resource --project=sockshop --stage=dev --service=carts --resource=./jmeter.jmx --resourceUri=jmeter/functional.jmx
 keptn add-resource --project=rockshop --stage=production --service=shop --resource=./basiccheck.jmx --resourceUri=jmeter/basiccheck.jmx`,
 	SilenceUsage: true,
-	Args: cobra.ExactArgs(0),
+	Args:         cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds()
 		if err != nil {

--- a/cli/cmd/auth.go
+++ b/cli/cmd/auth.go
@@ -25,12 +25,12 @@ var apiToken *string
 var authCmd = &cobra.Command{
 	Use:   "auth --endpoint=https://api.keptn.MY.DOMAIN.COM --api-token=SECRET_TOKEN",
 	Short: "Authenticates the Keptn CLI against a Keptn installation",
-	Long: `Authenticates the Keptn CLI against a Keptn installation using an endpoint
-and an API token. The endpoint and API token are automatically configured during the Keptn installation.
+	Long: `Authenticates the Keptn CLI against a Keptn installation using an endpoint and an API token. 
+The endpoint and API token are automatically configured during the Keptn installation.
 If the authentication is successful, the endpoint and the API token are stored in a password store of the underlying operating system.
-More precisely, the keptn CLI stores the endpoint and API token using *pass* in case of Linux, using *Keychain* in case of macOS, or *Wincred* in case of Windows.
+More precisely, the Keptn CLI stores the endpoint and API token using *pass* in case of Linux, using *Keychain* in case of macOS, or *Wincred* in case of Windows.
 
-**Note**: If you receive a warning *Using a file-based storage for the key because the password-store seems to be not set up.* this is because a password store could not be found in your environment. In this case, the credentials are stored in *~/.keptn/.keptn* in your home directory.
+**Note:** If you receive a warning *Using a file-based storage for the key because the password-store seems to be not set up.* this is because a password store could not be found in your environment. In this case, the credentials are stored in *~/.keptn/.keptn* in your home directory.
 	`,
 	Example:      `keptn auth --endpoint=https://api.keptn.MY.DOMAIN.COM --api-token=abcd-0123-wxyz-7890`,
 	SilenceUsage: true,
@@ -119,8 +119,8 @@ func authUsingKube(apiSvcType apiServiceType) error {
 	// get api token
 	apiToken, err := getAPITokenUsingKube()
 
-	const errorMsg = `Could not retrieve keptn API token: %s
-To manually set up your keptn CLI, please follow the instructions at https://keptn.sh/.`
+	const errorMsg = `Could not retrieve Keptn API token: %s
+To manually set up your Keptn CLI, please follow the instructions at https://keptn.sh/.`
 
 	if err != nil {
 		return fmt.Errorf(errorMsg, err)

--- a/cli/cmd/configure.go
+++ b/cli/cmd/configure.go
@@ -6,7 +6,7 @@ import (
 
 // configureCmd represents the configure command
 var configureCmd = &cobra.Command{
-	Use:          "configure [domain | monitoring | bridge]",
+	Use:          "configure [monitoring | bridge]",
 	Short:        "Configures one of the specified parts of Keptn",
 	SilenceUsage: true,
 }

--- a/cli/cmd/configure_monitoring.go
+++ b/cli/cmd/configure_monitoring.go
@@ -37,10 +37,12 @@ var allowedMonitoringTypes = []string{
 var monitoringCmd = &cobra.Command{
 	// Use:          "monitoring <monitoring_provider> --project=<project> --service=<service> --service-indicators=<service_indicators_file_path> --service-objectives=<service_objectives_file_path> --remediation=<remediation_file_path>",
 	Use:   "monitoring <monitoring_provider> --project=<project> --service=<service>",
-	Short: "Configures monitoring provider",
-	Long: `Configure a monitoring solution for a Keptn cluster. This command sets up Dynatrace or Prometheus monitoring if it is not installed. Before executing the command, the dynatrace-service or prometheus-service has to be deployed.
+	Short: "Configures a monitoring provider",
+	Long: `Configure a monitoring solution for the deployments managed by Keptn. 
+Before executing the command, the dynatrace-service or prometheus-service has to be deployed.
 
-**Note:** If you are executing *keptn configure monitoring dynatrace*, the service flag is optional since Keptn automatically detects the services of a project. See https://keptn.sh/docs/` + keptnReleaseDocsURL + `/monitoring/dynatrace/install/ for more information.
+**Note:** If you are executing *keptn configure monitoring dynatrace*, the service flag is optional since Keptn automatically detects the services of a project. 
+See https://keptn.sh/docs/` + keptnReleaseDocsURL + `/monitoring/dynatrace/install/ for more information.
 `,
 	Example: `keptn configure monitoring dynatrace --project=PROJECTNAME
 keptn configure monitoring prometheus --project=PROJECTNAME --service=SERVICENAME`,

--- a/cli/cmd/create.go
+++ b/cli/cmd/create.go
@@ -7,6 +7,7 @@ import (
 // createCmd implements the create command
 var createCmd = &cobra.Command{
 	Use:   "create [project | service]",
+	Short: `Creates a new project or service`,
 }
 
 func init() {

--- a/cli/cmd/create_project.go
+++ b/cli/cmd/create_project.go
@@ -40,14 +40,14 @@ keptn update project PROJECTNAME --git-user=GIT_USER --git-token=GIT_TOKEN --git
 var crProjectCmd = &cobra.Command{
 	Use:   "project PROJECTNAME --shipyard=FILEPATH",
 	Short: "Creates a new project",
-	Long: `Creates a new project with the provided name and shipyard file. 
+	Long: `Creates a new project with the provided name and Shipyard. 
 The shipyard file describes the used stages. These stages are defined by name, 
 deployment-, test-, and remediation strategy.
 
 By executing the *create project* command, Keptn initializes an internal Git repository that is used to maintain all project-related resources. 
 To upstream this internal Git repository to a remote repository, the Git user (*--git-user*), an access token (*--git-token*), and the remote URL (*--git-remote-url*) are required.
 
-For more information about shipyard files, creating projects, or upstream repositories, please go to [Manage Keptn](https://keptn.sh/docs/` + keptnReleaseDocsURL + `/manage/)
+For more information about Shipyard, creating projects, or upstream repositories, please go to [Manage Keptn](https://keptn.sh/docs/` + keptnReleaseDocsURL + `/manage/)
 `,
 	Example: `keptn create project PROJECTNAME --shipyard=FILEPATH
 keptn create project PROJECTNAME --shipyard=FILEPATH --git-user=GIT_USER --git-token=GIT_TOKEN --git-remote-url=GIT_REMOTE_URL`,

--- a/cli/cmd/create_service.go
+++ b/cli/cmd/create_service.go
@@ -27,7 +27,7 @@ var crServiceCmd = &cobra.Command{
 	Short: "Creates a new service",
 	Long: `Creates a new service with the provided name in the specified project.
 
-Please note: This command is different from keptn onboard service (which requires a helm chart).
+**Note:** This command is different from keptn onboard service which requires a Helm chart.
 `,
 	Example:      `keptn create service carts --project=sockshop`,
 	SilenceUsage: true,

--- a/cli/cmd/delete.go
+++ b/cli/cmd/delete.go
@@ -7,8 +7,8 @@ import (
 // deleteCmd represents the delete command
 var deleteCmd = &cobra.Command{
 	Use:   "delete [project]",
-	Short: "delete is the parent command of \"delete project\"",
-	Long:  `delete is the parent command of \"delete project\". \"delete\" without subcommand cannot be used.`,
+	Short: "Deletes a project",
+	Long:  `Deletes a project`,
 }
 
 func init() {

--- a/cli/cmd/delete_project.go
+++ b/cli/cmd/delete_project.go
@@ -23,7 +23,7 @@ var delProjectCmd = &cobra.Command{
 * If a Git upstream is configured for this project, the referenced upstream repository (e.g., on GitHub) will not be deleted. 
 * Services that have been deployed to the Kubernetes cluster are not deleted.
 * Namespaces that have been created on the Kuberentes cluster are not deleted.
-* Helm-releases created for deployments are not deleted. To clean-up deployed Helm releases, pelease see [Clean-up after deleting a project](https://keptn.sh/docs/` + keptnReleaseDocsURL + `/reference/helm/continuous_delivery/deployment_helm/#clean-up-after-deleting-a-project)
+* Helm-releases created for deployments are not deleted. To clean-up deployed Helm releases, pelease see [Clean-up after deleting a project](https://keptn.sh/docs/` + keptnReleaseDocsURL + `/continuous_delivery/deployment_helm/#clean-up-after-deleting-a-project)
 `,
 	Example:      `keptn delete project sockshop`,
 	SilenceUsage: true,

--- a/cli/cmd/delete_project.go
+++ b/cli/cmd/delete_project.go
@@ -19,8 +19,7 @@ var delProjectCmd = &cobra.Command{
 	Short: "Deletes a project identified by project name",
 	Long: `Deletes a project identified by project name. 
 
-**Known Limitations**:
-
+**Notes:**
 * If a Git upstream is configured for this project, the referenced upstream repository (e.g., on GitHub) will not be deleted. 
 * Services that have been deployed to the Kubernetes cluster are not deleted.
 * Namespaces that have been created on the Kuberentes cluster are not deleted.

--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -10,7 +10,8 @@ type generateCmdParams struct {
 
 // deleteCmd represents the delete command
 var generateCmd = &cobra.Command{
-	Use: "generate [docs | support-archive]",
+	Use:   `generate [docs | support-archive]`,
+	Short: `Generates the markdown CLI documentation or a support archive`,
 }
 
 func init() {

--- a/cli/cmd/generate_docs.go
+++ b/cli/cmd/generate_docs.go
@@ -26,14 +26,15 @@ slug: %s
 // generateDocsCmd implements the generate docs command
 var generateDocsCmd = &cobra.Command{
 	Use:   "docs",
-	Short: "Generates Markdown documentation for the keptn CLI.",
-	Long: `Generates Markdown documentation for the keptn CLI.
+	Short: "Generates the markdown documentation for the Keptn CLI",
+	Long: `Generates markdown documentation for the Keptn CLI.
 
-This command can be used to create an up-to-date documentation of Keptn's command-line interface for https://keptn.sh.
+This command can be used to create an up-to-date documentation of the Keptn CLI and as published on: https://keptn.sh/docs
 
-It creates one Markdown file per command, suitable for rendering in Hugo.
+It creates one markdown file per command, suitable for rendering in Hugo.
 `,
 	Example: `keptn generate docs
+
 keptn generate docs --dir=/some/directory`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/cmd/generate_support_archive.go
+++ b/cli/cmd/generate_support_archive.go
@@ -75,8 +75,8 @@ type metaData struct {
 // generateSupportArchiveCmd implements the generate support-archive command
 var generateSupportArchiveCmd = &cobra.Command{
 	Use:   "support-archive",
-	Short: "Generates a support archive.",
-	Long:  `Generates a support archive containing information of the Keptn installation.`,
+	Short: "Generates a support archive containing all logs",
+	Long:  `Generates a support archive containing information of the Keptn installation and logs from the services`,
 	Example: `keptn generate support-archive
 keptn generate support-archive --dir=/some/directory`,
 	SilenceUsage: true,

--- a/cli/cmd/get.go
+++ b/cli/cmd/get.go
@@ -5,8 +5,8 @@ import "github.com/spf13/cobra"
 // getCmd represents the send command
 var getCmd = &cobra.Command{
 	Use:   "get [event | project | projects | stage | stages | service | services]",
-	Short: `Display an event or one or many keptn entities such as project, stage, or service.`,
-	Long:  `Display an event or one or many Keptn entities such as project, stage, or service.`,
+	Short: "Displays an event or Keptn entities such as project, stage, or service",
+	Long:  `Displays an event or Keptn entities such as project, stage, or service.`,
 }
 
 func init() {

--- a/cli/cmd/get_event.go
+++ b/cli/cmd/get_event.go
@@ -22,11 +22,8 @@ import (
 var getEventCmd = &cobra.Command{
 	Use:     "event [eventType]",
 	Aliases: []string{"events"},
-	Short:   `Get event in combination with "eventType" allows to retrieve a Keptn event`,
-	Long: `Get event in combination with "eventType" allows to retrieve a Keptn event. Get event without subcommand cannot be used.
-
-Example:
-	keptn get event [eventType]`,
+	Short:   `Returns the latest Keptn event specified by event type`,
+	Long:    `Returns the latest Keptn event specified by event type. The event type is defined here: https://github.com/keptn/spec/blob/0.1.4/cloudevents.md`,
 }
 
 func init() {

--- a/cli/cmd/get_projects.go
+++ b/cli/cmd/get_projects.go
@@ -42,8 +42,8 @@ var getProject getProjectStruct
 var getProjectCmd = &cobra.Command{
 	Use:     "project",
 	Aliases: []string{"projects"},
-	Short:   "Get details of a keptn project",
-	Long:    `Get all projects or details of a given keptn project`,
+	Short:   "Get details of a Keptn project",
+	Long:    `Get all projects or details of a given Keptn project`,
 	Example: `keptn get projects
 NAME            CREATION DATE
 sockshop        2020-05-28T10:25:50+02:00
@@ -53,12 +53,10 @@ keptn get project sockshop
 NAME           CREATION DATE                 
 sockshop       2020-04-06T14:35:40.210Z
 
-# Returns project details in YAML format
-keptn get project sockshop -output=yaml
+keptn get project sockshop -output=yaml  # Returns project details in YAML format
 
-# Returns project details in JSON format
-keptn get project sockshop -output=json
-	`,
+keptn get project sockshop -output=json  # Returns project details in JSON format
+`,
 	SilenceUsage: true,
 	Args: func(cmd *cobra.Command, args []string) error {
 		_, _, err := credentialmanager.NewCredentialManager().GetCreds()

--- a/cli/cmd/get_services.go
+++ b/cli/cmd/get_services.go
@@ -40,20 +40,17 @@ var getServiceCmd = &cobra.Command{
 	Use:     "service",
 	Aliases: []string{"services"},
 	Short:   "Get service details",
-	Long:    `Get all services or details for a given service within a keptn project`,
+	Long:    `Get all services or details for a given service within a Keptn project`,
 	Example: `keptn get service carts --project=sockshop
 NAME           CREATION DATE                 
 carts          sockshop        2020-05-28T10:25:58+02:00
 
-List all services in keptn
-# keptn get services
+keptn get services                                   # List all services in keptn
 
-# List all services in the sockshop project
-keptn get services --project=sockshop
+keptn get services --project=sockshop                # List all services in the sockshop project
 
-# Get details of the carts service in the sockshop project as json output
-keptn get services carts --project=sockshop -o=json
-	`,
+keptn get services carts --project=sockshop -o=json  # Get details of the carts service in the sockshop project as json output
+`,
 	SilenceUsage: true,
 	Args: func(cmd *cobra.Command, args []string) error {
 		_, _, err := credentialmanager.NewCredentialManager().GetCreds()

--- a/cli/cmd/get_stages.go
+++ b/cli/cmd/get_stages.go
@@ -36,7 +36,7 @@ var getStageCmd = &cobra.Command{
 	Use:     "stage",
 	Aliases: []string{"stages"},
 	Short:   "Get details of a stage",
-	Long:    `Get all stages or details of a stage from a given keptn project`,
+	Long:    `Get all stages or details of a stage from a given Keptn project`,
 	Example: `keptn get stages --project=sockshop
 NAME           CREATION DATE                 
 staging        2020-04-06T14:37:45.210Z
@@ -45,7 +45,7 @@ production     2020-04-06T14:37:45.210Z
 keptn get stage staging --project sockshop
 NAME           CREATION DATE                 
 staging        2020-04-06T14:37:45.210Z
-	`,
+`,
 	SilenceUsage: true,
 	Args: func(cmd *cobra.Command, args []string) error {
 		_, _, err := credentialmanager.NewCredentialManager().GetCreds()

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -96,11 +96,13 @@ var installCmd = &cobra.Command{
 	Long: `The Keptn CLI allows installing Keptn on any Kubernetes derivate to which your kube config is pointing to, and on OpenShift.
 
 For more information, please follow the installation guide [Install Keptn](https://keptn.sh/docs/` + keptnReleaseDocsURL + `/operate/install/operate/install/#install-keptn)
-
 `,
-	Example: `keptn install # install on Kubernetes
-keptn install --platform=openshift --use-case=continuous-delivery # install continuous-delivery on Openshift
-keptn install --platform=kubernetes --endpoint-service-type=NodePort # install on a Kubernetes instance with gateway NodePort`,
+	Example: `keptn install                                                        # install on Kubernetes
+
+keptn install --platform=openshift --use-case=continuous-delivery    # install continuous delivery on Openshift
+
+keptn install --platform=kubernetes --endpoint-service-type=NodePort # install on Kubernetes with gateway NodePort
+`,
 	SilenceUsage: true,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 
@@ -125,12 +127,12 @@ keptn install --platform=kubernetes --endpoint-service-type=NodePort # install o
 			installParams.UseCase = val
 		} else {
 			return errors.New("value of 'use-case' flag is unknown. Supported values are " +
-				"[" + ContinuousDelivery.String() + "," + QualityGates.String() + "]")
+				"[" + ContinuousDelivery.String() + "]")
 		}
 
 		// Mark the quality-gates use case as deprecated - this is now the default option
 		if *installParams.UseCaseInput == QualityGates.String() {
-			logging.PrintLog("NOTE: The --use-case=quality-gates option is now deprecated and is now a synonym for the default installation of Keptn.", logging.InfoLevel)
+			logging.PrintLog("Note: The --use-case=quality-gates option is now deprecated and is now a synonym for the default installation of Keptn.", logging.InfoLevel)
 		}
 
 		var chartRepoURL string
@@ -278,13 +280,13 @@ func init() {
 	installParams = installCmdParams{}
 
 	installParams.PlatformIdentifier = installCmd.Flags().StringP("platform", "p", "kubernetes",
-		"The platform to run keptn on ["+kubernetes+","+openshift+"]")
+		"The platform to run Keptn on ["+kubernetes+","+openshift+"]")
 
 	installParams.ConfigFilePath = installCmd.Flags().StringP("creds", "c", "",
 		"Specify a JSON file containing cluster information needed for the installation (this allows skipping user prompts to execute a *silent* Keptn installation)")
 
 	installParams.UseCaseInput = installCmd.Flags().StringP("use-case", "u", "",
-		"The use case to install Keptn for ["+ContinuousDelivery.String()+","+QualityGates.String()+"]")
+		"The use case to install Keptn for: "+ContinuousDelivery.String())
 
 	installParams.ApiServiceTypeInput = installCmd.Flags().StringP("endpoint-service-type", "",
 		ClusterIP.String(), "Installation options for the endpoint-service type ["+ClusterIP.String()+","+
@@ -473,11 +475,11 @@ func doInstallation() error {
 
 	logging.PrintLog("Keptn has been successfully set up on your cluster.", logging.InfoLevel)
 	logging.PrintLog("---------------------------------------------------", logging.InfoLevel)
-	fmt.Println("* To quickly access Keptn, you can use a port-forward and then authenticate your Keptn CLI (in a Linux shell):\n"+
-		" - kubectl -n keptn port-forward service/api-gateway-nginx 8080:80\n"+
+	fmt.Println("* To quickly access Keptn, you can use a port-forward and then authenticate your Keptn CLI (in a Linux shell):\n" +
+		" - kubectl -n keptn port-forward service/api-gateway-nginx 8080:80\n" +
 		" - keptn auth --endpoint=http://localhost:8080/api --api-token=$(kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token} | base64 --decode)\n")
-	fmt.Println("* To expose Keptn on a public endpoint, please continue with the installation guidelines provided at:\n"+
-		" - https://keptn.sh/docs/"+keptnReleaseDocsURL+"/operate/install#install-keptn\n")
+	fmt.Println("* To expose Keptn on a public endpoint, please continue with the installation guidelines provided at:\n" +
+		" - https://keptn.sh/docs/" + keptnReleaseDocsURL + "/operate/install#install-keptn\n")
 	return nil
 }
 

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -95,7 +95,7 @@ var installCmd = &cobra.Command{
 	Short: "Installs Keptn on a Kubernetes cluster",
 	Long: `The Keptn CLI allows installing Keptn on any Kubernetes derivate to which your kube config is pointing to, and on OpenShift.
 
-For more information, please follow the installation guide [Install Keptn](https://keptn.sh/docs/` + keptnReleaseDocsURL + `/operate/install/operate/install/#install-keptn)
+For more information, please follow the installation guide [Install Keptn](https://keptn.sh/docs/` + keptnReleaseDocsURL + `/operate/install/#install-keptn)
 `,
 	Example: `keptn install                                                        # install on Kubernetes
 
@@ -198,7 +198,7 @@ Please see https://kubernetes.io/docs/tasks/tools/install-kubectl/`)
 			if *installParams.PlatformIdentifier != "openshift" {
 				if err := kube.CheckKubeServerVersion(KubeServerVersionConstraints); err != nil {
 					logging.PrintLog(err.Error(), logging.VerboseLevel)
-					logging.PrintLog("See https://keptn.sh/docs/"+keptnReleaseDocsURL+"/installation/k8s-support/ for details.", logging.VerboseLevel)
+					logging.PrintLog("See https://keptn.sh/docs/"+keptnReleaseDocsURL+"/operate/k8s_support/ for details.", logging.VerboseLevel)
 					return fmt.Errorf("Failed to check kubernetes server version: %w", err)
 				}
 			}
@@ -283,10 +283,10 @@ func init() {
 		"The platform to run Keptn on ["+kubernetes+","+openshift+"]")
 
 	installParams.ConfigFilePath = installCmd.Flags().StringP("creds", "c", "",
-		"Specify a JSON file containing cluster information needed for the installation (this allows skipping user prompts to execute a *silent* Keptn installation)")
+		"Specify a JSON file containing cluster information needed for the installation. This allows skipping user prompts to execute a *silent* Keptn installation.")
 
 	installParams.UseCaseInput = installCmd.Flags().StringP("use-case", "u", "",
-		"The use case to install Keptn for: "+ContinuousDelivery.String())
+		"The use case to install Keptn for ["+ContinuousDelivery.String()+"]")
 
 	installParams.ApiServiceTypeInput = installCmd.Flags().StringP("endpoint-service-type", "",
 		ClusterIP.String(), "Installation options for the endpoint-service type ["+ClusterIP.String()+","+

--- a/cli/cmd/onboard.go
+++ b/cli/cmd/onboard.go
@@ -7,8 +7,8 @@ import (
 // onboardCmd represents the onboard command
 var onboardCmd = &cobra.Command{
 	Use:   "onboard [service]",
-	Short: "onboard allows to create a new service",
-	Long:  `onboard currently allows to create a new service with "onboard service". onboard without sub-command cannot be used.`,
+	Short: "Creates a new service and uploads its Helm chart to the branches in the Git repository",
+	Long:  `Creates a new service and uploads its Helm chart to the branches in the Git repository.`,
 }
 
 func init() {

--- a/cli/cmd/onboard_service.go
+++ b/cli/cmd/onboard_service.go
@@ -30,11 +30,13 @@ var onboardServiceParams *onboardServiceCmdParams
 var serviceCmd = &cobra.Command{
 	Use:   "service SERVICENAME --project=PROJECTNAME --chart=FILEPATH",
 	Short: "Onboards a new service and its Helm chart to a project",
-	Long: `Onboards a new service and its Helm chart to the provided project. Therefore, this command 
-takes a folder to a Helm chart or an already packed Helm chart as .tgz.
+	Long: `Onboards a new service and its Helm chart to the provided project. 
+Therefore, this command takes a folder to a Helm chart or an already packed Helm chart as .tgz.
 `,
 	Example: `keptn onboard service SERVICENAME --project=PROJECTNAME --chart=FILEPATH
-keptn onboard service SERVICENAME --project=PROJECTNAME --chart=HELM_CHART.tgz`,
+
+keptn onboard service SERVICENAME --project=PROJECTNAME --chart=HELM_CHART.tgz
+`,
 	SilenceUsage: true,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 1 {

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -28,9 +28,8 @@ const authErrorMsg = "This command requires to be authenticated. See \"keptn aut
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "keptn",
-	Short: "This is a CLI for using keptn",
-	Long: `This is a CLI for using keptn. The CLI allows to authenticate against keptn, to configure your Github organization,
-to create projects, and to onboard services.
+	Short: "The CLI for using Keptn",
+	Long: `The CLI allows interaction with a Keptn installation to manage Keptn, to trigger workflows, and to get details.
 	`,
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
@@ -57,13 +56,12 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.PersistentFlags().BoolVarP(&verboseLogging, "verbose", "v", false, "verbose logging")
-	rootCmd.PersistentFlags().BoolVarP(&quietLogging, "quiet", "q", false, "suppress debug and info output")
-	rootCmd.PersistentFlags().BoolVarP(&mocking, "mock", "", false, "mocking of server communication - ATTENTION: your commands will not be sent to the keptn server")
+	rootCmd.PersistentFlags().BoolVarP(&verboseLogging, "verbose", "v", false, "Enables verbose logging to print debug messages")
+	rootCmd.PersistentFlags().BoolVarP(&quietLogging, "quiet", "q", false, "Suppresses debug and info messages")
+	rootCmd.PersistentFlags().BoolVarP(&mocking, "mock", "", false, "Disables communication to a Keptn endpoint")
 	rootCmd.PersistentFlags().BoolVarP(&SuppressWSCommunication, "suppress-websocket", "", false,
-		"disables websocket communication - use the ID of Keptn context (if provided) for checking the result of your command")
+		"Disables WebSocket communication to suppress info messages from services running inside Keptn")
 	cobra.OnInitialize(initConfig)
-
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cli/cmd/send.go
+++ b/cli/cmd/send.go
@@ -5,8 +5,7 @@ import "github.com/spf13/cobra"
 // sendCmd implements the send command
 var sendCmd = &cobra.Command{
 	Use:   "send [event]",
-	Short: `"send" can be used with the subcommand "event"`,
-	Long:  `"send" can be used with the subcommand "event"`,
+	Short: "Sends an event to Keptn",
 }
 
 func init() {

--- a/cli/cmd/send_event.go
+++ b/cli/cmd/send_event.go
@@ -35,15 +35,13 @@ var eventFilePath *string
 
 // sendEventCmd represents the send command
 var sendEventCmd = &cobra.Command{
-	Use:   "event --file=FILEPATH --stream-websocket",
-	Short: "Sends a Keptn event",
-	Long: `Allows to send an arbitrary Keptn event that is defined in the provided JSON file.
-An event has to follow the Cloud Events specification (https://cloudevents.io/) in version 0.2 and has to be written in JSON.
-In addition, the payload of the Cloud Event needs to follow the Keptn spec (https://github.com/keptn/spec/blob/0.1.3/cloudevents.md).
-
-For convenience, this command offers the *--stream-websocket* flag to open a web socket communication to Keptn. Consequently, messages from the receiving Keptn service, which processes the event, are sent to the CLI via WebSocket.
-	`,
-	Example:      `keptn send event --file=./new_artifact_event.json --stream-websocket`,
+	Use:   "event --file=FILEPATH",
+	Short: "Sends an event to Keptn",
+	Long: `Sends an arbitrary Keptn event that is defined in the provided JSON file.
+An event has to follow the CloudEvents specification (https://cloudevents.io/) in version 0.2 and has to be written in JSON.
+In addition, the payload of the CloudEvent needs to follow the Keptn spec (https://github.com/keptn/spec/blob/0.1.4/cloudevents.md).
+`,
+	Example:      `keptn send event --file=./new_artifact_event.json`,
 	SilenceUsage: true,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		eventString, err := file.ReadFile(*eventFilePath)

--- a/cli/cmd/send_event_approvalFinished.go
+++ b/cli/cmd/send_event_approvalFinished.go
@@ -38,8 +38,8 @@ var approvalFinishedCmd = &cobra.Command{
 		"with the specified ID in the provided project and stage",
 	Long: `Sends an approval.finished event to Keptn in order to confirm an open approval with the specified ID in the provided project and stage. 
 
-* This command takes the project (*--project*), stage (*--stage*). 
-* It is necessary to specify the ID (*--id*) of the corresponding approval.triggered event.
+* This command takes the project (*--project*) and stage (*--stage*). 
+* It is optional to specify the ID (*--id*) of the corresponding approval.triggered event. If the ID is not provided, the command asks the user which open approval should be accepted or declined.
 * The open approval.triggered events and their ID can be retrieved using the "keptn get event approval.triggered --project=<project> --stage=<stage>" command.
 `,
 	Example: `keptn send event approval.finished --project=sockshop --stage=hardening --id=1234-5678-9123`,

--- a/cli/cmd/send_event_approvalFinished.go
+++ b/cli/cmd/send_event_approvalFinished.go
@@ -36,11 +36,11 @@ var approvalFinishedCmd = &cobra.Command{
 	Use: "approval.finished",
 	Short: "Sends an approval.finished event to Keptn in order to confirm an open approval " +
 		"with the specified ID in the provided project and stage",
-	Long: `Sends an approval.finished event to Keptn in order to confirm an open approval
-with the specified ID in the provided project and stage. 
+	Long: `Sends an approval.finished event to Keptn in order to confirm an open approval with the specified ID in the provided project and stage. 
 
-This command takes the project (*--project*), stage (*--stage*). Besides, it is necessary to specify the ID (*--id*) of the corresponding approval.triggered event.
-The open approval.triggered events and their ID can be retrieved using the "keptn get event approval.triggered --project=<project> --stage=<stage>"" command."
+* This command takes the project (*--project*), stage (*--stage*). 
+* It is necessary to specify the ID (*--id*) of the corresponding approval.triggered event.
+* The open approval.triggered events and their ID can be retrieved using the "keptn get event approval.triggered --project=<project> --stage=<stage>" command.
 `,
 	Example: `keptn send event approval.finished --project=sockshop --stage=hardening --id=1234-5678-9123`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/cmd/send_event_evaluationStart.go
+++ b/cli/cmd/send_event_evaluationStart.go
@@ -49,17 +49,19 @@ var evaluationStart evaluationStartStruct
 // evaluationStartCmd represents the start-evaluation command
 var evaluationStartCmd = &cobra.Command{
 	Use: "start-evaluation",
-	Short: "Sends an start-evaluation event to Keptn in order to evaluate a test " +
+	Short: "Sends an start-evaluation event to Keptn to evaluate a test " +
 		"for the specified service in the provided project and stage",
-	Long: `Sends a start-evaluation event to Keptn in order to evaluate a test
-for the specified service in the provided project and stage. 
+	Long: `Sends a start-evaluation event to Keptn in order to evaluate a test for the specified service in the provided project and stage. 
 
-This command takes the project (*--project*), stage (*--stage*), and the service (*--service*), which should be
-evaluated. Besides, it is necessary to specify a time frame (*--timeframe*) of the evaluation. If, for example, the 
-flag is set to *--timeframe=5m*, the evaluation is conducted for the last 5 minutes. To specify a particular starting
-point, the flag *--start* flag can be used. In this case, the specified time frame is added to the starting point.`,
+* This command takes the project (*--project*), stage (*--stage*), and the service (*--service*), which should be evaluated. 
+* It is necessary to specify a time frame (*--timeframe*) of the evaluation. If, for example, the 
+flag is set to *--timeframe=5m*, the evaluation is conducted for the last 5 minutes. 
+* To specify a particular starting point, the flag *--start* flag can be used. In this case, the specified time frame is added to the starting point.
+`,
 	Example: `keptn send event start-evaluation --project=sockshop --stage=hardening --service=carts --timeframe=5m --start=2019-10-31T11:59:59
-    keptn send event start-evaluation --project=sockshop --stage=hardening --service=carts --start=2019-10-31T11:59:59 --end=2019-10-31T12:04:59 --labels=test-id=1234,test-name=performance-test`,
+
+keptn send event start-evaluation --project=sockshop --stage=hardening --service=carts --start=2019-10-31T11:59:59 --end=2019-10-31T12:04:59 --labels=test-id=1234,test-name=performance-test
+`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds()

--- a/cli/cmd/send_event_newArtifact.go
+++ b/cli/cmd/send_event_newArtifact.go
@@ -51,16 +51,15 @@ var newArtifactCmd = &cobra.Command{
 	Use: "new-artifact",
 	Short: "Sends a new-artifact event to Keptn in order to deploy a new artifact " +
 		"for the specified service in the provided project",
-	Long: `Sends a new-artifact event to Keptn in order to deploy a new artifact
-for the specified service in the provided project.
+	Long: `Sends a new-artifact event to Keptn in order to deploy a new artifact for the specified service in the provided project.
 Therefore, this command takes the project, service, image, and tag of the new artifact.
 
-The artifact is the name of a Docker image, which can be located at Docker Hub, Quay, or any other registry storing docker images. 
-The new artifact is pushed in the first stage specified in the projects *shipyard.yaml* file. Afterwards, Keptn takes care of deploying this new artifact to the other stages.
+* The artifact is the name of a image, which can be located at DockerHub, Quay, or any other registry storing docker images. 
+* The new artifact is pushed in the first stage specified in the Shipyard of the project. Afterwards, Keptn takes care of deploying this new artifact to the other stages.
 
-Furthermore, please note that the value provided in the *image* flag has to contain the full path to your Docker registry. The only exception is *docker.io* because this is the default in Kubernetes and, hence, can be omitted.
-
-**Note:** This command does not send the actual Docker image to Keptn, just the image name and tag. Instead, Keptn uses Kubernetes functionalities for pulling this image.
+**Notes:**
+* The value provided in the *image* flag has to contain the full path to your Docker registry. The only exception is *docker.io* because this is the default in Kubernetes and, hence, can be omitted.
+* This command does not send the actual Docker image to Keptn, just the image name and tag. Instead, Keptn uses Kubernetes functionalities for pulling this image.
 For pulling an image from a private registry, we would like to refer to the Kubernetes documentation (https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
 `,
 	Example:      `keptn send event new-artifact --project=sockshop --service=carts --image=docker.io/keptnexamples/carts --tag=0.7.0`,

--- a/cli/cmd/set.go
+++ b/cli/cmd/set.go
@@ -5,8 +5,8 @@ import "github.com/spf13/cobra"
 // setCmd implements the command set
 var setCmd = &cobra.Command{
 	Use:   "set [config]",
-	Short: `"set" can be used with the subcommand "config"`,
-	Long:  `"set" can be used with the subcommand "config"`,
+	Short: `Sets flags of the CLI configuration`,
+	Long:  `Sets flags of the CLI configuration.`,
 }
 
 func init() {

--- a/cli/cmd/set_config.go
+++ b/cli/cmd/set_config.go
@@ -17,12 +17,12 @@ var configMng *config.CLIConfigManager
 // setConfig implements the config command
 var setConfigCmd = &cobra.Command{
 	Use:   "config",
-	Short: "Allows to set the CLI configuration",
-	Long: `Allows to set the CLI configuration, which is stored in $HOME/.keptn/config.
-Therefore, this command takes a key and a new value as arguments. 
-	
-Example:
-	keptn set config AutomaticVersionCheck false`,
+	Short: "Sets flags of the CLI configuration",
+	Long: `Sets flags of the CLI configuration, which is stored in $HOME/.keptn/config.
+
+*	This command takes a key and a new value as arguments. 
+`,
+	Example:      `keptn set config AutomaticVersionCheck false`,
 	SilenceUsage: true,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 2 {

--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -23,14 +23,13 @@ var uninstallCmd = &cobra.Command{
 
 This command does *not* delete: 
 
-* Istio
 * Dynatrace monitoring
 * Prometheus monitoring
 * Any (third-party) service installed in addition to Keptn (e.g., notification-service, slackbot-service, ...)
 
 Besides, deployed services and the configuration on the Git upstream (i.e., GitHub, GitLab, or Bitbucket) are not deleted. To clean-up created projects and services, please see [Delete a project](https://keptn.sh/docs/` + keptnReleaseDocsURL + `/manage/project/#delete-a-project).
 
-**Note:** This command requires a *Kubernetes current context* pointing to the cluster where Keptn should get uninstalled.
+**Note:** This command requires a *Kubernetes current context* pointing to the cluster where Keptn should get uninstalled from.
 `,
 	Example:      `keptn uninstall`,
 	SilenceUsage: true,

--- a/cli/cmd/update.go
+++ b/cli/cmd/update.go
@@ -6,7 +6,8 @@ import (
 
 // createCmd implements the create command
 var updateCmd = &cobra.Command{
-	Use: "update [project]",
+	Use:   "update [project]",
+	Short: "Updates an existing Keptn project",
 }
 
 func init() {

--- a/cli/cmd/update_project.go
+++ b/cli/cmd/update_project.go
@@ -27,10 +27,11 @@ var upProjectCmd = &cobra.Command{
 	Use:   "project PROJECTNAME --git-user=GIT_USER --git-token=GIT_TOKEN --git-remote-url=GIT_REMOTE_URL",
 	Short: "Updates an existing Keptn project",
 	Long: `Updates an existing Keptn project with the provided name. 
+
 Updating a shipyard file is not possible.
 
-By executing the *update project* command, Keptn will add the provided upstream repository to the existing internal Git repository that is used to maintain all project-related resources. 
-To upstream this internal Git repository to a remote repository, the Git user (*--git-user*), an access token (*--git-token*), and the remote URL (*--git-remote-url*) are required.
+By executing the update project command, Keptn will add the provided upstream repository to the existing internal Git repository that is used to maintain all project-related resources. 
+To upstream this internal Git repository to a remote repository, the Git user (--git-user), an access token (--git-token), and the remote URL (--git-remote-url) are required.
 
 For more information about updating projects or upstream repositories, please go to [Manage Keptn](https://keptn.sh/docs/` + keptnReleaseDocsURL + `/manage/)
 `,

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -36,8 +36,8 @@ const enableVersionCheckMsg = "To %s the daily version check, please execute: \n
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{
 	Use:     "version",
-	Short:   "Shows the CLI version of Keptn.",
-	Long:    `Shows the CLI version of Keptn, as well as an indication whether a new version is available.`,
+	Short:   "Shows the CLI version of Keptn",
+	Long:    `Shows the CLI version of Keptn and a note when a new version is available.`,
 	Example: `keptn version`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("CLI version: " + Version)


### PR DESCRIPTION
After merging this PR:
1. execute `keptn generate docs` 
1. Update: https://keptn.sh/docs/0.7.x/reference/cli/commands/

- [x] Docu is up-to-date