### PR TITLE
#2388 include event IDs of compared events

### DIFF
--- a/lighthouse-service/event_handler/evaluate_sli_handler_test.go
+++ b/lighthouse-service/event_handler/evaluate_sli_handler_test.go
@@ -668,7 +668,7 @@ func TestEvaluateComparison(t *testing.T) {
 						Message: "",
 					},
 					Targets: nil,
-					Status:  "pass",
+					Status:  "fail",
 				},
 				{
 					Score: 2,
@@ -2603,6 +2603,7 @@ func TestEvaluateSLIHandler_getPreviousTestExecutionResult(t *testing.T) {
 				PageSize:    1,
 				Events: []struct {
 					Data interface{} `json:"data"`
+					ID   string      `json:"id"`
 				}{
 					{
 						Data: &keptnv2.TestFinishedEventData{
@@ -2707,6 +2708,7 @@ func TestEvaluateSLIHandler_getPreviousEvaluations(t *testing.T) {
 		args                args
 		resultFromDatastore datastoreResult
 		want                []*keptnv2.EvaluationFinishedEventData
+		want2               []string
 		wantErr             bool
 	}{
 		{
@@ -2737,6 +2739,7 @@ func TestEvaluateSLIHandler_getPreviousEvaluations(t *testing.T) {
 				PageSize:    1,
 				Events: []struct {
 					Data interface{} `json:"data"`
+					ID   string      `json:"id"`
 				}{
 					{
 						Data: &keptnv2.EvaluationFinishedEventData{
@@ -2748,6 +2751,7 @@ func TestEvaluateSLIHandler_getPreviousEvaluations(t *testing.T) {
 								Result:  "",
 							},
 						},
+						ID: "my-id",
 					},
 				},
 			},
@@ -2762,6 +2766,7 @@ func TestEvaluateSLIHandler_getPreviousEvaluations(t *testing.T) {
 					},
 				},
 			},
+			want2:   []string{"my-id"},
 			wantErr: false,
 		},
 	}
@@ -2774,12 +2779,15 @@ func TestEvaluateSLIHandler_getPreviousEvaluations(t *testing.T) {
 				Event:        tt.fields.Event,
 				HTTPClient:   tt.fields.HTTPClient,
 			}
-			got, err := eh.getPreviousEvaluations(tt.args.e, tt.args.numberOfPreviousResults, "all")
+			got, got2, err := eh.getPreviousEvaluations(tt.args.e, tt.args.numberOfPreviousResults, "all")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getPreviousEvaluations() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getPreviousEvaluations() got = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(got2, tt.want2) {
 				t.Errorf("getPreviousEvaluations() got = %v, want %v", got, tt.want)
 			}
 		})
@@ -2795,6 +2803,7 @@ func TestEvaluateSLIHandler_getPreviousEvaluationsWithPassFilter(t *testing.T) {
 		PageSize:    3,
 		Events: []struct {
 			Data interface{} `json:"data"`
+			ID   string      `json:"id"`
 		}{
 			{
 				Data: &keptnv2.EvaluationFinishedEventData{
@@ -2806,6 +2815,7 @@ func TestEvaluateSLIHandler_getPreviousEvaluationsWithPassFilter(t *testing.T) {
 						Result:  "pass",
 					},
 				},
+				ID: "my-id-1",
 			},
 			{
 				Data: &keptnv2.EvaluationFinishedEventData{
@@ -2817,6 +2827,7 @@ func TestEvaluateSLIHandler_getPreviousEvaluationsWithPassFilter(t *testing.T) {
 						Result:  "fail",
 					},
 				},
+				ID: "my-id-2",
 			},
 			{
 				Data: &keptnv2.EvaluationFinishedEventData{
@@ -2828,6 +2839,7 @@ func TestEvaluateSLIHandler_getPreviousEvaluationsWithPassFilter(t *testing.T) {
 						Result:  "fail",
 					},
 				},
+				ID: "my-id-3",
 			},
 		},
 	}
@@ -2838,6 +2850,7 @@ func TestEvaluateSLIHandler_getPreviousEvaluationsWithPassFilter(t *testing.T) {
 		PageSize:    3,
 		Events: []struct {
 			Data interface{} `json:"data"`
+			ID   string      `json:"id"`
 		}{
 			{
 				Data: &keptnv2.EvaluationFinishedEventData{
@@ -2849,6 +2862,7 @@ func TestEvaluateSLIHandler_getPreviousEvaluationsWithPassFilter(t *testing.T) {
 						Result:  "pass",
 					},
 				},
+				ID: "my-id-4",
 			},
 			{
 				Data: &keptnv2.EvaluationFinishedEventData{
@@ -2860,6 +2874,7 @@ func TestEvaluateSLIHandler_getPreviousEvaluationsWithPassFilter(t *testing.T) {
 						Result:  "pass",
 					},
 				},
+				ID: "my-id-5",
 			},
 			{
 				Data: &keptnv2.EvaluationFinishedEventData{
@@ -2871,6 +2886,7 @@ func TestEvaluateSLIHandler_getPreviousEvaluationsWithPassFilter(t *testing.T) {
 						Result:  "fail",
 					},
 				},
+				ID: "my-id-6",
 			},
 		},
 	}
@@ -2908,6 +2924,7 @@ func TestEvaluateSLIHandler_getPreviousEvaluationsWithPassFilter(t *testing.T) {
 		fields  fields
 		args    args
 		want    []*keptnv2.EvaluationFinishedEventData
+		want2   []string
 		wantErr bool
 	}{
 		{
@@ -2961,6 +2978,7 @@ func TestEvaluateSLIHandler_getPreviousEvaluationsWithPassFilter(t *testing.T) {
 					},
 				},
 			},
+			want2:   []string{"my-id-1", "my-id-4", "my-id-5"},
 			wantErr: false,
 		},
 	}
