### PR TITLE
#2529 Added built-in task sequence for evaluations

### DIFF
--- a/shipyard-controller/api/event.go
+++ b/shipyard-controller/api/event.go
@@ -506,7 +506,7 @@ func (sc *shipyardController) handleTriggeredEvent(event models.Event) error {
 	}
 
 	if err := sc.eventRepo.InsertEvent(eventScope.Project, event, db.TriggeredEvent); err != nil {
-		sc.logger.Info("could not store event that triggered tas sequence: " + err.Error())
+		sc.logger.Info("could not store event that triggered task sequence: " + err.Error())
 	}
 
 	eventScope.Stage = stageName

--- a/shipyard-controller/api/event_test.go
+++ b/shipyard-controller/api/event_test.go
@@ -993,21 +993,25 @@ func Test_shipyardController_Scenario1(t *testing.T) {
 		"hardening",
 		func(t *testing.T, event models.Event) bool {
 			marshal, _ := json.Marshal(event.Data)
-			testData := &keptnv2.DeploymentTriggeredEventData{}
+			deploymentEvent := &keptnv2.DeploymentTriggeredEventData{}
 
-			err := json.Unmarshal(marshal, testData)
+			err := json.Unmarshal(marshal, deploymentEvent)
 
 			if err != nil {
 				t.Errorf("Expected test.triggered data but could not convert: %v: %s", event.Data, err.Error())
 				return true
 			}
 
-			if len(testData.Deployment.DeploymentURIsLocal) != 2 {
+			if len(deploymentEvent.Deployment.DeploymentURIsLocal) != 2 {
 				t.Errorf("DeploymentURIsLocal property was not transmitted correctly")
 				return true
 			}
-			if len(testData.Deployment.DeploymentURIsPublic) != 2 {
+			if len(deploymentEvent.Deployment.DeploymentURIsPublic) != 2 {
 				t.Errorf("DeploymentURIsLocal property was not transmitted correctly")
+				return true
+			}
+			if deploymentEvent.ConfigurationChange.Values["image"] != "carts" {
+				t.Error(fmt.Sprintf("did not receive correct image. Expected 'carts' but got '%s'", deploymentEvent.ConfigurationChange.Values["image"]))
 				return true
 			}
 			return false

--- a/shipyard-controller/api/event_test.go
+++ b/shipyard-controller/api/event_test.go
@@ -1661,7 +1661,43 @@ func Test_shipyardController_getTaskSequenceInStage(t *testing.T) {
 		want    *keptnv2.Sequence
 		wantErr bool
 	}{
-		// TODO: Add test cases.
+		{
+			name: "get built-in evaluation task sequence",
+			fields: fields{
+				projectRepo:      nil,
+				eventRepo:        nil,
+				taskSequenceRepo: nil,
+				logger:           keptncommon.NewLogger("", "", ""),
+			},
+			args: args{
+				stageName:        "dev",
+				taskSequenceName: "evaluation",
+				shipyard: &keptnv2.Shipyard{
+					ApiVersion: "0.2.0",
+					Kind:       "shipyard",
+					Metadata:   keptnv2.Metadata{},
+					Spec: keptnv2.ShipyardSpec{
+						Stages: []keptnv2.Stage{
+							{
+								Name:      "dev",
+								Sequences: []keptnv2.Sequence{},
+							},
+						},
+					},
+				},
+			},
+			want: &keptnv2.Sequence{
+				Name:     "evaluation",
+				Triggers: nil,
+				Tasks: []keptnv2.Task{
+					{
+						Name:       "evaluation",
+						Properties: nil,
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1676,8 +1712,11 @@ func Test_shipyardController_getTaskSequenceInStage(t *testing.T) {
 				t.Errorf("getTaskSequenceInStage() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
+			if diff := deep.Equal(got, tt.want); len(diff) > 0 {
 				t.Errorf("getTaskSequenceInStage() got = %v, want %v", got, tt.want)
+				for _, d := range diff {
+					t.Log(d)
+				}
 			}
 		})
 	}

--- a/shipyard-controller/api/event_test.go
+++ b/shipyard-controller/api/event_test.go
@@ -831,15 +831,18 @@ func Test_shipyardController_Scenario1(t *testing.T) {
 			marshal, _ := json.Marshal(event.Data)
 			if err := json.Unmarshal(marshal, deploymentEvent); err != nil {
 				t.Error("could not parse incoming deployment.triggered event: " + err.Error())
+				return true
 			}
 
 			if deploymentEvent.Deployment.DeploymentStrategy != "direct" {
 				t.Error(fmt.Sprintf("did not receive correct deployment strategy. Expected 'direct' but got '%s'", deploymentEvent.Deployment.DeploymentStrategy))
+				return true
 			}
 			if deploymentEvent.ConfigurationChange.Values["image"] != "carts" {
 				t.Error(fmt.Sprintf("did not receive correct image. Expected 'carts' but got '%s'", deploymentEvent.ConfigurationChange.Values["image"]))
+				return true
 			}
-			return true
+			return false
 		},
 	)
 	if done {

--- a/shipyard-controller/api/event_test.go
+++ b/shipyard-controller/api/event_test.go
@@ -3,7 +3,6 @@ package api
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"github.com/go-test/deep"
 	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
@@ -839,11 +838,11 @@ func Test_shipyardController_Scenario1(t *testing.T) {
 			}
 
 			if deploymentEvent.Deployment.DeploymentStrategy != "direct" {
-				t.Error(fmt.Sprintf("did not receive correct deployment strategy. Expected 'direct' but got '%s'", deploymentEvent.Deployment.DeploymentStrategy))
+				t.Errorf("did not receive correct deployment strategy. Expected 'direct' but got '%s'", deploymentEvent.Deployment.DeploymentStrategy)
 				return true
 			}
 			if deploymentEvent.ConfigurationChange.Values["image"] != "carts" {
-				t.Error(fmt.Sprintf("did not receive correct image. Expected 'carts' but got '%s'", deploymentEvent.ConfigurationChange.Values["image"]))
+				t.Errorf("did not receive correct image. Expected 'carts' but got '%s'", deploymentEvent.ConfigurationChange.Values["image"])
 				return true
 			}
 			return false
@@ -1027,7 +1026,7 @@ func Test_shipyardController_Scenario1(t *testing.T) {
 				return true
 			}
 			if deploymentEvent.ConfigurationChange.Values["image"] != "carts" {
-				t.Error(fmt.Sprintf("did not receive correct image. Expected 'carts' but got '%s'", deploymentEvent.ConfigurationChange.Values["image"]))
+				t.Errorf("did not receive correct image. Expected 'carts' but got '%s'", deploymentEvent.ConfigurationChange.Values["image"])
 				return true
 			}
 			return false

--- a/shipyard-controller/api/event_test.go
+++ b/shipyard-controller/api/event_test.go
@@ -981,7 +981,23 @@ func Test_shipyardController_Scenario1(t *testing.T) {
 		return
 	}
 
-	done = shouldContainEvent(t, mockEV.receivedEvents, keptnv2.GetTriggeredEventType("hardening.artifact-delivery"), "hardening", nil)
+	done = shouldContainEvent(t, mockEV.receivedEvents, keptnv2.GetTriggeredEventType("hardening.artifact-delivery"), "hardening", func(t *testing.T, event models.Event) bool {
+		marshal, _ := json.Marshal(event.Data)
+		triggeredEvent := map[string]interface{}{}
+
+		err := json.Unmarshal(marshal, &triggeredEvent)
+
+		if err != nil {
+			t.Errorf("Expected hardening.artifact-delivery.triggered data but could not convert: %v: %s", event.Data, err.Error())
+			return true
+		}
+
+		if triggeredEvent["configurationChange"] == nil {
+			t.Error("expected 'configurationChange' property to be present")
+			return true
+		}
+		return false
+	})
 	if done {
 		return
 	}

--- a/shipyard-controller/api/event_test.go
+++ b/shipyard-controller/api/event_test.go
@@ -1698,6 +1698,62 @@ func Test_shipyardController_getTaskSequenceInStage(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "get user-defined evaluation task sequence",
+			fields: fields{
+				projectRepo:      nil,
+				eventRepo:        nil,
+				taskSequenceRepo: nil,
+				logger:           keptncommon.NewLogger("", "", ""),
+			},
+			args: args{
+				stageName:        "dev",
+				taskSequenceName: "evaluation",
+				shipyard: &keptnv2.Shipyard{
+					ApiVersion: "0.2.0",
+					Kind:       "shipyard",
+					Metadata:   keptnv2.Metadata{},
+					Spec: keptnv2.ShipyardSpec{
+						Stages: []keptnv2.Stage{
+							{
+								Name: "dev",
+								Sequences: []keptnv2.Sequence{
+									{
+										Name:     "evaluation",
+										Triggers: nil,
+										Tasks: []keptnv2.Task{
+											{
+												Name:       "evaluation",
+												Properties: nil,
+											},
+											{
+												Name:       "notify",
+												Properties: nil,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &keptnv2.Sequence{
+				Name:     "evaluation",
+				Triggers: nil,
+				Tasks: []keptnv2.Task{
+					{
+						Name:       "evaluation",
+						Properties: nil,
+					},
+					{
+						Name:       "notify",
+						Properties: nil,
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/shipyard-controller/go.mod
+++ b/shipyard-controller/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/json-iterator/go v1.1.10 // indirect
 	github.com/keptn/go-utils v0.6.3-0.20200908082455-010bbcf95e6f
 	github.com/mailru/easyjson v0.7.3 // indirect
-	github.com/mitchellh/mapstructure v1.2.2 // indirect
+	github.com/mitchellh/mapstructure v1.2.2
 	github.com/stretchr/testify v1.5.1
 	github.com/swaggo/files v0.0.0-20190704085106-630677cd5c14
 	github.com/swaggo/gin-swagger v1.2.0


### PR DESCRIPTION
Closes #2529 

This PR adds a built-in evaluation task sequence for the shipyard-controller. Now, if a `<stage-name>.evaluation.triggered` event reaches the shipyard controller, it will first check if a matching task sequence is available in the shipyard for the corresponding project/stage. If yes, then that task sequence will be used. If not, a default task sequence with one task (`evaluation`) will be generated and triggered.