### PR TITLE
#1714 Addition of mTLS to the CLI

### DIFF
--- a/cli/cmd/add_resource.go
+++ b/cli/cmd/add_resource.go
@@ -79,7 +79,8 @@ keptn add-resource --project=rockshop --stage=production --service=shop --resour
 
 		endPoint.Path = path.Join(endPoint.Path, "configuration-service")
 
-		resourceHandler := apiutils.NewAuthenticatedResourceHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
+		resourceHandler := apiutils.NewAuthenticatedResourceHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme,
+			ClientCertPath, ClientKeyPath, RootCertPath)
 
 		if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
 			return fmt.Errorf("Resource %s could not be uploaded: %s"+endPointErrorReasons,

--- a/cli/cmd/auth.go
+++ b/cli/cmd/auth.go
@@ -68,7 +68,8 @@ More precisely, the Keptn CLI stores the endpoint and API token using *pass* in 
 			url.Path = "/api"
 		}
 
-		authHandler := apiutils.NewAuthenticatedAuthHandler(url.String(), *authParams.apiToken, "x-token", nil, url.Scheme)
+		authHandler := apiutils.NewAuthenticatedAuthHandler(url.String(), *authParams.apiToken, "x-token", nil, url.Scheme,
+			ClientCertPath, ClientKeyPath, RootCertPath)
 
 		if !mocking {
 			authenticated := false

--- a/cli/cmd/configure_monitoring.go
+++ b/cli/cmd/configure_monitoring.go
@@ -103,7 +103,8 @@ keptn configure monitoring prometheus --project=PROJECTNAME --service=SERVICENAM
 				endPointErr)
 		}
 
-		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
+		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme,
+			ClientCertPath, ClientKeyPath, RootCertPath)
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)
 
 		eventByte, err := json.Marshal(sdkEvent)

--- a/cli/cmd/create_project.go
+++ b/cli/cmd/create_project.go
@@ -124,7 +124,8 @@ keptn create project PROJECTNAME --shipyard=FILEPATH --git-user=GIT_USER --git-t
 				endPointErr)
 		}
 
-		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
+		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme,
+			ClientCertPath, ClientKeyPath, RootCertPath)
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)
 
 		if !mocking {

--- a/cli/cmd/create_service.go
+++ b/cli/cmd/create_service.go
@@ -65,7 +65,8 @@ var crServiceCmd = &cobra.Command{
 				endPointErr)
 		}
 
-		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
+		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme,
+			ClientCertPath, ClientKeyPath, RootCertPath)
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)
 
 		if !mocking {

--- a/cli/cmd/delete_project.go
+++ b/cli/cmd/delete_project.go
@@ -65,8 +65,10 @@ var delProjectCmd = &cobra.Command{
 				endPointErr)
 		}
 
-		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
-		projectsHandler := apiutils.NewAuthenticatedProjectHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
+		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme,
+			ClientCertPath, ClientKeyPath, RootCertPath)
+		projectsHandler := apiutils.NewAuthenticatedProjectHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme,
+			ClientCertPath, ClientKeyPath, RootCertPath)
 
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)
 

--- a/cli/cmd/delete_service.go
+++ b/cli/cmd/delete_service.go
@@ -43,7 +43,8 @@ Furthermore, if Keptn is used for continuous delivery (i.e. services have been o
 
 		logging.PrintLog("Starting to delete service", logging.InfoLevel)
 
-		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
+		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme,
+			ClientCertPath, ClientKeyPath, RootCertPath)
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)
 
 		if !mocking {

--- a/cli/cmd/generate_support_archive.go
+++ b/cli/cmd/generate_support_archive.go
@@ -550,7 +550,8 @@ func getProjects() *errorableProjectResult {
 	if err != nil {
 		return newErrorableProjectResult(nil, err)
 	}
-	projectHandler := apiutils.NewAuthenticatedProjectHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
+	projectHandler := apiutils.NewAuthenticatedProjectHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme,
+		ClientCertPath, ClientKeyPath, RootCertPath)
 	return newErrorableProjectResult(projectHandler.GetAllProjects())
 }
 
