### PR TITLE
#2389 Highlight comparedEvents in heatmap

### DIFF
--- a/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.scss
+++ b/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.scss
@@ -1,0 +1,14 @@
+@import '../../../variables';
+@import '~@dynatrace/barista-components/core/src/style/variables';
+
+::ng-deep path.highlight-primary {
+  stroke-width: 2;
+  stroke: rgb(109, 109, 109);
+  fill: rgba(109, 109, 109, 0.4);
+}
+::ng-deep path.highlight-secondary {
+  stroke-width: 1;
+  stroke-dasharray: 5,5;
+  stroke: rgb(137, 137, 137);
+  fill: rgba(137, 137, 137, 0.2);
+}

--- a/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
+++ b/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
@@ -334,16 +334,24 @@ export class KtbEvaluationDetailsComponent implements OnInit, OnDestroy {
 
   highlightHeatmap() {
     let highlightIndex = this._heatmapOptions.xAxis[0].categories.indexOf(moment(this._selectedEvaluationData.time).format());
+    let secondaryHighlightIndexes = this._selectedEvaluationData?.data.evaluationdetails.comparedEvents?.map(eventId => this._heatmapSeries[0]?.data.find(e => e['evaluation'].id == eventId)?.x);
     let plotBands = [];
     if(highlightIndex >= 0)
       plotBands.push({
-        borderWidth: 2,
-        borderColor: '#6d6d6d',
-        color: 'rgba(109,109,109,.4)',
+        className: 'highlight-primary',
         from: highlightIndex-0.5,
         to: highlightIndex+0.5,
         zIndex: 20
       });
+    secondaryHighlightIndexes?.forEach(highlightIndex => {
+      if(highlightIndex >= 0)
+        plotBands.push({
+          className: 'highlight-secondary',
+          from: highlightIndex-0.5,
+          to: highlightIndex+0.5,
+          zIndex: 20
+        });
+    });
     this._heatmapOptions.xAxis[0].plotBands = plotBands;
     this.heatmapChart?._update();
     this._changeDetectorRef.markForCheck();

--- a/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
+++ b/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
@@ -334,7 +334,7 @@ export class KtbEvaluationDetailsComponent implements OnInit, OnDestroy {
 
   highlightHeatmap() {
     let highlightIndex = this._heatmapOptions.xAxis[0].categories.indexOf(moment(this._selectedEvaluationData.time).format());
-    let secondaryHighlightIndexes = this._selectedEvaluationData?.data.evaluationdetails.comparedEvents?.map(eventId => this._heatmapSeries[0]?.data.find(e => e['evaluation'].id == eventId)?.x);
+    let secondaryHighlightIndexes = this._selectedEvaluationData?.data.evaluationdetails.comparedEvents?.map(eventId => this._heatmapSeries[0]?.data.findIndex(e => e['evaluation'].id == eventId));
     let plotBands = [];
     if(highlightIndex >= 0)
       plotBands.push({

--- a/bridge/client/app/_models/trace.ts
+++ b/bridge/client/app/_models/trace.ts
@@ -50,6 +50,7 @@ class Trace {
     };
 
     evaluationdetails: {
+      comparedEvents: string[];
       indicatorResults: any;
       result: string;
       score: number;


### PR DESCRIPTION
If the comparedEvents are provided, those events are highlighted in the heatmap, so that the user now can easily see the selected event and with which it was compared with.

![image](https://user-images.githubusercontent.com/6098219/94442848-ba7dc100-01a4-11eb-8027-b8770c404556.png)
