### PR TITLE
#2231 Mark info SLI correctly when empty pass/warning array is provided

### DIFF
--- a/lighthouse-service/event_handler/evaluate_sli_handler.go
+++ b/lighthouse-service/event_handler/evaluate_sli_handler.go
@@ -175,7 +175,7 @@ func evaluateObjectives(e *keptn.InternalGetSLIDoneEventData, sloConfig *keptn.S
 		var warningTargets []*keptn.SLITarget
 		isPassed := true
 		isWarning := true
-		if objective.Pass != nil {
+		if objective.Pass != nil && len(objective.Pass) > 0 {
 			isPassed, passTargets, _ = evaluateOrCombinedCriteria(sliEvaluationResult.Value, objective.Pass, previousSLIResults, sloConfig.Comparison)
 			if isPassed {
 				sliEvaluationResult.Score = float64(objective.Weight)
@@ -186,7 +186,7 @@ func evaluateObjectives(e *keptn.InternalGetSLIDoneEventData, sloConfig *keptn.S
 		}
 
 		if !isPassed {
-			if objective.Warning != nil {
+			if objective.Warning != nil && len(objective.Warning) > 0 {
 				isWarning, warningTargets, _ = evaluateOrCombinedCriteria(sliEvaluationResult.Value, objective.Warning, previousSLIResults, sloConfig.Comparison)
 				if isWarning {
 					sliEvaluationResult.Score = 0.5 * float64(objective.Weight)

--- a/lighthouse-service/event_handler/evaluate_sli_handler_test.go
+++ b/lighthouse-service/event_handler/evaluate_sli_handler_test.go
@@ -1810,6 +1810,151 @@ func TestEvaluateObjectives(t *testing.T) {
 			ExpectedKeySLIFailed: false,
 		},
 		{
+			Name: "Logging SLI with empty pass criteria array should not affect score and have status 'info' - BUG 2231",
+			InGetSLIDoneEvent: &keptnevents.InternalGetSLIDoneEventData{
+				Project: "sockshop",
+				Service: "carts",
+				Stage:   "dev",
+				Start:   "2019-10-20T07:57:27.152330783Z",
+				End:     "2019-10-22T08:57:27.152330783Z",
+				IndicatorValues: []*keptnevents.SLIResult{
+					{
+						Metric:  "my-test-metric-1",
+						Value:   10.0,
+						Success: true,
+						Message: "",
+					},
+					{
+						Metric:  "my-log-metric",
+						Value:   30.0,
+						Success: true,
+						Message: "",
+					},
+				},
+			},
+			InSLOConfig: &keptnmodelsv2.ServiceLevelObjectives{
+				SpecVersion: "1.0",
+				Filter:      nil,
+				Comparison: &keptnmodelsv2.SLOComparison{
+					CompareWith:               "several_results",
+					IncludeResultWithScore:    "pass",
+					NumberOfComparisonResults: 2,
+					AggregateFunction:         "avg",
+				},
+				Objectives: []*keptnmodelsv2.SLO{
+					{
+						SLI: "my-test-metric-1",
+						Pass: []*keptnmodelsv2.SLOCriteria{
+							{
+								Criteria: []string{"<=15.0"},
+							},
+							{
+								Criteria: []string{"<=+10%"},
+							},
+						},
+						Warning: []*keptnmodelsv2.SLOCriteria{
+							{
+								Criteria: []string{"<=20.0"},
+							},
+							{
+								Criteria: []string{"<=+15%"},
+							},
+						},
+						Weight: 1,
+						KeySLI: false,
+					},
+					{
+						SLI:     "my-log-metric",
+						Weight:  1,
+						KeySLI:  false,
+						Pass:    []*keptnmodelsv2.SLOCriteria{},
+						Warning: []*keptnmodelsv2.SLOCriteria{},
+					},
+				},
+				TotalScore: &keptnmodelsv2.SLOScore{
+					Pass:    "90%",
+					Warning: "75%",
+				},
+			},
+			InPreviousEvaluationEvents: []*keptnevents.EvaluationDoneEventData{
+				{
+					EvaluationDetails: &keptnevents.EvaluationDetails{
+						TimeStart: "",
+						TimeEnd:   "",
+						Result:    "pass",
+						Score:     2,
+						IndicatorResults: []*keptnevents.SLIEvaluationResult{
+							{
+								Score: 2,
+								Value: &keptnevents.SLIResult{
+									Metric:  "my-test-metric-1",
+									Value:   10.0,
+									Success: true,
+									Message: "",
+								},
+								Targets: nil,
+								Status:  "pass",
+							},
+						},
+					},
+					Result:       "pass",
+					Project:      "sockshop",
+					Service:      "carts",
+					Stage:        "dev",
+					TestStrategy: "performance",
+				},
+			},
+			ExpectedEvaluationResult: &keptnevents.EvaluationDoneEventData{
+				EvaluationDetails: &keptnevents.EvaluationDetails{
+					TimeStart: "2019-10-20T07:57:27.152330783Z",
+					TimeEnd:   "2019-10-22T08:57:27.152330783Z",
+					Result:    "", // not set by the tested function
+					Score:     0,  // not calculated by tested function
+					IndicatorResults: []*keptnevents.SLIEvaluationResult{
+						{
+							Score: 1,
+							Value: &keptnevents.SLIResult{
+								Metric:  "my-test-metric-1",
+								Value:   10.0,
+								Success: true,
+								Message: "",
+							},
+							Targets: []*keptnevents.SLITarget{
+								{
+									Criteria:    "<=15.0",
+									TargetValue: 15.0,
+									Violated:    false,
+								},
+								{
+									Criteria:    "<=+10%",
+									TargetValue: 11,
+									Violated:    false,
+								},
+							},
+							Status: "pass",
+						},
+						{
+							Score: 0,
+							Value: &keptnevents.SLIResult{
+								Metric:  "my-log-metric",
+								Value:   30.0,
+								Success: true,
+								Message: "",
+							},
+							Status: "info",
+						},
+					},
+				},
+				Result:       "", // not set by the tested function
+				Project:      "sockshop",
+				Service:      "carts",
+				Stage:        "dev",
+				TestStrategy: "",
+			},
+			ExpectedMaximumScore: 1,
+			ExpectedKeySLIFailed: false,
+		},
+		{
 			Name: "BUG 1125",
 			InGetSLIDoneEvent: &keptnevents.InternalGetSLIDoneEventData{
 				Project: "sockshop",


### PR DESCRIPTION
Closes #2231 
Added a fix to check for empty pass/warning criteria arrays in addition to check for nil values. This avoids marking Info SLIs as being failed and sets the status to `info` instead.