### PR TITLE
#2195 Do not use namespace a root context

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -428,6 +428,7 @@ func waitForDeploymentsOfHelmRelease(helmManifest string) error {
 // Preconditions: 1. Already authenticated against the cluster.
 func doInstallation() error {
 	keptnNamespace := *installParams.Namespace
+
 	res, err := keptnutils.ExistsNamespace(false, keptnNamespace)
 	if err != nil {
 		return fmt.Errorf("Failed to check if namespace %s already exists: %v", keptnNamespace, err)
@@ -466,14 +467,6 @@ func doInstallation() error {
 				"type": installParams.ApiServiceType.String(),
 			},
 		},
-	}
-
-	if keptnNamespace != "keptn" {
-		controlPlaneMap := values["control-plane"]
-		switch controlPlaneMap := controlPlaneMap.(type) {
-		case map[string]interface{}:
-			controlPlaneMap["prefixPath"] = "/"+keptnNamespace
-		}
 	}
 
 	if err := upgradeChart(installChart, "keptn", keptnNamespace, values); err != nil {

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -30,9 +30,14 @@ var (
 	Version string
 )
 
-const versionCheckInfo = "Daily version check is %s. Keptn will%s collect statistical data and will%s notify about new versions and security patches for Keptn. Details can be found at https://keptn.sh/docs/0.7.x/reference/version_check\n"
-const enableVersionCheckMsg = "To %s the daily version check, please execute: \nkeptn set config AutomaticVersionCheck %s\n"
+const versionCheckInfo = `Daily version check is %s. 
+Keptn will%s collect statistical data and will%s notify about new versions and security patches for Keptn. Details can be found at: https://keptn.sh/docs/0.7.x/reference/version_check
+---------------------------------------------------
+`
+const enableVersionCheckMsg = `* To %s the daily version check, please execute:
+ - keptn set config AutomaticVersionCheck %s
 
+`
 const keptnReleaseDocsURL = "0.7.x"
 
 // KubeServerVersionConstraints the Kubernetes Cluster version's constraints is passed by ldflags
@@ -45,7 +50,7 @@ var versionCmd = &cobra.Command{
 	Long:    `Shows the CLI version of Keptn and a note when a new version is available.`,
 	Example: `keptn version`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("CLI version: " + Version)
+		fmt.Println("\nKeptn CLI version: " + Version + "\n")
 
 		configMng := config.NewCLIConfigManager()
 		cliConfig, err := configMng.LoadCLIConfig()


### PR DESCRIPTION
- Do not use namespace a root context for `keptn install`
- User message improvements for `keptn version`