### PR TITLE
Disabled Microk8s 1.19 integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -670,9 +670,9 @@ jobs:
     env:
       - MICROK8S_VERSION=1.18/stable # see https://snapcraft.io/microk8s channels
 
-  - <<: *microk8sStandaloneTest
-    env:
-      - MICROK8S_VERSION=1.19/stable # see https://snapcraft.io/microk8s channels
+  #- <<: *microk8sStandaloneTest
+  #  env:
+  #    - MICROK8S_VERSION=1.19/stable # see https://snapcraft.io/microk8s channels
 
   - &minikubeStandaloneTest
     stage: Test Minikube Standalone (--platform=kubernetes) # for detailed Minikube versions see https://github.com/kubernetes/minikube/blob/master/CHANGELOG.md


### PR DESCRIPTION
The installation of Keptn via Helm currently fails on MicroK8s 1.19. There is already an issue on the microk8s repo: https://github.com/ubuntu/microk8s/issues/1605 
Until this is fixed we should disable the Integration tests for MicroK8s 1.19