### PR TITLE
Removing distributor from api-service in control-plane helm chart

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/templates/core.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/core.yaml
@@ -105,24 +105,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-        - name: distributor
-          image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
-          {{- include "control-plane.livenessProbe" . | nindent 10 }}
-          imagePullPolicy: Always
-          ports:
-            - containerPort: 8080
-          resources:
-            requests:
-              memory: "32Mi"
-              cpu: "50m"
-            limits:
-              memory: "128Mi"
-              cpu: "500m"
-          env:
-            - name: PUBSUB_URL
-              value: 'nats://keptn-nats-cluster'
-            - name: PUBSUB_TOPIC
-              value: ''
       serviceAccountName: keptn-api-service
 ---
 apiVersion: v1


### PR DESCRIPTION
The distributor container in api-service deployment is not querying any Topic and `PUBSUB_RECIPIENT` is undefined/unset hence it is throwing "No pubsub recipient defined" error resulting in the Error state of the distributor container, which eventually puts the pod in CrashLoopBackOff. Hence removing the distributor container from api-service in control-plane helm chart