### PR TITLE
#2408 Enable caching for static files in express

### DIFF
--- a/bridge/server/app.js
+++ b/bridge/server/app.js
@@ -21,8 +21,9 @@ if (!cliDownloadLink) {
   cliDownloadLink = "https://github.com/keptn/keptn/releases"
 }
 
+const oneWeek       = 7*24*3600000;    // 3600000msec == 1hour
 // host static files (angular app)
-app.use(express.static(path.join(__dirname, '../dist')));
+app.use(express.static(path.join(__dirname, '../dist'), { maxAge: oneWeek }));
 
 // add some middlewares
 app.use(logger('dev'));


### PR DESCRIPTION
Backport of #2410 for 0.7.2.

This enables caching for static files in express by adding the appropriate header.

This allows upstream proxies (such as our api-gateway-nginx) to cache such a file in memory, if wanted/needed.