### PR TITLE
Added support to export endpoint and api-token

### DIFF
--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -9,3 +9,6 @@ cli
 
 # ignore support-archive folder if it exists
 support-archive
+
+# ignore the keptn cli binary generated after running go build -o keptn
+keptn

--- a/cli/cmd/auth.go
+++ b/cli/cmd/auth.go
@@ -16,9 +16,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var endPoint *string
-var apiToken *string
-var exportConfig *bool
+type authCmdParams struct {
+	endPoint     *string
+	apiToken     *string
+	exportConfig *bool
+}
+
+var authParams *authCmdParams
 var exportEndPoint url.URL
 var exportAPIToken string
 
@@ -35,30 +39,26 @@ More precisely, the Keptn CLI stores the endpoint and API token using *pass* in 
 	`,
 	Example:      `keptn auth --endpoint=https://api.keptn.MY.DOMAIN.COM --api-token=abcd-0123-wxyz-7890`,
 	SilenceUsage: true,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		return verifyAuthParams(authParams)
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		var err error
-		if *exportConfig {
+		// User wants to print current auth credentials
+		if *authParams.exportConfig {
 			exportEndPoint, exportAPIToken, err = credentialmanager.NewCredentialManager().GetCreds()
 			if err != nil {
 				return err
 			}
-			fmt.Println("Endpoint = ", exportEndPoint.String())
-			fmt.Println("API Token = ", exportAPIToken)
+			fmt.Println("Endpoint: ", exportEndPoint.String())
+			fmt.Println("API Token: ", exportAPIToken)
 			return nil
-		}
-
-		if *endPoint == "" && *apiToken == "" {
-			return errors.New("required flag(s) \"api-token\", \"endpoint\" not set")
-		} else if *endPoint == "" {
-			return errors.New("required flag \"endpoint\" not set")
-		} else if *apiToken == "" {
-			return errors.New("required flag \"api-token\" not set")
 		}
 
 		logging.PrintLog("Starting to authenticate", logging.InfoLevel)
 
-		url, err := url.Parse(*endPoint)
+		url, err := url.Parse(*authParams.endPoint)
 		if err != nil {
 			logging.PrintLog("Error parsing Keptn API URL", logging.InfoLevel)
 			return err
@@ -68,7 +68,7 @@ More precisely, the Keptn CLI stores the endpoint and API token using *pass* in 
 			url.Path = "/api"
 		}
 
-		authHandler := apiutils.NewAuthenticatedAuthHandler(url.String(), *apiToken, "x-token", nil, url.Scheme)
+		authHandler := apiutils.NewAuthenticatedAuthHandler(url.String(), *authParams.apiToken, "x-token", nil, url.Scheme)
 
 		if !mocking {
 			authenticated := false
@@ -77,7 +77,7 @@ More precisely, the Keptn CLI stores the endpoint and API token using *pass* in 
 				return fmt.Errorf("Authentication was unsuccessful - could not resolve hostname.")
 			}
 
-			if endPointErr := checkEndPointStatus(*endPoint); endPointErr != nil {
+			if endPointErr := checkEndPointStatus(*authParams.endPoint); endPointErr != nil {
 				return fmt.Errorf("Authentication was unsucessful: %s"+endPointErrorReasons,
 					endPointErr)
 			}
@@ -101,7 +101,7 @@ More precisely, the Keptn CLI stores the endpoint and API token using *pass* in 
 			}
 
 			logging.PrintLog("Successfully authenticated", logging.InfoLevel)
-			return credentialmanager.NewCredentialManager().SetCreds(*url, *apiToken)
+			return credentialmanager.NewCredentialManager().SetCreds(*url, *authParams.apiToken)
 		}
 
 		fmt.Println("skipping auth due to mocking flag set to true")
