### PR TITLE
#2087 Allow to filter services in environments screen by event type

### DIFF
--- a/bridge/angular.json
+++ b/bridge/angular.json
@@ -68,7 +68,7 @@
                 {
                   "type": "anyComponentStyle",
                   "maximumWarning": "6kb",
-                  "maximumError": "16kb"
+                  "maximumError": "18kb"
                 }
               ]
             }

--- a/bridge/client/app/_models/event-labels.ts
+++ b/bridge/client/app/_models/event-labels.ts
@@ -1,17 +1,17 @@
 import {EventTypes} from "./event-types";
 
 export const EVENT_LABELS = {
-  [EventTypes.SERVICE_CREATE]: "Service create",
-  [EventTypes.CONFIGURATION_CHANGE]: "Configuration change",
+  [EventTypes.SERVICE_CREATE]: "Service created",
+  [EventTypes.CONFIGURATION_CHANGE]: "Configuration changed",
   [EventTypes.CONFIGURE_MONITORING]: "Configure monitoring",
   [EventTypes.DEPLOYMENT_FINISHED]: "Deployment finished",
   [EventTypes.TESTS_FINISHED]: "Tests finished",
   [EventTypes.START_EVALUATION]: "Start evaluation",
   [EventTypes.EVALUATION_DONE]: "Evaluation done",
-  [EventTypes.START_SLI_RETRIEVAL]: "Start SLI retrieval",
+  [EventTypes.START_SLI_RETRIEVAL]: "SLI retrieval started",
   [EventTypes.SLI_RETRIEVAL_DONE]: "SLI retrieval done",
   [EventTypes.DONE]: "Done",
-  [EventTypes.PROBLEM_OPEN]: "Problem open",
+  [EventTypes.PROBLEM_OPEN]: "Problem opened",
   [EventTypes.PROBLEM_DETECTED]: "Problem detected",
   [EventTypes.PROBLEM_RESOLVED]: "Problem resolved",
   [EventTypes.PROBLEM_CLOSED]: "Problem closed",

--- a/bridge/client/app/_models/project.ts
+++ b/bridge/client/app/_models/project.ts
@@ -48,11 +48,11 @@ export class Project {
   }
 
   getLatestFailedRootEvents(stage: Stage): Root[] {
-    return this.getLatestRootEvents(stage).filter(root => root.isFailedEvaluation() === stage.stageName);
+    return this.getLatestRootEvents(stage).filter(root => root.isFailedEvaluation() === stage.stageName && root.isDeployment());
   }
 
   getLatestProblemEvents(stage: Stage): Root[] {
-    return this.getLatestRootEvents(stage).filter(root => root.isProblem() && !root.isProblemResolvedOrClosed());
+    return this.getLatestRootEvents(stage).filter(root => root?.isProblem() && !root?.isProblemResolvedOrClosed());
   }
 
   getRootEvent(service: Service, event: Trace): Root {

--- a/bridge/client/app/_models/project.ts
+++ b/bridge/client/app/_models/project.ts
@@ -38,6 +38,18 @@ export class Project {
       return currentService.roots
         .filter(root => !stage || root.isFaulty() != stage.stageName || root.getDeploymentDetails(stage)?.isDirectDeployment())
         .reduce((traces: Trace[], root) => [...traces, ...root.traces], [])
+        .find(trace => stage ? trace.isDeployment() == stage.stageName : !!trace.isDeployment());
+    else
+      return null;
+  }
+
+  getLatestArtifact(service: Service, stage?: Stage): Trace {
+    let currentService = this.getService(service.serviceName);
+
+    if(currentService.roots)
+      return currentService.roots
+        .filter(root => !stage || root.isFaulty() != stage.stageName || root.getDeploymentDetails(stage)?.isDirectDeployment())
+        .reduce((traces: Trace[], root) => [...traces, ...root.traces], [])
         .find(trace => stage ? trace.isDeployment() == stage.stageName || trace.isEvaluation() == stage.stageName : !!trace.isDeployment() || !!trace.isEvaluation());
     else
       return null;
@@ -48,7 +60,7 @@ export class Project {
   }
 
   getLatestFailedRootEvents(stage: Stage): Root[] {
-    return this.getLatestRootEvents(stage).filter(root => root.isFailedEvaluation() === stage.stageName && root.isDeployment());
+    return this.getLatestRootEvents(stage).filter(root => root?.isFailedEvaluation() === stage.stageName && root?.isDeployment());
   }
 
   getLatestProblemEvents(stage: Stage): Root[] {

--- a/bridge/client/app/_models/project.ts
+++ b/bridge/client/app/_models/project.ts
@@ -44,7 +44,7 @@ export class Project {
   }
 
   getLatestRootEvents(stage: Stage): Root[] {
-    return this.getServices().map(service => service.roots.find(root => root.traces.some(trace => trace.data.stage === stage.stageName)));
+    return this.getServices().map(service => service.roots?.find(root => root.traces.some(trace => trace.data.stage === stage.stageName)));
   }
 
   getLatestFailedRootEvents(stage: Stage): Root[] {
@@ -56,7 +56,7 @@ export class Project {
   }
 
   getRootEvent(service: Service, event: Trace): Root {
-    return service.roots.find(root => root.shkeptncontext == event.shkeptncontext);
+    return service.roots?.find(root => root.shkeptncontext == event.shkeptncontext);
   }
 
   getDeploymentEvaluation(trace: Trace): Trace {

--- a/bridge/client/app/_models/root.ts
+++ b/bridge/client/app/_models/root.ts
@@ -29,6 +29,10 @@ export class Root extends Trace {
     return result;
   }
 
+  isDeployment(): string {
+    return this.traces.reduce((result: string, trace: Trace) => trace.isDeployment(), null);
+  }
+
   isWarning(): string {
     return this.traces.reduce((result: string, trace: Trace) => trace.isWarning() ? trace.data.stage : result, null);
   }

--- a/bridge/client/app/_models/root.ts
+++ b/bridge/client/app/_models/root.ts
@@ -30,7 +30,7 @@ export class Root extends Trace {
   }
 
   isDeployment(): string {
-    return this.traces.reduce((result: string, trace: Trace) => trace.isDeployment(), null);
+    return this.traces.reduce((result: string, trace: Trace) => result ? result : trace.isDeployment(), null);
   }
 
   isWarning(): string {

--- a/bridge/client/app/_models/trace.spec.ts
+++ b/bridge/client/app/_models/trace.spec.ts
@@ -10,7 +10,7 @@ describe('Trace', () => {
     expect(rootTraces[0] instanceof Trace).toBe(true, 'instance of Trace');
 
     expect(rootTraces[0].type).toBe('sh.keptn.internal.event.service.create');
-    expect(rootTraces[0].getLabel()).toBe('Service create', 'Label for trace "sh.keptn.internal.event.service.create" should be "Service create"');
+    expect(rootTraces[0].getLabel()).toBe('Service created', 'Label for trace "sh.keptn.internal.event.service.create" should be "Service created"');
     expect(rootTraces[0].getShortImageName()).toBe(undefined);
     expect(rootTraces[0].getIcon()).toBe('information', 'Icon for trace "sh.keptn.internal.event.service.create" should be "information"');
     expect(rootTraces[0].isFaulty()).toBe(null);
@@ -20,7 +20,7 @@ describe('Trace', () => {
     expect(rootTraces[0].getService()).toBe('carts');
 
     expect(rootTraces[1].type).toBe('sh.keptn.event.configuration.change');
-    expect(rootTraces[1].getLabel()).toBe('Configuration change', 'Label for trace "sh.keptn.event.configuration.change" should be "Configuration change"');
+    expect(rootTraces[1].getLabel()).toBe('Configuration changed', 'Label for trace "sh.keptn.event.configuration.change" should be "Configuration changed"');
     expect(rootTraces[1].getShortImageName()).toBe('carts:0.10.1', 'ShortImageName for first trace "sh.keptn.event.configuration.change" should be "carts:0.10.1"');
     expect(rootTraces[1].getIcon()).toBe('duplicate', 'Icon for trace "sh.keptn.event.configuration.change" should be "duplicate"');
     expect(rootTraces[1].isFaulty()).toBe(null);
@@ -30,7 +30,7 @@ describe('Trace', () => {
     expect(rootTraces[1].getService()).toBe('carts');
 
     expect(rootTraces[2].type).toBe('sh.keptn.event.configuration.change');
-    expect(rootTraces[2].getLabel()).toBe('Configuration change', 'Label for trace "sh.keptn.event.configuration.change" should be "Configuration change"');
+    expect(rootTraces[2].getLabel()).toBe('Configuration changed', 'Label for trace "sh.keptn.event.configuration.change" should be "Configuration changed"');
     expect(rootTraces[2].getShortImageName()).toBe('carts:0.10.2', 'ShortImageName for second trace "sh.keptn.event.configuration.change" should be "carts:0.10.2"');
     expect(rootTraces[2].getIcon()).toBe('duplicate', 'Icon for trace "sh.keptn.event.configuration.change" should be "duplicate"');
     expect(rootTraces[2].isFaulty()).toBe(null);

--- a/bridge/client/app/_models/trace.ts
+++ b/bridge/client/app/_models/trace.ts
@@ -165,7 +165,7 @@ class Trace {
   }
 
   public isEvaluation(): string {
-    return this.type === EventTypes.EVALUATION_DONE ? this.data.stage : null;
+    return this.type === EventTypes.START_EVALUATION ? this.data.stage : null;
   }
 
   hasLabels(): boolean {

--- a/bridge/client/app/app.module.ts
+++ b/bridge/client/app/app.module.ts
@@ -34,6 +34,7 @@ import { DtSwitchModule } from '@dynatrace/barista-components/switch';
 import { DtTagModule } from '@dynatrace/barista-components/tag';
 import { DtTopBarNavigationModule } from "@dynatrace/barista-components/top-bar-navigation";
 import { DtCopyToClipboardModule } from "@dynatrace/barista-components/copy-to-clipboard";
+import { DtToggleButtonGroupModule } from "@dynatrace/barista-components/toggle-button-group";
 
 import { DtThemingModule } from '@dynatrace/barista-components/theming';
 import { DtTileModule } from '@dynatrace/barista-components/tile';
@@ -138,6 +139,7 @@ registerLocaleData(localeEn, 'en');
     DtToastModule,
     DtTopBarNavigationModule,
     DtCopyToClipboardModule,
+    DtToggleButtonGroupModule,
     MatDialogModule,
     DtIconModule.forRoot({
       svgIconLocation: `assets/icons/{{name}}.svg`,

--- a/bridge/client/app/project-board/project-board.component.html
+++ b/bridge/client/app/project-board/project-board.component.html
@@ -48,26 +48,26 @@
             <div class="mr-minus-15" fxLayout="row wrap" fxLayout.lt-sm="column" fxLayoutGap="15px" fxLayoutAlign="start">
               <ktb-selectable-tile *ngFor="let stage of project.stages; trackBy:trackStage"
                                    fxFlex="0 1 calc(33.3% - 15px)" fxFlex.lt-md="0 1 calc(50% - 15px)" fxFlex.lt-sm="100%"
-                                   (click)="selectStage(stage)" [selected]="selectedStage == stage">
+                                   (click)="selectStage($event, stage);" [selected]="selectedStage == stage">
                 <h2 class="m-0 mt-1 mb-1" [textContent]="stage.stageName"></h2>
                 <div class="stage-state" fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="15px">
-                  <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px">
-                    <ng-container *ngIf="project.getLatestProblemEvents(stage) as problemEvents">
-                      <dt-icon class="stage-state-icon event-icon" name="criticalevent" [class.error]="problemEvents.length > 0"></dt-icon>
-                      <span [textContent]="problemEvents.length"></span>
-                    </ng-container>
+                  <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px"
+                       *ngIf="project.getLatestProblemEvents(stage) as problemEvents"
+                       (click)="problemEvents.length > 0 && selectStage($event, stage, 'problem')">
+                    <dt-icon class="stage-state-icon event-icon" name="criticalevent" [class.error]="problemEvents.length > 0"></dt-icon>
+                    <span [textContent]="problemEvents.length"></span>
                   </div>
-                  <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px">
-                    <ng-container *ngIf="project.getLatestFailedRootEvents(stage) as failedRootEvents">
-                      <dt-icon class="stage-state-icon event-icon" name="traffic-light" [class.error]="failedRootEvents.length > 0"></dt-icon>
-                      <span [textContent]="failedRootEvents.length"></span>
-                    </ng-container>
+                  <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px"
+                       *ngIf="project.getLatestFailedRootEvents(stage) as failedRootEvents"
+                       (click)="failedRootEvents.length > 0 && selectStage($event, stage, 'evaluation')">
+                    <dt-icon class="stage-state-icon event-icon" name="traffic-light" [class.error]="failedRootEvents.length > 0"></dt-icon>
+                    <span [textContent]="failedRootEvents.length"></span>
                   </div>
-                  <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px">
-                    <ng-container *ngIf="openApprovals$ | async as openApprovals">
-                      <dt-icon class="stage-state-icon" name="deploy" [class.out-of-sync-service]="countOpenApprovals(openApprovals, project, stage) > 0"></dt-icon>
-                      <span [textContent]="countOpenApprovals(openApprovals, project, stage)"></span>
-                    </ng-container>
+                  <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px"
+                       *ngIf="openApprovals$ | async as openApprovals"
+                       (click)="countOpenApprovals(openApprovals, project, stage) > 0 && selectStage($event, stage, 'approval')">
+                    <dt-icon class="stage-state-icon" name="deploy" [class.out-of-sync-service]="countOpenApprovals(openApprovals, project, stage) > 0"></dt-icon>
+                    <span [textContent]="countOpenApprovals(openApprovals, project, stage)"></span>
                   </div>
                 </div>
                 <ng-container *ngIf="stage.services && stage.services.length > 0; else noService">
@@ -93,20 +93,20 @@
         <ng-container *ngIf="project.getLatestProblemEvents(selectedStage) as problemEvents">
           <ng-container *ngIf="openApprovals$ | async as openApprovals">
             <h2 [textContent]="selectedStage.stageName"></h2>
-            <dt-toggle-button-group #eventTypes>
-              <button dt-toggle-button-item class="default" [value]="'problem'" [class.error]="problemEvents.length > 0" [disabled]="problemEvents.length == 0">
+            <dt-toggle-button-group (change)="selectFilterEvent($event)">
+              <button dt-toggle-button-item class="default" [value]="'problem'" [class.error]="problemEvents.length > 0" [disabled]="problemEvents.length == 0" [selected]="filterEventType == 'problem'">
                 <dt-toggle-button-item-icon>
                   <dt-icon class="stage-state-icon event-icon" name="criticalevent"></dt-icon>
                 </dt-toggle-button-item-icon>
                 <p class="m-0"><span [textContent]="problemEvents.length"></span> Problem<span *ngIf="problemEvents.length != 1">s</span> open</p>
               </button>
-              <button dt-toggle-button-item class="default" [value]="'evaluation'" [class.error]="failedRootEvents.length > 0" [disabled]="failedRootEvents.length == 0">
+              <button dt-toggle-button-item class="default" [value]="'evaluation'" [class.error]="failedRootEvents.length > 0" [disabled]="failedRootEvents.length == 0" [selected]="filterEventType == 'evaluation'">
                 <dt-toggle-button-item-icon>
                   <dt-icon class="stage-state-icon event-icon" name="traffic-light"></dt-icon>
                 </dt-toggle-button-item-icon>
                 <p class="m-0"><span [textContent]="failedRootEvents.length"></span> Quality gate<span *ngIf="failedRootEvents.length != 1">s</span> failed</p>
               </button>
-              <button dt-toggle-button-item class="default" [value]="'approval'" [class.highlight]="countOpenApprovals(openApprovals, project, selectedStage) > 0" [disabled]="countOpenApprovals(openApprovals, project, selectedStage) == 0">
+              <button dt-toggle-button-item class="default" [value]="'approval'" [class.highlight]="countOpenApprovals(openApprovals, project, selectedStage) > 0" [disabled]="countOpenApprovals(openApprovals, project, selectedStage) == 0" [selected]="filterEventType == 'approval'">
                 <dt-toggle-button-item-icon>
                   <dt-icon class="stage-state-icon" name="deploy"></dt-icon>
                 </dt-toggle-button-item-icon>
@@ -119,7 +119,7 @@
             </div>
             <ng-container *ngFor="let service of selectedStage.services">
               <ktb-expandable-tile [expanded]="countOpenApprovals(openApprovals, project, selectedStage, service) > 0"
-                                   *ngIf="!eventTypes.value || eventTypes.value == 'problem' && findProblemEvent(problemEvents, service) || eventTypes.value == 'evaluation' && findFailedRootEvent(failedRootEvents, service) || eventTypes.value == 'approval' && countOpenApprovals(openApprovals, project, selectedStage, service) > 0">
+                                   *ngIf="!filterEventType || filterEventType == 'problem' && findProblemEvent(problemEvents, service) || filterEventType == 'evaluation' && findFailedRootEvent(failedRootEvents, service) || filterEventType == 'approval' && countOpenApprovals(openApprovals, project, selectedStage, service) > 0">
                 <ktb-expandable-tile-header>
                   <dt-info-group>
                     <dt-info-group-title>

--- a/bridge/client/app/project-board/project-board.component.html
+++ b/bridge/client/app/project-board/project-board.component.html
@@ -94,19 +94,19 @@
           <ng-container *ngIf="openApprovals$ | async as openApprovals">
             <h2 [textContent]="selectedStage.stageName"></h2>
             <dt-toggle-button-group (change)="selectFilterEvent($event)">
-              <button dt-toggle-button-item class="default" [value]="'problem'" [class.error]="problemEvents.length > 0" [disabled]="problemEvents.length == 0" [selected]="filterEventType == 'problem'">
+              <button #problemFilterEventButton dt-toggle-button-item class="default" [value]="'problem'" [class.error]="problemEvents.length > 0" [disabled]="problemEvents.length == 0" [selected]="filterEventType == 'problem'">
                 <dt-toggle-button-item-icon>
                   <dt-icon class="stage-state-icon event-icon" name="criticalevent"></dt-icon>
                 </dt-toggle-button-item-icon>
                 <p class="m-0"><span [textContent]="problemEvents.length"></span> Problem<span *ngIf="problemEvents.length != 1">s</span> open</p>
               </button>
-              <button dt-toggle-button-item class="default" [value]="'evaluation'" [class.error]="failedRootEvents.length > 0" [disabled]="failedRootEvents.length == 0" [selected]="filterEventType == 'evaluation'">
+              <button #evaluationFilterEventButton dt-toggle-button-item class="default" [value]="'evaluation'" [class.error]="failedRootEvents.length > 0" [disabled]="failedRootEvents.length == 0" [selected]="filterEventType == 'evaluation'">
                 <dt-toggle-button-item-icon>
                   <dt-icon class="stage-state-icon event-icon" name="traffic-light"></dt-icon>
                 </dt-toggle-button-item-icon>
                 <p class="m-0"><span [textContent]="failedRootEvents.length"></span> Quality gate<span *ngIf="failedRootEvents.length != 1">s</span> failed</p>
               </button>
-              <button dt-toggle-button-item class="default" [value]="'approval'" [class.highlight]="countOpenApprovals(openApprovals, project, selectedStage) > 0" [disabled]="countOpenApprovals(openApprovals, project, selectedStage) == 0" [selected]="filterEventType == 'approval'">
+              <button #approvalFilterEventButton dt-toggle-button-item class="default" [value]="'approval'" [class.highlight]="countOpenApprovals(openApprovals, project, selectedStage) > 0" [disabled]="countOpenApprovals(openApprovals, project, selectedStage) == 0" [selected]="filterEventType == 'approval'">
                 <dt-toggle-button-item-icon>
                   <dt-icon class="stage-state-icon" name="deploy"></dt-icon>
                 </dt-toggle-button-item-icon>

--- a/bridge/client/app/project-board/project-board.component.html
+++ b/bridge/client/app/project-board/project-board.component.html
@@ -98,19 +98,19 @@
                 <dt-toggle-button-item-icon>
                   <dt-icon class="stage-state-icon event-icon" name="traffic-light"></dt-icon>
                 </dt-toggle-button-item-icon>
-                <p class="m-0"><span [textContent]="problemEvents.length"></span> Problem<span *ngIf="problemEvents.length > 1">s</span> open</p>
+                <p class="m-0"><span [textContent]="problemEvents.length"></span> Problem<span *ngIf="problemEvents.length != 1">s</span> open</p>
               </button>
               <button dt-toggle-button-item class="default" [value]="'evaluation'" [class.error]="failedRootEvents.length > 0" [disabled]="failedRootEvents.length == 0">
                 <dt-toggle-button-item-icon>
                   <dt-icon class="stage-state-icon event-icon" name="traffic-light"></dt-icon>
                 </dt-toggle-button-item-icon>
-                <p class="m-0"><span [textContent]="failedRootEvents.length"></span> Quality gate<span *ngIf="failedRootEvents.length > 1">s</span> failed</p>
+                <p class="m-0"><span [textContent]="failedRootEvents.length"></span> Quality gate<span *ngIf="failedRootEvents.length != 1">s</span> failed</p>
               </button>
               <button dt-toggle-button-item class="default" [value]="'approval'" [class.highlight]="countOpenApprovals(openApprovals, project, selectedStage) > 0" [disabled]="countOpenApprovals(openApprovals, project, selectedStage) == 0">
                 <dt-toggle-button-item-icon>
                   <dt-icon class="stage-state-icon" name="deploy"></dt-icon>
                 </dt-toggle-button-item-icon>
-                <p class="m-0"><span [textContent]="countOpenApprovals(openApprovals, project, selectedStage)"></span> Service<span *ngIf="countOpenApprovals(openApprovals, project, selectedStage) > 1">s</span> out-of-sync</p>
+                <p class="m-0"><span [textContent]="countOpenApprovals(openApprovals, project, selectedStage)"></span> Service<span *ngIf="countOpenApprovals(openApprovals, project, selectedStage) != 1">s</span> out-of-sync</p>
               </button>
             </dt-toggle-button-group>
             <div fxLayout="row" fxLayoutAlign="start center" *ngIf="selectedStage.services.length == 0">

--- a/bridge/client/app/project-board/project-board.component.html
+++ b/bridge/client/app/project-board/project-board.component.html
@@ -93,24 +93,33 @@
         <ng-container *ngIf="project.getLatestProblemEvents(selectedStage) as problemEvents">
           <ng-container *ngIf="openApprovals$ | async as openApprovals">
             <h2 [textContent]="selectedStage.stageName"></h2>
-            <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px" *ngIf="problemEvents.length > 0">
-              <dt-icon class="stage-state-icon event-icon" name="traffic-light" [class.error]="problemEvents.length > 0"></dt-icon>
-              <p class="m-0"><span [textContent]="problemEvents.length"></span> Problem<span *ngIf="problemEvents.length > 1">s</span> open</p>
-            </div>
-            <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px" *ngIf="failedRootEvents.length > 0">
-              <dt-icon class="stage-state-icon event-icon" name="traffic-light" [class.error]="failedRootEvents.length > 0"></dt-icon>
-              <p class="m-0"><span [textContent]="failedRootEvents.length"></span> Quality gate<span *ngIf="failedRootEvents.length > 1">s</span> failed</p>
-            </div>
-            <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px">
-              <dt-icon class="stage-state-icon" name="deploy" [ngClass]="{'out-of-sync-service': countOpenApprovals(openApprovals, project, selectedStage) > 0}"></dt-icon>
-              <p class="m-0"><span [textContent]="countOpenApprovals(openApprovals, project, selectedStage)"></span> Service<span *ngIf="countOpenApprovals(openApprovals, project, selectedStage) > 1">s</span> are out-of-sync</p>
-            </div>
+            <dt-toggle-button-group #eventTypes>
+              <button dt-toggle-button-item class="default" [value]="'problem'" [class.error]="problemEvents.length > 0" [disabled]="problemEvents.length == 0">
+                <dt-toggle-button-item-icon>
+                  <dt-icon class="stage-state-icon event-icon" name="traffic-light"></dt-icon>
+                </dt-toggle-button-item-icon>
+                <p class="m-0"><span [textContent]="problemEvents.length"></span> Problem<span *ngIf="problemEvents.length > 1">s</span> open</p>
+              </button>
+              <button dt-toggle-button-item class="default" [value]="'evaluation'" [class.error]="failedRootEvents.length > 0" [disabled]="failedRootEvents.length == 0">
+                <dt-toggle-button-item-icon>
+                  <dt-icon class="stage-state-icon event-icon" name="traffic-light"></dt-icon>
+                </dt-toggle-button-item-icon>
+                <p class="m-0"><span [textContent]="failedRootEvents.length"></span> Quality gate<span *ngIf="failedRootEvents.length > 1">s</span> failed</p>
+              </button>
+              <button dt-toggle-button-item class="default" [value]="'approval'" [class.highlight]="countOpenApprovals(openApprovals, project, selectedStage) > 0" [disabled]="countOpenApprovals(openApprovals, project, selectedStage) == 0">
+                <dt-toggle-button-item-icon>
+                  <dt-icon class="stage-state-icon" name="deploy"></dt-icon>
+                </dt-toggle-button-item-icon>
+                <p class="m-0"><span [textContent]="countOpenApprovals(openApprovals, project, selectedStage)"></span> Service<span *ngIf="countOpenApprovals(openApprovals, project, selectedStage) > 1">s</span> out-of-sync</p>
+              </button>
+            </dt-toggle-button-group>
             <div fxLayout="row" fxLayoutAlign="start center" *ngIf="selectedStage.services.length == 0">
               <dt-icon class="icon" name="information"></dt-icon>
               <p class="m-0">No service onboarded yet. Follow the intructions to <a href="https://keptn.sh/docs/0.7.x/manage/service/#onboard-a-service" target="_blank" rel="noopener noreferrer">onboard a service</a>.</p>
             </div>
             <ng-container *ngFor="let service of selectedStage.services">
-              <ktb-expandable-tile [expanded]="countOpenApprovals(openApprovals, project, selectedStage, service) > 0">
+              <ktb-expandable-tile [expanded]="countOpenApprovals(openApprovals, project, selectedStage, service) > 0"
+                                   *ngIf="!eventTypes.value || eventTypes.value == 'problem' && findProblemEvent(problemEvents, service) || eventTypes.value == 'evaluation' && findFailedRootEvent(failedRootEvents, service) || eventTypes.value == 'approval' && countOpenApprovals(openApprovals, project, selectedStage, service) > 0">
                 <ktb-expandable-tile-header>
                   <dt-info-group>
                     <dt-info-group-title>

--- a/bridge/client/app/project-board/project-board.component.html
+++ b/bridge/client/app/project-board/project-board.component.html
@@ -96,7 +96,7 @@
             <dt-toggle-button-group #eventTypes>
               <button dt-toggle-button-item class="default" [value]="'problem'" [class.error]="problemEvents.length > 0" [disabled]="problemEvents.length == 0">
                 <dt-toggle-button-item-icon>
-                  <dt-icon class="stage-state-icon event-icon" name="traffic-light"></dt-icon>
+                  <dt-icon class="stage-state-icon event-icon" name="criticalevent"></dt-icon>
                 </dt-toggle-button-item-icon>
                 <p class="m-0"><span [textContent]="problemEvents.length"></span> Problem<span *ngIf="problemEvents.length != 1">s</span> open</p>
               </button>

--- a/bridge/client/app/project-board/project-board.component.html
+++ b/bridge/client/app/project-board/project-board.component.html
@@ -217,8 +217,8 @@
                   </div>
                 </div>
               </dt-info-group-title>
-              <p class="m-0 mb-1 mt-1" *ngIf="project.getLatestDeployment(service) as deployment; else noDeployment">
-                <span class="bold">Last processed artifact: </span><span *ngIf="deployment.getShortImageName()" [textContent]="deployment.getShortImageName()"></span><span *ngIf="!deployment.getShortImageName()">unknown</span>
+              <p class="m-0 mb-1 mt-1" *ngIf="project.getLatestArtifact(service) as artifact; else noDeployment">
+                <span class="bold">Last processed artifact: </span><span *ngIf="artifact.getShortImageName()" [textContent]="artifact.getShortImageName()"></span><span *ngIf="!artifact.getShortImageName()">unknown</span>
               </p>
               <button dt-button disabled variant="nested" *ngIf="!service.roots">
                 <dt-loading-spinner></dt-loading-spinner>

--- a/bridge/client/app/project-board/project-board.component.scss
+++ b/bridge/client/app/project-board/project-board.component.scss
@@ -101,7 +101,22 @@
 
   .dt-toggle-button-item {
 
-    &.error {
+    &:not([disabled]):focus {
+      outline: none;
+    }
+    &.dt-toggle-button-item-disabled {
+      .dt-toggle-button-item-icon {
+        background-color: $gray-300;
+      }
+      &.dt-toggle-button-item-selected {
+        border-color: $gray-200;
+        .dt-toggle-button-item-icon {
+          background-color: $gray-300;
+        }
+      }
+    }
+
+    &.error:not(.dt-toggle-button-item-disabled) {
       .dt-toggle-button-item-icon {
         background-color: $error-color;
       }
@@ -112,7 +127,7 @@
         }
       }
     }
-    &.error:hover {
+    &.error:not(.dt-toggle-button-item-disabled):hover {
       .dt-toggle-button-item-icon {
         background-color: $error-color-hover;
       }
@@ -124,7 +139,7 @@
       }
     }
 
-    &.highlight {
+    &.highlight:not(.dt-toggle-button-item-disabled) {
       .dt-toggle-button-item-icon {
         background-color: $blue-400;
       }
@@ -135,7 +150,7 @@
         }
       }
     }
-    &.highlight:hover {
+    &.highlight:not(.dt-toggle-button-item-disabled):hover {
       .dt-toggle-button-item-icon {
         background-color: $blue-500;
       }

--- a/bridge/client/app/project-board/project-board.component.scss
+++ b/bridge/client/app/project-board/project-board.component.scss
@@ -98,8 +98,8 @@
 }
 
 ::ng-deep .dt-toggle-button-group {
+  display: flex !important;
   flex-direction: column;
-  display: flex;
   align-items: start;
 
   .dt-toggle-button-item {

--- a/bridge/client/app/project-board/project-board.component.scss
+++ b/bridge/client/app/project-board/project-board.component.scss
@@ -98,9 +98,6 @@
 }
 
 ::ng-deep .dt-toggle-button-group {
-  display: flex !important;
-  flex-direction: column;
-  align-items: start;
 
   .dt-toggle-button-item {
 

--- a/bridge/client/app/project-board/project-board.component.scss
+++ b/bridge/client/app/project-board/project-board.component.scss
@@ -33,6 +33,12 @@
 .out-of-sync-service {
   border: 1px solid $blue-400;
 }
+::ng-deep .dt-icon {
+  &.out-of-sync-service {
+    border: none;
+    fill: $blue-400;
+  }
+}
 
 ::ng-deep {
   .dt-tag {
@@ -89,4 +95,69 @@
 
 ::ng-deep .ktb-expandable-tile .dt-show-more-icon {
   margin-right: 5px;
+}
+
+::ng-deep .dt-toggle-button-group {
+  flex-direction: column;
+  display: flex;
+  align-items: start;
+
+  .dt-toggle-button-item {
+
+    &.error {
+      .dt-toggle-button-item-icon {
+        background-color: $error-color;
+      }
+      &.dt-toggle-button-item-selected {
+        border-color: $error-color;
+        .dt-toggle-button-item-icon {
+          background-color: $error-color;
+        }
+      }
+    }
+    &.error:hover {
+      .dt-toggle-button-item-icon {
+        background-color: $error-color-hover;
+      }
+      &.dt-toggle-button-item-selected {
+        border-color: $error-color-hover;
+        .dt-toggle-button-item-icon {
+          background-color: $error-color-hover;
+        }
+      }
+    }
+
+    &.highlight {
+      .dt-toggle-button-item-icon {
+        background-color: $blue-400;
+      }
+      &.dt-toggle-button-item-selected {
+        border-color: $blue-400;
+        .dt-toggle-button-item-icon {
+          background-color: $blue-400;
+        }
+      }
+    }
+    &.highlight:hover {
+      .dt-toggle-button-item-icon {
+        background-color: $blue-500;
+      }
+      &.dt-toggle-button-item-selected {
+        border-color: $blue-500;
+        .dt-toggle-button-item-icon {
+          background-color: $blue-500;
+        }
+      }
+    }
+
+    .dt-toggle-button-item-icon {
+      width: 32px !important;
+      height: 32px !important;
+
+      .dt-icon {
+        width: 25px;
+        height: 25px;
+      }
+    }
+  }
 }

--- a/bridge/client/app/project-board/project-board.component.ts
+++ b/bridge/client/app/project-board/project-board.component.ts
@@ -52,9 +52,9 @@ export class ProjectBoardComponent implements OnInit, OnDestroy {
 
   public filterEventType: string = null;
 
-  @ViewChild('problemFilterEventButton') public problemFilterEventButton: DtToggleButtonItem;
-  @ViewChild('evaluationFilterEventButton') public evaluationFilterEventButton: DtToggleButtonItem;
-  @ViewChild('approvalFilterEventButton') public approvalFilterEventButton: DtToggleButtonItem;
+  @ViewChild('problemFilterEventButton') public problemFilterEventButton: DtToggleButtonItem<string>;
+  @ViewChild('evaluationFilterEventButton') public evaluationFilterEventButton: DtToggleButtonItem<string>;
+  @ViewChild('approvalFilterEventButton') public approvalFilterEventButton: DtToggleButtonItem<string>;
 
   public overlayConfig: DtOverlayConfig = {
     pinnable: true

--- a/bridge/client/app/project-board/project-board.component.ts
+++ b/bridge/client/app/project-board/project-board.component.ts
@@ -18,6 +18,7 @@ import {Stage} from "../_models/stage";
 import {DtCheckboxChange} from "@dynatrace/barista-components/checkbox";
 import {EVENT_LABELS} from "../_models/event-labels";
 import {DtOverlayConfig} from "@dynatrace/barista-components/overlay";
+import {DtToggleButtonItem} from "@dynatrace/barista-components/toggle-button-group";
 
 @Component({
   selector: 'app-project-board',
@@ -50,6 +51,10 @@ export class ProjectBoardComponent implements OnInit, OnDestroy {
   public filterEventTypes: string[] = [];
 
   public filterEventType: string = null;
+
+  @ViewChild('problemFilterEventButton') public problemFilterEventButton: DtToggleButtonItem;
+  @ViewChild('evaluationFilterEventButton') public evaluationFilterEventButton: DtToggleButtonItem;
+  @ViewChild('approvalFilterEventButton') public approvalFilterEventButton: DtToggleButtonItem;
 
   public overlayConfig: DtOverlayConfig = {
     pinnable: true
@@ -232,6 +237,10 @@ export class ProjectBoardComponent implements OnInit, OnDestroy {
   }
 
   selectStage($event, stage: Stage, filterType?: string) {
+    this.problemFilterEventButton?.deselect();
+    this.evaluationFilterEventButton?.deselect();
+    this.approvalFilterEventButton?.deselect();
+
     this.selectedStage = stage;
     this.filterEventType = filterType;
     $event.stopPropagation();

--- a/bridge/client/app/project-board/project-board.component.ts
+++ b/bridge/client/app/project-board/project-board.component.ts
@@ -1,4 +1,4 @@
-import {ChangeDetectorRef, Component, OnDestroy, OnInit} from '@angular/core';
+import {ChangeDetectorRef, Component, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {filter, map, startWith, switchMap, takeUntil} from "rxjs/operators";
 import {Observable, Subject, Subscription, timer} from "rxjs";
 import {ActivatedRoute, Router} from "@angular/router";
@@ -48,6 +48,8 @@ export class ProjectBoardComponent implements OnInit, OnDestroy {
 
   public eventTypes: string[] = [];
   public filterEventTypes: string[] = [];
+
+  public filterEventType: string = null;
 
   public overlayConfig: DtOverlayConfig = {
     pinnable: true
@@ -229,8 +231,15 @@ export class ProjectBoardComponent implements OnInit, OnDestroy {
       return roots.filter(r => this.filterEventTypes.indexOf(r.type) == -1);
   }
 
-  selectStage(stage) {
+  selectStage($event, stage: Stage, filterType?: string) {
     this.selectedStage = stage;
+    this.filterEventType = filterType;
+    $event.stopPropagation();
+  }
+
+  selectFilterEvent($event) {
+    if($event.isUserInput)
+      this.filterEventType = $event.source.selected ? $event.value : null;
   }
 
   countOpenApprovals(openApprovals: Trace[], project: Project, stage: Stage, service?: Service) {


### PR DESCRIPTION
Now the event types are displayed as toggle buttons with the details as labels.
By activating the toggle button, you will see only services with this event type.

![image](https://user-images.githubusercontent.com/6098219/91810871-eef66f80-ec2e-11ea-98c1-f177bc5830c1.png)
