### PR TITLE
Properly format output of get event command

### DIFF
--- a/cli/cmd/get_event.go
+++ b/cli/cmd/get_event.go
@@ -94,17 +94,23 @@ func getEvent(eventStruct GetEventStruct, args []string) error {
 	if len(events) == 0 {
 		logging.PrintLog("No event returned", logging.QuietLevel)
 		return nil
+	} else if len(events) == 1 {
+		printEvents(events[0], *eventStruct.Output)
+	} else {
+		printEvents(events, *eventStruct.Output)
 	}
 
-	if *eventStruct.Output == "yaml" {
+	return nil
+}
+
+func printEvents(events interface{}, outputType string) {
+	if outputType == "yaml" {
 		eventsYAML, _ := yaml.Marshal(events)
 		fmt.Println(string(eventsYAML))
 	} else {
 		eventsJSON, _ := json.MarshalIndent(events, "", "    ")
 		fmt.Println(string(eventsJSON))
 	}
-
-	return nil
 }
 
 func init() {

--- a/cli/cmd/get_event.go
+++ b/cli/cmd/get_event.go
@@ -96,14 +96,12 @@ func getEvent(eventStruct GetEventStruct, args []string) error {
 		return nil
 	}
 
-	for _, event := range events {
-		if *eventStruct.Output == "yaml" {
-			event, _ := yaml.Marshal(event)
-			fmt.Println(string(event))
-		} else {
-			event, _ := json.MarshalIndent(event, "", "    ")
-			fmt.Println(string(event))
-		}
+	if *eventStruct.Output == "yaml" {
+		eventsYAML, _ := yaml.Marshal(events)
+		fmt.Println(string(eventsYAML))
+	} else {
+		eventsJSON, _ := json.MarshalIndent(events, "", "    ")
+		fmt.Println(string(eventsJSON))
 	}
 
 	return nil

--- a/cli/cmd/get_event_approvalTriggered.go
+++ b/cli/cmd/get_event_approvalTriggered.go
@@ -111,11 +111,9 @@ func getAllApprovalEventsInStage(approvalTriggered approvalTriggeredStruct, serv
 func printApprovalEvents(allEvents []*apimodels.KeptnContextExtendedCE) {
 	if len(allEvents) == 0 {
 		logging.PrintLog("No approval.triggered events have been found", logging.InfoLevel)
-	}
-
-	for _, event := range allEvents {
-		prettyJSON, _ := json.MarshalIndent(event, "", "	")
-		fmt.Println(string(prettyJSON))
+	} else {
+		eventsJSON, _ := json.MarshalIndent(allEvents, "", "	")
+		fmt.Println(string(eventsJSON))
 	}
 }
 

--- a/cli/cmd/get_event_approvalTriggered.go
+++ b/cli/cmd/get_event_approvalTriggered.go
@@ -111,6 +111,9 @@ func getAllApprovalEventsInStage(approvalTriggered approvalTriggeredStruct, serv
 func printApprovalEvents(allEvents []*apimodels.KeptnContextExtendedCE) {
 	if len(allEvents) == 0 {
 		logging.PrintLog("No approval.triggered events have been found", logging.InfoLevel)
+	} else if len(allEvents) == 1 {
+		eventsJSON, _ := json.MarshalIndent(allEvents[0], "", "	")
+		fmt.Println(string(eventsJSON))
 	} else {
 		eventsJSON, _ := json.MarshalIndent(allEvents, "", "	")
 		fmt.Println(string(eventsJSON))

--- a/cli/cmd/get_event_evaluationDone.go
+++ b/cli/cmd/get_event_evaluationDone.go
@@ -63,13 +63,10 @@ var evaluationDoneCmd = &cobra.Command{
 			if len(evaluationDoneEvts) == 0 {
 				logging.PrintLog("No event returned", logging.QuietLevel)
 				return nil
+			} else {
+				eventsJSON, _ := json.MarshalIndent(evaluationDoneEvts, "", "	")
+				fmt.Println(string(eventsJSON))
 			}
-
-			for _, event := range evaluationDoneEvts {
-				event, _ := json.MarshalIndent(event, "", "    ")
-				fmt.Println(string(event))
-			}
-
 		} else {
 			fmt.Println("Skipping send evaluation-start due to mocking flag set to true")
 		}

--- a/cli/cmd/get_event_evaluationDone.go
+++ b/cli/cmd/get_event_evaluationDone.go
@@ -63,6 +63,9 @@ var evaluationDoneCmd = &cobra.Command{
 			if len(evaluationDoneEvts) == 0 {
 				logging.PrintLog("No event returned", logging.QuietLevel)
 				return nil
+			} else if len(evaluationDoneEvts) == 1 {
+				eventsJSON, _ := json.MarshalIndent(evaluationDoneEvts[0], "", "	")
+				fmt.Println(string(eventsJSON))
 			} else {
 				eventsJSON, _ := json.MarshalIndent(evaluationDoneEvts, "", "	")
 				fmt.Println(string(eventsJSON))

--- a/test/test_delivery_assistant.sh
+++ b/test/test_delivery_assistant.sh
@@ -99,8 +99,8 @@ check_no_open_approvals $PROJECT combi1
 
 check_number_open_approvals $PROJECT combi2 1
 
-combi2ApprovalId=$(keptn get event approval.triggered --project=delivery-assistant-project --stage=combi2 | awk '{if(NR>1)print}' | jq -r '.' | jq -r --slurp '.[0].id')
-keptn_context_id=$(keptn get event approval.triggered --project=delivery-assistant-project --stage=combi2 | awk '{if(NR>1)print}' | jq -r '.' | jq -r --slurp '.[0].shkeptncontext')
+combi2ApprovalId=$(keptn get event approval.triggered --project=delivery-assistant-project --stage=combi2 | awk '{if(NR>1)print}' | jq -r '.[0].id')
+keptn_context_id=$(keptn get event approval.triggered --project=delivery-assistant-project --stage=combi2 | awk '{if(NR>1)print}' | jq -r '.[0].shkeptncontext')
 keptn send event approval.finished --id=${combi2ApprovalId} --project=delivery-assistant-project --stage=combi2
 sleep 5
 check_no_open_approvals $PROJECT combi2
@@ -122,8 +122,8 @@ verify_using_jq "$response" ".data.valuesCanary.image" "docker.io/keptnexamples/
 
 check_number_open_approvals $PROJECT combi3 1
 
-combi3ApprovalId=$(keptn get event approval.triggered --project=delivery-assistant-project --stage=combi3 | awk '{if(NR>1)print}' | jq -r '.' | jq -r --slurp '.[0].id')
-keptn_context_id=$(keptn get event approval.triggered --project=delivery-assistant-project --stage=combi3 | awk '{if(NR>1)print}' | jq -r '.' | jq -r --slurp '.[0].shkeptncontext')
+combi3ApprovalId=$(keptn get event approval.triggered --project=delivery-assistant-project --stage=combi3 | awk '{if(NR>1)print}' | jq -r '.[0].id')
+keptn_context_id=$(keptn get event approval.triggered --project=delivery-assistant-project --stage=combi3 | awk '{if(NR>1)print}' | jq -r '.[0].shkeptncontext')
 keptn send event approval.finished --id=${combi3ApprovalId} --project=delivery-assistant-project --stage=combi3
 sleep 5
 check_no_open_approvals $PROJECT combi3
@@ -146,10 +146,10 @@ verify_using_jq "$response" ".data.valuesCanary.image" "docker.io/keptnexamples/
 
 check_number_open_approvals $PROJECT combi4 2
 
-combi4ApprovalId1=$(keptn get event approval.triggered --project=delivery-assistant-project --stage=combi4 | awk '{if(NR>1)print}' | jq -r '.' | jq -r --slurp '.[0].id')
-keptn_context_id_1=$(keptn get event approval.triggered --project=delivery-assistant-project --stage=combi4 | awk '{if(NR>1)print}' | jq -r '.' | jq -r --slurp '.[0].shkeptncontext')
-combi4ApprovalId2=$(keptn get event approval.triggered --project=delivery-assistant-project --stage=combi4 | awk '{if(NR>1)print}' | jq -r '.' | jq -r --slurp '.[1].id')
-keptn_context_id_2=$(keptn get event approval.triggered --project=delivery-assistant-project --stage=combi4 | awk '{if(NR>1)print}' | jq -r '.' | jq -r --slurp '.[0].shkeptncontext')
+combi4ApprovalId1=$(keptn get event approval.triggered --project=delivery-assistant-project --stage=combi4 | awk '{if(NR>1)print}' | jq -r '.[0].id')
+keptn_context_id_1=$(keptn get event approval.triggered --project=delivery-assistant-project --stage=combi4 | awk '{if(NR>1)print}' | jq -r '.[0].shkeptncontext')
+combi4ApprovalId2=$(keptn get event approval.triggered --project=delivery-assistant-project --stage=combi4 | awk '{if(NR>1)print}' | jq -r '.[1].id')
+keptn_context_id_2=$(keptn get event approval.triggered --project=delivery-assistant-project --stage=combi4 | awk '{if(NR>1)print}' | jq -r '.[0].shkeptncontext')
 
 keptn send event approval.finished --id=${combi4ApprovalId1} --project=delivery-assistant-project --stage=combi4
 sleep 5

--- a/test/utils.sh
+++ b/test/utils.sh
@@ -100,7 +100,7 @@ function check_number_open_approvals() {
   STAGE=$2
   EXPECTED=$3
 
-  result=$(keptn get event approval.triggered --project=$PROJECT --stage=$STAGE | awk '{if(NR>1)print}' | jq -r '.' | jq -r --slurp 'length')
+  result=$(keptn get event approval.triggered --project=$PROJECT --stage=$STAGE | awk '{if(NR>1)print}' | jq -r 'length')
   if [[ "$result" != "$EXPECTED" ]]; then
     echo "Received unexpected number of approval.triggered events"
     echo "${result}"


### PR DESCRIPTION
The JSON output of the three `get event` CLI commands returned an invalid output for multiple returned events:

```
{
	"contenttype": "application/json",
	"type": "sh.keptn.event.approval.triggered",
        ...
}
{
	"contenttype": "application/json",
	"type": "sh.keptn.event.approval.triggered",
        ...
}
```

Valid JSON array output should look like this:

```
[
        {
                "contenttype": "application/json",
                "type": "sh.keptn.event.approval.triggered",
                ...
        },
        {
                "contenttype": "application/json",
                "type": "sh.keptn.event.approval.triggered",
                ...
        }
]
```

- Fixed output when returning multiple events
- Updated Integration tests