### PR TITLE
#2387 Rename properties of evaluation

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -49,6 +49,7 @@ COPY --from=builder /go/src/github.com/keptn/keptn/api/project_model.yaml /swagg
 COPY --from=builder /go/src/github.com/keptn/keptn/api/response_model.yaml /swagger-ui/response_model.yaml
 COPY --from=builder /go/src/github.com/keptn/keptn/api/service_model.yaml /swagger-ui/service_model.yaml
 COPY --from=builder /go/src/github.com/keptn/keptn/api/configure_model.yaml /swagger-ui/configure_model.yaml
+COPY --from=builder /go/src/github.com/keptn/keptn/api/evaluation_model.yaml /swagger-ui/evaluation_model.yaml
 
 RUN sed -i "s|basePath: /v1|basePath: /api/v1 |g" /swagger-ui/swagger.yaml
 

--- a/api/evaluation_model.yaml
+++ b/api/evaluation_model.yaml
@@ -9,12 +9,12 @@ definitions:
         additionalProperties:
           type: string
 
-      from:
+      start:
         name: from
         type: string
         description: Evaluation start timestamp
 
-      to:
+      end:
         name: to
         type: string
         description: Evaluation end timestamp

--- a/api/handlers/evaluation.go
+++ b/api/handlers/evaluation.go
@@ -40,7 +40,7 @@ func TriggerEvaluationHandlerFunc(params evaluation.TriggerEvaluationParams, pri
 	logger := keptnutils.NewLogger(keptnContext, "", "api")
 	logger.Info("API received a trigger-evaluation request")
 
-	start, end, err := getStartEndTime(params.Evaluation.From, params.Evaluation.To, params.Evaluation.Timeframe)
+	start, end, err := getStartEndTime(params.Evaluation.Start, params.Evaluation.End, params.Evaluation.Timeframe)
 	if err != nil {
 		return evaluation.NewTriggerEvaluationBadRequest().WithPayload(&models.Error{
 			Code:    400,

--- a/api/models/evaluation.go
+++ b/api/models/evaluation.go
@@ -15,17 +15,17 @@ import (
 // swagger:model evaluation
 type Evaluation struct {
 
-	// Evaluation start timestamp
-	From string `json:"from,omitempty"`
+	// Evaluation end timestamp
+	End string `json:"end,omitempty"`
 
 	// labels
 	Labels map[string]string `json:"labels,omitempty"`
 
+	// Evaluation start timestamp
+	Start string `json:"start,omitempty"`
+
 	// Evaluation timeframe
 	Timeframe string `json:"timeframe,omitempty"`
-
-	// Evaluation end timestamp
-	To string `json:"to,omitempty"`
 }
 
 // Validate validates this evaluation

--- a/api/restapi/embedded_spec.go
+++ b/api/restapi/embedded_spec.go
@@ -896,10 +896,10 @@ func init() {
     "evaluation": {
       "type": "object",
       "properties": {
-        "from": {
-          "description": "Evaluation start timestamp",
+        "end": {
+          "description": "Evaluation end timestamp",
           "type": "string",
-          "name": "from"
+          "name": "to"
         },
         "labels": {
           "type": "object",
@@ -908,15 +908,15 @@ func init() {
           },
           "name": "labels"
         },
+        "start": {
+          "description": "Evaluation start timestamp",
+          "type": "string",
+          "name": "from"
+        },
         "timeframe": {
           "description": "Evaluation timeframe",
           "type": "string",
           "name": "timeframe"
-        },
-        "to": {
-          "description": "Evaluation end timestamp",
-          "type": "string",
-          "name": "to"
         }
       }
     },

--- a/api/restapi/embedded_spec.go
+++ b/api/restapi/embedded_spec.go
@@ -345,15 +345,6 @@ func init() {
         "operationId": "triggerEvaluation",
         "parameters": [
           {
-            "$ref": "#/parameters/projectName"
-          },
-          {
-            "$ref": "#/parameters/stageName"
-          },
-          {
-            "$ref": "#/parameters/serviceName"
-          },
-          {
             "$ref": "#/parameters/evaluation"
           }
         ],
@@ -377,7 +368,18 @@ func init() {
             }
           }
         }
-      }
+      },
+      "parameters": [
+        {
+          "$ref": "#/parameters/projectName"
+        },
+        {
+          "$ref": "#/parameters/stageName"
+        },
+        {
+          "$ref": "#/parameters/serviceName"
+        }
+      ]
     }
   },
   "parameters": {
@@ -807,27 +809,6 @@ func init() {
         "operationId": "triggerEvaluation",
         "parameters": [
           {
-            "type": "string",
-            "description": "Name of the project",
-            "name": "projectName",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Name of the stage",
-            "name": "stageName",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Name of the service",
-            "name": "serviceName",
-            "in": "path",
-            "required": true
-          },
-          {
             "description": "Evaluation",
             "name": "evaluation",
             "in": "body",
@@ -856,7 +837,30 @@ func init() {
             }
           }
         }
-      }
+      },
+      "parameters": [
+        {
+          "type": "string",
+          "description": "Name of the project",
+          "name": "projectName",
+          "in": "path",
+          "required": true
+        },
+        {
+          "type": "string",
+          "description": "Name of the stage",
+          "name": "stageName",
+          "in": "path",
+          "required": true
+        },
+        {
+          "type": "string",
+          "description": "Name of the service",
+          "name": "serviceName",
+          "in": "path",
+          "required": true
+        }
+      ]
     }
   },
   "definitions": {

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -177,15 +177,16 @@ paths:
             $ref: "response_model.yaml#/definitions/error"
 
   /project/{projectName}/stage/{stageName}/service/{serviceName}/evaluation:
+    parameters:
+      - $ref: "#/parameters/projectName"
+      - $ref: "#/parameters/stageName"
+      - $ref: "#/parameters/serviceName"
     post:
       tags:
         - evaluation
       summary: Trigger a new evaluation
       operationId: triggerEvaluation
       parameters:
-        - $ref: "#/parameters/projectName"
-        - $ref: "#/parameters/stageName"
-        - $ref: "#/parameters/serviceName"
         - $ref: "#/parameters/evaluation"
       responses:
         200:

--- a/cli/cmd/send_event_evaluationStart.go
+++ b/cli/cmd/send_event_evaluationStart.go
@@ -107,8 +107,8 @@ keptn send event start-evaluation --project=sockshop --stage=hardening --service
 				*evaluationStart.Stage,
 				*evaluationStart.Service,
 				apimodels.Evaluation{
-					From:   start.Format("2006-01-02T15:04:05"),
-					To:     end.Format("2006-01-02T15:04:05"),
+					Start:  start.Format("2006-01-02T15:04:05"),
+					End:    end.Format("2006-01-02T15:04:05"),
 					Labels: *evaluationStart.Labels,
 				},
 			)

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/googleapis/gnostic v0.1.0 // indirect
 	github.com/gorilla/websocket v1.4.1
 	github.com/hashicorp/go-version v1.2.0
