### PR TITLE
Fixed log messages for adding services to the database

### DIFF
--- a/configuration-service/common/projects_materialized_view.go
+++ b/configuration-service/common/projects_materialized_view.go
@@ -185,7 +185,7 @@ func (mv *projectsMaterializedView) CreateService(project string, stage string, 
 			for _, svc := range stg.Services {
 				if svc.ServiceName == service {
 					mv.Logger.Info("Service " + service + " already exists in stage " + stage + " in project " + project)
-					break
+					return nil
 				}
 			}
 			stg.Services = append(stg.Services, &models.ExpandedService{
@@ -197,6 +197,7 @@ func (mv *projectsMaterializedView) CreateService(project string, stage string, 
 			err := mv.updateProject(existingProject)
 			if err != nil {
 				mv.Logger.Error("Could not add service " + service + " to stage " + stage + " in project " + project + ". Could not update project: " + err.Error())
+				return err
 			}
 			mv.Logger.Info("Service " + service + " has been added to stage " + stage + " in project " + project)
 			break

--- a/configuration-service/common/projects_materialized_view.go
+++ b/configuration-service/common/projects_materialized_view.go
@@ -184,6 +184,7 @@ func (mv *projectsMaterializedView) CreateService(project string, stage string, 
 		if stg.StageName == stage {
 			for _, svc := range stg.Services {
 				if svc.ServiceName == service {
+					mv.Logger.Info("Service " + service + " already exists in stage " + stage + " in project " + project)
 					break
 				}
 			}
@@ -197,10 +198,11 @@ func (mv *projectsMaterializedView) CreateService(project string, stage string, 
 			if err != nil {
 				mv.Logger.Error("Could not add service " + service + " to stage " + stage + " in project " + project + ". Could not update project: " + err.Error())
 			}
+			mv.Logger.Info("Service " + service + " has been added to stage " + stage + " in project " + project)
 			break
 		}
 	}
-	mv.Logger.Info("Service " + service + " already exists in stage " + stage + " in project " + project)
+
 	return nil
 }
 


### PR DESCRIPTION
The log messages of the configuration service were misleading. When a service has been added to the materialized view successfully, the logs said that the service already exists. This has been fixed with this PR