### PR TITLE
#2295 Increase password and token entropy

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/charts/mongodb/templates/secret.yaml
+++ b/installer/manifests/keptn/charts/control-plane/charts/mongodb/templates/secret.yaml
@@ -10,7 +10,7 @@
 {{- end -}}
 
 
-{{- $mongoAdminPassword := (randAlphaNum 20) | b64enc | quote }}
+{{- $mongoAdminPassword := (randAlphaNum 45) | b64enc | quote }}
 {{- if $mongosecret }}
 {{- $mongoAdminPassword = index $mongosecret.data "admin_password" }}
 {{- end -}}

--- a/installer/manifests/keptn/charts/control-plane/templates/core.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/core.yaml
@@ -1,10 +1,10 @@
-{{- $apiToken := (randAlphaNum 20) | b64enc | quote }}
+{{- $apiToken := (randAlphaNum 45) | b64enc | quote }}
 {{- $apisecret := (lookup "v1" "Secret" .Release.Namespace "keptn-api-token") }}
 {{- if $apisecret }}
 {{- $apiToken = index $apisecret.data "keptn-api-token" }}
 {{- end -}}
 
-{{- $bridgePassword := (randAlphaNum 16) | b64enc | quote }}
+{{- $bridgePassword := (randAlphaNum 20) | b64enc | quote }}
 {{- $bridgesecret := (lookup "v1" "Secret" .Release.Namespace "bridge-credentials") }}
 {{- if $bridgesecret }}
 {{- $bridgePassword = index $bridgesecret.data "BASIC_AUTH_PASSWORD" }}


### PR DESCRIPTION
This PR increases the entropy of the api-token to >= 256 bit (Calculation: 62 possible characters (so almost 6 bit), 45 places -> 45 * 6 = 270 bit)

Also, I've increased the entropy of the mongo db admin password (I believe that's also one of those that can benefit)