### PR TITLE
#2061 Make links in labels clickable

### DIFF
--- a/bridge/client/app/_components/ktb-event-item/ktb-event-item.component.html
+++ b/bridge/client/app/_components/ktb-event-item/ktb-event-item.component.html
@@ -30,7 +30,7 @@
       <p class="bold nobreak m-0 mt-1 mb-1">Labels: </p>
       <dt-tag-list aria-label="affected-entities" (click)="$event.stopPropagation();">
         <dt-tag *ngFor="let tag of _event.data.ProblemDetails.tagsOfAffectedEntities">
-          <span [textContent]="tag.key"></span>:&nbsp;<span [textContent]="tag.value"></span>
+          <span [textContent]="tag.key"></span>:&nbsp;<span *ngIf="!isUrl(tag.value)" [textContent]="tag.value"></span><a [href]="tag.value" target="_blank" *ngIf="isUrl(tag.value)" [textContent]="tag.value"></a>
         </dt-tag>
       </dt-tag-list>
     </div>
@@ -40,7 +40,7 @@
       <p class="bold">Labels: </p>
       <dt-tag-list aria-label="evaluation-labels">
         <dt-tag *ngFor="let label of _event.data.labels | keyvalue">
-          <span [textContent]="label.key"></span>:&nbsp;<span [textContent]="label.value"></span>
+          <span [textContent]="label.key"></span>:&nbsp;<span *ngIf="!isUrl(label.value)" [textContent]="label.value"></span><a [href]="label.value" target="_blank" *ngIf="isUrl(label.value)" [textContent]="label.value"></a>
         </dt-tag>
       </dt-tag-list>
     </div>

--- a/bridge/client/app/_components/ktb-event-item/ktb-event-item.component.ts
+++ b/bridge/client/app/_components/ktb-event-item/ktb-event-item.component.ts
@@ -70,4 +70,14 @@ export class KtbEventItemComponent {
     this.clipboard.copy(plainEvent, 'event payload');
   }
 
+  isUrl(value: string): boolean {
+    var pattern = new RegExp('^(https?:\\/\\/)?'+ // protocol
+      '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.?)+[a-z]{2,}|'+ // domain name
+      '((\\d{1,3}\\.){3}\\d{1,3}))'+ // OR ip (v4) address
+      '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*'+ // port and path
+      '(\\?[;&a-z\\d%_.~+=-]*)?'+ // query string
+      '(\\#[-a-z\\d_]*)?$','i'); // fragment locator
+    return pattern.test(value);
+  }
+
 }

--- a/bridge/client/app/_components/ktb-event-item/ktb-event-item.component.ts
+++ b/bridge/client/app/_components/ktb-event-item/ktb-event-item.component.ts
@@ -71,13 +71,12 @@ export class KtbEventItemComponent {
   }
 
   isUrl(value: string): boolean {
-    var pattern = new RegExp('^(https?:\\/\\/)?'+ // protocol
-      '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.?)+[a-z]{2,}|'+ // domain name
-      '((\\d{1,3}\\.){3}\\d{1,3}))'+ // OR ip (v4) address
-      '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*'+ // port and path
-      '(\\?[;&a-z\\d%_.~+=-]*)?'+ // query string
-      '(\\#[-a-z\\d_]*)?$','i'); // fragment locator
-    return pattern.test(value);
+    try {
+      new URL(value);
+    } catch (_) {
+      return false;  
+    }
+    return true;
   }
 
 }


### PR DESCRIPTION
When the value of a label is an URL, the value is linked and opens in a new tab.
Fixes #2061 