### PR TITLE
Added copy button for SLO definition in bridge UI

### DIFF
--- a/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.html
+++ b/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.html
@@ -82,6 +82,7 @@
     <pre [textContent]="data"></pre>
   </div>
   <div mat-dialog-actions>
+    <button dt-button variant="secondary" (click)="copySloPayload(data)">Copy</button>
     <button dt-button (click)="closeSloDialog()">Close</button>
   </div>
 </ng-template>

--- a/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.scss
+++ b/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.scss
@@ -12,3 +12,7 @@
   stroke: rgb(137, 137, 137);
   fill: rgba(137, 137, 137, 0.2);
 }
+
+.dt-button + .dt-button {
+  fill: $cta-color-active;	  margin-left: $gap-normal;
+}

--- a/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
+++ b/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
@@ -26,6 +26,7 @@ import SearchUtil from "../../_utils/search.utils";
 import {Subject} from "rxjs";
 import {takeUntil} from "rxjs/operators";
 import {MatDialog, MatDialogRef} from "@angular/material/dialog";
+import { ClipboardService } from '../../_services/clipboard.service';
 
 @Component({
   selector: 'ktb-evaluation-details',
@@ -168,7 +169,7 @@ export class KtbEvaluationDetailsComponent implements OnInit, OnDestroy {
     }
   }
 
-  constructor(private _changeDetectorRef: ChangeDetectorRef, private dataService: DataService, private dialog: MatDialog) { }
+  constructor(private _changeDetectorRef: ChangeDetectorRef, private dataService: DataService, private dialog: MatDialog, private clipboard: ClipboardService) { }
 
   ngOnInit() {
     if(this._evaluationData) {
@@ -401,6 +402,10 @@ export class KtbEvaluationDetailsComponent implements OnInit, OnDestroy {
     if (this.sloDialogRef) {
       this.sloDialogRef.close();
     }
+  }
+
+  copySloPayload(plainEvent: string): void {
+    this.clipboard.copy(plainEvent, 'slo payload');
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
Issue #1997   

Added a copy button to the SLO definition dialog utilizing the clipboard service created for #1977 
![image](https://user-images.githubusercontent.com/5699104/94942966-50805700-04d7-11eb-8ccd-5a262830755f.png)
