### PR TITLE
#2405 Add build and run targets in the Makefile 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ configuration-service/cmd/configuration-service-server/__debug_bin
 !.idea/runConfigurations/
 
 vendor/
+
+bin/

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ UTILDIR := $(PROJECTROOT)/make-scripts/utils
 SPINNER := $(UTILDIR)/spinner.sh
 BUILDIR := $(PROJECTROOT)/make-scripts/build
 
-UNITTESTCOMMAND := $(shell cd cli/cmd/; go test -v)
+CREATEBIN := $(shell [ ! -d ./bin ] && mkdir bin)
 
 # Make is verbose in Linux. Make it silent.
 MAKEFLAGS += --silent
@@ -63,11 +63,12 @@ clean:
 ## Run unit tests on the CLI
 test-unit-cli:
 	@printf "⚙️ Running unit tests on the CLI\n" 
-	@$(UNITTESTCOMMAND)
+	@./make-scripts/run_cli_test.sh
 	@printf "👍 Done\n"
 
 ## Prepare code for PR
-prepare-for-pr: fmt lint test-unit-cli
+prepare-for-pr: fmt lint
+	@printf "❗️ Remember to run the tests"
 	@git diff-index --quiet HEAD -- ||\
 	(echo "-----------------" &&\
 	echo "NOTICE: There are some files that have not been committed." &&\
@@ -79,6 +80,17 @@ prepare-for-pr: fmt lint test-unit-cli
 	exit 0)
 
 help:
-	@printf "Keptn"
-	@printf "Help is coming soon..."
-	@printf ""
+	@echo "KEPTN"
+	@echo ""
+	@echo "* build-cli: Build the keptn cli and save it in bin/"
+	@echo "* start-bridge: Start the bridge server"
+	@echo "* install-helm: Install the helm binary in your local"
+	@echo "* install-golint: Install golint for linting the code"
+	@echo "* fmt: Formats the codebase"
+	@echo "* lint: Lints the codebase"
+	@echo "* clean: Cleans the build cache"
+	@echo "* test-unit-cli: Run unit tests on the Keptn CLI"
+	@echo "* prepare-for-pr: Makes the code ready for PR by formatting, linting and checking for uncommitted files"
+	@echo ""
+	@echo "Please visit https://keptn.sh for more information."
+	@echo "Get in touch with us via Slack: https://slack.keptn.sh"

