### PR TITLE
#2159 Shipyard Controller: manage .started events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -268,7 +268,7 @@ jobs:
         cd ..
       - |
         cd ${SHIPYARD_CONTROLLER_FOLDER}
-        go test -race -v -coverprofile=coverage.txt -covermode=atomic ./...
+        go test -v -coverprofile=coverage.txt -covermode=atomic ./...
         cd ..
       - |
         cd "${CONFIGURATION_SVC_FOLDER}"

--- a/shipyard-controller/db/event_repo.go
+++ b/shipyard-controller/db/event_repo.go
@@ -2,12 +2,16 @@ package db
 
 import "github.com/keptn/keptn/shipyard-controller/models"
 
+// EventStatus indicates the status type of an event, i.e. 'triggered', 'started', or 'finished'
 type EventStatus string
 
 const (
+	// TriggeredEvent describes a 'triggered' event
 	TriggeredEvent EventStatus = "triggered"
-	StartedEvent   EventStatus = "started"
-	FinishedEvent  EventStatus = "finished"
+	// StartedEvent describes a 'started' event
+	StartedEvent EventStatus = "started"
+	// FinishedEvent describes a 'finished' event
+	FinishedEvent EventStatus = "finished"
 )
 
 // EventFilter allows to pass filters

--- a/shipyard-controller/db/event_repo.go
+++ b/shipyard-controller/db/event_repo.go
@@ -1,6 +1,9 @@
 package db
 
-import "github.com/keptn/keptn/shipyard-controller/models"
+import (
+	"errors"
+	"github.com/keptn/keptn/shipyard-controller/models"
+)
 
 // EventStatus indicates the status type of an event, i.e. 'triggered', 'started', or 'finished'
 type EventStatus string
@@ -23,6 +26,9 @@ type EventFilter struct {
 	TriggeredID *string
 	Source      *string
 }
