### PR TITLE
#2112 Fix missleading message "service not deployed yet" in quality gates use-case

### DIFF
--- a/bridge/client/app/_models/project.ts
+++ b/bridge/client/app/_models/project.ts
@@ -31,14 +31,14 @@ export class Project {
     return this.stages.find(s => s.stageName == stageName);
   }
 
-  getLatestDeployment(service: Service, stage: Stage): Trace {
+  getLatestDeployment(service: Service, stage?: Stage): Trace {
     let currentService = this.getService(service.serviceName);
 
     if(currentService.roots)
       return currentService.roots
-        .filter(root => root.isFaulty() != stage.stageName || root.traces.find(trace => trace.type == EventTypes.DEPLOYMENT_FINISHED && trace.data.stage == stage.stageName)?.data.deploymentstrategy == "direct")
+        .filter(root => !stage || root.isFaulty() != stage.stageName || root.traces.find(trace => trace.type == EventTypes.DEPLOYMENT_FINISHED && trace.data.stage == stage.stageName)?.data.deploymentstrategy == "direct")
         .reduce((traces: Trace[], root) => [...traces, ...root.traces], [])
-        .find(trace => trace.type == EventTypes.DEPLOYMENT_FINISHED && trace.data.stage == stage.stageName);
+        .find(trace => stage ? trace.isDeployment() == stage.stageName || trace.isEvaluation() == stage.stageName : !!trace.isDeployment() || !!trace.isEvaluation());
     else
       return null;
   }

--- a/bridge/client/app/_models/trace.ts
+++ b/bridge/client/app/_models/trace.ts
@@ -140,6 +140,14 @@ class Trace {
     return this.data.approval?.result == ApprovalStates.DECLINED;
   }
 
+  public isDeployment(): string {
+    return this.type === EventTypes.DEPLOYMENT_FINISHED ? this.data.stage : null;
+  }
+
+  public isEvaluation(): string {
+    return this.type === EventTypes.EVALUATION_DONE ? this.data.stage : null;
+  }
+
   hasLabels(): boolean {
     return Object.keys(this.data.labels||{}).length > 0;
   }

--- a/bridge/client/app/project-board/project-board.component.html
+++ b/bridge/client/app/project-board/project-board.component.html
@@ -116,7 +116,7 @@
                 </dt-info-group-title>
                 <ng-container *ngIf="project.getLatestDeployment(service, selectedStage) as deployment; else noDeployment">
                   <p class="m-0 mt-1"><span [textContent]="deployment.data.image"></span>:<span [textContent]="deployment.data.tag"></span></p>
-                  <p class="m-0 mb-1"><span class="bold">Deployed at: </span><span [textContent]="deployment.time | amCalendar:getCalendarFormats()"></span></p>
+                  <p class="m-0 mb-1" *ngIf="deployment.isDeployment()"><span class="bold">Deployed at: </span><span [textContent]="deployment.time | amCalendar:getCalendarFormats()"></span></p>
                 </ng-container>
               </dt-info-group>
             </ktb-expandable-tile-header>
@@ -164,8 +164,8 @@
                   </div>
                 </div>
               </dt-info-group-title>
-              <p class="m-0 mb-1 mt-1" *ngIf="project.getLatestDeployment(service, project.stages[0]) as deployment; else noDeployment">
-                <span class="bold">Last processed artifact: </span><span [textContent]="deployment.getShortImageName()"></span>
+              <p class="m-0 mb-1 mt-1" *ngIf="project.getLatestDeployment(service) as deployment; else noDeployment">
+                <span class="bold">Last processed artifact: </span><span *ngIf="deployment.getShortImageName()" [textContent]="deployment.getShortImageName()"></span><span *ngIf="!deployment.getShortImageName()">unknown</span>
               </p>
               <button dt-button disabled variant="nested" *ngIf="!service.roots">
                 <dt-loading-spinner></dt-loading-spinner>
@@ -217,7 +217,7 @@
   </ng-container>
 </div>
 <ng-template #noDeployment>
-  <p class="m-0">Service not deployed yet. Use <a href="https://keptn.sh/docs/0.7.x/reference/cli/commands/keptn_send_event_new-artifact/" target="_blank" rel="noopener noreferrer">keptn send new-artifact</a> to trigger a deployment.</p>
+  <p class="m-0">Service not deployed yet. Use <a href="https://keptn.sh/docs/0.7.x/reference/cli/commands/keptn_send_event_new-artifact/" target="_blank" rel="noopener noreferrer">keptn send event new-artifact</a> to trigger a deployment.</p>
 </ng-template>
 <ng-template #noService>
   <div fxLayout="row" fxLayoutAlign="start center">


### PR DESCRIPTION
Fixes #2112 

Now checking for deployment.finished or evaluation.done event and if `image` and `tag` are provided on the evaluation event, that will be displayed as `Last processed artifact`.