-	github.com/keptn/go-utils v0.6.3-0.20200929121408-1c14750f2f1f
+	github.com/keptn/go-utils v0.6.3-0.20200929122933-df294e7a41c5
 	github.com/keptn/kubernetes-utils v0.2.0
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/magiconair/properties v1.8.1

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/googleapis/gnostic v0.1.0 // indirect
 	github.com/gorilla/websocket v1.4.1
 	github.com/hashicorp/go-version v1.2.0
-	github.com/keptn/go-utils v0.6.3-0.20200924105635-32aece7691fd
+	github.com/keptn/go-utils v0.6.3-0.20200929121408-1c14750f2f1f
 	github.com/keptn/kubernetes-utils v0.2.0
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/magiconair/properties v1.8.1

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -391,6 +391,8 @@ github.com/keptn/go-utils v0.6.3-0.20200924105635-32aece7691fd h1:O3xlmAa7EKCLmf
 github.com/keptn/go-utils v0.6.3-0.20200924105635-32aece7691fd/go.mod h1:jD+ZvrkwYyDMgeKANzVZsBSYgjYQxTJvxw/RB3vYFAE=
 github.com/keptn/go-utils v0.6.3-0.20200929121408-1c14750f2f1f h1:Jjtw86y4ukvSEUP4zR3DFi/HfDBBjClrgkvNz3BLKsU=
 github.com/keptn/go-utils v0.6.3-0.20200929121408-1c14750f2f1f/go.mod h1:jD+ZvrkwYyDMgeKANzVZsBSYgjYQxTJvxw/RB3vYFAE=
