### PR TITLE
#1349 Improve CLI error message when API connection fails

### DIFF
--- a/cli/cmd/add_resource.go
+++ b/cli/cmd/add_resource.go
@@ -81,6 +81,14 @@ keptn add-resource --project=rockshop --stage=production --service=shop --resour
 
 		resourceHandler := apiutils.NewAuthenticatedResourceHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 
+		if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
+			return fmt.Errorf("Resource %s could not be uploaded: %s"+`
+Possible reasons:
+* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
+* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+				*addResourceCmdParams.Resource, endPointErr)
+		}
+
 		if (addResourceCmdParams.Service != nil && *addResourceCmdParams.Service != "") && (addResourceCmdParams.Stage != nil && *addResourceCmdParams.Stage != "") {
 			logging.PrintLog("Adding resource "+*addResourceCmdParams.Resource+" to service "+*addResourceCmdParams.Service+" in stage "+*addResourceCmdParams.Stage+" in project "+*addResourceCmdParams.Project, logging.InfoLevel)
 		} else if (addResourceCmdParams.Service == nil || *addResourceCmdParams.Service == "") && (addResourceCmdParams.Stage != nil && *addResourceCmdParams.Stage != "") {

--- a/cli/cmd/add_resource.go
+++ b/cli/cmd/add_resource.go
@@ -82,10 +82,7 @@ keptn add-resource --project=rockshop --stage=production --service=shop --resour
 		resourceHandler := apiutils.NewAuthenticatedResourceHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 
 		if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
-			return fmt.Errorf("Resource %s could not be uploaded: %s"+`
-Possible reasons:
-* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
-* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+			return fmt.Errorf("Resource %s could not be uploaded: %s"+endPointErrorReasons,
 				*addResourceCmdParams.Resource, endPointErr)
 		}
 

