### PR TITLE
#2354 use safe operator for access to getShortImageName()

### DIFF
--- a/bridge/client/app/_components/ktb-event-item/ktb-event-item.component.html
+++ b/bridge/client/app/_components/ktb-event-item/ktb-event-item.component.html
@@ -51,7 +51,7 @@
     <table>
       <tr>
         <td><p class="m-0">Currently deployed artifact: </p></td>
-        <td><p class="m-0" [textContent]="project.getLatestDeployment(project.getService(_event.data.service), project.getStage(_event.data.stage)).getShortImageName()"></p></td>
+        <td><p class="m-0" [textContent]="project.getLatestDeployment(project.getService(_event.data.service), project.getStage(_event.data.stage))?.getShortImageName() || 'N/A'"></p></td>
       </tr>
       <tr>
         <td><p class="m-0">Deployable artifact: </p></td>


### PR DESCRIPTION
use safe operator for access to getShortImageName() on currently deployed artifact and show 'N/A' if no image deployed yet

fixes #2354 