+github.com/keptn/go-utils v0.6.3-0.20200929122933-df294e7a41c5 h1:n8FJzSLNtNFKbQpqVMycZhtBcoSByibBwKWDOltoYKQ=
+github.com/keptn/go-utils v0.6.3-0.20200929122933-df294e7a41c5/go.mod h1:jD+ZvrkwYyDMgeKANzVZsBSYgjYQxTJvxw/RB3vYFAE=
 github.com/keptn/go-utils v0.7.1 h1:qDViu8qhijdh7QK1+k+i4hEDtTwkHo2PxsomxKvxlpg=
 github.com/keptn/go-utils v0.7.1/go.mod h1:hf2FU6JFuOzLP5rEAlA1/XnNS28pDZbVfxDESeQsq1g=
 github.com/keptn/kubernetes-utils v0.2.0 h1:DEjTzixk7TJ6i2HopTlw/d4b1perJR1gmyOOCrWX5cA=

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -389,6 +389,8 @@ github.com/keptn/go-utils v0.6.3-0.20200924103349-e0d199f3e10e h1:5SYsMVSNmJZOcW
 github.com/keptn/go-utils v0.6.3-0.20200924103349-e0d199f3e10e/go.mod h1:jD+ZvrkwYyDMgeKANzVZsBSYgjYQxTJvxw/RB3vYFAE=
 github.com/keptn/go-utils v0.6.3-0.20200924105635-32aece7691fd h1:O3xlmAa7EKCLmfQk0ACoT3OBwDsqFK6Mymnpna3Chyc=
 github.com/keptn/go-utils v0.6.3-0.20200924105635-32aece7691fd/go.mod h1:jD+ZvrkwYyDMgeKANzVZsBSYgjYQxTJvxw/RB3vYFAE=
+github.com/keptn/go-utils v0.6.3-0.20200929121408-1c14750f2f1f h1:Jjtw86y4ukvSEUP4zR3DFi/HfDBBjClrgkvNz3BLKsU=
+github.com/keptn/go-utils v0.6.3-0.20200929121408-1c14750f2f1f/go.mod h1:jD+ZvrkwYyDMgeKANzVZsBSYgjYQxTJvxw/RB3vYFAE=
 github.com/keptn/go-utils v0.7.1 h1:qDViu8qhijdh7QK1+k+i4hEDtTwkHo2PxsomxKvxlpg=
 github.com/keptn/go-utils v0.7.1/go.mod h1:hf2FU6JFuOzLP5rEAlA1/XnNS28pDZbVfxDESeQsq1g=
 github.com/keptn/kubernetes-utils v0.2.0 h1:DEjTzixk7TJ6i2HopTlw/d4b1perJR1gmyOOCrWX5cA=

--- a/test/test_quality_gates_standalone.sh
+++ b/test/test_quality_gates_standalone.sh
@@ -98,53 +98,28 @@ sleep 10
 
 echo "Sending start-evaluation event for service 'wrong-service' in stage hardening"
 
-keptn_context_id=$(send_start_evaluation_event $PROJECT hardening wrong-service)
-sleep 10
+response=$(send_start_evaluation_request $PROJECT wrong-stage wrong-service)
 
-# try to fetch a evaluation-done event
-echo "Getting evaluation-done event with context-id: ${keptn_context_id}"
-response=$(get_evaluation_done_event ${keptn_context_id})
+# check if the error response tells us that the stage does not exist
+if [[ $response != *"Service not found"* ]]; then
+  echo "Did not receive expected response from Keptn API"
+  exit 1
+fi
 
-# print the response
-echo $response | jq .
-
-# validate the response
-verify_using_jq "$response" ".source" "lighthouse-service"
-verify_using_jq "$response" ".type" "sh.keptn.events.evaluation-done"
-verify_using_jq "$response" ".data.project" "${PROJECT}"
-verify_using_jq "$response" ".data.stage" "hardening"
-verify_using_jq "$response" ".data.service" "wrong-service"
-verify_using_jq "$response" ".data.result" "failed"
-verify_using_jq "$response" ".data.evaluationdetails.result" "error retrieving SLO file: service wrong-service not found"
-verify_using_jq "$response" ".data.evaluationdetails.score" "0"
-verify_using_jq "$response" ".data.evaluationdetails.sloFileContent" ""
 
 ########################################################################################################################
 # Testcase 0.b: Send a start-evaluation event for a stage that does not exist
 ########################################################################################################################
 
-echo "Sending start-evaluation event for service 'wrong-service' in stage 'wrong-service'"
+echo "Sending start-evaluation event for service 'wrong-service' in stage 'wrong-stage'"
 
-keptn_context_id=$(send_start_evaluation_event $PROJECT wrong-stage wrong-service)
-sleep 10
+response=$(send_start_evaluation_request $PROJECT wrong-stage wrong-service)
 
