### PR TITLE
#2293 Point user to upgrade docs, fix bug in update project

### DIFF
--- a/cli/cmd/update_project.go
+++ b/cli/cmd/update_project.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+
 	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
 
 	"github.com/keptn/keptn/cli/pkg/websockethelper"
@@ -103,7 +104,7 @@ func init() {
 	updateProjectParams.GitUser = upProjectCmd.Flags().StringP("git-user", "u", "", "The git user of the upstream target")
 	updateProjectParams.GitToken = upProjectCmd.Flags().StringP("git-token", "t", "", "The git token of the git user")
 	updateProjectParams.RemoteURL = upProjectCmd.Flags().StringP("git-remote-url", "r", "", "The remote url of the upstream target")
-	updateCmd.MarkFlagRequired("git-user")
-	updateCmd.MarkFlagRequired("git-token")
-	updateCmd.MarkFlagRequired("git-remote-url")
+	upProjectCmd.MarkFlagRequired("git-user")
+	upProjectCmd.MarkFlagRequired("git-token")
+	upProjectCmd.MarkFlagRequired("git-remote-url")
 }

--- a/cli/pkg/version/version_checker.go
+++ b/cli/pkg/version/version_checker.go
@@ -157,18 +157,24 @@ func (v *VersionChecker) CheckCLIVersion(cliVersion string, considerPrevCheck bo
 			}
 			msgPrinted := false
 			if newVersions.stable.newestCompatible != nil {
+				segments := newVersions.stable.newestCompatible.Segments()
+				majorMinorXVersion := fmt.Sprintf("%v.%v.x", segments[0], segments[1])
 				fmt.Printf(newCompatibleVersionMsg+"\n", newVersions.stable.newestCompatible.String(),
-					newVersions.stable.newestCompatible.String())
+					majorMinorXVersion)
 				msgPrinted = true
 			}
 			if newVersions.prerelease.newestCompatible != nil {
+				segments := newVersions.prerelease.newestCompatible.Segments()
+				majorMinorXVersion := fmt.Sprintf("%v.%v.x", segments[0], segments[1])
 				fmt.Printf(newCompatibleVersionMsg+"\n", newVersions.prerelease.newestCompatible.String(),
-					newVersions.prerelease.newestCompatible.String())
+					majorMinorXVersion)
 				msgPrinted = true
 			}
 			if newVersions.stable.newestIncompatible != nil {
+				segments := newVersions.stable.newestIncompatible.Segments()
+				majorMinorXVersion := fmt.Sprintf("%v.%v.x", segments[0], segments[1])
 				fmt.Printf(newIncompatibleVersionMsg+"\n", newVersions.stable.newestIncompatible.String(),
-					newVersions.stable.newestIncompatible.String())
+					majorMinorXVersion)
 				msgPrinted = true
 			}
 			if msgPrinted && considerPrevCheck {

--- a/cli/pkg/version/version_checker.go
+++ b/cli/pkg/version/version_checker.go
@@ -130,9 +130,9 @@ func (v *VersionChecker) getNewerCLIVersion(cliConfig config.CLIConfig, usedVers
 	return res, nil
 }
 
-const newCompatibleVersionMsg = `keptn version %s is available! Please visit https://keptn.sh for more information.`
-const newIncompatibleVersionMsg = `keptn version %s is available! Please note that this version might be incompatible with your Keptn cluster ` +
-	`version and requires to update the cluster too. Please visit https://keptn.sh for more information.`
+const newCompatibleVersionMsg = `Keptn CLI version %s is available! Please visit https://keptn.sh/docs/%s/operate/upgrade/ for more information.`
+const newIncompatibleVersionMsg = `Keptn CLI version %s is available! Please note that this version might be incompatible with your Keptn cluster ` +
+	`version and requires to update the cluster too. Please visit https://keptn.sh/docs/%s/operate/upgrade/ for more information.`
 const disableMsg = `To disable this notice, run: '%s set config AutomaticVersionCheck false'`
 
 // CheckCLIVersion checks whether there is a new CLI version available and prints corresponding
@@ -157,15 +157,18 @@ func (v *VersionChecker) CheckCLIVersion(cliVersion string, considerPrevCheck bo
 			}
 			msgPrinted := false
 			if newVersions.stable.newestCompatible != nil {
-				fmt.Printf(newCompatibleVersionMsg+"\n", newVersions.stable.newestCompatible.String())
+				fmt.Printf(newCompatibleVersionMsg+"\n", newVersions.stable.newestCompatible.String(),
+					newVersions.stable.newestCompatible.String())
 				msgPrinted = true
 			}
 			if newVersions.prerelease.newestCompatible != nil {
-				fmt.Printf(newCompatibleVersionMsg+"\n", newVersions.prerelease.newestCompatible)
+				fmt.Printf(newCompatibleVersionMsg+"\n", newVersions.prerelease.newestCompatible.String(),
+					newVersions.prerelease.newestCompatible.String())
 				msgPrinted = true
 			}
 			if newVersions.stable.newestIncompatible != nil {
-				fmt.Printf(newIncompatibleVersionMsg+"\n", newVersions.stable.newestIncompatible.String())
+				fmt.Printf(newIncompatibleVersionMsg+"\n", newVersions.stable.newestIncompatible.String(),
+					newVersions.stable.newestIncompatible.String())
 				msgPrinted = true
 			}
 			if msgPrinted && considerPrevCheck {


### PR DESCRIPTION
Closes #2293 

`keptn version` now outputs the following message, which contains the link to the upgrade instructions
```
Keptn CLI version 0.7.1 is available! Please visit https://keptn.sh/docs/0.7.1/operate/upgrade/ for more information.
To disable this notice, run: './keptn set config AutomaticVersionCheck false'

Keptn CLI version: 0.7.0

Daily version check is enabled. 
Keptn will collect statistical data and will notify about new versions and security patches for Keptn. Details can be found at: https://keptn.sh/docs/0.7.x/reference/version_check
---------------------------------------------------
* To disable the daily version check, please execute:
 - keptn set config AutomaticVersionCheck false

```

Please note that this requires that the alias in the docs is porperly set, e.g.
```
aliases:
  - /docs/0.7.0/operate/upgrade/
  - /docs/0.7.1/operate/upgrade/
```