@@ -111,10 +111,27 @@ More precisely, the Keptn CLI stores the endpoint and API token using *pass* in 
 
 func init() {
 	rootCmd.AddCommand(authCmd)
+	authParams = &authCmdParams{}
 
-	endPoint = authCmd.Flags().StringP("endpoint", "e", "", "The endpoint exposed by the Keptn installation (e.g., api.keptn.127.0.0.1.xip.io)")
-	apiToken = authCmd.Flags().StringP("api-token", "a", "", "The API token to communicate with the Keptn installation")
-	exportConfig = authCmd.Flags().BoolP("export", "c", false, "To export the current cluster config i.e API token and Endpoint")
+	authParams.endPoint = authCmd.Flags().StringP("endpoint", "e", "", "The endpoint exposed by the Keptn installation (e.g., api.keptn.127.0.0.1.xip.io)")
+	authParams.apiToken = authCmd.Flags().StringP("api-token", "a", "", "The API token to communicate with the Keptn installation")
+	authParams.exportConfig = authCmd.Flags().BoolP("export", "c", false, "To export the current cluster config i.e API token and Endpoint")
+}
+
+func verifyAuthParams(authParams *authCmdParams) error {
+
+	if *authParams.exportConfig {
+		return nil
+	}
+
+	if authParams.endPoint == nil && authParams.apiToken == nil {
+		return errors.New("required flag(s) \"api-token\", \"endpoint\" not set")
+	} else if authParams.endPoint == nil {
+		return errors.New("required flag \"endpoint\" not set")
+	} else if authParams.apiToken == nil {
+		return errors.New("required flag \"api-token\" not set")
+	}
+	return nil
 }
 
 func lookupHostname(hostname string) bool {

--- a/cli/cmd/auth.go
+++ b/cli/cmd/auth.go
@@ -124,12 +124,14 @@ func verifyAuthParams(authParams *authCmdParams) error {
 		return nil
 	}
 
-	if authParams.endPoint == nil && authParams.apiToken == nil {
-		return errors.New("required flag(s) \"api-token\", \"endpoint\" not set")
-	} else if authParams.endPoint == nil {
-		return errors.New("required flag \"endpoint\" not set")
-	} else if authParams.apiToken == nil {
-		return errors.New("required flag \"api-token\" not set")
+	if !mocking {
+		if (authParams.endPoint == nil || *authParams.endPoint == "") && (authParams.apiToken == nil || *authParams.apiToken == "") {
+			return errors.New("required flag(s) \"api-token\", \"endpoint\" not set")
+		} else if authParams.endPoint == nil || *authParams.endPoint == "" {
+			return errors.New("required flag \"endpoint\" not set")
+		} else if authParams.apiToken == nil || *authParams.apiToken == "" {
+			return errors.New("required flag \"api-token\" not set")
+		}
 	}
 	return nil
 }

--- a/cli/cmd/auth.go
+++ b/cli/cmd/auth.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -17,6 +18,9 @@ import (
 
 var endPoint *string
 var apiToken *string
+var exportConfig *bool
+var exportEndPoint url.URL
+var exportAPIToken string
 
 // authCmd represents the auth command
 var authCmd = &cobra.Command{
@@ -32,6 +36,26 @@ More precisely, the Keptn CLI stores the endpoint and API token using *pass* in 
 	Example:      `keptn auth --endpoint=https://api.keptn.MY.DOMAIN.COM --api-token=abcd-0123-wxyz-7890`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		var err error
+		if *exportConfig {
+			exportEndPoint, exportAPIToken, err = credentialmanager.NewCredentialManager().GetCreds()
+			if err != nil {
+				return err
+			}
+			fmt.Println("Endpoint = ", exportEndPoint.String())
+			fmt.Println("API Token = ", exportAPIToken)
+			return nil
+		}
+
+		if *endPoint == "" && *apiToken == "" {
+			return errors.New("required flag(s) \"api-token\", \"endpoint\" not set")
+		} else if *endPoint == "" {
+			return errors.New("required flag \"endpoint\" not set")
+		} else if *apiToken == "" {
+			return errors.New("required flag \"api-token\" not set")
+		}
+
 		logging.PrintLog("Starting to authenticate", logging.InfoLevel)
 
 		url, err := url.Parse(*endPoint)
@@ -89,9 +113,8 @@ func init() {
 	rootCmd.AddCommand(authCmd)
 
 	endPoint = authCmd.Flags().StringP("endpoint", "e", "", "The endpoint exposed by the Keptn installation (e.g., api.keptn.127.0.0.1.xip.io)")
-	authCmd.MarkFlagRequired("endpoint")
 	apiToken = authCmd.Flags().StringP("api-token", "a", "", "The API token to communicate with the Keptn installation")
-	authCmd.MarkFlagRequired("api-token")
+	exportConfig = authCmd.Flags().BoolP("export", "c", false, "To export the current cluster config i.e API token and Endpoint")
 }
 
 func lookupHostname(hostname string) bool {


### PR DESCRIPTION
As the feature request in this issue #2300, I have added the support for exporting the current configuration i.e api-token and endpoint.

The configuration is exported to stdout due to undefined structure of config file based on multi-cluster support.