### PR TITLE
#2487 Use default branch of origin

### DIFF
--- a/configuration-service/common/git.go
+++ b/configuration-service/common/git.go
@@ -4,16 +4,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/keptn/keptn/configuration-service/models"
-	"net/url"
-	"os"
-	"strings"
-
 	"github.com/keptn/keptn/configuration-service/config"
+	"github.com/keptn/keptn/configuration-service/models"
 	utils "github.com/keptn/kubernetes-utils/pkg"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"net/url"
+	"os"
+	"strings"
+	"time"
 )
 
 // GitCredentials contains git ccredentials info
@@ -359,13 +359,34 @@ func GetResourceMetadata(project string) *models.Version {
 
 // GetDefaultBranch returns the name of the default branch of the repo
 func GetDefaultBranch(project string) (string, error) {
-	// git symbolic-ref --short HEAD
 	projectConfigPath := config.ConfigDir + "/" + project
-	out, err := utils.ExecuteCommandInDirectory("git", []string{"symbolic-ref", `--short`, "HEAD"}, projectConfigPath)
-	if err != nil {
-		return "", err
+
+	credentials, err := GetCredentials(project)
+	if err == nil && credentials != nil {
+		retries := 5
+
+		for i := 0; i < retries; i = i + 1 {
+			out, err := utils.ExecuteCommandInDirectory("git", []string{"remote", "show", "origin"}, projectConfigPath)
+			if err != nil {
+				return "", err
+			}
+			lines := strings.Split(out, "\n")
+
+			for _, line := range lines {
+				if strings.Contains(line, "HEAD branch") {
+					split := strings.Split(line, ":")
+					if len(split) > 1 {
+						defaultBranch := strings.TrimSpace(split[1])
+						if defaultBranch != "(unknown)" {
+							return defaultBranch, nil
+						}
+					}
+				}
+			}
+			<-time.After(3 * time.Second)
+		}
 	}
-	return strings.Trim(out, "\n"), nil
+	return "master", nil
 }
 
 func addRepoURIToMetadata(credentials *GitCredentials, metadata *models.Version) {

--- a/configuration-service/common/git.go
+++ b/configuration-service/common/git.go
@@ -357,6 +357,17 @@ func GetResourceMetadata(project string) *models.Version {
 	return result
 }
 
+// GetDefaultBranch returns the name of the default branch of the repo
+func GetDefaultBranch(project string) (string, error) {
+	// git symbolic-ref --short HEAD
+	projectConfigPath := config.ConfigDir + "/" + project
+	out, err := utils.ExecuteCommandInDirectory("git", []string{"symbolic-ref", `--short`, "HEAD"}, projectConfigPath)
+	if err != nil {
+		return "", err
+	}
+	return strings.Trim(out, "\n"), nil
+}
+
 func addRepoURIToMetadata(credentials *GitCredentials, metadata *models.Version) {
 	// the git token should not be included in the repo URI in the first place, but let's make sure it's hidden in any case
 	remoteURI := credentials.RemoteURI

--- a/configuration-service/handlers/project_resource.go
+++ b/configuration-service/handlers/project_resource.go
@@ -165,7 +165,7 @@ func GetProjectProjectNameResourceResourceURIHandlerFunc(params project_resource
 	}
 	err = common.CheckoutBranch(params.ProjectName, defaultBranch, *params.DisableUpstreamSync)
 	if err != nil {
-		logger.Error(fmt.Sprintf("Could check out %s branch of project %s: %s", params.ProjectName, err.Error()))
+		logger.Error(fmt.Sprintf("Could check out %s branch of project %s: %s", defaultBranch, params.ProjectName, err.Error()))
 		return project_resource.NewGetProjectProjectNameResourceResourceURIDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
 	}
 

--- a/configuration-service/handlers/project_resource.go
+++ b/configuration-service/handlers/project_resource.go
@@ -25,10 +25,15 @@ func GetProjectProjectNameResourceHandlerFunc(params project_resource.GetProject
 	common.LockProject(params.ProjectName)
 	defer common.UnlockProject(params.ProjectName)
 
-	err := common.CheckoutBranch(params.ProjectName, "master", *params.DisableUpstreamSync)
+	defaultBranch, err := common.GetDefaultBranch(params.ProjectName)
 	if err != nil {
-		logger.Error(fmt.Sprintf("Could not check out master branch of project %s", params.ProjectName))
-		logger.Error(err.Error())
+		logger.Error(fmt.Sprintf("Could not determine default branch of project %s: %s", params.ProjectName, err.Error()))
+		return project_resource.NewGetProjectProjectNameResourceDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
+	}
+
+	err = common.CheckoutBranch(params.ProjectName, defaultBranch, *params.DisableUpstreamSync)
+	if err != nil {
+		logger.Error(fmt.Sprintf("Could not check out %s branch of project %s: %s", defaultBranch, params.ProjectName, err.Error()))
 		return project_resource.NewGetProjectProjectNameResourceDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
 	}
 
@@ -50,11 +55,17 @@ func PutProjectProjectNameResourceHandlerFunc(params project_resource.PutProject
 
 	projectConfigPath := config.ConfigDir + "/" + params.ProjectName
 	logger.Debug("Updating resource(s) in: " + projectConfigPath)
-	logger.Debug("Checking out master branch")
+	logger.Debug("Checking out default branch")
 
-	err := common.CheckoutBranch(params.ProjectName, "master", false)
+	defaultBranch, err := common.GetDefaultBranch(params.ProjectName)
 	if err != nil {
-		logger.Error(fmt.Sprintf("Could not check out master branch of project %s", params.ProjectName))
+		logger.Error(fmt.Sprintf("Could not determine default branch of project %s: %s", params.ProjectName, err.Error()))
+		return project_resource.NewPutProjectProjectNameResourceDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
+	}
+
+	err = common.CheckoutBranch(params.ProjectName, defaultBranch, false)
+	if err != nil {
+		logger.Error(fmt.Sprintf("Could not check out %s branch of project %s", defaultBranch, params.ProjectName))
 		logger.Error(err.Error())
 		return project_resource.NewPutProjectProjectNameResourceBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String("Could not check out branch")})
 	}
@@ -77,14 +88,14 @@ func PutProjectProjectNameResourceHandlerFunc(params project_resource.PutProject
 	logger.Debug("Staging Changes")
 	err = common.StageAndCommitAll(params.ProjectName, "Updated resources", true)
 	if err != nil {
-		logger.Error(fmt.Sprintf("Could not commit to master branch of project %s", params.ProjectName))
+		logger.Error(fmt.Sprintf("Could not commit to %s branch of project %s", defaultBranch, params.ProjectName))
 		logger.Error(err.Error())
 		return project_resource.NewPutProjectProjectNameResourceBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String("Could not commit changes")})
 	}
 	logger.Debug("Successfully updated resources")
 
 	metadata := common.GetResourceMetadata(params.ProjectName)
-	metadata.Branch = "master"
+	metadata.Branch = defaultBranch
 
 	return project_resource.NewPutProjectProjectNameResourceCreated().WithPayload(metadata)
 }
@@ -101,11 +112,17 @@ func PostProjectProjectNameResourceHandlerFunc(params project_resource.PostProje
 
 	projectConfigPath := config.ConfigDir + "/" + params.ProjectName
 	logger.Debug("Creating new resource(s) in: " + projectConfigPath)
-	logger.Debug("Checking out master branch")
+	logger.Debug("Checking out default branch")
 
-	err := common.CheckoutBranch(params.ProjectName, "master", false)
+	defaultBranch, err := common.GetDefaultBranch(params.ProjectName)
 	if err != nil {
-		logger.Error(fmt.Sprintf("Could not check out master branch of project %s", params.ProjectName))
+		logger.Error(fmt.Sprintf("Could not determine default branch of project %s: %s", params.ProjectName, err.Error()))
+		return project_resource.NewPostProjectProjectNameResourceDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
+	}
+
+	err = common.CheckoutBranch(params.ProjectName, defaultBranch, false)
+	if err != nil {
+		logger.Error(fmt.Sprintf("Could not check out %s branch of project %s", defaultBranch, params.ProjectName))
 		logger.Error(err.Error())
 		return project_resource.NewPostProjectProjectNameResourceBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String("Could not check out branch")})
 	}
@@ -119,15 +136,13 @@ func PostProjectProjectNameResourceHandlerFunc(params project_resource.PostProje
 	logger.Debug("Staging Changes")
 	err = common.StageAndCommitAll(params.ProjectName, "Added resources", true)
 	if err != nil {
-		logger.Error(fmt.Sprintf("Could not commit to master branch of project %s", params.ProjectName))
-		logger.Error(err.Error())
-
+		logger.Error(fmt.Sprintf("Could not commit to %s branch of project %s: %s", defaultBranch, params.ProjectName, err.Error()))
 		return project_resource.NewPostProjectProjectNameResourceBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String("Could not commit changes")})
 	}
 	logger.Debug("Successfully added resources")
 
 	metadata := common.GetResourceMetadata(params.ProjectName)
