### PR TITLE
Remove credentials before storing event

### DIFF
--- a/mongodb-datastore/handlers/events.go
+++ b/mongodb-datastore/handlers/events.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/mitchellh/mapstructure"
 	"strconv"
 	"sync"
 	"time"
@@ -100,6 +101,21 @@ func ProcessEvent(event *models.KeptnContextExtendedCE) error {
 
 	if event.Type == keptnutils.InternalProjectDeleteEventType {
 		return dropProjectEvents(logger, event)
+	}
+	if event.Type == keptnutils.InternalProjectCreateEventType {
+		createProjectData := &keptnutils.ProjectCreateEventData{}
+		err := mapstructure.Decode(event.Data, createProjectData)
+		if err != nil {
+			logger.Error("Could not decode project.create event: " + err.Error())
+			return err
+		}
+		if createProjectData.GitToken != "" {
+			createProjectData.GitToken = ""
+		}
+		if createProjectData.GitUser != "" {
+			createProjectData.GitUser = ""
+		}
+		event.Data = createProjectData
 	}
 	return insertEvent(logger, event)
 }

--- a/mongodb-datastore/handlers/events.go
+++ b/mongodb-datastore/handlers/events.go
@@ -103,6 +103,7 @@ func ProcessEvent(event *models.KeptnContextExtendedCE) error {
 		return dropProjectEvents(logger, event)
 	}
 	if event.Type == keptnutils.InternalProjectCreateEventType {
+
 		createProjectData := &keptnutils.ProjectCreateEventData{}
 		err := mapstructure.Decode(event.Data, createProjectData)
 		if err != nil {
@@ -115,7 +116,13 @@ func ProcessEvent(event *models.KeptnContextExtendedCE) error {
 		if createProjectData.GitUser != "" {
 			createProjectData.GitUser = ""
 		}
-		event.Data = createProjectData
+		marshal, err := json.Marshal(createProjectData)
+		var data interface{}
+		err = json.Unmarshal(marshal, &data)
+		if err != nil {
+			return err
+		}
+		event.Data = data
 	}
 	return insertEvent(logger, event)
 }


### PR DESCRIPTION
When a project is created, an internal event is sent by the API. This event also contains the git user and git token of the user, which should not be persisted. Therefore, this PR introduces a check for that specific event type in the mongodb-datastore, which makes sure that those properties are not persisted by removing them from the incoming payload