+
+// ErrNoEventFound indicates that no event could be found
+var ErrNoEventFound = errors.New("no matching event found")
 
 // EventRepo is an interface for retrieving and storing events
 type EventRepo interface {

--- a/shipyard-controller/db/event_repo.go
+++ b/shipyard-controller/db/event_repo.go
@@ -10,8 +10,8 @@ type EventFilter struct {
 	ID      *string
 }
 
-// TriggeredEventRepo is an interface for retrieving and storing events
-type TriggeredEventRepo interface {
+// EventRepo is an interface for retrieving and storing events
+type EventRepo interface {
 	// GetEvents gets all events of a project, based on the provided filter
 	GetEvents(project string, filter EventFilter) ([]models.Event, error)
 	// InsertEvent inserts an event into the collection of the specified project

--- a/shipyard-controller/db/event_repo.go
+++ b/shipyard-controller/db/event_repo.go
@@ -2,20 +2,30 @@ package db
 
 import "github.com/keptn/keptn/shipyard-controller/models"
 
+type EventStatus string
+
+const (
+	TriggeredEvent EventStatus = "triggered"
+	StartedEvent   EventStatus = "started"
+	FinishedEvent  EventStatus = "finished"
+)
+
 // EventFilter allows to pass filters
 type EventFilter struct {
-	Type    string
-	Stage   *string
-	Service *string
-	ID      *string
+	Type        string
+	Stage       *string
+	Service     *string
+	ID          *string
+	TriggeredID *string
+	Source      *string
 }
 
 // EventRepo is an interface for retrieving and storing events
 type EventRepo interface {
 	// GetEvents gets all events of a project, based on the provided filter
-	GetEvents(project string, filter EventFilter) ([]models.Event, error)
+	GetEvents(project string, filter EventFilter, status EventStatus) ([]models.Event, error)
 	// InsertEvent inserts an event into the collection of the specified project
-	InsertEvent(project string, event models.Event) error
+	InsertEvent(project string, event models.Event, status EventStatus) error
 	// DeleteEvent deletes an event from the collection
-	DeleteEvent(project string, eventID string) error
+	DeleteEvent(project string, eventID string, status EventStatus) error
 }

--- a/shipyard-controller/db/mongodb_event_repo.go
+++ b/shipyard-controller/db/mongodb_event_repo.go
@@ -44,6 +44,8 @@ func (mdbrepo *MongoDBEventsRepo) GetEvents(project string, filter EventFilter, 
 		return nil, ErrNoEventFound
 	} else if err != nil {
 		return nil, err
+	} else if cur.RemainingBatchLength() == 0 {
+		return nil, ErrNoEventFound
 	}
 
 	events := []models.Event{}

--- a/shipyard-controller/db/mongodb_event_repo.go
+++ b/shipyard-controller/db/mongodb_event_repo.go
@@ -41,7 +41,7 @@ func (mdbrepo *MongoDBEventsRepo) GetEvents(project string, filter EventFilter, 
 
 	cur, err := collection.Find(ctx, searchOptions)
 	if err != nil && err == mongo.ErrNoDocuments {
-		return nil, nil
+		return nil, ErrNoEventFound
 	} else if err != nil {
 		return nil, err
 	}

--- a/shipyard-controller/db/mongodb_event_repo.go
+++ b/shipyard-controller/db/mongodb_event_repo.go
@@ -12,16 +12,16 @@ import (
 	"time"
 )
 
-const collectionNameSuffix = "-triggeredEvents"
+const triggeredEventsCollectionNameSuffix = "-triggeredEvents"
 
-// MongoDBTriggeredEventsRepo retrieves and stores events in a mongodb collection
-type MongoDBTriggeredEventsRepo struct {
+// MongoDBEventsRepo retrieves and stores events in a mongodb collection
+type MongoDBEventsRepo struct {
 	DbConnection MongoDBConnection
 	Logger       keptn.LoggerInterface
 }
 
 // GetEvents gets all events of a project, based on the provided filter
-func (mdbrepo *MongoDBTriggeredEventsRepo) GetEvents(project string, filter EventFilter) ([]models.Event, error) {
+func (mdbrepo *MongoDBEventsRepo) GetEvents(project string, filter EventFilter) ([]models.Event, error) {
 	err := mdbrepo.DbConnection.EnsureDBConnection()
 	if err != nil {
 		return nil, err
@@ -29,7 +29,7 @@ func (mdbrepo *MongoDBTriggeredEventsRepo) GetEvents(project string, filter Even
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	collection := mdbrepo.getTriggeredEventsCollection(project)
+	collection := mdbrepo.getEventsCollection(project)
 
 	searchOptions := getSearchOptions(filter)
 
@@ -68,7 +68,7 @@ func (mdbrepo *MongoDBTriggeredEventsRepo) GetEvents(project string, filter Even
 }
 
 // InsertEvent inserts an event into the collection of the specified project
-func (mdbrepo *MongoDBTriggeredEventsRepo) InsertEvent(project string, event models.Event) error {
+func (mdbrepo *MongoDBEventsRepo) InsertEvent(project string, event models.Event) error {
 	err := mdbrepo.DbConnection.EnsureDBConnection()
 	if err != nil {
 		return err
@@ -76,7 +76,7 @@ func (mdbrepo *MongoDBTriggeredEventsRepo) InsertEvent(project string, event mod
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	collection := mdbrepo.getTriggeredEventsCollection(project)
+	collection := mdbrepo.getEventsCollection(project)
 
 	marshal, _ := json.Marshal(event)
 	var eventInterface interface{}
@@ -90,7 +90,7 @@ func (mdbrepo *MongoDBTriggeredEventsRepo) InsertEvent(project string, event mod
 }
 
 // DeleteEvent deletes an event from the collection
-func (mdbrepo *MongoDBTriggeredEventsRepo) DeleteEvent(project string, eventID string) error {
+func (mdbrepo *MongoDBEventsRepo) DeleteEvent(project string, eventID string) error {
 	err := mdbrepo.DbConnection.EnsureDBConnection()
 	if err != nil {
 		return err
@@ -98,7 +98,7 @@ func (mdbrepo *MongoDBTriggeredEventsRepo) DeleteEvent(project string, eventID s
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	collection := mdbrepo.getTriggeredEventsCollection(project)
+	collection := mdbrepo.getEventsCollection(project)
 	_, err = collection.DeleteMany(ctx, bson.M{"id": eventID})
 	if err != nil {
 		mdbrepo.Logger.Error(fmt.Sprintf("Could not delete event %s : %s\n", eventID, err.Error()))
@@ -108,8 +108,8 @@ func (mdbrepo *MongoDBTriggeredEventsRepo) DeleteEvent(project string, eventID s
 	return nil
 }
 
-func (mdbrepo *MongoDBTriggeredEventsRepo) getTriggeredEventsCollection(project string) *mongo.Collection {
-	projectCollection := mdbrepo.DbConnection.Client.Database(databaseName).Collection(project + collectionNameSuffix)
+func (mdbrepo *MongoDBEventsRepo) getEventsCollection(project string) *mongo.Collection {
+	projectCollection := mdbrepo.DbConnection.Client.Database(databaseName).Collection(project + triggeredEventsCollectionNameSuffix)
 	return projectCollection
 }
 

--- a/shipyard-controller/db/mongodb_event_repo.go
+++ b/shipyard-controller/db/mongodb_event_repo.go
@@ -92,6 +92,11 @@ func (mdbrepo *MongoDBEventsRepo) InsertEvent(project string, event models.Event
 	var eventInterface interface{}
 	_ = json.Unmarshal(marshal, &eventInterface)
 
+	existingEvent := collection.FindOne(ctx, bson.M{"id": event.ID})
+	if existingEvent.Err() == nil || existingEvent.Err() != mongo.ErrNoDocuments {
+		return errors.New("event with ID " + event.ID + " already exists in collection")
+	}
+
 	_, err = collection.InsertOne(ctx, eventInterface)
 	if err != nil {
 		mdbrepo.Logger.Error("Could not insert event " + event.ID + ": " + err.Error())

--- a/shipyard-controller/go.mod
+++ b/shipyard-controller/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/go-openapi/strfmt v0.19.3
 	github.com/go-openapi/swag v0.19.5
 	github.com/go-openapi/validate v0.19.5
+	github.com/go-test/deep v1.0.5
 	github.com/google/go-cmp v0.4.0 // indirect
 	github.com/jeremywohl/flatten v0.0.0-20190921043622-d936035e55cf
 	github.com/jessevdk/go-flags v1.4.0

--- a/shipyard-controller/handlers/event.go
+++ b/shipyard-controller/handlers/event.go
@@ -83,7 +83,7 @@ var eventManagerInstance *eventManager
 
 type eventManager struct {
 	projectRepo        db.ProjectRepo
-	triggeredEventRepo db.TriggeredEventRepo
+	triggeredEventRepo db.EventRepo
 	logger             *keptn.Logger
 }
 
@@ -94,7 +94,7 @@ func getEventManagerInstance() *eventManager {
 			projectRepo: &db.ProjectMongoDBRepo{
 				Logger: logger,
 			},
-			triggeredEventRepo: &db.MongoDBTriggeredEventsRepo{
+			triggeredEventRepo: &db.MongoDBEventsRepo{
 				Logger: logger,
 			},
 			logger: logger,

--- a/shipyard-controller/handlers/event.go
+++ b/shipyard-controller/handlers/event.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keptn/keptn/shipyard-controller/models"
 	"github.com/keptn/keptn/shipyard-controller/restapi/operations"
 	"strings"
+	"sync"
 )
 
 type eventData struct {
@@ -85,6 +86,7 @@ type eventManager struct {
 	projectRepo db.ProjectRepo
 	eventRepo   db.EventRepo
 	logger      *keptn.Logger
+	mutex       sync.Mutex
 }
 
 func getEventManagerInstance() *eventManager {
@@ -125,6 +127,8 @@ func (em *eventManager) getTriggeredEventsOfProject(project string, filter db.Ev
 }
 
 func (em *eventManager) handleIncomingEvent(event models.Event) error {
+	em.mutex.Lock()
+	defer em.mutex.Unlock()
 	// check if the status type is either 'triggered', 'started', or 'finished'
 	split := strings.Split(*event.Type, ".")
 

--- a/shipyard-controller/handlers/event.go
+++ b/shipyard-controller/handlers/event.go
@@ -152,6 +152,9 @@ func getEventProject(event models.Event) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if data.Project == "" {
+		return "", errors.New("event does not contain a project")
+	}
 	return data.Project, nil
 }
 
@@ -196,10 +199,6 @@ func (em *eventManager) handleFinishedEvent(event models.Event) error {
 		// if the previously deleted '.started' event was the last, the '.triggered' event can be removed
 		return em.eventRepo.DeleteEvent(project, event.Triggeredid, db.TriggeredEvent)
 	}
-	return nil
-}
-
-func (em *eventManager) closeTriggeredEvent(project, triggeredID string) error {
 	return nil
 }
 

--- a/shipyard-controller/handlers/event_test.go
+++ b/shipyard-controller/handlers/event_test.go
@@ -57,7 +57,7 @@ func getTestEvent() models.Event {
 func Test_eventManager_GetAllTriggeredEvents(t *testing.T) {
 	type fields struct {
 		projectRepo        db.ProjectRepo
-		triggeredEventRepo db.TriggeredEventRepo
+		triggeredEventRepo db.EventRepo
 	}
 	type args struct {
 		filter db.EventFilter
@@ -116,7 +116,7 @@ func stringp(s string) *string {
 func Test_eventManager_GetTriggeredEventsOfProject(t *testing.T) {
 	type fields struct {
 		projectRepo        db.ProjectRepo
-		triggeredEventRepo db.TriggeredEventRepo
+		triggeredEventRepo db.EventRepo
 	}
 	type args struct {
 		project string
@@ -169,7 +169,7 @@ func Test_eventManager_GetTriggeredEventsOfProject(t *testing.T) {
 func Test_eventManager_InsertEvent(t *testing.T) {
 	type fields struct {
 		projectRepo        db.ProjectRepo
-		triggeredEventRepo db.TriggeredEventRepo
+		triggeredEventRepo db.EventRepo
 	}
 	type args struct {
 		event models.Event

--- a/shipyard-controller/handlers/event_test.go
+++ b/shipyard-controller/handlers/event_test.go
@@ -582,10 +582,9 @@ func Test_eventManager_getEvents(t *testing.T) {
 					getEvents: func(project string, filter db.EventFilter, status db.EventStatus) ([]models.Event, error) {
 						if eventAvailable {
 							return []models.Event{getTestTriggeredEvent()}, nil
-						} else {
-							eventAvailable = true
-							return nil, db.ErrNoEventFound
 						}
+						eventAvailable = true
+						return nil, db.ErrNoEventFound
 					},
 				},
 				logger: keptn.NewLogger("", "", ""),


### PR DESCRIPTION
Closes #2159 

To avoid timing Issues, I have added a retry mechanism to the retrieval of triggered/started events. This way, it should not matter if events do not arrive in the expected order (triggered->started->finished).