### PR TITLE
Installer: Re-Enable uploading of index.yaml to google cloud

### DIFF
--- a/travis-scripts/build_release_installer.sh
+++ b/travis-scripts/build_release_installer.sh
@@ -38,7 +38,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # upload to gcloud
-# commented out on purpose by CKreuzberger: Do not upload index.yaml for now, as it might break things
-# gsutil cp keptn-charts/index.yaml gs://keptn-installer/index.yaml
+gsutil cp keptn-charts/index.yaml gs://keptn-installer/index.yaml
 
 gsutil cp keptn-charts/keptn-${VERSION}.tgz gs://keptn-installer/keptn-${VERSION}.tgz


### PR DESCRIPTION
I have disabled uploading index.yaml 2 weeks ago for the time being, so that we don't break our index.yaml in the process of creating the new release (also, to avoid accidental upgrades to 0.7.2).

With this PR I'm reverting this change.