### PR TITLE
#2340 Improve robustness and user-experience of generate support-archive

### DIFF
--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -6,3 +6,6 @@ carts
 
 #binary - go build
 cli
+
+# ignore support-archive folder if it exists
+support-archive


### PR DESCRIPTION
Fixes #2340 
(also requires backport for release-0.7.2 branch)

- Add a hint that no Keptn installation could be found in the respective namespace (and use `-n ...`) to specify a namespace
- Add a yes/no question on whether the correct cluster is used
- Exit the command if no Kubectl connection could be made[1]
- Exit the command if no Keptn installation was found on the cluster[1]

[1] We require a working kubectl connection to fetch logs. If this is not working, the support-archive might be empty, which is no help at all.

## Demo

```console
$ ./cli generate support-archive
Retrieving kubectl version
Checking whether kube context points to Keptn cluster
Please confirm that this is the cluster Keptn is running on: 
Cluster: gke_some-cluster
Is this all correct? (y/n)
y
Retrieving logs from cluster gke_sai-research_europe-west1-b_keptn-060-internal-demo-cluster
Retrieving Keptn domain
Retrieving namespaces
Checking availability of istio-system namespace
Retrieving list of services in istio-system
Retrieving list of config maps in keptn
Retrieving list of secrets in keptn
Retrieving list of deployments in keptn
...
Checking availability of Keptn API
The support archive is available here support-archive/keptn-support-archive-1600419639.zip
This support archive potentially contains sensitive data. Therefore, please first review it before distributing.
If you need help, please use the #help channel in the Keptn Slack workspace https://slack.keptn.sh
```

```console
$ ./cli generate support-archive -n other-namespace
Retrieving kubectl version
Checking whether kube context points to Keptn cluster
Could not find a valid Keptn installation in namespace other-namespace
Hint: use -n to specify another namespace.
```

```console
$ KUBECONFIG=./this/does/not/exist ./cli generate support-archive
Retrieving kubectl version
Availability check of kubectl failed with Error executing command kubectl version: exit status 1
W0918 11:01:40.994596  163265 loader.go:223] Config not found: ./this/does/not/exist
Client Version: version.Info{Major:"1", Minor:"19", GitVersion:"v1.19.0", GitCommit:"e19964183377d0ec2052d1f1fa930c4d7575bd50", GitTreeState:"clean", BuildDate:"2020-08-26T14:30:33Z", GoVersion:"go1.15", Compiler:"gc", Platform:"linux/amd64"}
The connection to the server localhost:8080 was refused - did you specify the right host or port?

Please reach out to your administrator to get a connection to the Kubernetes cluster on which your Keptn installation is running on.
```