--- a/Makefile
+++ b/Makefile
@@ -1,1 +1,84 @@
-target: ;
+PROJECTNAME := $(shell basename "$(PWD)")
+
+# Go related variables.
+PROJECTROOT := $(shell pwd)
+GOBIN := $(PROJECTROOT)/bin
+
+# Shell script related variables.
+UTILDIR := $(PROJECTROOT)/make-scripts/utils
+SPINNER := $(UTILDIR)/spinner.sh
+BUILDIR := $(PROJECTROOT)/make-scripts/build
+
+UNITTESTCOMMAND := $(shell cd cli/cmd/; go test -v)
+
+# Make is verbose in Linux. Make it silent.
+MAKEFLAGS += --silent
+
+.PHONY: default
+default: help
+
+## Build the cli binary
+build-cli:
+	@printf "🔨 Building binary $(GOBIN)/$(PROJECTNAME)\n" 
+	@./make-scripts/build/build-cli.sh
+	@cp ./cli/keptn $(GOBIN)/
+	@printf "👍 Done\n"
+
+## Start the bridge
+start-bridge:
+	@printf "🚀 Starting Bridge\n" 
+	@./make-scripts/start_bridge.sh
+
+## Install helm
+install-helm:
+	@printf "🔨 Installing Helm\n" 
+	@./make-scripts/install_helm.sh
+	@printf "👍 Done\n"
+
+## Lint the code
+install-golint:
+	@printf "🔨 Installing golint\n" 
+	@./make-scripts/install_golint.sh
+	@printf "👍 Done\n"
+
+## Format the code
+fmt:
+	@printf "🔨 Formatting\n" 
+	@gofmt -l -s .
+	@printf "👍 Done\n"
+
+## Check codebase for style mistakes
+lint: install-golint
+	@printf "🔨 Linting\n"
+	@golint ./...
+	@printf "👍 Done\n"
+
+## Clean build files
+clean:
+	@printf "🔨 Cleaning build cache\n" 
+	@go clean .
+	@printf "👍 Done\n"
+	@-rm $(GOBIN)/* 2>/dev/null
+
+## Run unit tests on the CLI
+test-unit-cli:
+	@printf "⚙️ Running unit tests on the CLI\n" 
+	@$(UNITTESTCOMMAND)
+	@printf "👍 Done\n"
+
+## Prepare code for PR
+prepare-for-pr: fmt lint test-unit-cli
+	@git diff-index --quiet HEAD -- ||\
+	(echo "-----------------" &&\
+	echo "NOTICE: There are some files that have not been committed." &&\
+	echo "-----------------\n" &&\
+	git status &&\
+	echo "\n-----------------" &&\
+	echo "NOTICE: There are some files that have not been committed." &&\
+	echo "-----------------\n"  &&\
+	exit 0)
+
+help:
+	@printf "Keptn"
+	@printf "Help is coming soon..."
+	@printf ""

--- a/make-scripts/build/build-cli.sh
+++ b/make-scripts/build/build-cli.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+VERSION=${1:-develop}
+KUBE_CONSTRAINTS=$2
+
+cd ./cli/
+
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    ############################################
+    # Linux
+    ############################################
+    echo "Building Keptn CLI for Linux"
+    env GOOS=linux GOARCH=amd64 go mod download
+    env GOOS=linux GOARCH=amd64 go build -v -x -ldflags="-X 'main.Version=$VERSION' -X 'main.KubeServerVersionConstraints=$KUBE_CONSTRAINTS'" -o keptn
+
+    if [ $? -ne 0 ]; then
+    echo "Error compiling Keptn CLI, exiting ..."
+    exit 1
+    fi
+
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    ############################################
+    # MAC OS
+    ############################################
+    echo "Building Keptn CLI for OSX"
+    env GOOS=darwin GOARCH=amd64 go mod download
+    env GOOS=darwin GOARCH=amd64 go build -v -x  -ldflags="-X 'main.Version=$VERSION' -X 'main.KubeServerVersionConstraints=$KUBE_CONSTRAINTS'" -o keptn
+
+    if [ $? -ne 0 ]; then
+    echo "Error compiling Keptn CLI, exiting ..."
+    exit 1
+    fi
+fi

--- a/make-scripts/install_golint.sh
+++ b/make-scripts/install_golint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash 
+
+set -e
+project_dir=$(pwd)
+if [ -f $project_dir/bin/golint ]; then
+    exit 0
+fi
+
+mkdir -p bin
+tmp_dir=$(mktemp -d -t ci-XXXXXXXXXX)
+cd $tmp_dir
+GOPATH=$tmp_dir go get golang.org/x/lint/golint
+cp $tmp_dir/bin/golint $project_dir/bin/golint
+rm -rf $tmp_dir

--- a/make-scripts/install_helm.sh
+++ b/make-scripts/install_helm.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# download
+curl https://get.helm.sh/helm-v3.2.4-linux-amd64.tar.gz > helm.tar.gz
+tar -zxvf helm.tar.gz
+if [ ! -d "$HOME/bin" ]; then
+  mkdir "$HOME/bin"
+fi
+
+mv linux-amd64/helm "$HOME/bin"
+export PATH=$PATH:"$HOME/bin"

--- a/make-scripts/run_cli_test.sh
+++ b/make-scripts/run_cli_test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# run cli tests
+cd ./cli/cmd
+go test -v

--- a/make-scripts/start_bridge.sh
+++ b/make-scripts/start_bridge.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+if ! command -v npm &> /dev/null
+then
+    echo "npm could not be found, install npm first"
+    exit
+fi
+
+cd ./bridge/
+
+# install the dependencies
+npm install
+
+# accept the API URL and API TOKEN as the user inputs
+read -p 'Enter API URL: ' API_URL
+read -sp 'Enter API Token: ' API_TOKEN
+
+# start the server
+npm run start:dev

--- a/make-scripts/start_bridge.sh
+++ b/make-scripts/start_bridge.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# check if npm command is present
 if ! command -v npm &> /dev/null
 then
     echo "npm could not be found, install npm first"
@@ -8,12 +9,35 @@ fi
 
 cd ./bridge/
 
-# install the dependencies
-npm install
+# Check if node_modules is absent
+if [ -d ./bridge/node_modules ]; then
+    # install the dependencies
+    npm install
+fi
 
-# accept the API URL and API TOKEN as the user inputs
-read -p 'Enter API URL: ' API_URL
-read -sp 'Enter API Token: ' API_TOKEN
+if [[ -z $API_URL && -z $API_TOKEN ]]; then
+    # accept the API URL and API TOKEN as the user inputs
+    read -p 'Enter API URL: ' API_URL
+    read -sp 'Enter API Token: ' API_TOKEN
+
+    if [ -z $API_URL ]; then
+        echo "Enter valid API URL"
+        exit 0
+    fi
+
+    if [ -z $API_TOKEN ]; then
+        echo "API Token is left blank, it will be automatically pulled via kubectl."
+        exit 0
+    fi
+elif [[ -z $API_URL && ! -z $API_TOKEN ]]; then
+    read -p 'Enter API URL: ' API_URL
+else
+    TOKENLEN = ${#API_TOKEN}
+    s = $(printf "%-${TOKENLEN}s" "*")
+    echo "API URL and API Token already set."
+    echo "API URL:" $API_URL
+    echo "API Token:" "${s// /*}"
+fi
 
 # start the server
 npm run start:dev

--- a/make-scripts/utils/spinner.sh
+++ b/make-scripts/utils/spinner.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+function spin {
+  sleep 0   # For deferring
+  message=$1
+  length=${#message}
+  blocks=$(seq -s '\b' $(($length+3))|tr -d '[:digit:]')
+  i=1
+  sp="🌑🌒🌓🌔🌕🌖🌗🌘"
+  echo -n ' '
+  while true
+  do
+    printf "${blocks}%s" "${sp:i++%${#sp}:1} ${message}"
+    sleep 0.1
+  done
+}
+
+function cleanup {
+  kill -9 $_main_pid 2>/dev/null
+  kill -9 $_sp_pid 2>/dev/null
+}
+
+message=$1
+command=$2
+
+trap "exit" INT TERM ERR
+trap cleanup EXIT
+
+printf "\n"
+eval "$command" 1>/dev/null &
+export _main_pid=$!
+spin "$message" &
+export _sp_pid=$!
+
+wait $_main_pid


### PR DESCRIPTION
This PR adds functionality to the Makefile to speed up the local development process. Some of the features and newer additions in this needs discussion. The following commands have currently been added to the Makefile:
* `build-cli`: For building the CLI binary and saving it in a `./bin` directory.
* `start-bridge`: For starting the bridge server
* `fmt`
* `lint`
* `clean`
* `test-unit-cli`: For running unit tests on the CLI
* `prepare-for-pr`: To format, lint and check for commits to prepare it for PR.

Some points that are open for discussion are:
* Should there be commands to deploy the different services as well? This is because all of them are mostly `kubectl -f ...`
* How should the end-to-end tests be tackled in the Makefile? Since they are a set of scripts, what should be the best approach?