@@ -572,7 +573,8 @@ func getKeptnMetadata() *errorableMetadataResult {
 	if err != nil {
 		return newErrorableMetadataResult(nil, err)
 	}
-	metadataHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
+	metadataHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme,
+		ClientCertPath, ClientKeyPath, RootCertPath)
 	metadataData, errMetadata := metadataHandler.GetMetadata()
 	if errMetadata != nil {
 		err = errors.New("Error occurred with response code " + strconv.FormatInt(errMetadata.Code, 10) + " with message " + *errMetadata.Message)

--- a/cli/cmd/get_event.go
+++ b/cli/cmd/get_event.go
@@ -80,7 +80,8 @@ func getEvent(eventStruct GetEventStruct, args []string) error {
 			endPointErr)
 	}
 
-	eventHandler := apiutils.NewAuthenticatedEventHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
+	eventHandler := apiutils.NewAuthenticatedEventHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme,
+		ClientCertPath, ClientKeyPath, RootCertPath)
 
 	events, modErr := eventHandler.GetEvents(&apiutils.EventFilter{
 		KeptnContext:  *eventStruct.KeptnContext,

--- a/cli/cmd/get_event_approvalTriggered.go
+++ b/cli/cmd/get_event_approvalTriggered.go
@@ -70,8 +70,10 @@ func getApprovalTriggeredEvents(approvalTriggered approvalTriggeredStruct) error
 			endPointErr)
 	}
 
-	serviceHandler := apiutils.NewAuthenticatedServiceHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
-	eventHandler := apiutils.NewAuthenticatedEventHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
+	serviceHandler := apiutils.NewAuthenticatedServiceHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme,
+		ClientCertPath, ClientKeyPath, RootCertPath)
+	eventHandler := apiutils.NewAuthenticatedEventHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme,
+		ClientCertPath, ClientKeyPath, RootCertPath)
 
 	logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)
 

--- a/cli/cmd/get_event_evaluationDone.go
+++ b/cli/cmd/get_event_evaluationDone.go
@@ -52,7 +52,8 @@ var evaluationDoneCmd = &cobra.Command{
 				endPointErr)
 		}
 
-		eventHandler := apiutils.NewAuthenticatedEventHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
+		eventHandler := apiutils.NewAuthenticatedEventHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme,
+			ClientCertPath, ClientKeyPath, RootCertPath)
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)
 
 		if !mocking {

--- a/cli/cmd/get_projects.go
+++ b/cli/cmd/get_projects.go
@@ -94,7 +94,8 @@ keptn get project sockshop -output=json  # Returns project details in JSON forma
 				endPointErr)
 		}
 
-		projectsHandler := apiutils.NewAuthenticatedProjectHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
+		projectsHandler := apiutils.NewAuthenticatedProjectHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme,
+			ClientCertPath, ClientKeyPath, RootCertPath)
 
 		if !mocking {
 

--- a/cli/cmd/get_services.go
+++ b/cli/cmd/get_services.go
@@ -79,8 +79,10 @@ keptn get services carts --project=sockshop -o=json  # Get details of the carts 
 				endPointErr)
 		}
 
-		projectsHandler := apiutils.NewAuthenticatedProjectHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
-		servicesHandler := apiutils.NewAuthenticatedServiceHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
+		projectsHandler := apiutils.NewAuthenticatedProjectHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme,
+			ClientCertPath, ClientKeyPath, RootCertPath)
+		servicesHandler := apiutils.NewAuthenticatedServiceHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme,
+			ClientCertPath, ClientKeyPath, RootCertPath)
 
 		if !mocking {
 			projects, err := projectsHandler.GetAllProjects()

--- a/cli/cmd/get_stages.go
+++ b/cli/cmd/get_stages.go
@@ -67,7 +67,8 @@ staging        2020-04-06T14:37:45.210Z
 				endPointErr)
 		}
 
