### PR TITLE
#2300 Added current-context in .keptn/config file, introduced namespace as …

### DIFF
--- a/cli/cmd/add_resource.go
+++ b/cli/cmd/add_resource.go
@@ -50,7 +50,7 @@ keptn add-resource --project=rockshop --stage=production --service=shop --resour
 	SilenceUsage: true,
 	Args:         cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds()
+		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}

--- a/cli/cmd/auth.go
+++ b/cli/cmd/auth.go
@@ -47,7 +47,7 @@ More precisely, the Keptn CLI stores the endpoint and API token using *pass* in 
 		var err error
 		// User wants to print current auth credentials
 		if *authParams.exportConfig {
-			exportEndPoint, exportAPIToken, err = credentialmanager.NewCredentialManager().GetCreds()
+			exportEndPoint, exportAPIToken, err = credentialmanager.NewCredentialManager().GetCreds(namespace)
 			if err != nil {
 				return err
 			}
@@ -101,7 +101,7 @@ More precisely, the Keptn CLI stores the endpoint and API token using *pass* in 
 			}
 
 			logging.PrintLog("Successfully authenticated against the Keptn cluster "+*authParams.endPoint, logging.InfoLevel)
-			return credentialmanager.NewCredentialManager().SetCreds(*url, *authParams.apiToken)
+			return credentialmanager.NewCredentialManager().SetCreds(*url, *authParams.apiToken, namespace)
 		}
 
 		fmt.Println("skipping auth due to mocking flag set to true")

