### PR TITLE
#2257 Hide api token and keptn auth command

### DIFF
--- a/bridge/client/app/_components/ktb-copy-to-clipboard/ktb-copy-to-clipboard.component.html
+++ b/bridge/client/app/_components/ktb-copy-to-clipboard/ktb-copy-to-clipboard.component.html
@@ -1,0 +1,14 @@
+<div class="mt-1" fxLayout="row" fxLayoutAlign="flex-start center">
+  <div>
+    <input class="copy-to-clipboard-label" dtInput [value]="label" [disabled]="true" />
+  </div>
+  <div>
+    <dt-copy-to-clipboard>
+      <input class="copy-to-clipboard-input" dtInput [value]="value" />
+      <dt-copy-to-clipboard-label><dt-icon [name]="'duplicate'"></dt-icon></dt-copy-to-clipboard-label>
+    </dt-copy-to-clipboard>
+  </div>
+  <div>
+    <button class="ml-2" dt-icon-button variant="secondary" (click)="visible=!visible"><dt-icon *ngIf="visible" [name]="'overview'"></dt-icon><dt-icon *ngIf="!visible" [name]="'dont-watch'"></dt-icon></button>
+  </div>
+</div>

--- a/bridge/client/app/_components/ktb-copy-to-clipboard/ktb-copy-to-clipboard.component.scss
+++ b/bridge/client/app/_components/ktb-copy-to-clipboard/ktb-copy-to-clipboard.component.scss
@@ -1,0 +1,27 @@
+@import '../../../variables';
+@import '~@dynatrace/barista-components/core/src/style/variables';
+
+.ktb-copy-to-clipboard {
+  .copy-to-clipboard-input {
+    display: none;
+  }
+
+  &.ktb-copy-input-visible {
+    .copy-to-clipboard-label {
+      display: none;
+    }
+    .copy-to-clipboard-input {
+      display: block;
+    }
+  }
+}
+
+.dt-copy-to-clipboard-btn-button {
+  min-width: 10px !important;
+  padding: 0px 6px;
+
+  .dt-icon {
+    width: 20px;
+    fill: $white;
+  }
+}

--- a/bridge/client/app/_components/ktb-copy-to-clipboard/ktb-copy-to-clipboard.component.spec.ts
+++ b/bridge/client/app/_components/ktb-copy-to-clipboard/ktb-copy-to-clipboard.component.spec.ts
@@ -1,0 +1,28 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import {KtbCopyToClipboardComponent, KtbExpandableTileHeader} from './ktb-copy-to-clipboard.component';
+import {AppModule} from '../../app.module';
+import {HttpClientTestingModule} from "@angular/common/http/testing";
+
+describe('KtbExpandableTileComponent', () => {
+  let component: KtbCopyToClipboardComponent;
+  let fixture: ComponentFixture<KtbCopyToClipboardComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+      ],
+      imports: [
+        AppModule,
+        HttpClientTestingModule,
+      ],
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(KtbCopyToClipboardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+});

--- a/bridge/client/app/_components/ktb-copy-to-clipboard/ktb-copy-to-clipboard.component.spec.ts
+++ b/bridge/client/app/_components/ktb-copy-to-clipboard/ktb-copy-to-clipboard.component.spec.ts
@@ -1,6 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
-import {KtbCopyToClipboardComponent, KtbExpandableTileHeader} from './ktb-copy-to-clipboard.component';
+import {KtbCopyToClipboardComponent} from './ktb-copy-to-clipboard.component';
 import {AppModule} from '../../app.module';
 import {HttpClientTestingModule} from "@angular/common/http/testing";
 

