### PR TITLE
#2131 Show labels on xAxis in Heatmap

### DIFF
--- a/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
+++ b/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
@@ -314,9 +314,9 @@ export class KtbEvaluationDetailsComponent implements OnInit, OnDestroy {
         let categories = series.data
           .sort((a, b) => moment(a.evaluationData.time).unix() - moment(b.evaluationData.time).unix())
           .map((item, index, items) => {
-            let uniqueIndex = items.filter(c => c.evaluationData.getHeatmapLabel() == item.evaluationData.getHeatmapLabel()).indexOf(item);
-            if(uniqueIndex > 0)
-              item.label = `${item.evaluationData.getHeatmapLabel()} (${uniqueIndex})`;
+            let duplicateItems = items.filter(c => c.evaluationData.getHeatmapLabel() == item.evaluationData.getHeatmapLabel());
+            if(duplicateItems.length > 1)
+              item.label = `${item.evaluationData.getHeatmapLabel()} (${duplicateItems.indexOf(item)+1})`;
             else
               item.label = item.evaluationData.getHeatmapLabel();
             return item;

--- a/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
+++ b/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
@@ -371,9 +371,11 @@ export class KtbEvaluationDetailsComponent implements OnInit, OnDestroy {
           to: highlightIndex+0.5,
           zIndex: 100,
           events: {
-            click: function (event) {
+            click: function () {
               let index = this.options.from+0.5;
-              _this.selectEvaluationData(_this._heatmapSeries[0].data[index]['evaluation']);
+              setTimeout(() => {
+                _this.selectEvaluationData(_this._heatmapSeries[0].data[index]['evaluation']);
+              });
             }
           }
         });

--- a/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
+++ b/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
@@ -326,7 +326,6 @@ export class KtbEvaluationDetailsComponent implements OnInit, OnDestroy {
             return item.evaluationData.getHeatmapLabel();
           });
 
-        console.log("categories", categories);
         this._heatmapOptions.xAxis[0].categories = categories;
       }
     });
@@ -353,6 +352,7 @@ export class KtbEvaluationDetailsComponent implements OnInit, OnDestroy {
   }
 
   highlightHeatmap() {
+    let _this = this;
     let highlightIndex = this._heatmapOptions.xAxis[0].categories.indexOf(this._selectedEvaluationData.getHeatmapLabel());
     let secondaryHighlightIndexes = this._selectedEvaluationData?.data.evaluationdetails.comparedEvents?.map(eventId => this._heatmapSeries[0]?.data.findIndex(e => e['evaluation'].id == eventId));
     let plotBands = [];
@@ -369,7 +369,13 @@ export class KtbEvaluationDetailsComponent implements OnInit, OnDestroy {
           className: 'highlight-secondary',
           from: highlightIndex-0.5,
           to: highlightIndex+0.5,
-          zIndex: 100
+          zIndex: 100,
+          events: {
+            click: function (event) {
+              let index = this.options.from+0.5;
+              _this.selectEvaluationData(_this._heatmapSeries[0].data[index]['evaluation']);
+            }
+          }
         });
     });
     this._heatmapOptions.xAxis[0].plotBands = plotBands;

--- a/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
+++ b/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
@@ -307,15 +307,19 @@ export class KtbEvaluationDetailsComponent implements OnInit, OnDestroy {
   }
 
   updateHeatmapOptions(chartSeries) {
-    chartSeries.forEach((d) =>
-      d.data.sort((a, b) => moment(a.evaluationData.time).unix() - moment(b.evaluationData.time).unix()).forEach((s) => {
-        let time = moment(s.evaluationData.time).format();
-        if(s.indicatorResult && this._heatmapOptions.yAxis[0].categories.indexOf(s.indicatorResult.value.metric) == -1)
-          this._heatmapOptions.yAxis[0].categories.unshift(s.indicatorResult.value.metric);
-        if(this._heatmapOptions.xAxis[0].categories.indexOf(s.evaluationData.getHeatmapLabel()) == -1)
-          this._heatmapOptions.xAxis[0].categories.push(s.evaluationData.getHeatmapLabel());
-      })
-    );
+    chartSeries.forEach((series) => {
+      if(this._heatmapOptions.yAxis[0].categories.indexOf(series.name) === -1)
+        this._heatmapOptions.yAxis[0].categories.unshift(series.name);
+      if(series.name == "Score") {
+        let categories = series.data
+          .sort((a, b) => moment(a.evaluationData.time).unix() - moment(b.evaluationData.time).unix())
+          .map((item) => item.evaluationData.getHeatmapLabel())
+          .map((category, index, categories) => categories.indexOf(category) != index ? category+" ("+index+")" : category);
+
+        console.log("categories", categories);
+        this._heatmapOptions.xAxis[0].categories = categories;
+      }
+    });
 
     this._heatmapOptions.chart.height = this._heatmapOptions.yAxis[0].categories.length*28 + 160;
   }

