### PR TITLE
Fix error in helm chart

### DIFF
--- a/installer/.gitignore
+++ b/installer/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+manifests/keptn/charts/control-plane/charts/nats-*.tgz

--- a/installer/manifests/keptn/charts/control-plane/templates/core.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/core.yaml
@@ -175,7 +175,7 @@ spec:
             - name: ENABLE_VERSION_CHECK
               value: {{ .Values.bridge.versionCheck.enabled }}
             - name: SHOW_API_TOKEN
-              value: {{ .Values.showApiToken.enabled } }
+              value: {{ .Values.showApiToken.enabled }}
           envFrom:
             - secretRef:
                 name: bridge-credentials

--- a/installer/manifests/keptn/charts/control-plane/templates/core.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/core.yaml
@@ -175,7 +175,7 @@ spec:
             - name: ENABLE_VERSION_CHECK
               value: {{ .Values.bridge.versionCheck.enabled }}
             - name: SHOW_API_TOKEN
-              value: {{ .Values.showApiToken.enabled }}
+              value: {{ .Values.bridge.showApiToken.enabled }}
           envFrom:
             - secretRef:
                 name: bridge-credentials


### PR DESCRIPTION
Our CI build currently exits with the following error message:
```
Installing Keptn ...
Start upgrading Helm Chart keptn in namespace keptn
Could not complete Keptn installation: Error when installing/upgrading Helm Chart keptn in namespace keptn: parse error at (keptn/charts/control-plane/templates/core.yaml:178): unexpected "}" in operand
Error: Error when installing/upgrading Helm Chart keptn in namespace keptn: parse error at (keptn/charts/control-plane/templates/core.yaml:178): unexpected "}" in operand
[keptn|ERROR] [2020-09-21 08:59:06] keptn install --platform=openshift --chart-repo=https://storage.googleapis.com/keptn-installer/keptn-0.7.2.tgz - failed
[keptn|ERROR] [2020-09-21 08:59:06] Keptn test step failed
The command "test/test_install_minishift_quality_gates.sh" exited with 1.
```

The error is in line 178 of keptn/charts/control-plane/templates/core.yaml, there was one space more than needed.

My PR fixes this, and also adds nats to .gitignore (if you run helm install/upgrade locally, this file gets created, and we don't want to accidentally commit it).