### PR TITLE
#2124 Correct basePath of swagger.yamls

### DIFF
--- a/api/deploy/service.yaml
+++ b/api/deploy/service.yaml
@@ -44,6 +44,8 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
           env:
+            - name: PREFIX_PATH
+              value: ""
             - name: EVENTBROKER_URI
               value: http://event-broker
             - name: DATASTORE_URI

--- a/api/swagger-ui/index.html
+++ b/api/swagger-ui/index.html
@@ -37,9 +37,7 @@
     <script src="./swagger-ui-standalone-preset.js"> </script>
     <script>
     window.onload = function() {
-      var pathname = window.location.pathname;
-      var res = pathname.substring(0, pathname.indexOf("/api/"));
-
+      const prefixPath = ""
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
         url: "swagger.yaml",
@@ -54,13 +52,13 @@
         ],
         layout: "StandaloneLayout",
         urls: [{
-          url: res.concat("/api/swagger-ui/swagger.yaml"),
+          url: prefixPath + "/api/swagger-ui/swagger.yaml",
           name: "api-service"
         }, {
-          url: res.concat("/api/configuration-service/swagger-ui/swagger.yaml"),
+          url: prefixPath + "/api/configuration-service/swagger-ui/swagger.yaml",
           name: "configuration-service"
         }, {
-          url: res.concat("/api/mongodb-datastore/swagger-ui/swagger.yaml"),
+          url: prefixPath + "/api/mongodb-datastore/swagger-ui/swagger.yaml",
           name: "mongodb-datastore"
         }],
       })

--- a/configuration-service/deploy/service.yaml
+++ b/configuration-service/deploy/service.yaml
@@ -33,6 +33,8 @@ spec:
       - name: configuration-service
         image: keptn/configuration-service:latest
         env:
+          - name: PREFIX_PATH
+            value: ""
           - name: MONGODB_HOST
             value: 'mongodb:27017'
           - name: MONGODB_USER

--- a/installer/manifests/keptn/charts/control-plane/templates/core.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/core.yaml
@@ -86,6 +86,8 @@ spec:
               memory: "256Mi"
               cpu: "500m"
           env:
+            - name: PREFIX_PATH
+              value: { .Values.prefixPath }
             - name: EVENTBROKER_URI
               value: event-broker
             - name: DATASTORE_URI
@@ -547,6 +549,8 @@ spec:
           {{- include "control-plane.livenessProbe" . | nindent 10 }}
           imagePullPolicy: Always
           env:
+            - name: PREFIX_PATH
+              value: { .Values.prefixPath }
             - name: MONGODB_HOST
               value: 'mongodb:27017'
             - name: MONGODB_USER

--- a/installer/manifests/keptn/charts/control-plane/templates/mongodb-datastore.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/mongodb-datastore.yaml
@@ -46,6 +46,8 @@ spec:
             memory: "128Mi"
             cpu: "500m"
         env:
+        - name: PREFIX_PATH
+          value: { .Values.prefixPath }
         - name: MONGODB_HOST
           value: 'mongodb:27017'
         - name: MONGODB_DATABASE

--- a/mongodb-datastore/deploy/mongodb-datastore.yaml
+++ b/mongodb-datastore/deploy/mongodb-datastore.yaml
@@ -47,6 +47,8 @@ spec:
             memory: "256Mi"
             cpu: "1000m"
         env:
+        - name: PREFIX_PATH
+          value: ""
         - name: MONGODB_HOST
           value: 'mongodb:27017'
         - name: MONGODB_DATABASE


### PR DESCRIPTION
With feature #2124, the Helm-chart now allows to set a prefix for the Keptn path. 
This PR adds this prefix to the swagger.yaml, which then allows to use the Swagger-UI.