--- a/cli/cmd/add_resource_test.go
+++ b/cli/cmd/add_resource_test.go
@@ -36,6 +36,7 @@ func testResource(t *testing.T, fileName string, fileContent string) func() {
 func TestAddResourceToProjectStageService(t *testing.T) {
 
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 
 	resourceFileName := "testResource.txt"
 	defer testResource(t, resourceFileName, "")()
@@ -52,6 +53,7 @@ func TestAddResourceToProjectStageService(t *testing.T) {
 func TestAddResourceToProjectStage(t *testing.T) {
 
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 
 	resourceFileName := "testResource.txt"
 	defer testResource(t, resourceFileName, "")()
@@ -68,6 +70,7 @@ func TestAddResourceToProjectStage(t *testing.T) {
 func TestAddResourceToProject(t *testing.T) {
 
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 
 	resourceFileName := "testResource.txt"
 	defer testResource(t, resourceFileName, "")()
@@ -84,6 +87,7 @@ func TestAddResourceToProject(t *testing.T) {
 func TestAddResourceToProjectService(t *testing.T) {
 
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 
 	*addResourceCmdParams.Stage = ""
 
@@ -102,19 +106,20 @@ func TestAddResourceToProjectService(t *testing.T) {
 func TestAddResourceWhenArgsArePresent(t *testing.T) {
 
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 
 	resourceFileName := "testResource.txt"
 	defer testResource(t, resourceFileName, "")()
 
 	cmd := fmt.Sprintf("add-resource --project=%s --stage=%s --service=%s --resource=%s "+
 		"-- resourceUri=%s --mock", "sockshop", "dev", "carts", resourceFileName, "resource/"+resourceFileName)
-	_, err := executeActionCommandC(cmd)	
+	_, err := executeActionCommandC(cmd)
 	if err == nil {
-		t.Errorf("Expected an error")	
+		t.Errorf("Expected an error")
 	}
 	got := err.Error()
 	expected := "accepts 0 arg(s), received 2"
 	if got != expected {
-		t.Errorf("Expected %q, got %q", expected, got)	
+		t.Errorf("Expected %q, got %q", expected, got)
 	}
 }

--- a/cli/cmd/auth.go
+++ b/cli/cmd/auth.go
@@ -53,6 +53,14 @@ More precisely, the Keptn CLI stores the endpoint and API token using *pass* in 
 				return fmt.Errorf("Authentication was unsuccessful - could not resolve hostname.")
 			}
 
+			if endPointErr := checkEndPointStatus(*endPoint); endPointErr != nil {
+				return fmt.Errorf("Authentication was unsucessful: %s"+`
+Possible reasons:
+* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
+* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+					endPointErr)
+			}
+
 			// try to authenticate (and retry it)
 			for retries := 0; retries < 3; time.Sleep(5 * time.Second) {
 				_, err := authHandler.Authenticate()

--- a/cli/cmd/auth.go
+++ b/cli/cmd/auth.go
@@ -54,10 +54,7 @@ More precisely, the Keptn CLI stores the endpoint and API token using *pass* in 
 			}
 
 			if endPointErr := checkEndPointStatus(*endPoint); endPointErr != nil {
-				return fmt.Errorf("Authentication was unsucessful: %s"+`
-Possible reasons:
-* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
-* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+				return fmt.Errorf("Authentication was unsucessful: %s"+endPointErrorReasons,
 					endPointErr)
 			}
 

--- a/cli/cmd/auth_test.go
+++ b/cli/cmd/auth_test.go
@@ -17,6 +17,7 @@ func init() {
 func TestAuthCmd(t *testing.T) {
 
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 
 	endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds()
 	if err != nil {

--- a/cli/cmd/check_endpoint_status.go
+++ b/cli/cmd/check_endpoint_status.go
@@ -7,6 +7,11 @@ import (
 	apiUtils "github.com/keptn/go-utils/pkg/api/utils"
 )
 
+var endPointErrorReasons = `
+Possible reasons:
+* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
+* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`
+
 var checkEndPointStatusMock = false
 
 var client = http.Client{

--- a/cli/cmd/check_endpoint_status.go
+++ b/cli/cmd/check_endpoint_status.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"crypto/tls"
+	"net/http"
+
+	apiUtils "github.com/keptn/go-utils/pkg/api/utils"
+)
+
+var client = http.Client{
+	Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		DialContext:     apiUtils.ResolveXipIoWithContext,
+	},
+}
+
+func checkEndPointStatus(endPoint string) error {
+	req, err := http.NewRequest("HEAD", endPoint, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
+}

--- a/cli/cmd/check_endpoint_status.go
+++ b/cli/cmd/check_endpoint_status.go
@@ -7,6 +7,8 @@ import (
 	apiUtils "github.com/keptn/go-utils/pkg/api/utils"
 )
 
+var checkEndPointStatusMock = false
+
 var client = http.Client{
 	Transport: &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
@@ -15,6 +17,9 @@ var client = http.Client{
 }
 
 func checkEndPointStatus(endPoint string) error {
+	if checkEndPointStatusMock {
+		return nil
+	}
 	req, err := http.NewRequest("HEAD", endPoint, nil)
 	if err != nil {
 		return err

--- a/cli/cmd/configure_monitoring.go
+++ b/cli/cmd/configure_monitoring.go
@@ -99,10 +99,7 @@ keptn configure monitoring prometheus --project=PROJECTNAME --service=SERVICENAM
 		sdkEvent.SetData(cloudevents.ApplicationJSON, configureMonitoringEventData)
 
 		if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
-			return fmt.Errorf("Error connecting to server: %s"+`
-Possible reasons:
-* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
-* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+			return fmt.Errorf("Error connecting to server: %s"+endPointErrorReasons,
 				endPointErr)
 		}
 

--- a/cli/cmd/configure_monitoring.go
+++ b/cli/cmd/configure_monitoring.go
@@ -98,6 +98,14 @@ keptn configure monitoring prometheus --project=PROJECTNAME --service=SERVICENAM
 		sdkEvent.SetDataContentType(cloudevents.ApplicationJSON)
 		sdkEvent.SetData(cloudevents.ApplicationJSON, configureMonitoringEventData)
 
+		if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
+			return fmt.Errorf("Error connecting to server: %s"+`
+Possible reasons:
+* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
+* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+				endPointErr)
+		}
+
 		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)
 

--- a/cli/cmd/configure_monitoring_test.go
+++ b/cli/cmd/configure_monitoring_test.go
@@ -16,6 +16,7 @@ func init() {
 func TestConfigureMonitoringCmd(t *testing.T) {
 
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 
 	*params.Project = ""
 	*params.Service = ""
@@ -29,6 +30,7 @@ func TestConfigureMonitoringCmd(t *testing.T) {
 func TestConfigureMonitoringCmdForPrometheus(t *testing.T) {
 
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 
 	*params.Project = ""
 	*params.Service = ""

--- a/cli/cmd/create_project.go
+++ b/cli/cmd/create_project.go
@@ -125,10 +125,7 @@ keptn create project PROJECTNAME --shipyard=FILEPATH --git-user=GIT_USER --git-t
 		}
 
 		if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
-			return fmt.Errorf("Error connecting to server: %s"+`
-Possible reasons:
-* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
-* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+			return fmt.Errorf("Error connecting to server: %s"+endPointErrorReasons,
 				endPointErr)
 		}
 

--- a/cli/cmd/create_project.go
+++ b/cli/cmd/create_project.go
@@ -4,8 +4,9 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
 	"os"
+
+	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
 
 	"github.com/keptn/keptn/cli/pkg/file"
 
@@ -121,6 +122,14 @@ keptn create project PROJECTNAME --shipyard=FILEPATH --git-user=GIT_USER --git-t
 			project.GitUser = *createProjectParams.GitUser
 			project.GitToken = *createProjectParams.GitToken
 			project.GitRemoteURL = *createProjectParams.RemoteURL
+		}
+
+		if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
+			return fmt.Errorf("Error connecting to server: %s"+`
+Possible reasons:
+* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
+* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+				endPointErr)
 		}
 
 		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)

--- a/cli/cmd/create_project_test.go
+++ b/cli/cmd/create_project_test.go
@@ -42,6 +42,7 @@ func testShipyard(t *testing.T, shipyardFileName string, shipyard string) func()
 // TestCreateProjectCmd tests the default use of the create project command
 func TestCreateProjectCmd(t *testing.T) {
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 
 	shipyardFileName := "shipyard.yaml"
 	defer testShipyard(t, shipyardFileName, "")()
@@ -57,6 +58,7 @@ func TestCreateProjectCmd(t *testing.T) {
 // due to a project name with upper case character
 func TestCreateProjectIncorrectProjectNameCmd(t *testing.T) {
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 
 	shipyardFileName := "shipyard.yaml"
 	defer testShipyard(t, shipyardFileName, "")()
@@ -73,6 +75,7 @@ func TestCreateProjectIncorrectProjectNameCmd(t *testing.T) {
 // due to a stage name, which contains a special character (-)
 func TestCreateProjectIncorrectStageNameCmd(t *testing.T) {
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 
 	shipyardFileName := "shipyard.yaml"
 	shipyardContent := `stages:
@@ -97,6 +100,7 @@ func TestCreateProjectIncorrectStageNameCmd(t *testing.T) {
 // due to a missing flag for defining a git upstream
 func TestCreateProjectCmdWithGitMissingParam(t *testing.T) {
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 
 	shipyardFileName := "shipyard.yaml"
 	defer testShipyard(t, shipyardFileName, "")()
@@ -114,6 +118,7 @@ func TestCreateProjectCmdWithGitMissingParam(t *testing.T) {
 // command with git upstream parameters
 func TestCreateProjectCmdWithGit(t *testing.T) {
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 
 	shipyardFileName := "shipyard.yaml"
 	defer testShipyard(t, shipyardFileName, "")()

--- a/cli/cmd/create_service.go
+++ b/cli/cmd/create_service.go
@@ -61,10 +61,7 @@ var crServiceCmd = &cobra.Command{
 		}
 
 		if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
-			return fmt.Errorf("Error connecting to server: %s"+`
-Possible reasons:
-* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
-* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+			return fmt.Errorf("Error connecting to server: %s"+endPointErrorReasons,
 				endPointErr)
 		}
 

--- a/cli/cmd/create_service.go
+++ b/cli/cmd/create_service.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+
 	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
 
 	"github.com/keptn/keptn/cli/pkg/websockethelper"
@@ -57,6 +58,14 @@ var crServiceCmd = &cobra.Command{
 
 		service := apimodels.CreateService{
 			ServiceName: &args[0],
+		}
+
+		if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
+			return fmt.Errorf("Error connecting to server: %s"+`
+Possible reasons:
+* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
+* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+				endPointErr)
 		}
 
 		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)

--- a/cli/cmd/create_service_test.go
+++ b/cli/cmd/create_service_test.go
@@ -17,6 +17,7 @@ func init() {
 // TestCreateProjectCmd tests the default use of the create project command
 func TestCreateServiceCmd(t *testing.T) {
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 
 	cmd := fmt.Sprintf("create service carts --project=%s --mock", "sockshop")
 	_, err := executeActionCommandC(cmd)

--- a/cli/cmd/delete_project.go
+++ b/cli/cmd/delete_project.go
@@ -60,6 +60,14 @@ var delProjectCmd = &cobra.Command{
 			ProjectName: args[0],
 		}
 
+		if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
+			return fmt.Errorf("Error connecting to server: %s"+`
+Possible reasons:
+* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
+* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+				endPointErr)
+		}
+
 		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 		projectsHandler := apiutils.NewAuthenticatedProjectHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 

--- a/cli/cmd/delete_project.go
+++ b/cli/cmd/delete_project.go
@@ -61,10 +61,7 @@ var delProjectCmd = &cobra.Command{
 		}
 
 		if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
-			return fmt.Errorf("Error connecting to server: %s"+`
-Possible reasons:
-* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
-* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+			return fmt.Errorf("Error connecting to server: %s"+endPointErrorReasons,
 				endPointErr)
 		}
 

--- a/cli/cmd/delete_project_test.go
+++ b/cli/cmd/delete_project_test.go
@@ -15,6 +15,7 @@ func init() {
 
 func TestDeleteProjectCmd(t *testing.T) {
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 
 	cmd := fmt.Sprintf("delete project %s --mock", "sockshop")
 	_, err := executeActionCommandC(cmd)

--- a/cli/cmd/get_event.go
+++ b/cli/cmd/get_event.go
@@ -18,23 +18,24 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
+	"os"
+
 	"github.com/ghodss/yaml"
 	apiutils "github.com/keptn/go-utils/pkg/api/utils"
 	"github.com/keptn/keptn/cli/pkg/credentialmanager"
 	"github.com/keptn/keptn/cli/pkg/logging"
 	"github.com/spf13/cobra"
-	"net/url"
-	"os"
 )
 
 type GetEventStruct struct {
-	KeptnContext 	*string
-	Project			*string
-	Stage			*string
-	Service			*string
-	PageSize		*string
-	Output			*string
-	NumOfPages		*int
+	KeptnContext *string
+	Project      *string
+	Stage        *string
+	Service      *string
+	PageSize     *string
+	Output       *string
+	NumOfPages   *int
 }
 
 var getEventParams GetEventStruct
@@ -74,15 +75,23 @@ func getEvent(eventStruct GetEventStruct, args []string) error {
 		return errors.New(authErrorMsg)
 	}
 
+	if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
+		return fmt.Errorf("Error connecting to server: %s"+`
+Possible reasons:
+* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
+* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+			endPointErr)
+	}
+
 	eventHandler := apiutils.NewAuthenticatedEventHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 
 	events, modErr := eventHandler.GetEvents(&apiutils.EventFilter{
-		KeptnContext: *eventStruct.KeptnContext,
-		Service: *eventStruct.Service,
-		Stage: *eventStruct.Stage,
-		Project: *eventStruct.Project,
-		EventType:    eventType,
-		PageSize: pageSize,
+		KeptnContext:  *eventStruct.KeptnContext,
+		Service:       *eventStruct.Service,
+		Stage:         *eventStruct.Stage,
+		Project:       *eventStruct.Project,
+		EventType:     eventType,
+		PageSize:      pageSize,
 		NumberOfPages: *eventStruct.NumOfPages,
 	})
 

--- a/cli/cmd/get_event.go
+++ b/cli/cmd/get_event.go
@@ -76,10 +76,7 @@ func getEvent(eventStruct GetEventStruct, args []string) error {
 	}
 
 	if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
-		return fmt.Errorf("Error connecting to server: %s"+`
-Possible reasons:
-* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
-* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+		return fmt.Errorf("Error connecting to server: %s"+endPointErrorReasons,
 			endPointErr)
 	}
 

--- a/cli/cmd/get_event_approvalTriggered.go
+++ b/cli/cmd/get_event_approvalTriggered.go
@@ -66,10 +66,7 @@ func getApprovalTriggeredEvents(approvalTriggered approvalTriggeredStruct) error
 	logging.PrintLog("Starting to get approval.triggered events", logging.InfoLevel)
 
 	if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
-		return fmt.Errorf("Error connecting to server: %s"+`
-Possible reasons:
-* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
-* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+		return fmt.Errorf("Error connecting to server: %s"+endPointErrorReasons,
 			endPointErr)
 	}
 

--- a/cli/cmd/get_event_approvalTriggered.go
+++ b/cli/cmd/get_event_approvalTriggered.go
@@ -65,6 +65,14 @@ func getApprovalTriggeredEvents(approvalTriggered approvalTriggeredStruct) error
 
 	logging.PrintLog("Starting to get approval.triggered events", logging.InfoLevel)
 
+	if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
+		return fmt.Errorf("Error connecting to server: %s"+`
+Possible reasons:
+* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
+* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+			endPointErr)
+	}
+
 	serviceHandler := apiutils.NewAuthenticatedServiceHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 	eventHandler := apiutils.NewAuthenticatedEventHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 

--- a/cli/cmd/get_event_evaluationDone.go
+++ b/cli/cmd/get_event_evaluationDone.go
@@ -48,10 +48,7 @@ var evaluationDoneCmd = &cobra.Command{
 		logging.PrintLog("Starting to get evaluation-done event", logging.InfoLevel)
 
 		if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
-			return fmt.Errorf("Error connecting to server: %s"+`
-Possible reasons:
-* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
-* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+			return fmt.Errorf("Error connecting to server: %s"+endPointErrorReasons,
 				endPointErr)
 		}
 

--- a/cli/cmd/get_event_evaluationDone.go
+++ b/cli/cmd/get_event_evaluationDone.go
@@ -47,6 +47,14 @@ var evaluationDoneCmd = &cobra.Command{
 
 		logging.PrintLog("Starting to get evaluation-done event", logging.InfoLevel)
 
+		if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
+			return fmt.Errorf("Error connecting to server: %s"+`
+Possible reasons:
+* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
+* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+				endPointErr)
+		}
+
 		eventHandler := apiutils.NewAuthenticatedEventHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)
 

--- a/cli/cmd/get_event_evaluationDone_test.go
+++ b/cli/cmd/get_event_evaluationDone_test.go
@@ -17,6 +17,7 @@ func init() {
 func TestEvaluationDoneGetEvent(t *testing.T) {
 
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 
 	cmd := fmt.Sprintf("get event evaluation-done --keptn-context=%s --mock", "8929e5e5-3826-488f-9257-708bfa974909")
 	_, err := executeActionCommandC(cmd)

--- a/cli/cmd/get_projects.go
+++ b/cli/cmd/get_projects.go
@@ -90,10 +90,7 @@ keptn get project sockshop -output=json  # Returns project details in JSON forma
 		}
 
 		if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
-			return fmt.Errorf("Error connecting to server: %s"+`
-Possible reasons:
-* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
-* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+			return fmt.Errorf("Error connecting to server: %s"+endPointErrorReasons,
 				endPointErr)
 		}
 

--- a/cli/cmd/get_projects.go
+++ b/cli/cmd/get_projects.go
@@ -18,12 +18,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
 	"os"
 	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
+
+	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
 
 	"github.com/keptn/keptn/cli/pkg/logging"
 
@@ -86,6 +87,14 @@ keptn get project sockshop -output=json  # Returns project details in JSON forma
 		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds()
 		if err != nil {
 			return errors.New(authErrorMsg)
+		}
+
+		if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
+			return fmt.Errorf("Error connecting to server: %s"+`
+Possible reasons:
+* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
+* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+				endPointErr)
 		}
 
 		projectsHandler := apiutils.NewAuthenticatedProjectHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)

--- a/cli/cmd/get_projects_test.go
+++ b/cli/cmd/get_projects_test.go
@@ -17,6 +17,7 @@ func init() {
 func TestGetProject(t *testing.T) {
 
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 
 	cmd := fmt.Sprintf("get project sockshop --mock")
 	_, err := executeActionCommandC(cmd)
@@ -28,6 +29,7 @@ func TestGetProject(t *testing.T) {
 func TestGetProjectOutput(t *testing.T) {
 
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 
 	cmd := fmt.Sprintf("get project sockshop --output=error --mock")
 	_, err := executeActionCommandC(cmd)

--- a/cli/cmd/get_services.go
+++ b/cli/cmd/get_services.go
@@ -75,10 +75,7 @@ keptn get services carts --project=sockshop -o=json  # Get details of the carts 
 		}
 
 		if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
-			return fmt.Errorf("Error connecting to server: %s"+`
-Possible reasons:
-* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
-* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+			return fmt.Errorf("Error connecting to server: %s"+endPointErrorReasons,
 				endPointErr)
 		}
 

--- a/cli/cmd/get_services.go
+++ b/cli/cmd/get_services.go
@@ -74,6 +74,14 @@ keptn get services carts --project=sockshop -o=json  # Get details of the carts 
 			return errors.New(authErrorMsg)
 		}
 
+		if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
+			return fmt.Errorf("Error connecting to server: %s"+`
+Possible reasons:
+* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
+* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+				endPointErr)
+		}
+
 		projectsHandler := apiutils.NewAuthenticatedProjectHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 		servicesHandler := apiutils.NewAuthenticatedServiceHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 

--- a/cli/cmd/get_services_test.go
+++ b/cli/cmd/get_services_test.go
@@ -17,6 +17,7 @@ func init() {
 func TestGetService(t *testing.T) {
 
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 
 	cmd := fmt.Sprintf("get service carts --project=sockshop --mock")
 	_, err := executeActionCommandC(cmd)
@@ -28,6 +29,7 @@ func TestGetService(t *testing.T) {
 func TestGetServiceOutput(t *testing.T) {
 
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 
 	cmd := fmt.Sprintf("get service carts  --project=sockshop --output=error --mock")
 	_, err := executeActionCommandC(cmd)

--- a/cli/cmd/get_stages.go
+++ b/cli/cmd/get_stages.go
@@ -63,10 +63,7 @@ staging        2020-04-06T14:37:45.210Z
 		}
 
 		if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
-			return fmt.Errorf("Error connecting to server: %s"+`
-Possible reasons:
-* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
-* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+			return fmt.Errorf("Error connecting to server: %s"+endPointErrorReasons,
 				endPointErr)
 		}
 

--- a/cli/cmd/get_stages.go
+++ b/cli/cmd/get_stages.go
@@ -62,6 +62,14 @@ staging        2020-04-06T14:37:45.210Z
 			return errors.New(authErrorMsg)
 		}
 
+		if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
+			return fmt.Errorf("Error connecting to server: %s"+`
+Possible reasons:
+* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
+* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+				endPointErr)
+		}
+
 		stagesHandler := apiutils.NewAuthenticatedStageHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 		if !mocking {
 			stages, err := stagesHandler.GetAllStages(*stageParameter.project)

--- a/cli/cmd/get_stages_test.go
+++ b/cli/cmd/get_stages_test.go
@@ -17,6 +17,7 @@ func init() {
 func TestGetStage(t *testing.T) {
 
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 
 	cmd := fmt.Sprintf("get stage hardening --project=sockshop --mock")
 	_, err := executeActionCommandC(cmd)

--- a/cli/cmd/onboard_service.go
+++ b/cli/cmd/onboard_service.go
@@ -94,10 +94,7 @@ keptn onboard service SERVICENAME --project=PROJECTNAME --chart=HELM_CHART.tgz
 		logging.PrintLog("Starting to onboard service", logging.InfoLevel)
 
 		if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
-			return fmt.Errorf("Error connecting to server: %s"+`
-Possible reasons:
-* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
-* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+			return fmt.Errorf("Error connecting to server: %s"+endPointErrorReasons,
 				endPointErr)
 		}
 

--- a/cli/cmd/onboard_service.go
+++ b/cli/cmd/onboard_service.go
@@ -4,8 +4,9 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
 	"os"
+
+	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
 
 	"github.com/keptn/keptn/cli/pkg/websockethelper"
 
@@ -91,6 +92,14 @@ keptn onboard service SERVICENAME --project=PROJECTNAME --chart=HELM_CHART.tgz
 			return errors.New(authErrorMsg)
 		}
 		logging.PrintLog("Starting to onboard service", logging.InfoLevel)
+
+		if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
+			return fmt.Errorf("Error connecting to server: %s"+`
+Possible reasons:
+* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
+* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+				endPointErr)
+		}
 
 		chart, err := keptnutils.LoadChartFromPath(*onboardServiceParams.ChartFilePath)
 		if err != nil {

--- a/cli/cmd/onboard_service_test.go
+++ b/cli/cmd/onboard_service_test.go
@@ -17,6 +17,7 @@ func init() {
 func TestOnboardServiceWrongHelmChartPath(t *testing.T) {
 
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 
 	cmd := fmt.Sprintf("onboard service carts --project=sockshop --chart=cartsX")
 	_, err := executeActionCommandC(cmd)
@@ -34,6 +35,7 @@ func TestOnboardServiceWrongHelmChartPath(t *testing.T) {
 func TestOnboardServiceDeploymentStrategy(t *testing.T) {
 
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 
 	cmd := fmt.Sprintf("onboard service carts --project=sockshop --deployment-strategy=directX")
 	_, err := executeActionCommandC(cmd)

--- a/cli/cmd/send_event.go
+++ b/cli/cmd/send_event.go
@@ -67,6 +67,14 @@ In addition, the payload of the CloudEvent needs to follow the Keptn spec (https
 			return fmt.Errorf("Failed to map event to API event model. %s", err.Error())
 		}
 
+		if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
+			return fmt.Errorf("Error connecting to server: %s"+`
+Possible reasons:
+* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
+* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+				endPointErr)
+		}
+
 		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)
 

--- a/cli/cmd/send_event.go
+++ b/cli/cmd/send_event.go
@@ -68,10 +68,7 @@ In addition, the payload of the CloudEvent needs to follow the Keptn spec (https
 		}
 
 		if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
-			return fmt.Errorf("Error connecting to server: %s"+`
-Possible reasons:
-* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
-* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+			return fmt.Errorf("Error connecting to server: %s"+endPointErrorReasons,
 				endPointErr)
 		}
 

--- a/cli/cmd/send_event_approvalFinished.go
+++ b/cli/cmd/send_event_approvalFinished.go
@@ -76,10 +76,7 @@ func sendApprovalFinishedEvent(sendApprovalFinishedOptions sendApprovalFinishedS
 	logging.PrintLog("Starting to send approval.finished event", logging.InfoLevel)
 
 	if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
-		return fmt.Errorf("Error connecting to server: %s"+`
-Possible reasons:
-* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
-* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+		return fmt.Errorf("Error connecting to server: %s"+endPointErrorReasons,
 			endPointErr)
 	}
 

--- a/cli/cmd/send_event_approvalFinished.go
+++ b/cli/cmd/send_event_approvalFinished.go
@@ -75,6 +75,14 @@ func sendApprovalFinishedEvent(sendApprovalFinishedOptions sendApprovalFinishedS
 
 	logging.PrintLog("Starting to send approval.finished event", logging.InfoLevel)
 
+	if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
+		return fmt.Errorf("Error connecting to server: %s"+`
+Possible reasons:
+* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
+* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+			endPointErr)
+	}
+
 	apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 	eventHandler := apiutils.NewAuthenticatedEventHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 

--- a/cli/cmd/send_event_evaluationStart.go
+++ b/cli/cmd/send_event_evaluationStart.go
@@ -71,6 +71,14 @@ keptn send event start-evaluation --project=sockshop --stage=hardening --service
 		logging.PrintLog("Starting to send a start-evaluation event to evaluate the service "+
 			*evaluationStart.Service+" in project "+*evaluationStart.Project, logging.InfoLevel)
 
+		if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
+			return fmt.Errorf("Error connecting to server: %s"+`
+Possible reasons:
+* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
+* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+				endPointErr)
+		}
+
 		startPoint := ""
 		if evaluationStart.Start != nil {
 			startPoint = *evaluationStart.Start

--- a/cli/cmd/send_event_evaluationStart.go
+++ b/cli/cmd/send_event_evaluationStart.go
@@ -72,10 +72,7 @@ keptn send event start-evaluation --project=sockshop --stage=hardening --service
 			*evaluationStart.Service+" in project "+*evaluationStart.Project, logging.InfoLevel)
 
 		if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
-			return fmt.Errorf("Error connecting to server: %s"+`
-Possible reasons:
-* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
-* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+			return fmt.Errorf("Error connecting to server: %s"+endPointErrorReasons,
 				endPointErr)
 		}
 

--- a/cli/cmd/send_event_evaluationStart_test.go
+++ b/cli/cmd/send_event_evaluationStart_test.go
@@ -19,6 +19,7 @@ func init() {
 func TestEvaluationStart(t *testing.T) {
 
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 
 	*evaluationStart.Timeframe = ""
 	*evaluationStart.Start = ""
@@ -35,6 +36,7 @@ func TestEvaluationStart(t *testing.T) {
 func TestEvaluationStartWrongFormat(t *testing.T) {
 
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 
 	*evaluationStart.Timeframe = ""
 	*evaluationStart.Start = ""
@@ -52,6 +54,7 @@ func TestEvaluationStartWrongFormat(t *testing.T) {
 func TestEvaluationStartTimeSpecified(t *testing.T) {
 
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 
 	*evaluationStart.Timeframe = ""
 	*evaluationStart.Start = ""
@@ -69,6 +72,7 @@ func TestEvaluationStartTimeSpecified(t *testing.T) {
 func TestEvaluationStartAndEndTimeSpecified(t *testing.T) {
 
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 
 	*evaluationStart.Timeframe = ""
 	*evaluationStart.Start = ""
@@ -86,6 +90,7 @@ func TestEvaluationStartAndEndTimeSpecified(t *testing.T) {
 func TestEvaluationStartAndEndTimeAndTimeframeSpecified(t *testing.T) {
 
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 
 	*evaluationStart.Timeframe = ""
 	*evaluationStart.Start = ""
@@ -106,6 +111,7 @@ func TestEvaluationStartAndEndTimeAndTimeframeSpecified(t *testing.T) {
 func TestEvaluationStartAndEndTimeWrongOrder(t *testing.T) {
 
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 
 	*evaluationStart.Timeframe = ""
 	*evaluationStart.Start = ""

--- a/cli/cmd/send_event_newArtifact.go
+++ b/cli/cmd/send_event_newArtifact.go
@@ -81,6 +81,14 @@ For pulling an image from a private registry, we would like to refer to the Kube
 		logging.PrintLog("Starting to send a new-artifact-event to deploy the service "+
 			*newArtifact.Service+" in project "+*newArtifact.Project+" in version "+*newArtifact.Image+":"+*newArtifact.Tag, logging.InfoLevel)
 
+		if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
+			return fmt.Errorf("Error connecting to server: %s"+`
+Possible reasons:
+* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
+* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+				endPointErr)
+		}
+
 		valuesCanary := make(map[string]interface{})
 		valuesCanary["image"] = *newArtifact.Image + ":" + *newArtifact.Tag
 		canary := keptnevents.Canary{Action: keptnevents.Set, Value: 100}

--- a/cli/cmd/send_event_newArtifact.go
+++ b/cli/cmd/send_event_newArtifact.go
@@ -82,10 +82,7 @@ For pulling an image from a private registry, we would like to refer to the Kube
 			*newArtifact.Service+" in project "+*newArtifact.Project+" in version "+*newArtifact.Image+":"+*newArtifact.Tag, logging.InfoLevel)
 
 		if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
-			return fmt.Errorf("Error connecting to server: %s"+`
-Possible reasons:
-* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
-* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+			return fmt.Errorf("Error connecting to server: %s"+endPointErrorReasons,
 				endPointErr)
 		}
 

--- a/cli/cmd/send_event_newArtifact_test.go
+++ b/cli/cmd/send_event_newArtifact_test.go
@@ -18,6 +18,7 @@ func init() {
 func TestNewArtifact(t *testing.T) {
 
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 
 	cmd := fmt.Sprintf("send event new-artifact --project=%s --service=%s "+
 		"--image=%s --tag=%s  --mock", "sockshop", "carts", "docker.io/keptnexamples/carts", "0.9.1")
@@ -45,6 +46,7 @@ func TestCheckImageAvailability(t *testing.T) {
 		{"httpd", ""}}
 
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 	buf := new(bytes.Buffer)
 	rootCmd.SetOutput(buf)
 
@@ -67,6 +69,7 @@ func TestCheckImageNonAvailability(t *testing.T) {
 	invalidImgs := []DockerImg{{"docker.io/keptnexamples/carts:0.7.5", ""}}
 
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 	buf := new(bytes.Buffer)
 	rootCmd.SetOutput(buf)
 

--- a/cli/cmd/send_event_test.go
+++ b/cli/cmd/send_event_test.go
@@ -36,6 +36,7 @@ const ce = `{
 func TestSendEvent(t *testing.T) {
 
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 
 	resourceFileName := "ce.json"
 	defer testResource(t, resourceFileName, ce)()

--- a/cli/cmd/update_project.go
+++ b/cli/cmd/update_project.go
@@ -66,10 +66,7 @@ For more information about updating projects or upstream repositories, please go
 		logging.PrintLog("Starting to update project", logging.InfoLevel)
 
 		if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
-			return fmt.Errorf("Error connecting to server: %s"+`
-Possible reasons:
-* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
-* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+			return fmt.Errorf("Error connecting to server: %s"+endPointErrorReasons,
 				endPointErr)
 		}
 

--- a/cli/cmd/update_project.go
+++ b/cli/cmd/update_project.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+
 	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
 
 	"github.com/keptn/keptn/cli/pkg/websockethelper"
@@ -63,6 +64,14 @@ For more information about updating projects or upstream repositories, please go
 			return errors.New(authErrorMsg)
 		}
 		logging.PrintLog("Starting to update project", logging.InfoLevel)
+
+		if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
+			return fmt.Errorf("Error connecting to server: %s"+`
+Possible reasons:
+* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
+* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`,
+				endPointErr)
+		}
 
 		project := apimodels.Project{
 			ProjectName: args[0],

--- a/cli/cmd/update_project_test.go
+++ b/cli/cmd/update_project_test.go
@@ -16,6 +16,7 @@ func init() {
 // TestCreateProjectCmd tests the default use of the update project command
 func TestUpdateProjectCmd(t *testing.T) {
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 
 	cmd := fmt.Sprintf("update project sockshop -t token -u user -r https:// --mock")
 	_, err := executeActionCommandC(cmd)
@@ -28,6 +29,7 @@ func TestUpdateProjectCmd(t *testing.T) {
 // due to a project name with upper case character
 func TestUpdateProjectIncorrectProjectNameCmd(t *testing.T) {
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
 
 	cmd := fmt.Sprintf("update project Sockshop -t token -u user -r https://github.com/user/upstream.git --mock")
 	_, err := executeActionCommandC(cmd)


### PR DESCRIPTION
This PR adds the functionality to improve the CLI error message when no API connection can be made. 
It adds a generic utility function in the `cli/cmd/check_endpoint_status.go` which pings the API using the HEAD request method and checks whether it's active. This allows for handling these kind of errors more elegantly and also makes provision to suggest remedial measures.