### PR TITLE
#2412 CLI: print keptn cluster version backport (#2419)

### DIFF
--- a/cli/cmd/generate_support_archive.go
+++ b/cli/cmd/generate_support_archive.go
@@ -575,7 +575,7 @@ func getKeptnMetadata() *errorableMetadataResult {
 	metadataHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 	metadataData, errMetadata := metadataHandler.GetMetadata()
 	if errMetadata != nil {
-		err = errors.New("Error occurred with response code " + string(errMetadata.Code) + " with message " + *errMetadata.Message)
+		err = errors.New("Error occurred with response code " + strconv.FormatInt(errMetadata.Code, 10) + " with message " + *errMetadata.Message)
 	}
 	return newErrorableMetadataResult(metadataData, err)
 }

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -145,9 +145,6 @@ func getKeptnServerVersion() (string, error) {
 	if err != nil {
 		return "", errors.New(authErrorMsg)
 	}
-	if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
-		return "", fmt.Errorf("Error connecting to server: %s"+endPointErrorReasons, endPointErr)
-	}
 	apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
 	if !mocking {
 		metadataData, errMetadata := apiHandler.GetMetadata()

--- a/cli/cmd/version_test.go
+++ b/cli/cmd/version_test.go
@@ -24,6 +24,8 @@ import (
 
 func TestVersionCmd(t *testing.T) {
 	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
+	mocking = true
 
 	cmd := fmt.Sprintf("version")
 	Version = "0.6.1"
@@ -39,5 +41,8 @@ func TestVersionCmd(t *testing.T) {
 	out := r.revertStdOut()
 	if !strings.Contains(out, "CLI version: 0.6.1") {
 		t.Errorf("unexpected used version: %s", out)
+	}
+	if !strings.Contains(out, "cluster version") {
+		t.Error("expected cluster version")
 	}
 }

--- a/cli/cmd/version_test.go
+++ b/cli/cmd/version_test.go
@@ -24,7 +24,6 @@ import (
 
 func TestVersionCmd(t *testing.T) {
 	credentialmanager.MockAuthCreds = true
-	checkEndPointStatusMock = true
 	mocking = true
 
 	cmd := fmt.Sprintf("version")

--- a/cli/pkg/version/ketpn_version_checker.go
+++ b/cli/pkg/version/ketpn_version_checker.go
@@ -3,8 +3,10 @@ package version
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-version"
+	"github.com/keptn/keptn/cli/pkg/config"
 	"github.com/keptn/keptn/cli/pkg/logging"
 )
 
@@ -18,6 +20,68 @@ func NewKeptnVersionChecker() *KeptnVersionChecker {
 	versionChecker := KeptnVersionChecker{}
 	versionChecker.versionFetcherClient = newVersionFetcherClient()
 	return &versionChecker
+}
+
+const newKeptnVersionMsg = `* Keptn version %s is available! Please visit https://keptn.sh/docs/%s/operate/upgrade/ for more information.`
+
+// CheckKeptnVersion checks whether there is a new Keptn version available and prints corresponding
+// messages to the stdout
+func (c KeptnVersionChecker) CheckKeptnVersion(cliVersion, clusterVersion string, considerPrevCheck bool) (bool, bool) {
+	configMng := config.NewCLIConfigManager()
+	cliConfig, err := configMng.LoadCLIConfig()
+	if err != nil {
+		logging.PrintLog(err.Error(), logging.InfoLevel)
+		return false, false
+	}
+
+	msgPrinted := false
+	if cliConfig.AutomaticVersionCheck && IsOfficialKeptnVersion(clusterVersion) {
+		checkTime := time.Now()
+		if !considerPrevCheck || cliConfig.LastVersionCheck == nil ||
+			checkTime.Sub(*cliConfig.LastVersionCheck) >= checkInterval {
+			newVersion, err := c.getNewestStableVersion(cliVersion, clusterVersion)
+			if err != nil {
+				logging.PrintLog(err.Error(), logging.InfoLevel)
+				return false, false
+			}
+			if newVersion != nil {
+				segments := newVersion.Segments()
+				majorMinorXVersion := fmt.Sprintf("%v.%v.x", segments[0], segments[1])
+				fmt.Printf(newKeptnVersionMsg+"\n", newVersion.String(), majorMinorXVersion)
+				msgPrinted = true
+			}
+			return true, msgPrinted
+		}
+	}
+	return false, msgPrinted
+}
+
+// getNewestStableVersion returns the newest stable version to which the current version can be upgraded
+func (c KeptnVersionChecker) getNewestStableVersion(cliVersion, keptnVersion string) (*version.Version, error) {
+	keptnVersionInfo, err := c.versionFetcherClient.getKeptnVersionInfo(cliVersion)
+	if err != nil {
+		return nil, fmt.Errorf("error when fetching Keptn version infos: %v", err)
+	}
+
+	currentVersion, err := version.NewSemver(keptnVersion)
+	if err != nil {
+		return nil, fmt.Errorf("error when parsing current Keptn version: %v", err)
+	}
+
+	var latestVersion *version.Version
+	for _, kv := range keptnVersionInfo.Stable {
+		availableVersion, err := version.NewSemver(kv.Version)
+		if err != nil {
+			logging.PrintLog(fmt.Sprintf("error when parsing version %s", kv.Version), logging.InfoLevel)
+			continue
+		}
+		if availableVersion.Compare(currentVersion) > 0 && contains(kv.UpgradableVersions, keptnVersion) {
+			if latestVersion == nil || availableVersion.Compare(latestVersion) > 0 {
+				latestVersion = availableVersion
+			}
+		}
+	}
+	return latestVersion, nil
 }
 
 // GetStableVersions returns a list of all stable version to which the current version can be upgraded

--- a/cli/pkg/version/version_checker.go
+++ b/cli/pkg/version/version_checker.go
@@ -3,7 +3,6 @@ package version
 import (
 	"errors"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/keptn/keptn/cli/pkg/logging"
@@ -115,8 +114,8 @@ func NewVersionChecker() *VersionChecker {
 	return &versionChecker
 }
 
-// getNewerCLIVersion checks for newer CLI versions if the automatic version check is enabled in the config
-func (v *VersionChecker) getNewerCLIVersion(cliConfig config.CLIConfig, usedVersionString string) (availableNewestVersions, error) {
+// getNewerCLIVersion checks for newer CLI versions
+func (v *VersionChecker) getNewerCLIVersion(usedVersionString string) (availableNewestVersions, error) {
 
 	cliVersionInfo, err := v.versionFetcherClient.getCLIVersionInfo(usedVersionString)
 	if err != nil {
@@ -130,32 +129,31 @@ func (v *VersionChecker) getNewerCLIVersion(cliConfig config.CLIConfig, usedVers
 	return res, nil
 }
 
-const newCompatibleVersionMsg = `Keptn CLI version %s is available! Please visit https://keptn.sh/docs/%s/operate/upgrade/ for more information.`
-const newIncompatibleVersionMsg = `Keptn CLI version %s is available! Please note that this version might be incompatible with your Keptn cluster ` +
+const newCompatibleVersionMsg = `* Keptn CLI version %s is available! Please visit https://keptn.sh/docs/%s/operate/upgrade/ for more information.`
+const newIncompatibleVersionMsg = `* Keptn CLI version %s is available! Please note that this version might be incompatible with your Keptn cluster ` +
 	`version and requires to update the cluster too. Please visit https://keptn.sh/docs/%s/operate/upgrade/ for more information.`
-const disableMsg = `To disable this notice, run: '%s set config AutomaticVersionCheck false'`
 
 // CheckCLIVersion checks whether there is a new CLI version available and prints corresponding
 // messages to the stdout
-func (v *VersionChecker) CheckCLIVersion(cliVersion string, considerPrevCheck bool) {
+func (v *VersionChecker) CheckCLIVersion(cliVersion string, considerPrevCheck bool) (bool, bool) {
 
 	configMng := config.NewCLIConfigManager()
 	cliConfig, err := configMng.LoadCLIConfig()
 	if err != nil {
 		logging.PrintLog(err.Error(), logging.InfoLevel)
-		return
+		return false, false
 	}
 
+	msgPrinted := false
 	if cliConfig.AutomaticVersionCheck && IsOfficialKeptnVersion(cliVersion) {
 		checkTime := time.Now()
 		if !considerPrevCheck || cliConfig.LastVersionCheck == nil ||
 			checkTime.Sub(*cliConfig.LastVersionCheck) >= checkInterval {
-			newVersions, err := v.getNewerCLIVersion(cliConfig, cliVersion)
+			newVersions, err := v.getNewerCLIVersion(cliVersion)
 			if err != nil {
 				logging.PrintLog(err.Error(), logging.InfoLevel)
-				return
+				return false, false
 			}
-			msgPrinted := false
 			if newVersions.stable.newestCompatible != nil {
 				segments := newVersions.stable.newestCompatible.Segments()
 				majorMinorXVersion := fmt.Sprintf("%v.%v.x", segments[0], segments[1])
@@ -177,21 +175,10 @@ func (v *VersionChecker) CheckCLIVersion(cliVersion string, considerPrevCheck bo
 					majorMinorXVersion)
 				msgPrinted = true
 			}
-			if msgPrinted && considerPrevCheck {
-				if len(os.Args) > 0 {
-					fmt.Printf(disableMsg+"\n", os.Args[0])
-				} else {
-					fmt.Printf(disableMsg+"\n", "keptn")
-				}
-			}
-
-			cliConfig.LastVersionCheck = &checkTime
-			if err := configMng.StoreCLIConfig(cliConfig); err != nil {
-				logging.PrintLog(err.Error(), logging.InfoLevel)
-				return
-			}
+			return true, msgPrinted
 		}
 	}
+	return false, msgPrinted
 }
 
 // IsOfficialKeptnVersion checks whether the provided version string follows a Keptn version pattern

--- a/cli/pkg/version/version_checker_test.go
+++ b/cli/pkg/version/version_checker_test.go
@@ -4,11 +4,9 @@ import (
 	"io"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/go-version"
 
-	"github.com/keptn/keptn/cli/pkg/config"
 	"github.com/magiconair/properties/assert"
 )
 
@@ -81,10 +79,7 @@ func TestCheckCLIVersion(t *testing.T) {
 	versionChecker.versionFetcherClient.httpClient = httpClient
 	versionChecker.versionFetcherClient.versionUrl = url
 
-	lastChecked := time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)
-
-	cliConfig := config.CLIConfig{AutomaticVersionCheck: true, LastVersionCheck: &lastChecked}
-	res, err := versionChecker.getNewerCLIVersion(cliConfig, "0.6.0")
+	res, err := versionChecker.getNewerCLIVersion("0.6.0")
 
 	expectedRes := availableVersionInitHelper("0.6.1", "", "", "")
 

--- a/cli/pkg/version/version_fetcher_test.go
+++ b/cli/pkg/version/version_fetcher_test.go
@@ -79,6 +79,10 @@ const versionJSONTest = `{
             {
               "version": "0.8.0",
               "upgradableVersions": [ "0.7.0", "0.7.1" ]
+            },
+            {
+              "version": "0.9.0",
+              "upgradableVersions": [ "0.8.0" ]
             }
         ]
     }
@@ -101,7 +105,7 @@ func TestGetKeptnVersionInfo(t *testing.T) {
 
 	keptnVersionInfo, err := client.getKeptnVersionInfo("0.6.0")
 	assert.Equal(t, err, nil, "Received unexpected error")
-	assert.Equal(t, len(keptnVersionInfo.Stable), 2, "Received unexpected content")
+	assert.Equal(t, len(keptnVersionInfo.Stable), 3, "Received unexpected content")
 	assert.Equal(t, keptnVersionInfo.Stable[0].Version, "0.7.1", "Received unexpected content")
 	assert.Equal(t, keptnVersionInfo.Stable[0].UpgradableVersions, []string{"0.7.0"}, "Received unexpected content")
 }


### PR DESCRIPTION
Backport of https://github.com/keptn/keptn/pull/2419 for release-0.7.2

I had to remove one function call from the original PR to make it compatible with 0.7.2