--- a/cli/cmd/auth_test.go
+++ b/cli/cmd/auth_test.go
@@ -19,7 +19,7 @@ func TestAuthCmd(t *testing.T) {
 	credentialmanager.MockAuthCreds = true
 	checkEndPointStatusMock = true
 
-	endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds()
+	endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
 	if err != nil {
 		t.Error(err)
 		return

--- a/cli/cmd/configure_bridge.go
+++ b/cli/cmd/configure_bridge.go
@@ -44,7 +44,7 @@ var bridgeCmd = &cobra.Command{
 		return verifyConfigureBridgeParams(configureBridgeParams)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		endpoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds()
+		endpoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}

--- a/cli/cmd/configure_monitoring.go
+++ b/cli/cmd/configure_monitoring.go
@@ -61,7 +61,7 @@ keptn configure monitoring prometheus --project=PROJECTNAME --service=SERVICENAM
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds()
+		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}

--- a/cli/cmd/create_project.go
+++ b/cli/cmd/create_project.go
@@ -57,7 +57,7 @@ For more information about Shipyard, creating projects, or upstream repositories
 keptn create project PROJECTNAME --shipyard=FILEPATH --git-user=GIT_USER --git-token=GIT_TOKEN --git-remote-url=GIT_REMOTE_URL`,
 	SilenceUsage: true,
 	Args: func(cmd *cobra.Command, args []string) error {
-		_, _, err := credentialmanager.NewCredentialManager().GetCreds()
+		_, _, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}
@@ -98,7 +98,7 @@ keptn create project PROJECTNAME --shipyard=FILEPATH --git-user=GIT_USER --git-t
 		return checkGitCredentials()
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds()
+		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}

--- a/cli/cmd/create_service.go
+++ b/cli/cmd/create_service.go
@@ -30,7 +30,7 @@ var crServiceCmd = &cobra.Command{
 	Example:      `keptn create service carts --project=sockshop`,
 	SilenceUsage: true,
 	Args: func(cmd *cobra.Command, args []string) error {
-		_, _, err := credentialmanager.NewCredentialManager().GetCreds()
+		_, _, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}
@@ -48,7 +48,7 @@ var crServiceCmd = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds()
+		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}

--- a/cli/cmd/delete_project.go
+++ b/cli/cmd/delete_project.go
@@ -32,7 +32,7 @@ var delProjectCmd = &cobra.Command{
 	Example:      `keptn delete project sockshop`,
 	SilenceUsage: true,
 	Args: func(cmd *cobra.Command, args []string) error {
-		_, _, err := credentialmanager.NewCredentialManager().GetCreds()
+		_, _, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}
@@ -48,7 +48,7 @@ var delProjectCmd = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds()
+		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}

--- a/cli/cmd/delete_service.go
+++ b/cli/cmd/delete_service.go
@@ -28,7 +28,7 @@ Furthermore, if Keptn is used for continuous delivery (i.e. services have been o
 	SilenceUsage: true,
 	Args:         cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds()
+		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}

--- a/cli/cmd/generate_support_archive.go
+++ b/cli/cmd/generate_support_archive.go
@@ -34,7 +34,6 @@ import (
 
 type generateSupportArchiveCmdParams struct {
 	generateCmdParams
-	KeptnNamespace *string
 }
 
 var generateSupportArchiveParams *generateSupportArchiveCmdParams
@@ -101,7 +100,7 @@ keptn generate support-archive --dir=/some/directory`,
 		s.OperatingSystem = runtime.GOOS
 		s.KeptnCLIVersion = Version
 
-		keptnNS := *generateSupportArchiveParams.KeptnNamespace
+		keptnNS := namespace
 
 		// create temporary directory for storing log files
 		tmpDir, err := ioutil.TempDir("", "keptn-support-archive")
@@ -370,13 +369,13 @@ func newErrorableMetadataResult(result *models.Metadata, err error) *errorableMe
 
 func getKeptnAPIUrl() *errorableStringResult {
 	fmt.Println("Retrieving Keptn API")
-	endPoint, _, err := credentialmanager.NewCredentialManager().GetCreds()
+	endPoint, _, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
 	return newErrorableStringResult(endPoint.String(), err)
 }
 
 func getKeptnAPIReachable() *errorableBoolResult {
 	fmt.Println("Checking availability of Keptn API")
-	endPoint, _, err := credentialmanager.NewCredentialManager().GetCreds()
+	endPoint, _, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
 	if err != nil {
 		return newErrorableBoolResult(false, err)
 	}
@@ -546,7 +545,7 @@ func writePodLogs(namespace, dir string) {
 
 func getProjects() *errorableProjectResult {
 	fmt.Println("Retrieving list of Keptn projects")
-	endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds()
+	endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
 	if err != nil {
 		return newErrorableProjectResult(nil, err)
 	}
@@ -568,7 +567,7 @@ func writeKeptnInstallerLog(logFileName string, dir string) {
 
 func getKeptnMetadata() *errorableMetadataResult {
 	fmt.Println("Retrieving Keptn Metadata from API Service")
-	endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds()
+	endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
 	if err != nil {
 		return newErrorableMetadataResult(nil, err)
 	}
@@ -586,6 +585,4 @@ func init() {
 	generateSupportArchiveParams = &generateSupportArchiveCmdParams{}
 	generateSupportArchiveParams.Directory = generateSupportArchiveCmd.Flags().StringP("dir", "",
 		"./support-archive", "directory where the docs should be written to")
-	generateSupportArchiveParams.KeptnNamespace = generateSupportArchiveCmd.Flags().StringP("namespace", "n",
-		"keptn", "namespace where Keptn is installed")
 }

--- a/cli/cmd/get_event.go
+++ b/cli/cmd/get_event.go
@@ -64,7 +64,7 @@ func getEvent(eventStruct GetEventStruct, args []string) error {
 	var apiToken string
 	var err error
 	if !mocking {
-		endPoint, apiToken, err = credentialmanager.NewCredentialManager().GetCreds()
+		endPoint, apiToken, err = credentialmanager.NewCredentialManager().GetCreds(namespace)
 	} else {
 		endPointPtr, _ := url.Parse(os.Getenv("MOCK_SERVER"))
 		endPoint = *endPointPtr

--- a/cli/cmd/get_event_approvalTriggered.go
+++ b/cli/cmd/get_event_approvalTriggered.go
@@ -54,7 +54,7 @@ func getApprovalTriggeredEvents(approvalTriggered approvalTriggeredStruct) error
 	var apiToken string
 	var err error
 	if !mocking {
-		endPoint, apiToken, err = credentialmanager.NewCredentialManager().GetCreds()
+		endPoint, apiToken, err = credentialmanager.NewCredentialManager().GetCreds(namespace)
 	} else {
 		endPointPtr, _ := url.Parse(os.Getenv("MOCK_SERVER"))
 		endPoint = *endPointPtr

--- a/cli/cmd/get_event_evaluationDone.go
+++ b/cli/cmd/get_event_evaluationDone.go
@@ -40,7 +40,7 @@ var evaluationDoneCmd = &cobra.Command{
 	Example:      `keptn get event evaluation-done --keptn-context=1234-5678-90ab-cdef`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds()
+		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}

--- a/cli/cmd/get_projects.go
+++ b/cli/cmd/get_projects.go
@@ -61,7 +61,7 @@ keptn get project sockshop -output=json  # Returns project details in JSON forma
 `,
 	SilenceUsage: true,
 	Args: func(cmd *cobra.Command, args []string) error {
-		_, _, err := credentialmanager.NewCredentialManager().GetCreds()
+		_, _, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}
@@ -84,7 +84,7 @@ keptn get project sockshop -output=json  # Returns project details in JSON forma
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds()
+		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}

--- a/cli/cmd/get_services.go
+++ b/cli/cmd/get_services.go
@@ -55,7 +55,7 @@ keptn get services carts --project=sockshop -o=json  # Get details of the carts 
 `,
 	SilenceUsage: true,
 	Args: func(cmd *cobra.Command, args []string) error {
-		_, _, err := credentialmanager.NewCredentialManager().GetCreds()
+		_, _, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}
@@ -69,7 +69,7 @@ keptn get services carts --project=sockshop -o=json  # Get details of the carts 
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds()
+		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}

--- a/cli/cmd/get_stages.go
+++ b/cli/cmd/get_stages.go
@@ -48,7 +48,7 @@ staging        2020-04-06T14:37:45.210Z
 `,
 	SilenceUsage: true,
 	Args: func(cmd *cobra.Command, args []string) error {
-		_, _, err := credentialmanager.NewCredentialManager().GetCreds()
+		_, _, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}
@@ -57,7 +57,7 @@ staging        2020-04-06T14:37:45.210Z
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 
-		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds()
+		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -182,9 +182,6 @@ func init() {
 
 	installCmd.PersistentFlags().BoolVarP(&insecureSkipTLSVerify, "insecure-skip-tls-verify", "s",
 		false, "Skip tls verification for kubectl commands")
-
-	installParams.Namespace = installCmd.Flags().StringP("namespace", "n", "keptn",
-		"Specify the namespace where Keptn should be installed in (default keptn).")
 	installParams.HideSensitiveData = installCmd.Flags().BoolP("hide-sensitive-data", "", false,
 		"Hide the sensitive data like api-tokens and endpoints in post-installation output.")
 
@@ -192,7 +189,7 @@ func init() {
 
 // Preconditions: 1. Already authenticated against the cluster.
 func doInstallation() error {
-	keptnNamespace := *installParams.Namespace
+	keptnNamespace := namespace
 	showFallbackConnectMessage := true
 
 	res, err := keptnutils.ExistsNamespace(false, keptnNamespace)

--- a/cli/cmd/onboard_service.go
+++ b/cli/cmd/onboard_service.go
@@ -49,7 +49,7 @@ keptn onboard service SERVICENAME --project=PROJECTNAME --chart=HELM_CHART.tgz
 	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 
-		_, _, err := credentialmanager.NewCredentialManager().GetCreds()
+		_, _, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}
@@ -78,7 +78,7 @@ keptn onboard service SERVICENAME --project=PROJECTNAME --chart=HELM_CHART.tgz
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds()
+		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -20,6 +20,7 @@ var SuppressWSCommunication bool
 
 var insecureSkipTLSVerify bool
 var kubectlOptions string
+var namespace string
 
 const authErrorMsg = "This command requires to be authenticated. See \"keptn auth\" for details"
 
@@ -56,6 +57,8 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&mocking, "mock", "", false, "Disables communication to a Keptn endpoint")
 	rootCmd.PersistentFlags().BoolVarP(&SuppressWSCommunication, "suppress-websocket", "", false,
 		"Disables WebSocket communication to suppress info messages from services running inside Keptn")
+	rootCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "keptn",
+		"Specify the namespace where Keptn should be installed, used and uninstalled in (default keptn).")
 	cobra.OnInitialize(initConfig)
 }
 

--- a/cli/cmd/send_event.go
+++ b/cli/cmd/send_event.go
@@ -52,7 +52,7 @@ In addition, the payload of the CloudEvent needs to follow the Keptn spec (https
 		return json.Unmarshal([]byte(eventString), &body)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds()
+		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}

--- a/cli/cmd/send_event_approvalFinished.go
+++ b/cli/cmd/send_event_approvalFinished.go
@@ -64,7 +64,7 @@ func sendApprovalFinishedEvent(sendApprovalFinishedOptions sendApprovalFinishedS
 	var apiToken string
 	var err error
 	if !mocking {
-		endPoint, apiToken, err = credentialmanager.NewCredentialManager().GetCreds()
+		endPoint, apiToken, err = credentialmanager.NewCredentialManager().GetCreds(namespace)
 	} else {
 		endPointPtr, _ := url.Parse(os.Getenv("MOCK_SERVER"))
 		endPoint = *endPointPtr

--- a/cli/cmd/send_event_evaluationStart.go
+++ b/cli/cmd/send_event_evaluationStart.go
@@ -63,7 +63,7 @@ keptn send event start-evaluation --project=sockshop --stage=hardening --service
 `,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds()
+		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}

--- a/cli/cmd/send_event_newArtifact.go
+++ b/cli/cmd/send_event_newArtifact.go
@@ -73,7 +73,7 @@ For pulling an image from a private registry, we would like to refer to the Kube
 		return docker.CheckImageAvailability(*newArtifact.Image, *newArtifact.Tag, nil)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds()
+		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -14,10 +14,10 @@ var statusCmd = &cobra.Command{
 	Short: "Checks the status of the CLI",
 	Long: `Checks the status of the CLI. This includes a test whether the CLI is authenticated against the Keptn API. 
 `,
-	Example: `keptn status`,
+	Example:      `keptn status`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds()
+		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
 		if err != nil || endPoint.String() == "" || apiToken == "" {
 			fmt.Println("CLI is not authenticated against any Keptn cluster.  For authenticating your CLI use \"keptn auth\"")
 			return nil

--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -16,12 +16,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type uninstallCmdParams struct {
-	Namespace *string
-}
-
-var uninstallParams uninstallCmdParams
-
 // uninstallCmd represents the uninstall command
 var uninstallCmd = &cobra.Command{
 	Use:   "uninstall",
@@ -46,7 +40,7 @@ Besides, deployed services and the configuration on the Git upstream (i.e., GitH
 			kubectlOptions = "--insecure-skip-tls-verify=true"
 		}
 
-		keptnNamespace := *uninstallParams.Namespace
+		keptnNamespace := namespace
 
 		ctx, _ := platform.GetKubeContext()
 		fmt.Println("Your Kubernetes current context is configured to cluster: " + strings.TrimSpace(ctx))
@@ -129,11 +123,5 @@ func deleteNamespace(namespace string) error {
 
 func init() {
 	rootCmd.AddCommand(uninstallCmd)
-
-	uninstallParams = uninstallCmdParams{}
-
-	uninstallParams.Namespace = uninstallCmd.Flags().StringP("namespace", "n", "keptn",
-		"Specify the namespace Keptn should be installed in (default keptn).")
-
 	uninstallCmd.PersistentFlags().BoolVarP(&insecureSkipTLSVerify, "insecure-skip-tls-verify", "s", false, "Skip tls verification for kubectl commands")
 }

--- a/cli/cmd/update_project.go
+++ b/cli/cmd/update_project.go
@@ -37,7 +37,7 @@ For more information about updating projects or upstream repositories, please go
 	Example:      `keptn update project PROJECTNAME --git-user=GIT_USER --git-token=GIT_TOKEN --git-remote-url=GIT_REMOTE_URL`,
 	SilenceUsage: true,
 	Args: func(cmd *cobra.Command, args []string) error {
-		_, _, err := credentialmanager.NewCredentialManager().GetCreds()
+		_, _, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}
@@ -57,7 +57,7 @@ For more information about updating projects or upstream repositories, please go
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds()
+		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -151,7 +151,7 @@ func isUpgradeCompatible() (bool, error) {
 }
 
 func getLatestKeptnRelease() (*release.Release, error) {
-	keptnNamespace := *upgradeParams.Namespace
+	keptnNamespace := namespace
 	releases, err := helm.NewHelper().GetHistory(keptnReleaseName, keptnNamespace)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to check if Keptn release is available in namespace %s: %v", keptnNamespace, err)
@@ -173,13 +173,10 @@ func init() {
 	upgradeParams.ChartRepoURL = upgraderCmd.Flags().StringP("chart-repo", "",
 		"", "URL of the Keptn Helm Chart repository")
 	upgraderCmd.Flags().MarkHidden("chart-repo")
-
-	upgradeParams.Namespace = upgraderCmd.Flags().StringP("namespace", "n", "keptn",
-		"Specify the namespace where Keptn should be upgraded (default keptn).")
 }
 
 func doUpgrade() error {
-	keptnNamespace := *upgradeParams.Namespace
+	keptnNamespace := namespace
 
 	installedKeptnVersion, err := getInstalledKeptnVersion()
 	if err != nil {

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -141,7 +141,7 @@ func updateLastVersionCheck() {
 }
 
 func getKeptnServerVersion() (string, error) {
-	endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds()
+	endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
 	if err != nil {
 		return "", errors.New(authErrorMsg)
 	}

--- a/cli/pkg/config/cli_config.go
+++ b/cli/pkg/config/cli_config.go
@@ -16,6 +16,7 @@ import (
 type CLIConfig struct {
 	AutomaticVersionCheck bool       `json:"automatic_version_check"`
 	LastVersionCheck      *time.Time `json:"last_version_check"`
+	CurrentContext        string     `json:"current-context"`
 }
 
 // CLIConfigManager manages the path of the CLI config

--- a/cli/pkg/config/cli_config_test.go
+++ b/cli/pkg/config/cli_config_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/keptn/keptn/cli/pkg/file"
 )
 
-const testConfig = `{"automatic_version_check":true,"last_version_check":"2020-02-20T00:00:00Z"}`
+const testConfig = `{"automatic_version_check":true,"last_version_check":"2020-02-20T00:00:00Z","current-context":""}`
 
 var testTime time.Time
 

--- a/cli/pkg/credentialmanager/handler.go
+++ b/cli/pkg/credentialmanager/handler.go
@@ -124,6 +124,12 @@ func handleCustomCreds(configLocation string) (url.URL, string, error) {
 }
 
 func getCurrentContextFromKubeConfig() (string, error) {
+	if MockAuthCreds {
+		// Do nothing
+		kubeConfigFile.CurrentContext = ""
+		return "", nil
+	}
+
 	var kubeconfig string
 	if os.Getenv("KUBECONFIG") != "" {
 		kubeconfig = keptnutils.ExpandTilde(os.Getenv("KUBECONFIG"))
@@ -146,6 +152,11 @@ func getCurrentContextFromKubeConfig() (string, error) {
 }
 
 func checkForContextChange(currentContext string, cliConfigManager *config.CLIConfigManager) error {
+
+	if MockAuthCreds {
+		// Do nothing
+		return nil
+	}
 	cliConfig, err := cliConfigManager.LoadCLIConfig()
 	if err != nil {
 		log.Fatal(err)

--- a/cli/pkg/credentialmanager/handler.go
+++ b/cli/pkg/credentialmanager/handler.go
@@ -1,14 +1,21 @@
 package credentialmanager
 
 import (
+	"bufio"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/url"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/docker/docker-credential-helpers/credentials"
+	"github.com/keptn/keptn/cli/pkg/config"
+	"github.com/keptn/keptn/cli/pkg/file"
 	keptnutils "github.com/keptn/kubernetes-utils/pkg"
+	"gopkg.in/yaml.v2"
 )
 
 var testEndPoint = url.URL{Scheme: "https", Host: "my-endpoint"}
@@ -26,12 +33,19 @@ type credsConfig struct {
 	Endpoint string `json:"endpoint"`
 }
 
-func init() {
+type kubeConfigFileType struct {
+	CurrentContext string `yaml:"current-context"`
+}
 
-	_, err := keptnutils.GetKeptnDirectory()
+var kubeConfigFile kubeConfigFileType
+
+func init() {
+	cliConfigManager := config.NewCLIConfigManager()
+	currentContext, err := getCurrentContextFromKubeConfig()
 	if err != nil {
 		log.Fatal(err)
 	}
+	checkForContextChange(currentContext, cliConfigManager)
 	credentials.SetCredsLabel(credsLab)
 }
 
@@ -52,34 +66,34 @@ func getInstallCreds(h credentials.Helper) (string, error) {
 	return creds, err
 }
 
-func setCreds(h credentials.Helper, endPoint url.URL, apiToken string) error {
+func setCreds(h credentials.Helper, endPoint url.URL, apiToken string, namespace string) error {
 	if MockAuthCreds {
 		// Do nothing
 		return nil
 	}
-
+	customServerURL := serverURL + "/" + kubeConfigFile.CurrentContext + "/" + namespace
 	c := &credentials.Credentials{
-		ServerURL: serverURL,
+		ServerURL: customServerURL,
 		Username:  endPoint.String(),
 		Secret:    apiToken,
 	}
 	return h.Add(c)
 }
 
-func getCreds(h credentials.Helper) (url.URL, string, error) {
+func getCreds(h credentials.Helper, namespace string) (url.URL, string, error) {
 
 	if MockAuthCreds {
 		return url.URL{}, "", nil
 	}
 
+	customServerURL := serverURL + "/" + kubeConfigFile.CurrentContext + "/" + namespace
 	// Check if creds file is specified in the 'KEPTNCONFIG' environment variable
 	if customCredsLocation, ok := os.LookupEnv("KEPTNCONFIG"); ok {
 		if customCredsLocation != "" {
 			return handleCustomCreds(customCredsLocation)
 		}
 	}
-
-	endPointStr, apiToken, err := h.Get(serverURL)
+	endPointStr, apiToken, err := h.Get(customServerURL)
 	if err != nil {
 		return url.URL{}, "", err
 	}
@@ -107,4 +121,53 @@ func handleCustomCreds(configLocation string) (url.URL, string, error) {
 	}
 
 	return *parsedURL, credsConfig.APIToken, nil
+}
+
+func getCurrentContextFromKubeConfig() (string, error) {
+	var kubeconfig string
+	if os.Getenv("KUBECONFIG") != "" {
+		kubeconfig = keptnutils.ExpandTilde(os.Getenv("KUBECONFIG"))
+	} else {
+		kubeconfig = filepath.Join(
+			keptnutils.UserHomeDir(), ".kube", "config",
+		)
+	}
+
+	fileContent, err := file.ReadFile(kubeconfig)
+	if err != nil {
+		return "", err
+	}
+
+	err = yaml.Unmarshal([]byte(fileContent), &kubeConfigFile)
+	if err != nil {
+		log.Fatalf("Unmarshal: %v", err)
+	}
+	return kubeConfigFile.CurrentContext, nil
+}
+
+func checkForContextChange(currentContext string, cliConfigManager *config.CLIConfigManager) error {
+	cliConfig, err := cliConfigManager.LoadCLIConfig()
+	if err != nil {
+		log.Fatal(err)
+	}
+	if cliConfig.CurrentContext != currentContext {
+		fmt.Printf("Kube context has been changed to %s", currentContext)
+		fmt.Println()
+		fmt.Println("Do you want to continue with this? (y/n)")
+		reader := bufio.NewReader(os.Stdin)
+		in, err := reader.ReadString('\n')
+		if err != nil {
+			return err
+		}
+		in = strings.ToLower(strings.TrimSpace(in))
+		if !(in == "y" || in == "yes") {
+			return fmt.Errorf("stopping installation")
+		}
+		cliConfig.CurrentContext = currentContext
+		err = cliConfigManager.StoreCLIConfig(cliConfig)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/cli/pkg/credentialmanager/handler_darwin.go
+++ b/cli/pkg/credentialmanager/handler_darwin.go
@@ -14,13 +14,13 @@ func NewCredentialManager() (cm *CredentialManager) {
 }
 
 // SetCreds stores the credentials consisting of an endpoint and an api token in the keychain.
-func (cm *CredentialManager) SetCreds(endPoint url.URL, apiToken string) error {
-	return setCreds(osxkeychain.Osxkeychain{}, endPoint, apiToken)
+func (cm *CredentialManager) SetCreds(endPoint url.URL, apiToken string, namespace string) error {
+	return setCreds(osxkeychain.Osxkeychain{}, endPoint, apiToken, namespace)
 }
 
 // GetCreds reads the credentials and returns an endpoint, the api token, or potentially an error.
-func (cm *CredentialManager) GetCreds() (url.URL, string, error) {
-	return getCreds(osxkeychain.Osxkeychain{})
+func (cm *CredentialManager) GetCreds(namespace string) (url.URL, string, error) {
+	return getCreds(osxkeychain.Osxkeychain{}, namespace)
 }
 
 // SetInstallCreds sets the install credentials

--- a/cli/pkg/credentialmanager/handler_darwin.go
+++ b/cli/pkg/credentialmanager/handler_darwin.go
@@ -10,6 +10,7 @@ type CredentialManager struct {
 }
 
 func NewCredentialManager() (cm *CredentialManager) {
+	initChecks()
 	return &CredentialManager{}
 }
 

--- a/cli/pkg/credentialmanager/handler_darwin_test.go
+++ b/cli/pkg/credentialmanager/handler_darwin_test.go
@@ -14,11 +14,11 @@ func init() {
 func TestSetAndGetCreds(t *testing.T) {
 
 	cm := NewCredentialManager()
-	if err := cm.SetCreds(testEndPoint, testAPIToken); err != nil {
+	if err := cm.SetCreds(testEndPoint, testAPIToken, ""); err != nil {
 		t.Fatal(err)
 	}
 
-	endPoint, apiToken, err := cm.GetCreds()
+	endPoint, apiToken, err := cm.GetCreds("")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -30,15 +30,15 @@ func TestSetAndGetCreds(t *testing.T) {
 func TestOverwriteCreds(t *testing.T) {
 
 	cm := NewCredentialManager()
-	if err := cm.SetCreds(testEndPoint, "old-secret"); err != nil {
+	if err := cm.SetCreds(testEndPoint, "old-secret", ""); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := cm.SetCreds(testEndPoint, testAPIToken); err != nil {
+	if err := cm.SetCreds(testEndPoint, testAPIToken, ""); err != nil {
 		t.Fatal(err)
 	}
 
-	endPoint, apiToken, err := cm.GetCreds()
+	endPoint, apiToken, err := cm.GetCreds("")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli/pkg/credentialmanager/handler_darwin_test.go
+++ b/cli/pkg/credentialmanager/handler_darwin_test.go
@@ -12,13 +12,13 @@ func init() {
 }
 
 func TestSetAndGetCreds(t *testing.T) {
-
+	MockKubeConfigCheck = true
 	cm := NewCredentialManager()
-	if err := cm.SetCreds(testEndPoint, testAPIToken, ""); err != nil {
+	if err := cm.SetCreds(testEndPoint, testAPIToken, testNamespace); err != nil {
 		t.Fatal(err)
 	}
 
-	endPoint, apiToken, err := cm.GetCreds("")
+	endPoint, apiToken, err := cm.GetCreds(testNamespace)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -28,17 +28,17 @@ func TestSetAndGetCreds(t *testing.T) {
 }
 
 func TestOverwriteCreds(t *testing.T) {
-
+	MockKubeConfigCheck = true
 	cm := NewCredentialManager()
-	if err := cm.SetCreds(testEndPoint, "old-secret", ""); err != nil {
+	if err := cm.SetCreds(testEndPoint, "old-secret", testNamespace); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := cm.SetCreds(testEndPoint, testAPIToken, ""); err != nil {
+	if err := cm.SetCreds(testEndPoint, testAPIToken, testNamespace); err != nil {
 		t.Fatal(err)
 	}
 
-	endPoint, apiToken, err := cm.GetCreds("")
+	endPoint, apiToken, err := cm.GetCreds(testNamespace)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli/pkg/credentialmanager/handler_linux.go
+++ b/cli/pkg/credentialmanager/handler_linux.go
@@ -11,7 +11,6 @@ import (
 	"io/ioutil"
 
 	"github.com/docker/docker-credential-helpers/pass"
-	"github.com/keptn/keptn/cli/pkg/config"
 	keptnutils "github.com/keptn/kubernetes-utils/pkg"
 )
 
@@ -38,12 +37,7 @@ func NewCredentialManager() (cm *CredentialManager) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	cliConfigManager := config.NewCLIConfigManager()
-	currentContext, err := getCurrentContextFromKubeConfig()
-	if err != nil {
-		log.Fatal(err)
-	}
-	checkForContextChange(currentContext, cliConfigManager)
+	initChecks()
 	return &CredentialManager{apiTokenFile: dir + ".keptn", credsFile: dir + ".keptn-creds"}
 }
 

--- a/cli/pkg/credentialmanager/handler_linux.go
+++ b/cli/pkg/credentialmanager/handler_linux.go
@@ -46,7 +46,7 @@ func NewCredentialManager() (cm *CredentialManager) {
 func (cm *CredentialManager) SetCreds(endPoint url.URL, apiToken string, namespace string) error {
 	if _, err := os.Stat(passwordStoreDirectory); os.IsNotExist(err) {
 		fmt.Println("Using a file-based storage for the key because the password-store seems to be not set up.")
-		apiTokenFile := cm.apiTokenFile + "__" + kubeConfigFile.CurrentContext + "__" + namespace
+		apiTokenFile := cm.getLinuxApiTokenFile(namespace)
 		return ioutil.WriteFile(apiTokenFile, []byte(endPoint.String()+"\n"+apiToken), 0644)
 	}
 	return setCreds(pass.Pass{}, endPoint, apiToken, namespace)
@@ -69,7 +69,7 @@ func (cm *CredentialManager) GetCreds(namespace string) (url.URL, string, error)
 	// try to read credentials from password-store
 	if _, err := os.Stat(passwordStoreDirectory); os.IsNotExist(err) {
 		// password-store not found, read credentials from apiTokenFile
-		apiTokenFile := cm.apiTokenFile + "__" + kubeConfigFile.CurrentContext + "__" + namespace
+		apiTokenFile := cm.getLinuxApiTokenFile(namespace)
 		data, err := ioutil.ReadFile(apiTokenFile)
 		if err != nil {
 			return url.URL{}, "", err
@@ -106,4 +106,8 @@ func (cm *CredentialManager) GetInstallCreds() (string, error) {
 		return dataStr, nil
 	}
 	return getInstallCreds(pass.Pass{})
+}
+
+func (cm *CredentialManager) getLinuxApiTokenFile(namespace string) string {
+	return cm.apiTokenFile + "__" + kubeConfigFile.CurrentContext + "__" + namespace
 }

--- a/cli/pkg/credentialmanager/handler_linux_test.go
+++ b/cli/pkg/credentialmanager/handler_linux_test.go
@@ -15,11 +15,11 @@ func init() {
 func TestSetAndGetCreds(t *testing.T) {
 
 	cm := NewCredentialManager()
-	if err := cm.SetCreds(testEndPoint, testAPIToken); err != nil {
+	if err := cm.SetCreds(testEndPoint, testAPIToken, ""); err != nil {
 		t.Fatal(err)
 	}
 
-	endPoint, apiToken, err := cm.GetCreds()
+	endPoint, apiToken, err := cm.GetCreds("")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +48,7 @@ func TestGetCredsFromFile(t *testing.T) {
 	cm := NewCredentialManager()
 	cm.apiTokenFile = file.Name()
 
-	url, token, err := cm.GetCreds()
+	url, token, err := cm.GetCreds("")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli/pkg/credentialmanager/handler_linux_test.go
+++ b/cli/pkg/credentialmanager/handler_linux_test.go
@@ -3,6 +3,7 @@ package credentialmanager
 import (
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/keptn/keptn/cli/pkg/logging"
@@ -13,13 +14,13 @@ func init() {
 }
 
 func TestSetAndGetCreds(t *testing.T) {
-
+	MockKubeConfigCheck = true
 	cm := NewCredentialManager()
-	if err := cm.SetCreds(testEndPoint, testAPIToken, ""); err != nil {
+	if err := cm.SetCreds(testEndPoint, testAPIToken, testNamespace); err != nil {
 		t.Fatal(err)
 	}
 
-	endPoint, apiToken, err := cm.GetCreds("")
+	endPoint, apiToken, err := cm.GetCreds(testNamespace)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -31,8 +32,8 @@ func TestSetAndGetCreds(t *testing.T) {
 }
 
 func TestGetCredsFromFile(t *testing.T) {
-
-	file, err := ioutil.TempFile("", "")
+	MockKubeConfigCheck = true
+	file, err := ioutil.TempFile("", "*__"+kubeConfigFile.CurrentContext+"__"+testNamespace)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,9 +47,10 @@ func TestGetCredsFromFile(t *testing.T) {
 	}
 
 	cm := NewCredentialManager()
-	cm.apiTokenFile = file.Name()
+	tempFileName := strings.Split(file.Name(), "__")[0]
+	cm.apiTokenFile = tempFileName
 
-	url, token, err := cm.GetCreds("")
+	url, token, err := cm.GetCreds(testNamespace)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli/pkg/credentialmanager/handler_windows.go
+++ b/cli/pkg/credentialmanager/handler_windows.go
@@ -14,13 +14,13 @@ func NewCredentialManager() (cm *CredentialManager) {
 }
 
 // SetCreds stores the credentials consisting of an endpoint and an api token in the keychain.
-func (cm *CredentialManager) SetCreds(endPoint url.URL, apiToken string) error {
-	return setCreds(wincred.Wincred{}, endPoint, apiToken)
+func (cm *CredentialManager) SetCreds(endPoint url.URL, apiToken string, namespace string) error {
+	return setCreds(wincred.Wincred{}, endPoint, apiToken, namespace)
 }
 
 // GetCreds reads the credentials and returns an endpoint, the api token, or potentially an error.
-func (cm *CredentialManager) GetCreds() (url.URL, string, error) {
-	return getCreds(wincred.Wincred{})
+func (cm *CredentialManager) GetCreds(namespace string) (url.URL, string, error) {
+	return getCreds(wincred.Wincred{}, namespace)
 }
 
 // SetInstallCreds sets the install credentials

--- a/cli/pkg/credentialmanager/handler_windows.go
+++ b/cli/pkg/credentialmanager/handler_windows.go
@@ -10,6 +10,7 @@ type CredentialManager struct {
 }
 
 func NewCredentialManager() (cm *CredentialManager) {
+	initChecks()
 	return &CredentialManager{}
 }
 

--- a/cli/pkg/credentialmanager/handler_windows_test.go
+++ b/cli/pkg/credentialmanager/handler_windows_test.go
@@ -14,11 +14,11 @@ func init() {
 func TestSetAndGetCreds(t *testing.T) {
 
 	cm := NewCredentialManager()
-	if err := cm.SetCreds(testEndPoint, testAPIToken); err != nil {
+	if err := cm.SetCreds(testEndPoint, testAPIToken, ""); err != nil {
 		t.Fatal(err)
 	}
 
-	endPoint, apiToken, err := cm.GetCreds()
+	endPoint, apiToken, err := cm.GetCreds("")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli/pkg/credentialmanager/handler_windows_test.go
+++ b/cli/pkg/credentialmanager/handler_windows_test.go
@@ -12,13 +12,13 @@ func init() {
 }
 
 func TestSetAndGetCreds(t *testing.T) {
-
+	MockKubeConfigCheck = true
 	cm := NewCredentialManager()
-	if err := cm.SetCreds(testEndPoint, testAPIToken, ""); err != nil {
+	if err := cm.SetCreds(testEndPoint, testAPIToken, testNamespace); err != nil {
 		t.Fatal(err)
 	}
 
-	endPoint, apiToken, err := cm.GetCreds("")
+	endPoint, apiToken, err := cm.GetCreds(testNamespace)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
In regards to #2300 
- [x] Added current-context in `~/.keptn.config` file
- [x] Introduced namespace as a global variable so we can run keptn cli commands just like kubectl command if we have multiple keptn installations in same cluster.
- [x] Added support for multi-context in credential manager for mac and windows
- [x] Multi-context testing is still left for Linux.