--- a/bridge/client/app/_components/ktb-copy-to-clipboard/ktb-copy-to-clipboard.component.ts
+++ b/bridge/client/app/_components/ktb-copy-to-clipboard/ktb-copy-to-clipboard.component.ts
@@ -1,0 +1,33 @@
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  Directive,
+  Input,
+  OnInit,
+  ViewEncapsulation
+} from '@angular/core';
+
+@Component({
+  selector: 'ktb-copy-to-clipboard',
+  templateUrl: './ktb-copy-to-clipboard.component.html',
+  styleUrls: ['./ktb-copy-to-clipboard.component.scss'],
+  host: {
+    class: 'ktb-copy-to-clipboard',
+    '[attr.aria-visible]': 'visible',
+    '[class.ktb-copy-input-visible]': 'visible',
+  },
+  encapsulation: ViewEncapsulation.None,
+  preserveWhitespaces: false,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class KtbCopyToClipboardComponent {
+
+  @Input() public value: string;
+  @Input() public label: string;
+
+  public visible: boolean = false;
+
+  constructor(private _changeDetectorRef: ChangeDetectorRef) {}
+
+}

--- a/bridge/client/app/app-header/app-header.component.html
+++ b/bridge/client/app/app-header/app-header.component.html
@@ -26,6 +26,7 @@
     </div>
   </div>
   <div class="mt-2 mb-2" *ngIf="keptnInfo?.bridgeInfo?.showApiToken">
+    <a class="mt-1 mb-2" [href]="keptnInfo.bridgeInfo.apiUrl" rel="noopener noreferrer" target="_blank">Keptn API</a>
     <div class="mt-1">
       <ktb-copy-to-clipboard [value]="keptnInfo.bridgeInfo.apiToken" [label]="'Keptn API token'"></ktb-copy-to-clipboard>
     </div>

--- a/bridge/client/app/app-header/app-header.component.html
+++ b/bridge/client/app/app-header/app-header.component.html
@@ -34,7 +34,7 @@
     </div>
   </div>
   <hr/>
-  <div class="mt-2 mb-3" fxLayout="row" fxLayoutAlign="flex-start center" *ngIf="keptnInfo?.bridgeInfo?.showApiToken && !keptnInfo.versionCheckEnabled">
+  <div class="mt-2 mb-3" fxLayout="row" fxLayoutAlign="flex-start center" *ngIf="keptnInfo?.bridgeInfo?.enableVersionCheckFeature && !keptnInfo.versionCheckEnabled">
     <dt-icon class="error" [name]="'criticalevent'"></dt-icon>
     <p class="small m-0">Automatic version and security check disabled</p>
   </div>

--- a/bridge/client/app/app-header/app-header.component.html
+++ b/bridge/client/app/app-header/app-header.component.html
@@ -26,31 +26,15 @@
     </div>
   </div>
   <div class="mt-2 mb-2" *ngIf="keptnInfo?.bridgeInfo?.showApiToken">
-    <div class="mt-1" fxLayout="row" fxLayoutAlign="flex-start center">
-      <div fxFlex>
-        <p class="m-0 mr-2 nobreak">API token</p>
-      </div>
-      <div>
-        <dt-copy-to-clipboard>
-          <input dtInput [value]="keptnInfo.bridgeInfo.apiToken" aria-label="Keptn API token" />
-          <dt-copy-to-clipboard-label>Copy</dt-copy-to-clipboard-label>
-        </dt-copy-to-clipboard>
-      </div>
+    <div class="mt-1">
+      <ktb-copy-to-clipboard [value]="keptnInfo.bridgeInfo.apiToken" [label]="'Keptn API token'"></ktb-copy-to-clipboard>
     </div>
-    <div class="mt-1" fxLayout="row" fxLayoutAlign="flex-start center">
-      <div fxFlex>
-        <p class="m-0 mr-2 nobreak"><a href="https://keptn.sh/docs/0.7.x/reference/cli/commands/keptn_auth/" rel="noopener noreferrer" target="_blank">keptn auth</a> command</p>
-      </div>
-      <div>
-        <dt-copy-to-clipboard>
-          <input dtInput [value]="keptnInfo.bridgeInfo.authCommand" aria-label="keptn auth command" />
-          <dt-copy-to-clipboard-label>Copy</dt-copy-to-clipboard-label>
-        </dt-copy-to-clipboard>
-      </div>
+    <div class="mt-1">
+      <ktb-copy-to-clipboard [value]="keptnInfo.bridgeInfo.authCommand" [label]="'keptn auth command'"></ktb-copy-to-clipboard>
     </div>
   </div>
   <hr/>
-  <div class="mt-2 mb-3" fxLayout="row" fxLayoutAlign="flex-start center" *ngIf="!keptnInfo.versionCheckEnabled">
+  <div class="mt-2 mb-3" fxLayout="row" fxLayoutAlign="flex-start center" *ngIf="keptnInfo?.bridgeInfo?.showApiToken && !keptnInfo.versionCheckEnabled">
     <dt-icon class="error" [name]="'criticalevent'"></dt-icon>
     <p class="small m-0">Automatic version and security check disabled</p>
   </div>

--- a/bridge/client/app/app-header/app-header.component.scss
+++ b/bridge/client/app/app-header/app-header.component.scss
@@ -43,15 +43,10 @@ dt-top-bar-navigation {
     color: lighten($primary-color, 55%);
   }
 
-  .dt-icon {
+  .dt-icon.error {
     width: 20px;
     height: 20px;
     fill: $error-color;
-  }
-
-  .dt-copy-to-clipboard-btn-button {
-    min-width: 50px !important;
-    padding: 0px 6px;
   }
 }
 

--- a/bridge/client/app/app.module.ts
+++ b/bridge/client/app/app.module.ts
@@ -59,6 +59,7 @@ import { KtbSliBreakdownComponent } from './_components/ktb-sli-breakdown/ktb-sl
 import { KtbHideHttpLoadingDirective } from './_directives/ktb-hide-http-loading/ktb-hide-http-loading.directive';
 import { KtbShowHttpLoadingDirective } from './_directives/ktb-show-http-loading/ktb-show-http-loading.directive';
 import { KtbApprovalItemComponent } from "./_components/ktb-approval-item/ktb-approval-item.component";
+import {KtbCopyToClipboardComponent} from "./_components/ktb-copy-to-clipboard/ktb-copy-to-clipboard.component";
 
 import { HttpErrorInterceptor } from './_interceptors/http-error-interceptor';
 import { HttpLoadingInterceptor } from './_interceptors/http-loading-interceptor';
@@ -101,6 +102,7 @@ registerLocaleData(localeEn, 'en');
     KtbSliBreakdownComponent,
     KtbNotificationBarComponent,
     KtbApprovalItemComponent,
+    KtbCopyToClipboardComponent,
   ],
   imports: [
     BrowserModule,


### PR DESCRIPTION
The api token and keptn auth command are now initially hidden and only a label is visible. By clicking on the toggle button, you can see the value, but the copy button still works in visible or hidden state.

![image](https://user-images.githubusercontent.com/6098219/93467539-21ba8c00-f8ee-11ea-92ef-dbbede0d1e55.png)
