### PR TITLE
#2319 Added functionality to show a download link to Keptn Bridge CLI

### DIFF
--- a/bridge/README.md
+++ b/bridge/README.md
@@ -82,7 +82,7 @@ kubectl delete -f deploy/bridge.yaml
    API_TOKEN=1234-exam-ple
    ```
    **Note**: On Windows, use `set API_...=...`. On Linux, use `export API_...=...`
-1. Run `npm start:dev` to start the express server and the Angular app.
+1. Run `npm run start:dev` to start the express server and the Angular app.
 1. Access the web through the url shown on the console (e.g., http://localhost:3000/ ).
 
 ## Production deployment

--- a/bridge/client/app/_services/api.service.ts
+++ b/bridge/client/app/_services/api.service.ts
@@ -31,7 +31,7 @@ export class ApiService {
   }
 
   public getKeptnInfo(): Observable<any> {
-    let url = `${this._baseUrl}/`;
+    let url = `${this._baseUrl}/bridgeInfo`;
     return this.http
       .get<any>(url, { headers: this.defaultHeaders })
   }

--- a/bridge/client/app/app-header/app-header.component.html
+++ b/bridge/client/app/app-header/app-header.component.html
@@ -22,7 +22,7 @@
   <div class="mt-1" fxLayout="row" fxLayoutAlign="flex-start center" *ngIf="keptnInfo?.bridgeInfo?.cliDownloadLink">
     <div fxFlex>
       <p class="m-0 mr-2 nobreak">
-        <a [attr.href]="keptnInfo.bridgeInfo.cliDownloadLink" rel="noopener noreferrer" target="_blank">Download keptn CLI</a></p>
+        <a [attr.href]="keptnInfo.bridgeInfo.cliDownloadLink" rel="noopener noreferrer" target="_blank">Download Keptn CLI</a></p>
     </div>
   </div>
   <div class="mt-1" fxLayout="row" fxLayoutAlign="flex-start center" *ngIf="keptnInfo?.bridgeInfo?.apiToken">

--- a/bridge/client/app/app-header/app-header.component.html
+++ b/bridge/client/app/app-header/app-header.component.html
@@ -19,6 +19,12 @@
 </dt-top-bar-navigation>
 <dt-context-dialog #dialog aria-label="User menu" ariaLabelClose="Close user menu">
   <h3 class="m-0">Get started</h3>
+  <div class="mt-1" fxLayout="row" fxLayoutAlign="flex-start center" *ngIf="keptnInfo?.bridgeInfo?.cliDownloadLink">
+    <div fxFlex>
+      <p class="m-0 mr-2 nobreak">
+        <a [attr.href]="keptnInfo.bridgeInfo.cliDownloadLink" rel="noopener noreferrer" target="_blank">Download keptn CLI</a></p>
+    </div>
+  </div>
   <div class="mt-1" fxLayout="row" fxLayoutAlign="flex-start center" *ngIf="keptnInfo?.bridgeInfo?.apiToken">
     <div fxFlex>
       <p class="m-0 mr-2 nobreak">API token</p>
@@ -32,7 +38,7 @@
   </div>
   <div class="mt-1" fxLayout="row" fxLayoutAlign="flex-start center" *ngIf="keptnInfo?.bridgeInfo?.authCommand">
     <div fxFlex>
-      <p class="m-0 mr-2 nobreak"><a href="https://keptn.sh/docs/0.7.x/reference/cli/commands/keptn_auth/" target="_blank">keptn auth</a> command</p>
+      <p class="m-0 mr-2 nobreak"><a href="https://keptn.sh/docs/0.7.x/reference/cli/commands/keptn_auth/" rel="noopener noreferrer" target="_blank">keptn auth</a> command</p>
     </div>
     <div>
       <dt-copy-to-clipboard>

--- a/bridge/deploy/bridge.yaml
+++ b/bridge/deploy/bridge.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: bridge
-  namespace: keptn
+  namespace: keptndev
   labels:
     app.kubernetes.io/name: bridge
     app.kubernetes.io/instance: keptn

--- a/bridge/deploy/bridge.yaml
+++ b/bridge/deploy/bridge.yaml
@@ -38,6 +38,8 @@ spec:
              secretKeyRef:
                name: keptn-api-token
                key: keptn-api-token
+         - name: CLI_DOWNLOAD_LINK
+           value: "https://github.com/keptn/keptn/releases/tag/0.7.1"
         envFrom:
           - secretRef:
               name: bridge-credentials

--- a/bridge/package-lock.json
+++ b/bridge/package-lock.json
@@ -3119,6 +3119,14 @@
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "dev": true
+            }
           }
         },
         "loader-utils": {
@@ -4132,6 +4140,14 @@
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "dev": true
+            }
           }
         },
         "loader-utils": {
@@ -5783,6 +5799,14 @@
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "dev": true
+            }
           }
         },
         "loader-utils": {
@@ -9590,6 +9614,14 @@
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "dev": true
+            }
           }
         },
         "loader-utils": {
@@ -10053,6 +10085,14 @@
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "dev": true
+            }
           }
         },
         "loader-utils": {
@@ -11009,9 +11049,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
       }
@@ -11723,6 +11763,14 @@
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "dev": true
+            }
           }
         },
         "loader-utils": {
@@ -12560,6 +12608,14 @@
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "dev": true
+            }
           }
         },
         "loader-utils": {
@@ -13087,6 +13143,14 @@
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "dev": true
+            }
           }
         },
         "loader-utils": {
@@ -13855,6 +13919,14 @@
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "dev": true
+            }
           }
         },
         "loader-utils": {
@@ -14357,6 +14429,14 @@
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "dev": true
+            }
           }
         },
         "loader-utils": {
@@ -14453,6 +14533,14 @@
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "dev": true
+            }
           }
         },
         "loader-utils": {
@@ -15930,6 +16018,14 @@
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "dev": true
+            }
           }
         },
         "loader-utils": {
@@ -16606,6 +16702,14 @@
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "dev": true
+            }
           }
         },
         "loader-utils": {

--- a/bridge/server/api/index.js
+++ b/bridge/server/api/index.js
@@ -5,7 +5,8 @@ const https = require('https');
 const router = express.Router();
 
 module.exports = (params) => {
-  const { apiUrl, apiToken } = params;
+  // fetch parameters for bridgeInfo endpoint
+  const { apiUrl, apiToken, cliDownloadLink } = params;
   const bridgeVersion = process.env.VERSION;
 
   // accepts self-signed ssl certificate
@@ -13,9 +14,10 @@ module.exports = (params) => {
     rejectUnauthorized: false
   });
 
-  router.get('/', async (req, res, next) => {
+  // bridgeInfo endpoint: Provide certain metadata for Bridge
+  router.get('/bridgeInfo', async (req, res, next) => {
     try {
-      return res.json({ bridgeVersion, apiUrl, apiToken });
+      return res.json({ bridgeVersion, apiUrl, apiToken, cliDownloadLink });
     } catch (err) {
       return next(err);
     }

--- a/bridge/server/app.js
+++ b/bridge/server/app.js
@@ -9,10 +9,16 @@ const apiRouter = require('./api');
 const app = express();
 let apiUrl = process.env.API_URL;
 let apiToken = process.env.API_TOKEN;
+let cliDownloadLink = process.env.CLI_DOWNLOAD_LINK;
 
 if(!apiToken) {
   console.log("API_TOKEN was not provided. Fetching from kubectl.");
   apiToken = Buffer.from(execSync('kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token}').toString(), 'base64').toString();
+}
+
+if (!cliDownloadLink) {
+  console.log("CLI Download Link was not provided, defaulting to github.com/keptn/keptn releases")
+  cliDownloadLink = "https://github.com/keptn/keptn/releases"
 }
 
 // host static files (angular app)
@@ -50,7 +56,7 @@ if (process.env.BASIC_AUTH_USERNAME && process.env.BASIC_AUTH_PASSWORD) {
 
 
 // everything starting with /api is routed to the api implementation
-app.use('/api', apiRouter({ apiUrl, apiToken }));
+app.use('/api', apiRouter({ apiUrl, apiToken, cliDownloadLink }));
 
 // fallback: go to index.html
 app.use((req, res, next) => {

--- a/installer/manifests/keptn/charts/control-plane/templates/core.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/core.yaml
@@ -168,6 +168,8 @@ spec:
                 secretKeyRef:
                   name: keptn-api-token
                   key: keptn-api-token
+            - name: CLI_DOWNLOAD_LINK
+              value: "https://github.com/keptn/keptn/releases/tag/0.7.1"
           envFrom:
             - secretRef:
                 name: bridge-credentials

--- a/installer/manifests/keptn/charts/control-plane/templates/core.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/core.yaml
@@ -169,7 +169,7 @@ spec:
                   name: keptn-api-token
                   key: keptn-api-token
             - name: CLI_DOWNLOAD_LINK
-              value: "https://github.com/keptn/keptn/releases/tag/0.7.1"
+              value: {{ .Values.bridge.cliDownloadLink | default (print "https://github.com/keptn/keptn/releases/tag/" .Chart.AppVersion) }}
           envFrom:
             - secretRef:
                 name: bridge-credentials


### PR DESCRIPTION
This PR introduces a download-link for Keptn CLI.

In addition, I added the `rel="noopener noreferrer"` in the app-header component.

Other changes:
* Updated `deploy.yaml` with the download link
* Updated bridge installer manifest to also contain the download link to the github releases page based on appVersion
* Moved the `index` api endpoint of `bridge/api/` to `bridge/api/bridgeInfo` (this goes along with what it is called in the Angular UI)
* Whatever has been done to the package.lock.json is beyond my knowledge

![image](https://user-images.githubusercontent.com/56065213/93080635-4e706880-f68e-11ea-953f-1232a88efa0c.png)

