### PR TITLE
#2220 Added endpoint for forwarding events to Keptn API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -254,7 +254,7 @@ jobs:
         cd ..
       - |
         cd "${DISTRIBUTOR_FOLDER}"
-        go test -race -v -coverprofile=coverage.txt -covermode=atomic ./...
+        go test -v -coverprofile=coverage.txt -covermode=atomic ./...
         cd ..
       - |
         cd "${EVENTBROKER_FOLDER}"

--- a/distributor/cmd/main.go
+++ b/distributor/cmd/main.go
@@ -75,7 +75,7 @@ func main() {
 const connectionTypeNATS = "nats"
 const connectionTypeHTTP = "http"
 
-const defaultApiEndpoint = "http://api-service:8080/v1/event"
+const defaultAPIEndpoint = "http://api-service:8080/v1/event"
 
 func _main(args []string, env envConfig) int {
 
@@ -155,7 +155,7 @@ func gotEvent(event cloudevents.Event) error {
 	fmt.Println("Received CloudEvent with ID " + event.ID() + ". Forwarding to Keptn API.")
 	apiEndpoint := os.Getenv("HTTP_EVENT_FORWARDING_ENDPOINT")
 	if apiEndpoint == "" {
-		apiEndpoint = defaultApiEndpoint
+		apiEndpoint = defaultAPIEndpoint
 	}
 	fmt.Println("Keptn API endpoint: " + apiEndpoint)
 	apiToken := os.Getenv("HTTP_EVENT_ENDPOINT_AUTH_TOKEN")

--- a/distributor/cmd/main.go
+++ b/distributor/cmd/main.go
@@ -102,7 +102,7 @@ func _main(args []string, env envConfig) int {
 }
 
 func createEventForwardingEndpoint(env envConfig) {
-	fmt.Println("Creating event forwarding endpointx")
+	fmt.Println("Creating event forwarding endpoint")
 	ctx := context.Background()
 
 	t, err := cloudeventshttp.New(

--- a/distributor/cmd/main.go
+++ b/distributor/cmd/main.go
@@ -77,6 +77,10 @@ const connectionTypeNATS = "nats"
 const connectionTypeHTTP = "http"
 
 func _main(args []string, env envConfig) int {
+
+	go func() {
+		createEventForwardingEndpoint(env)
+	}()
 	// initialize the http client
 	connectionType := strings.ToLower(os.Getenv("CONNECTION_TYPE"))
 
@@ -94,12 +98,11 @@ func _main(args []string, env envConfig) int {
 		createNATSConnection()
 	}
 
-	createEventForwardingEndpoint(env)
-
 	return 0
 }
 
 func createEventForwardingEndpoint(env envConfig) {
+	fmt.Println("Creating event forwarding endpointx")
 	ctx := context.Background()
 
 	t, err := cloudeventshttp.New(

--- a/distributor/cmd/main.go
+++ b/distributor/cmd/main.go
@@ -94,6 +94,12 @@ func _main(args []string, env envConfig) int {
 		createNATSConnection()
 	}
 
+	createEventForwardingEndpoint(env)
+
+	return 0
+}
+
+func createEventForwardingEndpoint(env envConfig) {
 	ctx := context.Background()
 
 	t, err := cloudeventshttp.New(
@@ -110,8 +116,6 @@ func _main(args []string, env envConfig) int {
 	}
 
 	log.Fatalf("failed to start receiver: %s", c.StartReceiver(ctx, gotEvent))
-
-	return 0
 }
 
 const defaultPollingInterval = 10

--- a/distributor/cmd/main.go
+++ b/distributor/cmd/main.go
@@ -107,25 +107,6 @@ func createEventForwardingEndpoint(env envConfig) {
 	http.HandleFunc("/event", EventForwardHandler)
 	go http.ListenAndServe("localhost:8081", nil)
 
-	/*
-		ctx := context.Background()
-
-		t, err := cloudeventshttp.New(
-			cloudeventshttp.WithPort(8081),
-			cloudeventshttp.WithPath("/event"),
-		)
-
-		if err != nil {
-			log.Fatalf("failed to create transport, %v", err)
-		}
-		c, err := client.New(t)
-		if err != nil {
-			log.Fatalf("failed to create client, %v", err)
-		}
-
-		log.Fatalf("failed to start receiver: %s", c.StartReceiver(ctx, gotEvent))
-
-	*/
 }
 
 // EventForwardHandler godoc

--- a/distributor/cmd/main.go
+++ b/distributor/cmd/main.go
@@ -127,7 +127,7 @@ func gotEvent(ctx context.Context, event cloudevents.Event) error {
 	fmt.Println("Received CloudEvent with ID " + event.ID() + ". Forwarding to Keptn API.")
 	apiEndpoint := os.Getenv("HTTP_EVENT_FORWARDING_ENDPOINT")
 	if apiEndpoint == "" {
-		apiEndpoint = "http://api-service:8080/v1/event"
+		apiEndpoint = "http://event-broker/keptn"
 	}
 	fmt.Println("Keptn API endpoint: " + apiEndpoint)
 	apiToken := os.Getenv("HTTP_EVENT_ENDPOINT_AUTH_TOKEN")

--- a/distributor/cmd/main.go
+++ b/distributor/cmd/main.go
@@ -75,7 +75,7 @@ func main() {
 const connectionTypeNATS = "nats"
 const connectionTypeHTTP = "http"
 
-const defaultAPIEndpoint = "http://api-service:8080/v1/event"
+const defaultAPIEndpoint = "http://event-broker/keptn"
 
 func _main(args []string, env envConfig) int {
 
@@ -143,8 +143,12 @@ func gotEvent(event cloudevents.Event) error {
 
 	payload, err := event.MarshalJSON()
 	req, err := http.NewRequest("POST", apiEndpoint, bytes.NewBuffer(payload))
-
-	req.Header.Set("Content-Type", "application/json")
+	if apiEndpoint == defaultAPIEndpoint {
+		// if the event goes directly to the cluster-internal event-broker, we need to set the Content-Type header accordingly
+		req.Header.Set("Content-Type", "application/cloudevents+json")
+	} else {
+		req.Header.Set("Content-Type", "application/json")
+	}
 	if apiToken != "" {
 		fmt.Println("Adding x-token header to HTTP request")
 		req.Header.Add("x-token", apiToken)

--- a/distributor/cmd/main.go
+++ b/distributor/cmd/main.go
@@ -106,8 +106,8 @@ func createEventForwardingEndpoint(env envConfig) {
 	ctx := context.Background()
 
 	t, err := cloudeventshttp.New(
-		cloudeventshttp.WithPort(env.Port),
-		cloudeventshttp.WithPath(env.Path),
+		cloudeventshttp.WithPort(8081),
+		cloudeventshttp.WithPath("/event"),
 	)
 
 	if err != nil {


### PR DESCRIPTION
Closes #2220 

The Endpoint can be configured using the env var `HTTP_EVENT_FORWARDING_ENDPOINT`
The API token can be configured using the env var `HTTP_EVENT_ENDPOINT_AUTH_TOKEN`

Further changes:
The env var for configuring the endpoint for polling events via HTTP has been renamed to `HTTP_EVENT_POLLING_ENDPOINT`