-		stagesHandler := apiutils.NewAuthenticatedStageHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
+		stagesHandler := apiutils.NewAuthenticatedStageHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme,
+			ClientCertPath, ClientKeyPath, RootCertPath)
 		if !mocking {
 			stages, err := stagesHandler.GetAllStages(*stageParameter.project)
 			if err != nil {

--- a/cli/cmd/onboard_service.go
+++ b/cli/cmd/onboard_service.go
@@ -128,7 +128,8 @@ keptn onboard service SERVICENAME --project=PROJECTNAME --chart=HELM_CHART.tgz
 			service.DeploymentStrategies = deplStrategies
 		}
 
-		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
+		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme,
+			ClientCertPath, ClientKeyPath, RootCertPath)
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)
 
 		if !mocking {

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/keptn/keptn/cli/pkg/config"
 	"github.com/keptn/keptn/cli/pkg/version"
 
 	"github.com/keptn/keptn/cli/pkg/logging"
@@ -19,6 +20,11 @@ var mocking bool
 
 // SuppressWSCommunication suppresses the WebSocket communication if it is true
 var SuppressWSCommunication bool
+
+// Certificate and key paths to configure mTLS for the CLI
+var ClientCertPath string = ""
+var ClientKeyPath string = ""
+var RootCertPath string = ""
 
 var insecureSkipTLSVerify bool
 var kubectlOptions string
@@ -45,6 +51,19 @@ func Execute() {
 	logging.LogLevel = logging.QuietLevel
 
 	runDailyVersionCheck()
+
+	configMng := config.NewCLIConfigManager()
+	cliConfig, err := configMng.LoadCLIConfig()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	if cliConfig.ClientCertPath != "" && cliConfig.ClientKeyPath != "" && cliConfig.RootCertPath != "" {
+		ClientCertPath = cliConfig.ClientCertPath
+		ClientKeyPath = cliConfig.ClientKeyPath
+		RootCertPath = cliConfig.RootCertPath
+	}
 
 	// Set LogLevel back to previous state
 	logging.LogLevel = currentLogLevel

--- a/cli/cmd/send_event.go
+++ b/cli/cmd/send_event.go
@@ -72,7 +72,8 @@ In addition, the payload of the CloudEvent needs to follow the Keptn spec (https
 				endPointErr)
 		}
 
-		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
+		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme,
+			ClientCertPath, ClientKeyPath, RootCertPath)
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)
 
 		if !mocking {

--- a/cli/cmd/send_event_approvalFinished.go
+++ b/cli/cmd/send_event_approvalFinished.go
@@ -80,8 +80,10 @@ func sendApprovalFinishedEvent(sendApprovalFinishedOptions sendApprovalFinishedS
 			endPointErr)
 	}
 
-	apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
-	eventHandler := apiutils.NewAuthenticatedEventHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
+	apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme,
+		ClientCertPath, ClientKeyPath, RootCertPath)
+	eventHandler := apiutils.NewAuthenticatedEventHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme,
+		ClientCertPath, ClientKeyPath, RootCertPath)
 
 	logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)
 
@@ -92,7 +94,8 @@ func sendApprovalFinishedEvent(sendApprovalFinishedOptions sendApprovalFinishedS
 	if *sendApprovalFinishedOptions.ID != "" {
 		keptnContext, triggeredID, approvalFinishedEvent, err = getApprovalFinishedForID(eventHandler, sendApprovalFinishedOptions)
 	} else if *sendApprovalFinishedOptions.Service != "" {
-		serviceHandler := apiutils.NewAuthenticatedServiceHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
+		serviceHandler := apiutils.NewAuthenticatedServiceHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme,
+			ClientCertPath, ClientKeyPath, RootCertPath)
 		keptnContext, triggeredID, approvalFinishedEvent, err = getApprovalFinishedForService(eventHandler,
 			serviceHandler, sendApprovalFinishedOptions)
 	}

