### PR TITLE
#2505 Remove version check for root cmds

### DIFF
--- a/cli/cmd/check_endpoint_status.go
+++ b/cli/cmd/check_endpoint_status.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+	"time"
+
+	apiUtils "github.com/keptn/go-utils/pkg/api/utils"
+)
+
+var maxHTTPTimeout = 5 * time.Second
+
+var endPointErrorReasons = `
+Possible reasons:
+* The Keptn API server is currently not available. Check if your Kubernetes cluster is available.
+* Your Keptn CLI points to the wrong API server (verify using 'keptn status')`
+
+var checkEndPointStatusMock = false
+
+var client = http.Client{
+	Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		DialContext:     apiUtils.ResolveXipIoWithContext,
+	},
+}
+
+func checkEndPointStatus(endPoint string) error {
+	if checkEndPointStatusMock {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), maxHTTPTimeout)
+	defer cancel()
+
+	req, err := http.NewRequest("HEAD", endPoint, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Do(req.WithContext(ctx))
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
+}

--- a/cli/cmd/check_endpoint_status_test.go
+++ b/cli/cmd/check_endpoint_status_test.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func Test_checkEndPointStatus(t *testing.T) {
+	checkEndPointStatusMock = false
+
+	ts := getTestAPI()
+
+	type args struct {
+		endPoint string
+		timeout  time.Duration
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"simulate timeout", args{endPoint: ts.URL, timeout: 1 * time.Microsecond}, true},
+		{"does not simulate timeout", args{endPoint: ts.URL, timeout: 5 * time.Second}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			//override maxHTTPTimeout to simulate http timeout
+			maxHTTPTimeout = tt.args.timeout
+
+			if err := checkEndPointStatus(tt.args.endPoint); (err != nil) != tt.wantErr && err != context.DeadlineExceeded {
+				t.Errorf("checkEndPointStatus() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/keptn/keptn/cli/pkg/version"
-
 	"github.com/keptn/keptn/cli/pkg/logging"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
@@ -43,8 +41,6 @@ func Execute() {
 	// Set LogLevel to QuietLevel
 	currentLogLevel := logging.LogLevel
 	logging.LogLevel = logging.QuietLevel
-
-	runDailyVersionCheck()
 
 	// Set LogLevel back to previous state
 	logging.LogLevel = currentLogLevel
@@ -106,31 +102,5 @@ type options []string
 func (s *options) appendIfNotEmpty(newOption string) {
 	if newOption != "" {
 		*s = append(*s, newOption)
-	}
-}
-
-func runDailyVersionCheck() {
-	var cliMsgPrinted, cliChecked, keptnMsgPrinted, keptnChecked bool
-
-	vChecker := version.NewVersionChecker()
-	cliChecked, cliMsgPrinted = vChecker.CheckCLIVersion(Version, true)
-
-	keptnVersion, err := getKeptnServerVersion()
-	if err != nil {
-		logging.PrintLog(err.Error(), logging.InfoLevel)
-	} else {
-		kvChecker := version.NewKeptnVersionChecker()
-		keptnChecked, keptnMsgPrinted = kvChecker.CheckKeptnVersion(Version, keptnVersion, true)
-	}
-
-	if cliMsgPrinted || keptnMsgPrinted {
-		if len(os.Args) > 0 {
-			fmt.Printf(disableVersionCheckMsg+"\n", os.Args[0])
-		} else {
-			fmt.Printf(disableVersionCheckMsg+"\n", "keptn")
-		}
-	}
-	if cliChecked || keptnChecked {
-		updateLastVersionCheck()
 	}
 }


### PR DESCRIPTION
- adding 5 seconds of a timeout to avoid hanging connection

* Remove version check for root calls
- keeping only on version command

* Add tests for http timeout
- add tests for check endpoint status function

* Does not mock the tests for checkEndpointStatus function
- forcing the checkEndPointStatusMock as true to avoid random tests

# To-be-discussed
- [ ] Providing a backport of https://github.com/keptn/keptn/pull/2540 does not work on release-0.7.3 since this branch does not know the function `checkEndPointStatus`. 
- [ ] When merging it, we must implement: https://github.com/keptn/keptn/issues/2571