-# try to fetch a evaluation-done event
-echo "Getting evaluation-done event with context-id: ${keptn_context_id}"
-response=$(get_evaluation_done_event ${keptn_context_id})
-
-# print the response
-echo $response | jq .
-
-# validate the response
-verify_using_jq "$response" ".source" "lighthouse-service"
-verify_using_jq "$response" ".type" "sh.keptn.events.evaluation-done"
-verify_using_jq "$response" ".data.project" "${PROJECT}"
-verify_using_jq "$response" ".data.stage" "wrong-stage"
-verify_using_jq "$response" ".data.service" "wrong-service"
-verify_using_jq "$response" ".data.result" "failed"
-verify_using_jq "$response" ".data.evaluationdetails.result" "error retrieving SLO file: stage wrong-stage not found"
-verify_using_jq "$response" ".data.evaluationdetails.score" "0"
-verify_using_jq "$response" ".data.evaluationdetails.sloFileContent" ""
+# check if the error response tells us that the stage does not exist
+if [[ $response != *"Stage not found"* ]]; then
+  echo "Did not receive expected response from Keptn API"
+  exit 1
+fi
 
 ########################################################################################################################
 # Testcase 0.c: Send a start-evaluation event for a project that does not exist
@@ -152,26 +127,13 @@ verify_using_jq "$response" ".data.evaluationdetails.sloFileContent" ""
 
 echo "Sending start-evaluation event for service 'wrong-service' in stage 'wrong-service' in project 'wrong-project'"
 
-keptn_context_id=$(send_start_evaluation_event wrong-project wrong-stage wrong-service)
-sleep 10
+response=$(send_start_evaluation_request $PROJECT wrong-stage wrong-service)
 
-# try to fetch a evaluation-done event
-echo "Getting evaluation-done event with context-id: ${keptn_context_id}"
-response=$(get_evaluation_done_event ${keptn_context_id})
-
-# print the response
-echo $response | jq .
-
-# validate the response
-verify_using_jq "$response" ".source" "lighthouse-service"
-verify_using_jq "$response" ".type" "sh.keptn.events.evaluation-done"
-verify_using_jq "$response" ".data.project" "wrong-project"
-verify_using_jq "$response" ".data.stage" "wrong-stage"
-verify_using_jq "$response" ".data.service" "wrong-service"
-verify_using_jq "$response" ".data.result" "failed"
-verify_using_jq "$response" ".data.evaluationdetails.result" "error retrieving SLO file: project wrong-project not found"
-verify_using_jq "$response" ".data.evaluationdetails.score" "0"
-verify_using_jq "$response" ".data.evaluationdetails.sloFileContent" ""
+# check if the error response tells us that the stage does not exist
+if [[ $response != *"Project not found"* ]]; then
+  echo "Did not receive expected response from Keptn API"
+  exit 1
+fi
 
 ########################################################################################################################
 # Testcase 1:

--- a/test/test_quality_gates_standalone.sh
+++ b/test/test_quality_gates_standalone.sh
@@ -100,7 +100,7 @@ echo "Sending start-evaluation event for service 'wrong-service' in stage harden
 
 response=$(send_start_evaluation_request $PROJECT wrong-stage wrong-service)
 
-# check if the error response tells us that the stage does not exist
+# check if the error response tells us that the service does not exist
 if [[ $response != *"Service not found"* ]]; then
   echo "Did not receive expected response from Keptn API"
   exit 1
@@ -129,7 +129,7 @@ echo "Sending start-evaluation event for service 'wrong-service' in stage 'wrong
 
 response=$(send_start_evaluation_request $PROJECT wrong-stage wrong-service)
 
-# check if the error response tells us that the stage does not exist
+# check if the error response tells us that the project does not exist
 if [[ $response != *"Project not found"* ]]; then
   echo "Did not receive expected response from Keptn API"
   exit 1

--- a/test/utils.sh
+++ b/test/utils.sh
@@ -32,6 +32,16 @@ function auth_at_keptn() {
   fi
 }
 
+function send_start_evaluation_request() {
+  PROJECT=$1
+  STAGE=$2
+  SERVICE=$3
+
+  response=$(keptn send event start-evaluation --project=$PROJECT --stage=$STAGE --service=$SERVICE --timeframe=5m 2>&1)
+
+  echo "$response"
+}
+
 function send_start_evaluation_event() {
   PROJECT=$1
   STAGE=$2


### PR DESCRIPTION
Closes #2387

The properties `from` and `to` for triggering an evaluation have been renamed to `start` end `end`.
This PR also fixes an issue with the swagger-ui which caused the model description for triggering evaluations to be empty.
Further changes: adapted integration tests