### PR TITLE
#2263 update jmeter service to use next-gen events

### DIFF
--- a/installer/manifests/keptn/charts/continuous-delivery/templates/continuous-deployment.yaml
+++ b/installer/manifests/keptn/charts/continuous-delivery/templates/continuous-deployment.yaml
@@ -303,7 +303,7 @@ spec:
             - name: PUBSUB_URL
               value: 'nats://keptn-nats-cluster'
             - name: PUBSUB_TOPIC
-              value: 'sh.keptn.events.deployment-finished'
+              value: 'sh.keptn.event.test.triggered'
             - name: PUBSUB_RECIPIENT
               value: '127.0.0.1'
 ---

--- a/jmeter-service/deploy/service.yaml
+++ b/jmeter-service/deploy/service.yaml
@@ -59,7 +59,7 @@ spec:
           - name: PUBSUB_URL
             value: 'nats://keptn-nats-cluster'
           - name: PUBSUB_TOPIC
-            value: 'sh.keptn.events.deployment-finished'
+            value: 'sh.keptn.event.test.triggered'
           - name: PUBSUB_RECIPIENT
             value: '127.0.0.1'
 ---

--- a/jmeter-service/go.mod
+++ b/jmeter-service/go.mod
@@ -7,5 +7,5 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/uuid v1.1.1
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.6.3-0.20200909085330-1ec9ad2c6889
+	github.com/keptn/go-utils v0.6.3-0.20200908082455-010bbcf95e6f
 )

--- a/jmeter-service/go.mod
+++ b/jmeter-service/go.mod
@@ -7,5 +7,5 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/uuid v1.1.1
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.6.3-0.20200908082455-010bbcf95e6f
+	github.com/keptn/go-utils v0.6.3-0.20200909085330-1ec9ad2c6889
 )

--- a/jmeter-service/go.sum
+++ b/jmeter-service/go.sum
@@ -166,6 +166,8 @@ github.com/keptn/go-utils v0.6.3-0.20200907143311-189e0ad20c27 h1:xSeigps+hb52Ml
 github.com/keptn/go-utils v0.6.3-0.20200907143311-189e0ad20c27/go.mod h1:jD+ZvrkwYyDMgeKANzVZsBSYgjYQxTJvxw/RB3vYFAE=
 github.com/keptn/go-utils v0.6.3-0.20200908082455-010bbcf95e6f h1:YU/mwHVC5wrtjxe1H96VkGCr/9JeleZZZ73P9Pj/zYo=
 github.com/keptn/go-utils v0.6.3-0.20200908082455-010bbcf95e6f/go.mod h1:jD+ZvrkwYyDMgeKANzVZsBSYgjYQxTJvxw/RB3vYFAE=
+github.com/keptn/go-utils v0.6.3-0.20200909085330-1ec9ad2c6889 h1:2xuW6KjoE7KpC/XqD3fGlZtdqvkFWhC3h/YgVSTK96k=
+github.com/keptn/go-utils v0.6.3-0.20200909085330-1ec9ad2c6889/go.mod h1:jD+ZvrkwYyDMgeKANzVZsBSYgjYQxTJvxw/RB3vYFAE=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=

--- a/jmeter-service/main_test.go
+++ b/jmeter-service/main_test.go
@@ -1,23 +1,20 @@
 package main
 
 import (
+	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 	"log"
 	"net/url"
 	"reflect"
 	"testing"
-
-	keptnevents "github.com/keptn/go-utils/pkg/lib"
 )
 
 var serviceURLTests = []struct {
 	name  string
-	event keptnevents.DeploymentFinishedEventData
+	event keptnv2.TestTriggeredEventData
 	url   *url.URL
 }{
 	{"local", deploymentFinishedEventInitHelper("sockshop", "carts", "dev", "direct", "https://carts.sockshop-dev.svc.cluster.local/test", "carts.sockshop-dev.mydomain.com"), getURL("https://carts.sockshop-dev.svc.cluster.local/test")},
 	{"public", deploymentFinishedEventInitHelper("sockshop", "carts", "dev", "direct", "", "http://carts.sockshop-dev.mydomain.com:8080/myendpoint"), getURL("http://carts.sockshop-dev.mydomain.com:8080/myendpoint")},
-	{"educatedGuessDirect", deploymentFinishedEventInitHelper("sockshop", "carts", "dev", "direct", "", ""), getURL("http://carts.sockshop-dev/health")},
-	{"educatedGuessBG", deploymentFinishedEventInitHelper("sockshop", "carts", "dev", "blue_green_service", "", ""), getURL("http://carts-canary.sockshop-dev/health")},
 }
 
 func getURL(urlString string) *url.URL {
@@ -29,8 +26,21 @@ func getURL(urlString string) *url.URL {
 }
 
 func deploymentFinishedEventInitHelper(project, service, stage, deploymentStrategy,
-	deploymentURILocal, deploymentURIPublic string) keptnevents.DeploymentFinishedEventData {
-	return keptnevents.DeploymentFinishedEventData{Project: project, Service: service, Stage: stage, DeploymentStrategy: deploymentStrategy, DeploymentURILocal: deploymentURILocal, DeploymentURIPublic: deploymentURIPublic}
+	deploymentURILocal, deploymentURIPublic string) keptnv2.TestTriggeredEventData {
+	return keptnv2.TestTriggeredEventData{
+		EventData: keptnv2.EventData{
+			Project: project,
+			Service: service,
+			Stage:   stage,
+		},
+		Deployment: struct {
+			DeploymentURIsLocal  []string `json:"deploymentURIsLocal,omitempty"`
+			DeploymentURIsPublic []string `json:"deploymentURIsPublic,omitempty"`
+		}{
+			DeploymentURIsLocal:  []string{deploymentURILocal},
+			DeploymentURIsPublic: []string{deploymentURIPublic},
+		},
+	}
 }
 
 func TestGetServiceURL(t *testing.T) {


### PR DESCRIPTION
Closes #2263 

WIth this PR, the jmeter-service will send sh.keptn.event.test.started events whenever a test is being executed, and a sh.keptn.event.test.finished when it is finished.
Instead of listening to sh.keptn.events.deployment-finished events it now listens to sh.keptn.event.test.triggered events