### PR TITLE
#2325 Remove anything scheme related to let swagger automatically determine the scheme

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -51,7 +51,6 @@ COPY --from=builder /go/src/github.com/keptn/keptn/api/service_model.yaml /swagg
 COPY --from=builder /go/src/github.com/keptn/keptn/api/configure_model.yaml /swagger-ui/configure_model.yaml
 
 RUN sed -i "s|basePath: /v1|basePath: /api/v1 |g" /swagger-ui/swagger.yaml
-RUN sed -i '/schemes:/a\ \ - https' /swagger-ui/swagger.yaml
 
 EXPOSE 8080
 

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -3,8 +3,6 @@ swagger: "2.0"
 info:
   title: keptn api
   version: develop
-schemes:
-  - http
 basePath: /v1
 consumes:
   - application/json

--- a/configuration-service/Dockerfile
+++ b/configuration-service/Dockerfile
@@ -54,7 +54,6 @@ COPY --from=builder /go/src/github.com/keptn/keptn/configuration-service/swagger
 COPY --from=builder /go/src/github.com/keptn/keptn/configuration-service/swagger.yaml /swagger-ui/swagger.yaml
 # Replace contents for api proxy
 RUN sed -i "s|basePath: /v1|basePath: /api/configuration-service/v1 |g" /swagger-ui/swagger.yaml
-RUN sed -i '/schemes:/a\ \ - https' /swagger-ui/swagger.yaml
 RUN sed -i '/paths:/i securityDefinitions:\n  key:\n    type: apiKey\n    in: header\n    name: x-token\nsecurity:\n  - key: []\n' /swagger-ui/swagger.yaml
 
 EXPOSE 8080

--- a/configuration-service/swagger.yaml
+++ b/configuration-service/swagger.yaml
@@ -11,9 +11,6 @@ consumes:
   - application/cloudevents+json
   - application/json
 
-schemes:
-  - http
-
 definitions:
   Error:
     type: object

--- a/mongodb-datastore/Dockerfile
+++ b/mongodb-datastore/Dockerfile
@@ -49,7 +49,6 @@ COPY --from=builder /go/src/github.com/keptn/keptn/mongodb-datastore/swagger.yam
 COPY --from=builder /go/src/github.com/keptn/keptn/mongodb-datastore/swagger.yaml /swagger-ui/swagger.yaml
 # Replace contents for api proxy
 RUN sed -i "s|basePath: /|basePath: /api/mongodb-datastore |g" /swagger-ui/swagger.yaml
-RUN sed -i '/schemes:/a\ \ - https' /swagger-ui/swagger.yaml
 RUN sed -i '/paths:/i securityDefinitions:\n  key:\n    type: apiKey\n    in: header\n    name: x-token\nsecurity:\n  - key: []\n' /swagger-ui/swagger.yaml
 
 EXPOSE 8080

--- a/mongodb-datastore/swagger.yaml
+++ b/mongodb-datastore/swagger.yaml
@@ -3,8 +3,6 @@ swagger: '2.0'
 info:
   title: mongodb-datastore
   version: 0.1.0
-schemes:
-  - http
 basePath: /
 consumes:
   - application/cloudevents+json


### PR DESCRIPTION
Fixes #2328 
This PR drops `scheme` from swagger.yaml, as well as from the docker builds.

This allows swagger-ui to automatically determine the correct scheme by using the scheme that is used to access swagger-ui.