@@ -2972,12 +2990,15 @@ func TestEvaluateSLIHandler_getPreviousEvaluationsWithPassFilter(t *testing.T) {
 				Event:        tt.fields.Event,
 				HTTPClient:   tt.fields.HTTPClient,
 			}
-			got, err := eh.getPreviousEvaluations(tt.args.e, tt.args.numberOfPreviousResults, "pass")
+			got, got2, err := eh.getPreviousEvaluations(tt.args.e, tt.args.numberOfPreviousResults, "pass")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getPreviousEvaluations() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getPreviousEvaluations() got = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(got2, tt.want2) {
 				t.Errorf("getPreviousEvaluations() got = %v, want %v", got, tt.want)
 			}
 		})

--- a/lighthouse-service/go.mod
+++ b/lighthouse-service/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/googleapis/gnostic v0.1.0 // indirect
 	github.com/json-iterator/go v1.1.9 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.6.3-0.20200908082455-010bbcf95e6f
+	github.com/keptn/go-utils v0.6.3-0.20200923082506-f715579724ec
 	github.com/mitchellh/mapstructure v1.3.3
 	github.com/nats-io/nats-server/v2 v2.1.6
 	github.com/onsi/ginkgo v1.11.0 // indirect

--- a/lighthouse-service/go.sum
+++ b/lighthouse-service/go.sum
@@ -208,6 +208,8 @@ github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dv
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/keptn/go-utils v0.6.3-0.20200908082455-010bbcf95e6f h1:YU/mwHVC5wrtjxe1H96VkGCr/9JeleZZZ73P9Pj/zYo=
 github.com/keptn/go-utils v0.6.3-0.20200908082455-010bbcf95e6f/go.mod h1:jD+ZvrkwYyDMgeKANzVZsBSYgjYQxTJvxw/RB3vYFAE=
+github.com/keptn/go-utils v0.6.3-0.20200923082506-f715579724ec h1:ZTLQTaazPP1tDJ0YEv606F92FWZTyvUAsKftjRZC7Do=
+github.com/keptn/go-utils v0.6.3-0.20200923082506-f715579724ec/go.mod h1:jD+ZvrkwYyDMgeKANzVZsBSYgjYQxTJvxw/RB3vYFAE=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=


### PR DESCRIPTION
Closes #2388
This PR adds a list of event IDs that were used for a comparison-based evaluation of SLOs.
Also, the PR removes the filtering logic on the SLI level and instead applies the compare_results_with filter on an event level.