--- a/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
+++ b/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
@@ -317,7 +317,7 @@ export class KtbEvaluationDetailsComponent implements OnInit, OnDestroy {
       })
     );
 
-    this._heatmapOptions.chart.height = this._heatmapOptions.yAxis[0].categories.length*28 + 60;
+    this._heatmapOptions.chart.height = this._heatmapOptions.yAxis[0].categories.length*28 + 160;
   }
 
   seriesVisibilityChanged(_: DtChartSeriesVisibilityChangeEvent): void {

--- a/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
+++ b/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
@@ -313,8 +313,18 @@ export class KtbEvaluationDetailsComponent implements OnInit, OnDestroy {
       if(series.name == "Score") {
         let categories = series.data
           .sort((a, b) => moment(a.evaluationData.time).unix() - moment(b.evaluationData.time).unix())
-          .map((item) => item.evaluationData.getHeatmapLabel())
-          .map((category, index, categories) => categories.indexOf(category) != index ? category+" ("+index+")" : category);
+          .map((item, index, items) => {
+            let uniqueIndex = items.filter(c => c.evaluationData.getHeatmapLabel() == item.evaluationData.getHeatmapLabel()).indexOf(item);
+            if(uniqueIndex > 0)
+              item.label = `${item.evaluationData.getHeatmapLabel()} (${uniqueIndex})`;
+            else
+              item.label = item.evaluationData.getHeatmapLabel();
+            return item;
+          })
+          .map((item) => {
+            item.evaluationData.setHeatmapLabel(item.label);
+            return item.evaluationData.getHeatmapLabel();
+          });
 
         console.log("categories", categories);
         this._heatmapOptions.xAxis[0].categories = categories;
@@ -351,7 +361,7 @@ export class KtbEvaluationDetailsComponent implements OnInit, OnDestroy {
         className: 'highlight-primary',
         from: highlightIndex-0.5,
         to: highlightIndex+0.5,
-        zIndex: 20
+        zIndex: 100
       });
     secondaryHighlightIndexes?.forEach(highlightIndex => {
       if(highlightIndex >= 0)
@@ -359,7 +369,7 @@ export class KtbEvaluationDetailsComponent implements OnInit, OnDestroy {
           className: 'highlight-secondary',
           from: highlightIndex-0.5,
           to: highlightIndex+0.5,
-          zIndex: 20
+          zIndex: 100
         });
     });
     this._heatmapOptions.xAxis[0].plotBands = plotBands;

--- a/bridge/client/app/_models/trace.ts
+++ b/bridge/client/app/_models/trace.ts
@@ -1,3 +1,5 @@
+import * as moment from 'moment';
+
 import {EventTypes} from "./event-types";
 import {ResultTypes} from "./result-types";
 import {ApprovalStates} from "./approval-states";
@@ -228,7 +230,11 @@ class Trace {
   }
 
   getChartLabel(): string {
-    return this.data.labels?.["buildId"] ?? this.time;
+    return this.data.labels?.["buildId"] ?? moment(this.time).format("YYYY-MM-DD HH:mm");
+  }
+
+  getHeatmapLabel(): string {
+    return this.getChartLabel();
   }
 
   static fromJSON(data: any) {

--- a/bridge/client/app/_models/trace.ts
+++ b/bridge/client/app/_models/trace.ts
@@ -17,6 +17,7 @@ class Trace {
   time: Date;
   type: string;
   label: string;
+  heatmapLabel: string;
   icon: string;
   image: string;
   plainEvent: string;
@@ -234,7 +235,14 @@ class Trace {
   }
 
   getHeatmapLabel(): string {
-    return this.getChartLabel();
+    if(!this.heatmapLabel) {
+      this.heatmapLabel = this.getChartLabel();
+    }
+    return this.heatmapLabel;
+  }
+
+  setHeatmapLabel(label: string) {
+    this.heatmapLabel = label;
   }
 
   static fromJSON(data: any) {


### PR DESCRIPTION
The Heatmap has now labels on the xAxis (either the timestamp or the `buildId` label if it is provided on the event payload is used)

![image](https://user-images.githubusercontent.com/6098219/94552155-ba3dfe00-0256-11eb-99ad-6e9b1472dca0.png)
