### PR TITLE
#2085 Show remediation workflow in environment screen

### DIFF
--- a/bridge/client/app/_models/project.ts
+++ b/bridge/client/app/_models/project.ts
@@ -52,7 +52,7 @@ export class Project {
   }
 
   getLatestProblemEvents(stage: Stage): Root[] {
-    return this.getLatestRootEvents(stage).filter(root => root.isProblem() /* TODO: && !root.isProblemResolvedOrClosed()*/);
+    return this.getLatestRootEvents(stage).filter(root => root.isProblem() && !root.isProblemResolvedOrClosed());
   }
 
   getRootEvent(service: Service, event: Trace): Root {

--- a/bridge/client/app/_models/project.ts
+++ b/bridge/client/app/_models/project.ts
@@ -44,11 +44,15 @@ export class Project {
   }
 
   getLatestRootEvents(stage: Stage): Root[] {
-    return this.getServices().map(service => service.roots.find(root => root.traces.some(trace => trace.type == EventTypes.CONFIGURATION_CHANGE && trace.data.stage === stage.stageName)));
+    return this.getServices().map(service => service.roots.find(root => root.traces.some(trace => trace.data.stage === stage.stageName)));
   }
 
   getLatestFailedRootEvents(stage: Stage): Root[] {
     return this.getLatestRootEvents(stage).filter(root => root.isFailedEvaluation() === stage.stageName);
+  }
+
+  getLatestProblemEvents(stage: Stage): Root[] {
+    return this.getLatestRootEvents(stage).filter(root => root.isProblem() /* TODO: && !root.isProblemResolvedOrClosed()*/);
   }
 
   getRootEvent(service: Service, event: Trace): Root {

--- a/bridge/client/app/_models/root.ts
+++ b/bridge/client/app/_models/root.ts
@@ -85,6 +85,17 @@ export class Root extends Trace {
     return this.traces.filter(trace => trace.type == EventTypes.ACTION_TRIGGERED);
   }
 
+  getRemediationActions(): Root[] {
+    // create chunks of Remediations and start new chunk at REMEDIATION_TRIGGERED event
+    return this.traces.reduce((result, trace: Trace) => {
+      if(trace.type == EventTypes.ACTION_TRIGGERED)
+        result.push(Root.fromJSON(JSON.parse(JSON.stringify(trace))));
+      else if(result.length)
+        result[result.length-1].traces = [...result[result.length-1].traces||[], trace];
+      return result;
+    }, []);
+  }
+
   static fromJSON(data: any) {
     return Object.assign(new this, data);
   }

--- a/bridge/client/app/_models/root.ts
+++ b/bridge/client/app/_models/root.ts
@@ -13,6 +13,10 @@ export class Root extends Trace {
     return this.traces.reduce((result: boolean, trace: Trace) => trace.isProblem() && !trace.isProblemResolvedOrClosed() ? true : result, false);
   }
 
+  isProblemResolvedOrClosed(): boolean {
+    return this.traces.reduce((result: boolean, trace: Trace) => trace.isProblem() && trace.isProblemResolvedOrClosed() ? true : result, false);
+  }
+
   isFailedEvaluation(): string {
     let result: string = null;
     if(this.traces) {
@@ -75,6 +79,10 @@ export class Root extends Trace {
 
   getDeploymentDetails(stage: Stage): Trace {
     return this.traces.find(t => t.type == EventTypes.DEPLOYMENT_FINISHED && t.data.stage == stage.stageName);
+  }
+
+  getRemediationActions(): Trace[] {
+    return this.traces.filter(trace => trace.type == EventTypes.ACTION_TRIGGERED);
   }
 
   static fromJSON(data: any) {

--- a/bridge/client/app/_models/root.ts
+++ b/bridge/client/app/_models/root.ts
@@ -81,10 +81,6 @@ export class Root extends Trace {
     return this.traces.find(t => t.type == EventTypes.DEPLOYMENT_FINISHED && t.data.stage == stage.stageName);
   }
 
-  getRemediationActions(): Trace[] {
-    return this.traces.filter(trace => trace.type == EventTypes.ACTION_TRIGGERED);
-  }
-
   getRemediationActions(): Root[] {
     // create chunks of Remediations and start new chunk at REMEDIATION_TRIGGERED event
     return this.traces.reduce((result, trace: Trace) => {

--- a/bridge/client/app/_models/trace.ts
+++ b/bridge/client/app/_models/trace.ts
@@ -74,6 +74,12 @@ class Trace {
       status: string;
     };
 
+    action: {
+      action: string;
+      description: string;
+      name: string;
+    }
+
     Tags: string;
     State: string;
   };

--- a/bridge/client/app/project-board/project-board.component.html
+++ b/bridge/client/app/project-board/project-board.component.html
@@ -139,8 +139,14 @@
                 </ktb-expandable-tile-header>
                 <ng-container *ngIf="findProblemEvent(problemEvents, service) as problemEvent">
                   <p class="m-0"><span class="bold">Problem: </span><span [textContent]="problemEvent.data.ImpactedEntity"></span></p>
-                  <div class="mt-1" *ngFor="let remediationAction of problemEvent.getRemediationActions()">
-                    <p class="m-0" [textContent]="remediationAction.data.action.description"></p>
+                  <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px" *ngFor="let remediationAction of problemEvent.getRemediationActions()">
+                    <p class="m-0">- <span [textContent]="remediationAction.data.action.description"></span></p>
+                    <dt-tag-list aria-label="evaluation-info" *ngIf="remediationAction.getEvaluation(selectedStage) as evaluation">
+                      <dt-tag class="justify-content-center" [dtOverlay]="evaluationOverlay" [dtOverlayConfig]="overlayConfig" [class.error]="evaluation.isFaulty()" [class.warning]="evaluation.isWarning()" [class.success]="evaluation.isSuccessful()" [textContent]="evaluation.data.evaluationdetails.score | number:'1.0-0'"></dt-tag>
+                      <ng-template #evaluationOverlay>
+                        <ktb-evaluation-details [evaluationData]="evaluation" [showChart]="false"></ktb-evaluation-details>
+                      </ng-template>
+                    </dt-tag-list>
                   </div>
                   <hr />
                 </ng-container>
@@ -202,8 +208,8 @@
                   </div>
                 </div>
               </dt-info-group-title>
-              <p class="m-0 mb-1 mt-1" *ngIf="project.getLatestDeployment(service) as deployment; else noDeployment">
-                <span class="bold">Last processed artifact: </span><span *ngIf="deployment.getShortImageName()" [textContent]="deployment.getShortImageName()"></span><span *ngIf="!deployment.getShortImageName()">unknown</span>
+              <p class="m-0 mb-1 mt-1" *ngIf="project.getLatestDeployment(service, project.stages[0]) as deployment; else noDeployment">
+                <span class="bold">Last processed artifact: </span><span [textContent]="deployment.getShortImageName()"></span>
               </p>
               <button dt-button disabled variant="nested" *ngIf="!service.roots">
                 <dt-loading-spinner></dt-loading-spinner>
@@ -255,7 +261,7 @@
   </ng-container>
 </div>
 <ng-template #noDeployment>
-  <p class="m-0">Service not deployed yet. Use <a href="https://keptn.sh/docs/0.7.x/reference/cli/commands/keptn_send_event_new-artifact/" target="_blank" rel="noopener noreferrer">keptn send event new-artifact</a> to trigger a deployment.</p>
+  <p class="m-0">Service not deployed yet. Use <a href="https://keptn.sh/docs/0.7.x/reference/cli/commands/keptn_send_event_new-artifact/" target="_blank" rel="noopener noreferrer">keptn send new-artifact</a> to trigger a deployment.</p>
 </ng-template>
 <ng-template #noService>
   <div fxLayout="row" fxLayoutAlign="start center">

--- a/bridge/client/app/project-board/project-board.component.html
+++ b/bridge/client/app/project-board/project-board.component.html
@@ -159,6 +159,7 @@
                       </ng-template>
                     </dt-tag-list>
                   </div>
+                  <p class="m-0" *ngIf="!failedRootEvent.getDeploymentDetails(selectedStage).isDirectDeployment()">Rollback to <span *ngIf="project.getLatestDeployment(service, selectedStage) as deployment" [textContent]="deployment.getShortImageName()"></span> performed.</p>
                   <hr />
                 </ng-container>
                 <div *ngIf="countOpenApprovals(openApprovals, project, selectedStage, service) > 0; else noOutOfSyncDeployments">
@@ -207,8 +208,8 @@
                   </div>
                 </div>
               </dt-info-group-title>
-              <p class="m-0 mb-1 mt-1" *ngIf="project.getLatestDeployment(service, project.stages[0]) as deployment; else noDeployment">
-                <span class="bold">Last processed artifact: </span><span [textContent]="deployment.getShortImageName()"></span>
+              <p class="m-0 mb-1 mt-1" *ngIf="project.getLatestDeployment(service) as deployment; else noDeployment">
+                <span class="bold">Last processed artifact: </span><span *ngIf="deployment.getShortImageName()" [textContent]="deployment.getShortImageName()"></span><span *ngIf="!deployment.getShortImageName()">unknown</span>
               </p>
               <button dt-button disabled variant="nested" *ngIf="!service.roots">
                 <dt-loading-spinner></dt-loading-spinner>
@@ -260,7 +261,7 @@
   </ng-container>
 </div>
 <ng-template #noDeployment>
-  <p class="m-0">Service not deployed yet. Use <a href="https://keptn.sh/docs/0.7.x/reference/cli/commands/keptn_send_event_new-artifact/" target="_blank" rel="noopener noreferrer">keptn send new-artifact</a> to trigger a deployment.</p>
+  <p class="m-0">Service not deployed yet. Use <a href="https://keptn.sh/docs/0.7.x/reference/cli/commands/keptn_send_event_new-artifact/" target="_blank" rel="noopener noreferrer">keptn send event new-artifact</a> to trigger a deployment.</p>
 </ng-template>
 <ng-template #noService>
   <div fxLayout="row" fxLayoutAlign="start center">

--- a/bridge/client/app/project-board/project-board.component.html
+++ b/bridge/client/app/project-board/project-board.component.html
@@ -52,8 +52,10 @@
                 <h2 class="m-0 mt-1 mb-1" [textContent]="stage.stageName"></h2>
                 <div class="stage-state" fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="15px">
                   <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px">
-                    <dt-icon class="stage-state-icon event-icon" name="criticalevent"></dt-icon>
-                    <span>0</span>
+                    <ng-container *ngIf="project.getLatestProblemEvents(stage) as problemEvents">
+                      <dt-icon class="stage-state-icon event-icon" name="criticalevent" [class.error]="problemEvents.length > 0"></dt-icon>
+                      <span [textContent]="problemEvents.length"></span>
+                    </ng-container>
                   </div>
                   <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px">
                     <ng-container *ngIf="project.getLatestFailedRootEvents(stage) as failedRootEvents">
@@ -69,19 +71,16 @@
                   </div>
                 </div>
                 <ng-container *ngIf="stage.services && stage.services.length > 0; else noService">
-                  <dt-tag-list aria-label="services">
-                    <dt-tag *ngFor="let service of stage.services">
-                      <ng-container *ngIf="openApprovals$ | async as openApprovals">
-                        <span *ngIf="project.getLatestDeployment(service, stage) as deployment; else noDeploymentOfServiceTag"
-                              [ngClass]="{'out-of-sync-service': countOpenApprovals(openApprovals, project, stage, service) > 0}"
-                              (click)="selectDeployment(deployment, project)"
-                              [textContent]="deployment.getShortImageName()"></span>
+                  <ng-container *ngIf="openApprovals$ | async as openApprovals">
+                    <dt-tag-list aria-label="services">
+                      <dt-tag *ngFor="let service of stage.services" [class.out-of-sync-service]="countOpenApprovals(openApprovals, project, stage, service) > 0" [class.error]="findProblemEvent(project.getLatestProblemEvents(stage), service)">
+                        <span *ngIf="project.getLatestDeployment(service, stage) as deployment; else noDeploymentOfServiceTag" (click)="selectDeployment(deployment, project)" [textContent]="deployment.getShortImageName()"></span>
                         <ng-template #noDeploymentOfServiceTag>
-                          <span class="no-deployment" [ngClass]="{'out-of-sync-service': countOpenApprovals(openApprovals, project, stage, service) > 0}"  [textContent]="service.serviceName"></span>
+                          <span class="no-deployment" [textContent]="service.serviceName"></span>
                         </ng-template>
-                      </ng-container>
-                    </dt-tag>
-                  </dt-tag-list>
+                      </dt-tag>
+                    </dt-tag-list>
+                  </ng-container>
                 </ng-container>
               </ktb-selectable-tile>
             </div>
@@ -91,63 +90,79 @@
     </div>
     <div class="container dark" fxFlex="34" fxLayout="column" fxLayoutGap="15px" *ngIf="selectedStage">
       <ng-container *ngIf="project.getLatestFailedRootEvents(selectedStage) as failedRootEvents">
-        <ng-container *ngIf="openApprovals$ | async as openApprovals">
-          <h2 [textContent]="selectedStage.stageName"></h2>
-          <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px" *ngIf="failedRootEvents.length > 0">
-            <dt-icon class="stage-state-icon event-icon" name="traffic-light" [class.error]="failedRootEvents.length > 0"></dt-icon>
-            <p class="m-0"><span [textContent]="failedRootEvents.length"></span> Quality gate<span *ngIf="failedRootEvents.length > 1">s</span> failed</p>
-          </div>
-          <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px">
-            <dt-icon class="stage-state-icon" name="deploy" [ngClass]="{'out-of-sync-service': countOpenApprovals(openApprovals, project, selectedStage) > 0}"></dt-icon>
-            <p class="m-0" *ngIf="countOpenApprovals(openApprovals, project, selectedStage) == 1"><span [textContent]="countOpenApprovals(openApprovals, project, selectedStage)"></span> Service is out-of-sync</p>
-            <p class="m-0" *ngIf="countOpenApprovals(openApprovals, project, selectedStage) != 1"><span [textContent]="countOpenApprovals(openApprovals, project, selectedStage)"></span> Services are out-of-sync</p>
-          </div>
-          <div fxLayout="row" fxLayoutAlign="start center" *ngIf="selectedStage.services.length == 0">
-            <dt-icon class="icon" name="information"></dt-icon>
-            <p class="m-0">No service onboarded yet. Follow the intructions to <a href="https://keptn.sh/docs/0.7.x/manage/service/#onboard-a-service" target="_blank" rel="noopener noreferrer">onboard a service</a>.</p>
-          </div>
-          <ng-container *ngFor="let service of selectedStage.services">
-            <ktb-expandable-tile [expanded]="countOpenApprovals(openApprovals, project, selectedStage, service) > 0">
-              <ktb-expandable-tile-header>
-                <dt-info-group>
-                  <dt-info-group-title>
-                    <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px">
-                      <h2 class="m-0" [textContent]="service.serviceName"></h2>
-                      <ng-container *ngIf="findFailedRootEvent(failedRootEvents, service) as failedRootEvent">
-                        <dt-icon class="stage-state-icon event-icon error" name="traffic-light"></dt-icon>
-                      </ng-container>
-                      <ng-container *ngIf="openApprovals$ | async as openApprovals">
-                        <dt-icon class="stage-state-icon out-of-sync-service" *ngIf="countOpenApprovals(openApprovals, project, selectedStage, service) > 0" name="deploy"></dt-icon>
-                      </ng-container>
-                      <ng-container *ngIf="project.getLatestDeployment(service, selectedStage) as deployment">
-                        <a *ngIf="deployment.data.deploymentURIPublic" [href]="deployment.data.deploymentURIPublic" target="_blank"><button dt-icon-button variant="nested"><dt-icon name="externallink"></dt-icon></button></a>
-                      </ng-container>
-                    </div>
-                  </dt-info-group-title>
-                  <ng-container *ngIf="project.getLatestDeployment(service, selectedStage) as deployment; else noDeployment">
-                    <p class="m-0 mt-1"><span [textContent]="deployment.data.image"></span>:<span [textContent]="deployment.data.tag"></span></p>
-                    <p class="m-0 mb-1" *ngIf="deployment.isDeployment()"><span class="bold">Deployed at: </span><span [textContent]="deployment.time | amCalendar:getCalendarFormats()"></span></p>
-                  </ng-container>
-                </dt-info-group>
-              </ktb-expandable-tile-header>
-              <ng-container *ngIf="findFailedRootEvent(failedRootEvents, service) as failedRootEvent">
-                <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px">
-                  <p class="m-0">Quality gate of <span [textContent]="failedRootEvent.getShortImageName()"></span> failed with a score of:</p>
-                  <dt-tag-list aria-label="evaluation-info" *ngIf="failedRootEvent.getEvaluation(selectedStage) as evaluation">
-                    <dt-tag class="justify-content-center" [dtOverlay]="overlay" [dtOverlayConfig]="overlayConfig" [class.error]="evaluation.isFaulty()" [class.warning]="evaluation.isWarning()" [class.success]="evaluation.isSuccessful()" [textContent]="evaluation.data.evaluationdetails.score | number:'1.0-0'"></dt-tag>
-                    <ng-template #overlay>
-                      <ktb-evaluation-details [evaluationData]="evaluation" [showChart]="false"></ktb-evaluation-details>
-                    </ng-template>
-                  </dt-tag-list>
+        <ng-container *ngIf="project.getLatestProblemEvents(selectedStage) as problemEvents">
+          <ng-container *ngIf="openApprovals$ | async as openApprovals">
+            <h2 [textContent]="selectedStage.stageName"></h2>
+            <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px" *ngIf="problemEvents.length > 0">
+              <dt-icon class="stage-state-icon event-icon" name="traffic-light" [class.error]="problemEvents.length > 0"></dt-icon>
+              <p class="m-0"><span [textContent]="problemEvents.length"></span> Problems open</p>
+            </div>
+            <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px" *ngIf="failedRootEvents.length > 0">
+              <dt-icon class="stage-state-icon event-icon" name="traffic-light" [class.error]="failedRootEvents.length > 0"></dt-icon>
+              <p class="m-0"><span [textContent]="failedRootEvents.length"></span> Quality gate<span *ngIf="failedRootEvents.length > 1">s</span> failed</p>
+            </div>
+            <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px">
+              <dt-icon class="stage-state-icon" name="deploy" [ngClass]="{'out-of-sync-service': countOpenApprovals(openApprovals, project, selectedStage) > 0}"></dt-icon>
+              <p class="m-0" *ngIf="countOpenApprovals(openApprovals, project, selectedStage) == 1"><span [textContent]="countOpenApprovals(openApprovals, project, selectedStage)"></span> Service is out-of-sync</p>
+              <p class="m-0" *ngIf="countOpenApprovals(openApprovals, project, selectedStage) != 1"><span [textContent]="countOpenApprovals(openApprovals, project, selectedStage)"></span> Services are out-of-sync</p>
+            </div>
+            <div fxLayout="row" fxLayoutAlign="start center" *ngIf="selectedStage.services.length == 0">
+              <dt-icon class="icon" name="information"></dt-icon>
+              <p class="m-0">No service onboarded yet. Follow the intructions to <a href="https://keptn.sh/docs/0.7.x/manage/service/#onboard-a-service" target="_blank" rel="noopener noreferrer">onboard a service</a>.</p>
+            </div>
+            <ng-container *ngFor="let service of selectedStage.services">
+              <ktb-expandable-tile [expanded]="countOpenApprovals(openApprovals, project, selectedStage, service) > 0">
+                <ktb-expandable-tile-header>
+                  <dt-info-group>
+                    <dt-info-group-title>
+                      <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px">
+                        <h2 class="m-0" [textContent]="service.serviceName"></h2>
+                        <ng-container *ngIf="findFailedRootEvent(failedRootEvents, service) as failedRootEvent">
+                          <dt-icon class="stage-state-icon event-icon error" name="traffic-light"></dt-icon>
+                        </ng-container>
+                        <ng-container *ngIf="findProblemEvent(problemEvents, service) as problemEvent">
+                          <dt-icon class="stage-state-icon event-icon error" name="criticalevent"></dt-icon>
+                        </ng-container>
+                        <ng-container *ngIf="openApprovals$ | async as openApprovals">
+                          <dt-icon class="stage-state-icon out-of-sync-service" *ngIf="countOpenApprovals(openApprovals, project, selectedStage, service) > 0" name="deploy"></dt-icon>
+                        </ng-container>
+                        <ng-container *ngIf="project.getLatestDeployment(service, selectedStage) as deployment">
+                          <a *ngIf="deployment.data.deploymentURIPublic" [href]="deployment.data.deploymentURIPublic" target="_blank"><button dt-icon-button variant="nested"><dt-icon name="externallink"></dt-icon></button></a>
+                        </ng-container>
+                      </div>
+                    </dt-info-group-title>
+                    <ng-container *ngIf="project.getLatestDeployment(service, selectedStage) as deployment; else noDeployment">
+                      <p class="m-0 mt-1"><span [textContent]="deployment.data.image"></span>:<span [textContent]="deployment.data.tag"></span></p>
+                      <p class="m-0 mb-1"><span class="bold">Deployed at: </span><span [textContent]="deployment.time | amCalendar:getCalendarFormats()"></span></p>
+                    </ng-container>
+                  </dt-info-group>
+                </ktb-expandable-tile-header>
+                <ng-container *ngIf="findProblemEvent(problemEvents, service) as problemEvent">
+                  <p class="m-0"><span class="bold">Problem: </span><span [textContent]="problemEvent.data.ImpactedEntity"></span></p>
+                  <div class="mt-1" *ngFor="let remediationAction of problemEvent.getRemediationActions()">
+                    <p class="m-0" [textContent]="remediationAction.data.action.description"></p>
+                  </div>
+                  <hr />
+                </ng-container>
+                <ng-container *ngIf="findFailedRootEvent(failedRootEvents, service) as failedRootEvent">
+                  <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px">
+                    <p class="m-0">Quality gate of <span [textContent]="failedRootEvent.getShortImageName()"></span> failed with a score of:</p>
+                    <dt-tag-list aria-label="evaluation-info" *ngIf="failedRootEvent.getEvaluation(selectedStage) as evaluation">
+                      <dt-tag class="justify-content-center" [dtOverlay]="overlay" [dtOverlayConfig]="overlayConfig" [class.error]="evaluation.isFaulty()" [class.warning]="evaluation.isWarning()" [class.success]="evaluation.isSuccessful()" [textContent]="evaluation.data.evaluationdetails.score | number:'1.0-0'"></dt-tag>
+                      <ng-template #overlay>
+                        <ktb-evaluation-details [evaluationData]="evaluation" [showChart]="false"></ktb-evaluation-details>
+                      </ng-template>
+                    </dt-tag-list>
+                  </div>
+                  <hr />
+                </ng-container>
+                <div *ngIf="countOpenApprovals(openApprovals, project, selectedStage, service) > 0; else noOutOfSyncDeployments">
+                  <p class="m-0">Deployable artifacts for <span [textContent]="service.serviceName"></span> service</p>
+                  <ktb-approval-item class="mt-1" *ngFor="let approval of getOpenApprovals(openApprovals, project, selectedStage, service)" [event]="approval"></ktb-approval-item>
                 </div>
-                <hr />
-              </ng-container>
-              <div *ngIf="countOpenApprovals(openApprovals, project, selectedStage, service) > 0; else noOutOfSyncDeployments">
-                <p class="m-0">Deployable artifacts for <span [textContent]="service.serviceName"></span> service</p>
-                <ktb-approval-item class="mt-1" *ngFor="let approval of getOpenApprovals(openApprovals, project, selectedStage, service)" [event]="approval"></ktb-approval-item>
-              </div>
-              <ng-template #noOutOfSyncDeployments>No pending deployments for this stage available.</ng-template>
-            </ktb-expandable-tile>
+                <ng-template #noOutOfSyncDeployments>No pending deployments for this stage available.</ng-template>
+              </ktb-expandable-tile>
+            </ng-container>
           </ng-container>
         </ng-container>
       </ng-container>

--- a/bridge/client/app/project-board/project-board.component.html
+++ b/bridge/client/app/project-board/project-board.component.html
@@ -95,7 +95,7 @@
             <h2 [textContent]="selectedStage.stageName"></h2>
             <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px" *ngIf="problemEvents.length > 0">
               <dt-icon class="stage-state-icon event-icon" name="traffic-light" [class.error]="problemEvents.length > 0"></dt-icon>
-              <p class="m-0"><span [textContent]="problemEvents.length"></span> Problems open</p>
+              <p class="m-0"><span [textContent]="problemEvents.length"></span> Problem<span *ngIf="problemEvents.length > 1">s</span> open</p>
             </div>
             <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px" *ngIf="failedRootEvents.length > 0">
               <dt-icon class="stage-state-icon event-icon" name="traffic-light" [class.error]="failedRootEvents.length > 0"></dt-icon>
@@ -103,8 +103,7 @@
             </div>
             <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px">
               <dt-icon class="stage-state-icon" name="deploy" [ngClass]="{'out-of-sync-service': countOpenApprovals(openApprovals, project, selectedStage) > 0}"></dt-icon>
-              <p class="m-0" *ngIf="countOpenApprovals(openApprovals, project, selectedStage) == 1"><span [textContent]="countOpenApprovals(openApprovals, project, selectedStage)"></span> Service is out-of-sync</p>
-              <p class="m-0" *ngIf="countOpenApprovals(openApprovals, project, selectedStage) != 1"><span [textContent]="countOpenApprovals(openApprovals, project, selectedStage)"></span> Services are out-of-sync</p>
+              <p class="m-0"><span [textContent]="countOpenApprovals(openApprovals, project, selectedStage)"></span> Service<span *ngIf="countOpenApprovals(openApprovals, project, selectedStage) > 1">s</span> are out-of-sync</p>
             </div>
             <div fxLayout="row" fxLayoutAlign="start center" *ngIf="selectedStage.services.length == 0">
               <dt-icon class="icon" name="information"></dt-icon>

--- a/bridge/client/app/project-board/project-board.component.scss
+++ b/bridge/client/app/project-board/project-board.component.scss
@@ -31,8 +31,7 @@
   color: $gray-500;
 }
 .out-of-sync-service {
-  color: $blue-400;
-  fill: $blue-400;
+  border: 1px solid $blue-400;
 }
 
 ::ng-deep {

--- a/bridge/client/app/project-board/project-board.component.ts
+++ b/bridge/client/app/project-board/project-board.component.ts
@@ -245,6 +245,10 @@ export class ProjectBoardComponent implements OnInit, OnDestroy {
     return failedRootEvents.find(root => root.data.service == service.serviceName);
   }
 
+  findProblemEvent(problemEvents: Root[], service: Service) {
+    return problemEvents.find(root => root.data.service == service.serviceName);
+  }
+
   ngOnDestroy(): void {
     this.unsubscribe$.next();
     this._tracesTimer.unsubscribe();

--- a/bridge/client/index.html
+++ b/bridge/client/index.html
@@ -5,8 +5,8 @@
   <title>keptn</title>
   <base id="base-href" href="/">
   <script>
-    if(window.location.hostname != "localhost" && window.location.pathname.indexOf('bridge/') != -1)
-      document.getElementById("base-href").href = window.location.pathname.substring(0, window.location.pathname.indexOf('bridge/')) + 'bridge/';
+    if(window.location.hostname != "localhost" && window.location.pathname.indexOf('bridge') != -1)
+      document.getElementById("base-href").href = window.location.pathname.substring(0, window.location.pathname.indexOf('bridge')) + 'bridge/';
   </script>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/png" href="assets/keptn_logo.png">


### PR DESCRIPTION
The environment screen now allows to easily see problems on a specific stage and remediation actions.
The stage tile shows the problem icon in red and a count how many services on this stage are "broken".
By clicking on the stage and expanding the details for a service you get the details about the problem and the remediation actions that are executed with the evaluation score after each remediation action. By hovering over the score, you can see the evaluation details in a popup.

![image](https://user-images.githubusercontent.com/6098219/91457886-2ce94180-e885-11ea-8aed-19b35e72ad12.png)