-	metadata.Branch = "master"
+	metadata.Branch = defaultBranch
 
 	return project_resource.NewPostProjectProjectNameResourceCreated().WithPayload(metadata)
 }
@@ -142,11 +157,15 @@ func GetProjectProjectNameResourceResourceURIHandlerFunc(params project_resource
 	common.LockProject(params.ProjectName)
 	defer common.UnlockProject(params.ProjectName)
 
-	logger.Debug("Checking out master branch")
-	err := common.CheckoutBranch(params.ProjectName, "master", *params.DisableUpstreamSync)
+	logger.Debug("Checking out default branch")
+	defaultBranch, err := common.GetDefaultBranch(params.ProjectName)
 	if err != nil {
-		logger.Error(fmt.Sprintf("Could check out master branch of project %s", params.ProjectName))
-		logger.Error(err.Error())
+		logger.Error(fmt.Sprintf("Could not determine default branch of project %s: %s", params.ProjectName, err.Error()))
+		return project_resource.NewGetProjectProjectNameResourceDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
+	}
+	err = common.CheckoutBranch(params.ProjectName, defaultBranch, *params.DisableUpstreamSync)
+	if err != nil {
+		logger.Error(fmt.Sprintf("Could check out %s branch of project %s: %s", params.ProjectName, err.Error()))
 		return project_resource.NewGetProjectProjectNameResourceResourceURIDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
 	}
 
@@ -170,7 +189,7 @@ func GetProjectProjectNameResourceResourceURIHandlerFunc(params project_resource
 	}
 
 	metadata := common.GetResourceMetadata(params.ProjectName)
-	metadata.Branch = "master"
+	metadata.Branch = defaultBranch
 	resource.Metadata = metadata
 
 	return project_resource.NewGetProjectProjectNameResourceResourceURIOK().WithPayload(resource)
@@ -186,14 +205,19 @@ func PutProjectProjectNameResourceResourceURIHandlerFunc(params project_resource
 	common.LockProject(params.ProjectName)
 	defer common.UnlockProject(params.ProjectName)
 
+	defaultBranch, err := common.GetDefaultBranch(params.ProjectName)
+	if err != nil {
+		logger.Error(fmt.Sprintf("Could not determine default branch of project %s: %s", params.ProjectName, err.Error()))
+		return project_resource.NewPutProjectProjectNameResourceResourceURIDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
+	}
+
 	projectConfigPath := config.ConfigDir + "/" + params.ProjectName
 	logger.Debug("Creating new resource(s) in: " + projectConfigPath)
-	logger.Debug("Checking out branch: master")
+	logger.Debug("Checking out branch: " + defaultBranch)
 
-	err := common.CheckoutBranch(params.ProjectName, "master", false)
+	err = common.CheckoutBranch(params.ProjectName, defaultBranch, false)
 	if err != nil {
-		logger.Error(fmt.Sprintf("Could not check out master branch of project %s", params.ProjectName))
-		logger.Error(err.Error())
+		logger.Error(fmt.Sprintf("Could not check out %s branch of project %s: %s", defaultBranch, params.ProjectName, err.Error()))
 		return project_resource.NewPutProjectProjectNameResourceResourceURIBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String("Could not check out branch")})
 	}
 
