### PR TITLE
#1335 show git upstream link in project overview or info how to update project

### DIFF
--- a/bridge/client/app/_components/ktb-project-tile/ktb-project-tile.component.html
+++ b/bridge/client/app/_components/ktb-project-tile/ktb-project-tile.component.html
@@ -4,7 +4,7 @@
     <p class="mt-0 mb-2" *ngIf="project.stages"><span [textContent]="project.stages.length"></span> Stages, <span [textContent]="project.getServices().length"></span> Services</p>
     <p class="mt-0 mb-2" *ngIf="project.gitRemoteURI"><a [href]="project.gitRemoteURI" [textContent]="project.gitRemoteURI" target="_blank" (click)="$event.stopPropagation()"></a></p>
     <div class="mb-2" fxLayout="row" fxLayoutAlign="flex-start center" *ngIf="!project.gitRemoteURI">
-      <dt-icon class="error mr-1" [name]="'information'"></dt-icon>
+      <dt-icon class="info mr-1" [name]="'information'"></dt-icon>
       <p class="small m-0">No Git upstream configured. Please use <br/><a href="https://keptn.sh/docs/0.7.x/reference/cli/commands/keptn_update_project/" target="_blank" (click)="$event.stopPropagation()">keptn update project</a> to set a Git upstream.</p>
     </div>
   </dt-tile-subtitle>

--- a/bridge/client/app/_components/ktb-project-tile/ktb-project-tile.component.html
+++ b/bridge/client/app/_components/ktb-project-tile/ktb-project-tile.component.html
@@ -5,7 +5,7 @@
     <p class="mt-0 mb-2" *ngIf="project.gitRemoteURI"><a [href]="project.gitRemoteURI" [textContent]="project.gitRemoteURI" target="_blank" (click)="$event.stopPropagation()"></a></p>
     <div class="mb-2" fxLayout="row" fxLayoutAlign="flex-start center" *ngIf="!project.gitRemoteURI">
       <dt-icon class="info mr-1" [name]="'information'"></dt-icon>
-      <p class="small m-0">No Git upstream configured. Please use <br/><a href="https://keptn.sh/docs/0.7.x/reference/cli/commands/keptn_update_project/" target="_blank" rel="noopener noreferrer" (click)="$event.stopPropagation()">keptn update project</a> to set a Git upstream.</p>
+      <p class="small m-0">No Git upstream configured. <br/>Please use <a href="https://keptn.sh/docs/0.7.x/reference/cli/commands/keptn_update_project/" target="_blank" rel="noopener noreferrer" (click)="$event.stopPropagation()">keptn update project</a> to set a Git upstream.</p>
     </div>
   </dt-tile-subtitle>
   <dt-tag-list aria-label="stages">

--- a/bridge/client/app/_components/ktb-project-tile/ktb-project-tile.component.html
+++ b/bridge/client/app/_components/ktb-project-tile/ktb-project-tile.component.html
@@ -1,6 +1,13 @@
 <dt-tile [id]="project.projectName" [routerLink]="['/project', project.projectName]" *ngIf="project">
   <dt-tile-title [textContent]="project.projectName"></dt-tile-title>
-  <dt-tile-subtitle><span *ngIf="project.stages"><span [textContent]="project.stages.length"></span> Stages, <span [textContent]="project.getServices().length"></span> Services</span></dt-tile-subtitle>
+  <dt-tile-subtitle>
+    <p class="mt-0 mb-2" *ngIf="project.stages"><span [textContent]="project.stages.length"></span> Stages, <span [textContent]="project.getServices().length"></span> Services</p>
+    <p class="mt-0 mb-2" *ngIf="project.gitRemoteURI"><a [href]="project.gitRemoteURI" [textContent]="project.gitRemoteURI" target="_blank" (click)="$event.stopPropagation()"></a></p>
+    <div class="mb-2" fxLayout="row" fxLayoutAlign="flex-start center" *ngIf="!project.gitRemoteURI">
+      <dt-icon class="error mr-1" [name]="'information'"></dt-icon>
+      <p class="small m-0">No Git upstream configured. Please use <br/><a href="https://keptn.sh/docs/0.7.x/reference/cli/commands/keptn_update_project/" target="_blank" (click)="$event.stopPropagation()">keptn update project</a> to set a Git upstream.</p>
+    </div>
+  </dt-tile-subtitle>
   <dt-tag-list aria-label="stages">
     <dt-tag *ngFor="let stage of project.stages" [textContent]="stage.stageName"></dt-tag>
   </dt-tag-list>

--- a/bridge/client/app/_components/ktb-project-tile/ktb-project-tile.component.html
+++ b/bridge/client/app/_components/ktb-project-tile/ktb-project-tile.component.html
@@ -5,7 +5,7 @@
     <p class="mt-0 mb-2" *ngIf="project.gitRemoteURI"><a [href]="project.gitRemoteURI" [textContent]="project.gitRemoteURI" target="_blank" (click)="$event.stopPropagation()"></a></p>
     <div class="mb-2" fxLayout="row" fxLayoutAlign="flex-start center" *ngIf="!project.gitRemoteURI">
       <dt-icon class="info mr-1" [name]="'information'"></dt-icon>
-      <p class="small m-0">No Git upstream configured. Please use <br/><a href="https://keptn.sh/docs/0.7.x/reference/cli/commands/keptn_update_project/" target="_blank" (click)="$event.stopPropagation()">keptn update project</a> to set a Git upstream.</p>
+      <p class="small m-0">No Git upstream configured. Please use <br/><a href="https://keptn.sh/docs/0.7.x/reference/cli/commands/keptn_update_project/" target="_blank" rel="noopener noreferrer" (click)="$event.stopPropagation()">keptn update project</a> to set a Git upstream.</p>
     </div>
   </dt-tile-subtitle>
   <dt-tag-list aria-label="stages">

--- a/bridge/client/app/_components/ktb-project-tile/ktb-project-tile.component.scss
+++ b/bridge/client/app/_components/ktb-project-tile/ktb-project-tile.component.scss
@@ -1,0 +1,15 @@
+@import '../../../variables';
+@import '~@dynatrace/barista-components/core/src/style/variables';
+
+::ng-deep ktb-project-tile .dt-tile-header {
+  height: auto;
+}
+
+.dt-icon {
+  width: 16px;
+  height: 16px;
+
+  &.error {
+    fill: $gray-700;
+  }
+}

--- a/bridge/client/app/_components/ktb-project-tile/ktb-project-tile.component.scss
+++ b/bridge/client/app/_components/ktb-project-tile/ktb-project-tile.component.scss
@@ -10,6 +10,6 @@
   height: 16px;
 
   &.error {
-    fill: $gray-700;
+    fill: $primary-color;
   }
 }

--- a/bridge/client/app/_components/ktb-project-tile/ktb-project-tile.component.scss
+++ b/bridge/client/app/_components/ktb-project-tile/ktb-project-tile.component.scss
@@ -9,7 +9,7 @@
   width: 16px;
   height: 16px;
 
-  &.error {
+  &.info {
     fill: $primary-color;
   }
 }

--- a/bridge/client/styles.scss
+++ b/bridge/client/styles.scss
@@ -75,6 +75,13 @@ span.italic {
   font-style: italic;;
 }
 
+a {
+  color: $gray-800;
+}
+a:hover {
+  color: $gray-700;
+}
+
 .m-0 {
   margin: 0;
 }


### PR DESCRIPTION
The project overview now also shows the git upstream link if available or an information how to update the project with link to the docs.

![image](https://user-images.githubusercontent.com/6098219/93487796-ecba3380-f905-11ea-8ab6-38908b94cc3d.png)
