### PR TITLE
#2301 Incorrect file path

### DIFF
--- a/bridge/client/index.html
+++ b/bridge/client/index.html
@@ -5,8 +5,10 @@
   <title>keptn</title>
   <base id="base-href" href="/">
   <script>
-    if(window.location.hostname != "localhost" && window.location.pathname.indexOf('bridge') != -1)
-      document.getElementById("base-href").href = window.location.pathname.substring(0, window.location.pathname.indexOf('bridge')) + 'bridge/';
+    if(window.location.href.indexOf('/bridge') != -1)
+      document.getElementById("base-href").href = window.location.href.substring(0, window.location.href.indexOf('/bridge')) + '/bridge/';
+    else
+      document.getElementById("base-href").href = window.location.origin;
   </script>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/png" href="assets/keptn_logo.png">


### PR DESCRIPTION
fix incorrect file path when using deep link in portforwarded bridge by setting always an absolute path for base href

fixes #2301 