### PR TITLE
Makefile: Add a way to build all Dockerfile. Fixes #2464

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,12 @@ build-cli:
 	@cp ./cli/keptn $(GOBIN)/
 	@printf "👍 Done\n"
 
+## Build all docker images
+build-docker:
+	@printf "🔨 Building docker images\n"
+	@./make-scripts/build/build-docker.sh
+	@printf "👍 Done\n"
+
 ## Start the bridge
 start-bridge:
 	@printf "🚀 Starting Bridge\n" 
@@ -83,6 +89,7 @@ help:
 	@echo "KEPTN"
 	@echo ""
 	@echo "* build-cli: Build the keptn cli and save it in bin/"
+	@echo "* build-docker: Build the keptn docker images"
 	@echo "* start-bridge: Start the bridge server"
 	@echo "* install-helm: Install the helm binary in your local"
 	@echo "* install-golint: Install golint for linting the code"

--- a/make-scripts/build/build-docker.sh
+++ b/make-scripts/build/build-docker.sh
@@ -49,5 +49,6 @@ for dockerfile in "${DOCKERFILE_LIST[@]}"; do
 
   DOCKER_TAG="$DOCKER_ORG_NAME/$DOCKER_NAME:$DOCKER_VERSION"
 
+  echo "Building docker image $DOCKER_TAG using $dockerfile"
   docker build -t $DOCKER_TAG "$DOCKER_PATH"
 done

--- a/make-scripts/build/build-docker.sh
+++ b/make-scripts/build/build-docker.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -e
+
+DOCKER_ORG_NAME="kept"
+DOCKER_VERSION=$(git describe --abbrev=1 --tags)
+DOCKER_ROOT_PATH="./"
+
+cd "$DOCKER_ROOT_PATH"
+
+# List of docker images
+mapfile -t DOCKERFILE_LIST < <(find . -name 'Dockerfile')
+
+# List of excluded docker images
+DOCKERFILE_EXCLUSIONS=(
+  "upgrader"
+)
+
+# List of docker name overrides
+declare -A OVERRIDES
+OVERRIDES["bridge"]="bridge2"
+
+# String tokenizer using the '/' delimiter
+tokenizeString() {
+  IFS='/'
+  read -ra DOCKERFILE_PATH <<<"$1"
+  IFS=' '
+}
+
+for dockerfile in "${DOCKERFILE_LIST[@]}"; do
+  tokenizeString "$dockerfile"
+
+  TOKENS_SIZE=${#DOCKERFILE_PATH[@]}
+  DOCKER_PATH=${dockerfile%/*}
+  DOCKER_DIR=${DOCKERFILE_PATH[$TOKENS_SIZE-2]}
+  DOCKER_PARENT_DIR=${DOCKERFILE_PATH[$TOKENS_SIZE-3]}
+
+  if printf '%s\n' "${DOCKERFILE_EXCLUSIONS[@]}" | grep -q -P "^$DOCKER_PARENT_DIR$"; then
+    echo "Excluded $dockerfile"
+    continue
+  fi
+
+  if [[ -v OVERRIDES[${DOCKER_DIR}] ]]; then
+    DOCKER_NAME="${OVERRIDES[${DOCKER_DIR}]}"
+    echo "Overridden docker tag $DOCKER_DIR -> $DOCKER_NAME"
+  else
+    DOCKER_NAME=$DOCKER_DIR
+  fi
+
+  DOCKER_TAG="$DOCKER_ORG_NAME/$DOCKER_NAME:$DOCKER_VERSION"
+
+  docker build -t $DOCKER_TAG "$DOCKER_PATH"
+done

--- a/make-scripts/build/build-docker.sh
+++ b/make-scripts/build/build-docker.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-DOCKER_ORG_NAME="kept"
+DOCKER_ORG_NAME="keptn"
 DOCKER_VERSION=$(git describe --abbrev=1 --tags)
 DOCKER_ROOT_PATH="./"
 

--- a/make-scripts/build/build-docker.sh
+++ b/make-scripts/build/build-docker.sh
@@ -35,11 +35,13 @@ for dockerfile in "${DOCKERFILE_LIST[@]}"; do
   DOCKER_DIR=${DOCKERFILE_PATH[$TOKENS_SIZE-2]}
   DOCKER_PARENT_DIR=${DOCKERFILE_PATH[$TOKENS_SIZE-3]}
 
+  # Apply Dockerfile exclusions
   if printf '%s\n' "${DOCKERFILE_EXCLUSIONS[@]}" | grep -q -P "^$DOCKER_PARENT_DIR$"; then
     echo "Excluded $dockerfile"
     continue
   fi
 
+  # Apply Dockerfile name overrides
   if [[ -v OVERRIDES[${DOCKER_DIR}] ]]; then
     DOCKER_NAME="${OVERRIDES[${DOCKER_DIR}]}"
     echo "Overridden docker tag $DOCKER_DIR -> $DOCKER_NAME"
@@ -47,6 +49,7 @@ for dockerfile in "${DOCKERFILE_LIST[@]}"; do
     DOCKER_NAME=$DOCKER_DIR
   fi
 
+  # Build docker image
   DOCKER_TAG="$DOCKER_ORG_NAME/$DOCKER_NAME:$DOCKER_VERSION"
 
   echo "Building docker image $DOCKER_TAG using $dockerfile"


### PR DESCRIPTION
Fixes #2464

The building of all docker images can be launched using the `make build-docker` command.