### PR TITLE
#2147 Adapted K8s labels in local manifests

### DIFF
--- a/api/deploy/service.yaml
+++ b/api/deploy/service.yaml
@@ -4,15 +4,26 @@ kind: Deployment
 metadata:
   name: api-service
   namespace: keptn
+  labels:
+    app.kubernetes.io/name: api-service
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/part-of: keptn-keptn
+    app.kubernetes.io/component: control-plane
+    app.kubernetes.io/version: develop
 spec:
   selector:
     matchLabels:
-      run: api-service
+      app.kubernetes.io/name: api-service
+      app.kubernetes.io/instance: keptn
   replicas: 1
   template:
     metadata:
       labels:
-        run: api-service
+        app.kubernetes.io/name: api-service
+        app.kubernetes.io/instance: keptn
+        app.kubernetes.io/part-of: keptn-keptn
+        app.kubernetes.io/component: control-plane
+        app.kubernetes.io/version: develop
     spec:
       containers:
         - name: api-service
@@ -54,7 +65,10 @@ metadata:
   name: api-service
   namespace: keptn
   labels:
-    run: api-service
+    app.kubernetes.io/name: api-service
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/part-of: keptn-keptn
+    app.kubernetes.io/component: control-plane
 spec:
   ports:
     - port: 8080
@@ -62,4 +76,5 @@ spec:
       targetPort: 8080
       protocol: TCP
   selector:
-    run: api-service
+    app.kubernetes.io/name: api-service
+    app.kubernetes.io/instance: keptn

--- a/bridge/deploy/bridge.yaml
+++ b/bridge/deploy/bridge.yaml
@@ -4,15 +4,26 @@ kind: Deployment
 metadata:
   name: bridge
   namespace: keptn
+  labels:
+    app.kubernetes.io/name: bridge
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/part-of: keptn-keptn
+    app.kubernetes.io/component: control-plane
+    app.kubernetes.io/version: develop
 spec:
   selector:
     matchLabels:
-      run: bridge
+      app.kubernetes.io/name: bridge
+      app.kubernetes.io/instance: keptn
   replicas: 1
   template:
     metadata:
       labels:
-        run: bridge
+        app.kubernetes.io/name: bridge
+        app.kubernetes.io/instance: keptn
+        app.kubernetes.io/part-of: keptn-keptn
+        app.kubernetes.io/component: control-plane
+        app.kubernetes.io/version: develop
     spec:
       serviceAccountName: keptn-default
       containers:
@@ -47,11 +58,15 @@ metadata:
   name: bridge
   namespace: keptn
   labels:
-    run: bridge
+    app.kubernetes.io/name: bridge
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/part-of: keptn-keptn
+    app.kubernetes.io/component: control-plane
 spec:
   ports:
   - port: 8080
     targetPort: 3000
     protocol: TCP
   selector:
-    run: bridge
+    app.kubernetes.io/name: bridge
+    app.kubernetes.io/instance: keptn

--- a/configuration-service/deploy/pvc.yaml
+++ b/configuration-service/deploy/pvc.yaml
@@ -5,6 +5,11 @@ metadata:
   creationTimestamp: null
   name: configuration-volume
   namespace: keptn
+  labels:
+    app.kubernetes.io/name: configuration-volume
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/part-of: keptn-keptn
+    app.kubernetes.io/component: control-plane
 spec:
   accessModes:
   - ReadWriteOnce

--- a/configuration-service/deploy/service.yaml
+++ b/configuration-service/deploy/service.yaml
@@ -4,10 +4,17 @@ kind: Deployment
 metadata:
   name: configuration-service
   namespace: keptn
+  labels:
+    app.kubernetes.io/name: configuration-service
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/part-of: keptn-keptn
+    app.kubernetes.io/component: control-plane
+    app.kubernetes.io/version: develop
 spec:
   selector:
     matchLabels:
-      run: configuration-service
+      app.kubernetes.io/name: configuration-service
+      app.kubernetes.io/instance: keptn
   replicas: 1
   # recreate the deployment if anything changes (we can not do a rolling upgrade of this deployment as we use a volume)
   strategy:
@@ -15,7 +22,11 @@ spec:
   template:
     metadata:
       labels:
-        run: configuration-service
+        app.kubernetes.io/name: configuration-service
+        app.kubernetes.io/instance: keptn
+        app.kubernetes.io/part-of: keptn-keptn
+        app.kubernetes.io/component: control-plane
+        app.kubernetes.io/version: develop
     spec:
       serviceAccountName: keptn-configuration-service
       containers:
@@ -91,11 +102,15 @@ metadata:
   name: configuration-service
   namespace: keptn
   labels:
-    run: configuration-service
+    app.kubernetes.io/name: configuration-service
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/part-of: keptn-keptn
+    app.kubernetes.io/component: control-plane
 spec:
   ports:
   - port: 8080
     targetPort: 8080
     protocol: TCP
   selector:
-    run: configuration-service
+    app.kubernetes.io/name: configuration-service
+    app.kubernetes.io/instance: keptn

--- a/distributor/deploy/distributor.yaml
+++ b/distributor/deploy/distributor.yaml
@@ -4,15 +4,26 @@ kind: Deployment
 metadata:
   name: service-distributor
   namespace: keptn
+  labels:
+    app.kubernetes.io/name: distributor
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/part-of: keptn-keptn
+    app.kubernetes.io/component: control-plane
+    app.kubernetes.io/version: develop
 spec:
   selector:
     matchLabels:
-      run: distributor
+      app.kubernetes.io/name: distributor
+      app.kubernetes.io/instance: keptn
   replicas: 1
   template:
     metadata:
       labels:
-        run: distributor
+        app.kubernetes.io/name: distributor
+        app.kubernetes.io/instance: keptn
+        app.kubernetes.io/part-of: keptn-keptn
+        app.kubernetes.io/component: control-plane
+        app.kubernetes.io/version: develop
     spec:
       serviceAccountName: keptn-default
       containers:

--- a/eventbroker/deploy/eventbroker.yaml
+++ b/eventbroker/deploy/eventbroker.yaml
@@ -4,15 +4,26 @@ kind: Deployment
 metadata:
   name: eventbroker-go
   namespace: keptn
+  labels:
+    app.kubernetes.io/name: eventbroker-go
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/part-of: keptn-keptn
+    app.kubernetes.io/component: control-plane
+    app.kubernetes.io/version: develop
 spec:
   selector:
     matchLabels:
-      run: eventbroker-go
+      app.kubernetes.io/name: eventbroker-go
+      app.kubernetes.io/instance: keptn
   replicas: 1
   template:
     metadata:
       labels:
-        run: eventbroker-go
+        app.kubernetes.io/name: eventbroker-go
+        app.kubernetes.io/instance: keptn
+        app.kubernetes.io/part-of: keptn-keptn
+        app.kubernetes.io/component: control-plane
+        app.kubernetes.io/version: develop
     spec:
       serviceAccountName: keptn-default
       containers:
@@ -45,11 +56,15 @@ metadata:
   name: event-broker
   namespace: keptn
   labels:
-    run: eventbroker-go
+    app.kubernetes.io/name: eventbroker-go
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/part-of: keptn-keptn
+    app.kubernetes.io/component: control-plane
 spec:
   ports:
   - port: 80
     targetPort: 8080
     protocol: TCP
   selector:
-    run: eventbroker-go
+    app.kubernetes.io/name: eventbroker-go
+    app.kubernetes.io/instance: keptn

--- a/gatekeeper-service/deploy/service.yaml
+++ b/gatekeeper-service/deploy/service.yaml
@@ -3,15 +3,26 @@ kind: Deployment
 metadata:
   name: gatekeeper-service
   namespace: keptn
+  labels:
+    app.kubernetes.io/name: gatekeeper-service
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/part-of: keptn-keptn
+    app.kubernetes.io/component: control-plane
+    app.kubernetes.io/version: develop
 spec:
   selector:
     matchLabels:
-      run: gatekeeper-service
+      app.kubernetes.io/name: gatekeeper-service
+      app.kubernetes.io/instance: keptn
   replicas: 1
   template:
     metadata:
       labels:
-        run: gatekeeper-service
+        app.kubernetes.io/name: gatekeeper-service
+        app.kubernetes.io/instance: keptn
+        app.kubernetes.io/part-of: keptn-keptn
+        app.kubernetes.io/component: control-plane
+        app.kubernetes.io/version: develop
     spec:
       serviceAccountName: keptn-default
       containers:
@@ -71,10 +82,14 @@ metadata:
   name: gatekeeper-service
   namespace: keptn
   labels:
-    run: gatekeeper-service
+    app.kubernetes.io/name: gatekeeper-service
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/part-of: keptn-keptn
+    app.kubernetes.io/component: control-plane
 spec:
   ports:
   - port: 8080
     protocol: TCP
   selector:
-    run: gatekeeper-service
+    app.kubernetes.io/name: gatekeeper-service
+    app.kubernetes.io/instance: keptn

--- a/helm-service/deploy/service.yaml
+++ b/helm-service/deploy/service.yaml
@@ -3,15 +3,26 @@ kind: Deployment
 metadata:
   name: helm-service
   namespace: keptn
+  labels:
+    app.kubernetes.io/name: helm-service
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/part-of: keptn-keptn
+    app.kubernetes.io/component: control-plane
+    app.kubernetes.io/version: develop
 spec:
   selector:
     matchLabels:
-      run: helm-service
+      app.kubernetes.io/name: helm-service
+      app.kubernetes.io/instance: keptn
   replicas: 1
   template:
     metadata:
       labels:
-        run: helm-service
+        app.kubernetes.io/name: helm-service
+        app.kubernetes.io/instance: keptn
+        app.kubernetes.io/part-of: keptn-keptn
+        app.kubernetes.io/component: control-plane
+        app.kubernetes.io/version: develop
     spec:
       serviceAccountName: keptn-helm-service
       containers:
@@ -99,10 +110,14 @@ metadata:
   name: helm-service
   namespace: keptn
   labels:
-    run: helm-service
+    app.kubernetes.io/name: helm-service
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/part-of: keptn-keptn
+    app.kubernetes.io/component: control-plane
 spec:
   ports:
   - port: 8080
     protocol: TCP
   selector:
-    run: helm-service
+    app.kubernetes.io/name: helm-service
+    app.kubernetes.io/instance: keptn

--- a/jmeter-service/deploy/service.yaml
+++ b/jmeter-service/deploy/service.yaml
@@ -3,15 +3,26 @@ kind: Deployment
 metadata:
   name: jmeter-service
   namespace: keptn
+  labels:
+    app.kubernetes.io/name: jmeter-service
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/part-of: keptn-keptn
+    app.kubernetes.io/component: control-plane
+    app.kubernetes.io/version: develop
 spec:
   selector:
     matchLabels:
-      run: jmeter-service
+      app.kubernetes.io/name: jmeter-service
+      app.kubernetes.io/instance: keptn
   replicas: 1
   template:
     metadata:
       labels:
-        run: jmeter-service
+        app.kubernetes.io/name: jmeter-service
+        app.kubernetes.io/instance: keptn
+        app.kubernetes.io/part-of: keptn-keptn
+        app.kubernetes.io/component: control-plane
+        app.kubernetes.io/version: develop
     spec:
       containers:
       - name: jmeter-service
@@ -58,10 +69,14 @@ metadata:
   name: jmeter-service
   namespace: keptn
   labels:
-    run: jmeter-service
+    app.kubernetes.io/name: jmeter-service
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/part-of: keptn-keptn
+    app.kubernetes.io/component: control-plane
 spec:
   ports:
   - port: 8080
     protocol: TCP
   selector:
-    run: jmeter-service
+    app.kubernetes.io/name: jmeter-service
+    app.kubernetes.io/instance: keptn

--- a/lighthouse-service/deploy/service.yaml
+++ b/lighthouse-service/deploy/service.yaml
@@ -3,15 +3,26 @@ kind: Deployment
 metadata:
   name: lighthouse-service
   namespace: keptn
+  labels:
+    app.kubernetes.io/name: lighthouse-service
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/part-of: keptn-keptn
+    app.kubernetes.io/component: control-plane
+    app.kubernetes.io/version: develop
 spec:
   selector:
     matchLabels:
-      run: lighthouse-service
+      app.kubernetes.io/name: lighthouse-service
+      app.kubernetes.io/instance: keptn
   replicas: 1
   template:
     metadata:
       labels:
-        run: lighthouse-service
+        app.kubernetes.io/name: lighthouse-service
+        app.kubernetes.io/instance: keptn
+        app.kubernetes.io/part-of: keptn-keptn
+        app.kubernetes.io/component: control-plane
+        app.kubernetes.io/version: develop
     spec:
       serviceAccountName: keptn-lighthouse-service
       containers:
@@ -72,10 +83,14 @@ metadata:
   name: lighthouse-service
   namespace: keptn
   labels:
-    run: lighthouse-service
+    app.kubernetes.io/name: lighthouse-service
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/part-of: keptn-keptn
+    app.kubernetes.io/component: control-plane
 spec:
   ports:
     - port: 8080
       protocol: TCP
   selector:
-    run: lighthouse-service
+    app.kubernetes.io/name: lighthouse-service
+    app.kubernetes.io/instance: keptn

--- a/mongodb-datastore/deploy/mongodb-datastore.yaml
+++ b/mongodb-datastore/deploy/mongodb-datastore.yaml
@@ -6,15 +6,26 @@ metadata:
   namespace: keptn
   annotations:
     fluentbit.io/exclude: "true"
+  labels:
+    app.kubernetes.io/name: mongodb-datastore
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/part-of: keptn-keptn
+    app.kubernetes.io/component: control-plane
+    app.kubernetes.io/version: develop
 spec:
   selector:
     matchLabels:
-      run: mongodb-datastore
+      app.kubernetes.io/name: mongodb-datastore
+      app.kubernetes.io/instance: keptn
   replicas: 1
   template:
     metadata:
       labels:
-        run: mongodb-datastore
+        app.kubernetes.io/name: mongodb-datastore
+        app.kubernetes.io/instance: keptn
+        app.kubernetes.io/part-of: keptn-keptn
+        app.kubernetes.io/component: control-plane
+        app.kubernetes.io/version: develop
     spec:
       serviceAccountName: keptn-default
       containers:
@@ -86,10 +97,14 @@ metadata:
   name: mongodb-datastore
   namespace: keptn
   labels:
-    run: mongodb-datastore
+    app.kubernetes.io/name: mongodb-datastore
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/part-of: keptn-keptn
+    app.kubernetes.io/component: control-plane
 spec:
   ports:
   - port: 8080
     protocol: TCP
   selector:
-    run: mongodb-datastore
+    app.kubernetes.io/name: mongodb-datastore
+    app.kubernetes.io/instance: keptn

--- a/platform-support/openshift-route-service/deploy/service.yaml
+++ b/platform-support/openshift-route-service/deploy/service.yaml
@@ -46,15 +46,26 @@ kind: Deployment
 metadata:
   name: openshift-route-service
   namespace: keptn
+  labels:
+    app.kubernetes.io/name: openshift-route-service
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/part-of: keptn-keptn
+    app.kubernetes.io/component: control-plane
+    app.kubernetes.io/version: develop
 spec:
   selector:
     matchLabels:
-      run: openshift-route-service
+      app.kubernetes.io/name: openshift-route-service
+      app.kubernetes.io/instance: keptn
   replicas: 1
   template:
     metadata:
       labels:
