### PR TITLE
Ignore case for user input

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -443,7 +443,7 @@ func doInstallation() error {
 		if err != nil {
 			return err
 		}
-		in = strings.TrimSpace(in)
+		in = strings.ToLower(strings.TrimSpace(in))
 		if !(in == "y" || in == "yes") {
 			return fmt.Errorf("Stopping installation.")
 		}

--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -48,7 +48,7 @@ Besides, deployed services and the configuration on the Git upstream (i.e., GitH
 		if err != nil {
 			return err
 		}
-		in = strings.TrimSpace(in)
+		in = strings.ToLower(strings.TrimSpace(in))
 		if in != "y" && in != "yes" {
 			return nil
 		}


### PR DESCRIPTION
The CLI asks the user when installing and uninstalling Keptn for his/her input. The user can then confirm with "y" or "yes". 
With this PR we ignore the case of the input.