@@ -203,14 +227,14 @@ func PutProjectProjectNameResourceResourceURIHandlerFunc(params project_resource
 	logger.Debug("Staging Changes")
 	err = common.StageAndCommitAll(params.ProjectName, "Updated resource: "+params.ResourceURI, true)
 	if err != nil {
-		logger.Error(fmt.Sprintf("Could not commit to master branch of project %s", params.ProjectName))
+		logger.Error(fmt.Sprintf("Could not commit to %s branch of project %s: %s", defaultBranch, params.ProjectName, err.Error()))
 		logger.Error(err.Error())
 		return project_resource.NewPutProjectProjectNameResourceResourceURIBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String("Could not commit changes")})
 	}
 	logger.Debug("Successfully updated resource: " + params.ResourceURI)
 
 	metadata := common.GetResourceMetadata(params.ProjectName)
-	metadata.Branch = "master"
+	metadata.Branch = defaultBranch
 
 	return project_resource.NewPutProjectProjectNameResourceResourceURICreated().WithPayload(metadata)
 
@@ -226,10 +250,15 @@ func DeleteProjectProjectNameResourceResourceURIHandlerFunc(params project_resou
 	common.LockProject(params.ProjectName)
 	defer common.UnlockProject(params.ProjectName)
 
-	err := common.CheckoutBranch(params.ProjectName, "master", false)
+	defaultBranch, err := common.GetDefaultBranch(params.ProjectName)
 	if err != nil {
-		logger.Error(fmt.Sprintf("Could not check out master branch of project %s", params.ProjectName))
-		logger.Error(err.Error())
+		logger.Error(fmt.Sprintf("Could not determine default branch of project %s: %s", params.ProjectName, err.Error()))
+		return project_resource.NewDeleteProjectProjectNameResourceResourceURIDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
+	}
+
+	err = common.CheckoutBranch(params.ProjectName, defaultBranch, false)
+	if err != nil {
+		logger.Error(fmt.Sprintf("Could not check out %s branch of project %s: %s", defaultBranch, params.ProjectName, err.Error()))
 		return project_resource.NewDeleteProjectProjectNameResourceResourceURIDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
 	}
 
@@ -245,8 +274,7 @@ func DeleteProjectProjectNameResourceResourceURIHandlerFunc(params project_resou
 	logger.Debug("Staging Changes")
 	err = common.StageAndCommitAll(params.ProjectName, "Deleted resources", true)
 	if err != nil {
-		logger.Error(fmt.Sprintf("Could not commit to master branch of project %s", params.ProjectName))
-		logger.Error(err.Error())
+		logger.Error(fmt.Sprintf("Could not commit to %s branch of project %s: %s", defaultBranch, params.ProjectName, err.Error()))
 		return project_resource.NewDeleteProjectProjectNameResourceResourceURIDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not commit changes")})
 	}
 	logger.Debug("Successfully deleted resources")

--- a/configuration-service/handlers/project_resource.go
+++ b/configuration-service/handlers/project_resource.go
@@ -165,7 +165,7 @@ func GetProjectProjectNameResourceResourceURIHandlerFunc(params project_resource
 	}
 	err = common.CheckoutBranch(params.ProjectName, defaultBranch, *params.DisableUpstreamSync)
 	if err != nil {
-		logger.Error(fmt.Sprintf("Could check out %s branch of project %s: %s", defaultBranch, params.ProjectName, err.Error()))
+		logger.Error(fmt.Sprintf("Could not check out %s branch of project %s: %s", defaultBranch, params.ProjectName, err.Error()))
 		return project_resource.NewGetProjectProjectNameResourceResourceURIDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
 	}
 

--- a/configuration-service/handlers/service_default_resource.go
+++ b/configuration-service/handlers/service_default_resource.go
@@ -38,8 +38,12 @@ func PostProjectProjectNameServiceServiceNameResourceHandlerFunc(params service_
 		return service_default_resource.NewPostProjectProjectNameServiceServiceNameResourceDefault(500).WithPayload(&models.Error{Code: 400, Message: swag.String("Could not get stages for project")})
 	}
 
+	defaultBranch, _ := common.GetDefaultBranch(params.ProjectName)
+	if defaultBranch == "" {
+		defaultBranch = "master"
+	}
 	for _, branch := range branches {
-		if branch == "master" {
+		if branch == defaultBranch {
 			continue
 		}
 		if !common.ServiceExists(params.ProjectName, branch, params.ServiceName, false) {

--- a/configuration-service/handlers/service_default_resource.go
+++ b/configuration-service/handlers/service_default_resource.go
@@ -2,10 +2,9 @@ package handlers
 
 import (
 	"fmt"
-	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
-
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/swag"
+	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
 	"github.com/keptn/keptn/configuration-service/common"
 	"github.com/keptn/keptn/configuration-service/config"
 	"github.com/keptn/keptn/configuration-service/models"
@@ -38,7 +37,11 @@ func PostProjectProjectNameServiceServiceNameResourceHandlerFunc(params service_
 		return service_default_resource.NewPostProjectProjectNameServiceServiceNameResourceDefault(500).WithPayload(&models.Error{Code: 400, Message: swag.String("Could not get stages for project")})
 	}
 
-	defaultBranch, _ := common.GetDefaultBranch(params.ProjectName)
+	defaultBranch, err := common.GetDefaultBranch(params.ProjectName)
+	if err != nil {
+		logger.Error(fmt.Sprintf("Could not determine default branch of project %s: %s", params.ProjectName, err.Error()))
+		return service_default_resource.NewPostProjectProjectNameServiceServiceNameResourceDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
+	}
 	if defaultBranch == "" {
 		defaultBranch = "master"
 	}

--- a/configuration-service/handlers/service_resource.go
+++ b/configuration-service/handlers/service_resource.go
@@ -286,7 +286,11 @@ func PutProjectProjectNameStageStageNameServiceServiceNameResourceHandlerFunc(
 	logger.Debug("Successfully updated resources")
 
 	metadata := common.GetResourceMetadata(params.ProjectName)
-	defaultBranch, _ := common.GetDefaultBranch(params.ProjectName)
+	defaultBranch, err := common.GetDefaultBranch(params.ProjectName)
+	if err != nil {
+		logger.Error(fmt.Sprintf("Could not determine default branch of project %s: %s", params.ProjectName, err.Error()))
+		return service_resource.NewPutProjectProjectNameStageStageNameServiceServiceNameResourceDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
+	}
 	if defaultBranch == "" {
 		defaultBranch = "master"
 	}
@@ -333,7 +337,11 @@ func PutProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIHan
 	logger.Debug("Successfully updated resource: " + params.ResourceURI)
 
 	metadata := common.GetResourceMetadata(params.ProjectName)
-	defaultBranch, _ := common.GetDefaultBranch(params.ProjectName)
+	defaultBranch, err := common.GetDefaultBranch(params.ProjectName)
+	if err != nil {
+		logger.Error(fmt.Sprintf("Could not determine default branch of project %s: %s", params.ProjectName, err.Error()))
+		return service_resource.NewPutProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
+	}
 	if defaultBranch == "" {
 		defaultBranch = "master"
 	}

--- a/configuration-service/handlers/service_resource.go
+++ b/configuration-service/handlers/service_resource.go
@@ -286,7 +286,11 @@ func PutProjectProjectNameStageStageNameServiceServiceNameResourceHandlerFunc(
 	logger.Debug("Successfully updated resources")
 
 	metadata := common.GetResourceMetadata(params.ProjectName)
-	metadata.Branch = "master"
+	defaultBranch, _ := common.GetDefaultBranch(params.ProjectName)
+	if defaultBranch == "" {
+		defaultBranch = "master"
+	}
+	metadata.Branch = defaultBranch
 	return service_resource.NewPutProjectProjectNameStageStageNameServiceServiceNameResourceCreated().WithPayload(metadata)
 }
 
@@ -329,7 +333,11 @@ func PutProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIHan
 	logger.Debug("Successfully updated resource: " + params.ResourceURI)
 
 	metadata := common.GetResourceMetadata(params.ProjectName)
-	metadata.Branch = "master"
+	defaultBranch, _ := common.GetDefaultBranch(params.ProjectName)
+	if defaultBranch == "" {
+		defaultBranch = "master"
+	}
+	metadata.Branch = defaultBranch
 	return service_resource.NewPutProjectProjectNameStageStageNameServiceServiceNameResourceResourceURICreated().
 		WithPayload(metadata)
 }

--- a/configuration-service/handlers/stage.go
+++ b/configuration-service/handlers/stage.go
@@ -78,10 +78,10 @@ func PostProjectProjectNameStageHandlerFunc(params stage.PostProjectProjectNameS
 		logger.Error(fmt.Sprintf("Could not determine default branch for project %s: %s", params.ProjectName, err.Error()))
 		return stage.NewPostProjectProjectNameStageDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not create stage.")})
 	}
+	logger.Info(fmt.Sprintf("creating stage %s from base %s", params.Stage.StageName, defaultBranch))
 	err = common.CreateBranch(params.ProjectName, params.Stage.StageName, defaultBranch)
 	if err != nil {
-		logger.Error(fmt.Sprintf("Could not create %s branch for project %s", params.Stage.StageName, params.ProjectName))
-		logger.Error(err.Error())
+		logger.Error(fmt.Sprintf("Could not create %s branch for project %s: %s", params.Stage.StageName, params.ProjectName, err.Error()))
 		return stage.NewPostProjectProjectNameStageBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String("Could not create stage.")})
 	}
 


### PR DESCRIPTION
Closes #2487 

This PR changes the configuration service to retrieve the name of the default branch of the upstream repository (if specified).
For this purpose, the output of the following command is used:

```
$ git remote show origin
remote origin
  Fetch URL: https://github.com/my-git-repo
  Push  URL: https://github.com/my-git-repo
  HEAD branch: master
  Remote branches:
    dev        new (next fetch will store in remotes/origin)
    master     tracked
    production new (next fetch will store in remotes/origin)
    staging    new (next fetch will store in remotes/origin)
  Local branch configured for 'git pull':
    master merges with remote master
  Local ref configured for 'git push':
    master pushes to master (local out of date)
```

The line containing `HEAD branch:` will tell us the name of the default branch (e.g. `master` in most cases, or `main` in newly created GitHub repositories).

NOTE: I have added a retry mechanism for this command, because it seems like it takes a couple of seconds until GitHub updates this information even when something has been pushed to the `master` branch (when using an empty repository as an upstream repo). During my tests, I noticed that right after the first commit has been pushed to the `master` branch, the name of the `HEAD branch` was set to `(unknown)` - therefore the check for that value within the code of the `GetDefaultBranch()` func.

I have tested this fix with the following scenarios:

- No upstream repository
- Empty GitHub repository 
- Initialized GitHub repository with `main` branch as default
- Empty GitLab repo 
- Empty Bitbucket repo
- Create project without upstream; add empty GitHub repo afterwards
- Create project without upstream; add GitHub repo with `main` branch afterwards