--- a/cli/cmd/send_event_evaluationStart.go
+++ b/cli/cmd/send_event_evaluationStart.go
@@ -124,7 +124,8 @@ keptn send event start-evaluation --project=sockshop --stage=hardening --service
 			return fmt.Errorf("Failed to map cloud event to API event model. %s", err.Error())
 		}
 
-		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
+		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme,
+			ClientCertPath, ClientKeyPath, RootCertPath)
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)
 
 		if !mocking {

--- a/cli/cmd/send_event_newArtifact.go
+++ b/cli/cmd/send_event_newArtifact.go
@@ -117,7 +117,8 @@ For pulling an image from a private registry, we would like to refer to the Kube
 			return fmt.Errorf("Failed to map cloud event to API event model. %s", err.Error())
 		}
 
-		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
+		apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme,
+			ClientCertPath, ClientKeyPath, RootCertPath)
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)
 
 		if !mocking {

--- a/cli/cmd/set_config.go
+++ b/cli/cmd/set_config.go
@@ -56,6 +56,15 @@ var setConfigCmd = &cobra.Command{
 			}
 			cliConfig.LastVersionCheck = &val
 			newConfig = true
+		case "clientcertificate":
+			cliConfig.ClientCertPath = args[1]
+			newConfig = true
+		case "clientkey":
+			cliConfig.ClientKeyPath = args[1]
+			newConfig = true
+		case "rootcert":
+			cliConfig.RootCertPath = args[1]
+			newConfig = true
 		default:
 			return fmt.Errorf("Unsupported key %s", args[0])
 		}

--- a/cli/cmd/update_project.go
+++ b/cli/cmd/update_project.go
@@ -80,7 +80,8 @@ For more information about updating projects or upstream repositories, please go
 			project.GitRemoteURI = *updateProjectParams.RemoteURL
 		}
 
-		projectHandler := apiutils.NewAuthenticatedProjectHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
+		projectHandler := apiutils.NewAuthenticatedProjectHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme,
+			ClientCertPath, ClientKeyPath, RootCertPath)
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)
 
 		if !mocking {

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -148,7 +148,8 @@ func getKeptnServerVersion() (string, error) {
 	if endPointErr := checkEndPointStatus(endPoint.String()); endPointErr != nil {
 		return "", fmt.Errorf("Error connecting to server: %s"+endPointErrorReasons, endPointErr)
 	}
-	apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme)
+	apiHandler := apiutils.NewAuthenticatedAPIHandler(endPoint.String(), apiToken, "x-token", nil, endPoint.Scheme,
+		ClientCertPath, ClientKeyPath, RootCertPath)
 	if !mocking {
 		metadataData, errMetadata := apiHandler.GetMetadata()
 		if errMetadata != nil {

--- a/cli/pkg/config/cli_config.go
+++ b/cli/pkg/config/cli_config.go
@@ -16,6 +16,9 @@ import (
 type CLIConfig struct {
 	AutomaticVersionCheck bool       `json:"automatic_version_check"`
 	LastVersionCheck      *time.Time `json:"last_version_check"`
+	ClientCertPath        string     `json:"client_cert_path"`
+	ClientKeyPath         string     `json:"client_key_path"`
+	RootCertPath          string     `json:"root_cert_path"`
 }
 
 // CLIConfigManager manages the path of the CLI config


### PR DESCRIPTION
This PR adds the mTLS configuration to the CLI client. The primary configuration is handled on the go-utils package and suggested in this PR: https://github.com/keptn/go-utils/pull/213. 
The config is used for caching the configuration.
The certs can be created first and then set using the set config commands:
```
keptn set config clientcertificate cc.crt 
keptn set config clientkey cc.key 
keptn set config rootcert root.crt 
```
Or can be directly set in the .ketpn/config like this:
```
{"automatic_version_check":true,"last_version_check":"2020-09-28T04:05:56.382293+05:30","client_cert_path":"cc.crt","client_key_path":"cc.key","root_cert_path":"root.crt"}
```
The rest of it is automatically handled in the TLS client setup.