-        run: openshift-route-service
+        app.kubernetes.io/name: openshift-route-service
+        app.kubernetes.io/instance: keptn
+        app.kubernetes.io/part-of: keptn-keptn
+        app.kubernetes.io/component: control-plane
+        app.kubernetes.io/version: develop
     spec:
       serviceAccountName: keptn-openshift-route-service
       containers:
@@ -95,7 +106,10 @@ metadata:
   name: openshift-route-service
   namespace: keptn
   labels:
-    run: openshift-route-service
+    app.kubernetes.io/name: openshift-route-service
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/part-of: keptn-keptn
+    app.kubernetes.io/component: control-plane
 spec:
   ports:
   - name: cloudevents
@@ -103,4 +117,5 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    run: openshift-route-service
+    app.kubernetes.io/name: openshift-route-service
+    app.kubernetes.io/instance: keptn

--- a/remediation-service/deploy/service.yaml
+++ b/remediation-service/deploy/service.yaml
@@ -4,15 +4,26 @@ kind: Deployment
 metadata:
   name: remediation-service
   namespace: keptn
+  labels:
+    app.kubernetes.io/name: remediation-service
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/part-of: keptn-keptn
+    app.kubernetes.io/component: control-plane
+    app.kubernetes.io/version: develop
 spec:
   selector:
     matchLabels:
-      run: remediation-service
+      app.kubernetes.io/name: remediation-service
+      app.kubernetes.io/instance: keptn
   replicas: 1
   template:
     metadata:
       labels:
-        run: remediation-service
+        app.kubernetes.io/name: remediation-service
+        app.kubernetes.io/instance: keptn
+        app.kubernetes.io/part-of: keptn-keptn
+        app.kubernetes.io/component: control-plane
+        app.kubernetes.io/version: develop
     spec:
       serviceAccountName: keptn-default
       containers:
@@ -65,11 +76,15 @@ metadata:
   name: remediation-service
   namespace: keptn
   labels:
-    run: remediation-service
+    app.kubernetes.io/name: remediation-service
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/part-of: keptn-keptn
+    app.kubernetes.io/component: control-plane
 spec:
   ports:
   - port: 8080
     targetPort: 8080
     protocol: TCP
   selector:
-    run: remediation-service
+    app.kubernetes.io/name: remediation-service
+    app.kubernetes.io/instance: keptn

--- a/shipyard-service/deploy/service.yaml
+++ b/shipyard-service/deploy/service.yaml
@@ -4,15 +4,26 @@ kind: Deployment
 metadata:
   name: shipyard-service
   namespace: keptn
+  labels:
+    app.kubernetes.io/name: shipyard-service
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/part-of: keptn-keptn
+    app.kubernetes.io/component: control-plane
+    app.kubernetes.io/version: develop
 spec:
   selector:
     matchLabels:
-      run: shipyard-service
+      app.kubernetes.io/name: shipyard-service
+      app.kubernetes.io/instance: keptn
   replicas: 1
   template:
     metadata:
       labels:
-        run: shipyard-service
+        app.kubernetes.io/name: shipyard-service
+        app.kubernetes.io/instance: keptn
+        app.kubernetes.io/part-of: keptn-keptn
+        app.kubernetes.io/component: control-plane
+        app.kubernetes.io/version: develop
     spec:
       serviceAccountName: keptn-default
       containers:
@@ -72,10 +83,14 @@ metadata:
   name: shipyard-service
   namespace: keptn
   labels:
-    run: shipyard-service
+    app.kubernetes.io/name: shipyard-service
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/part-of: keptn-keptn
+    app.kubernetes.io/component: control-plane
 spec:
   ports:
   - port: 8080
     protocol: TCP
   selector:
-    run: shipyard-service
+    app.kubernetes.io/name: shipyard-service
+    app.kubernetes.io/instance: keptn


### PR DESCRIPTION
This PR adds the recommended K8s labels to the local manifest files. 
As a result, `skafold` is working again. This has been validated with each manifest. 