### PR TITLE
Added docs on how to install the current master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To get started with keptn you need a Kubernetes cluster. Supported Kubernetes en
 Here is a quick guide on how to get started with keptn on [k3s](https://k3s.io/):  
 
 **Install K3s**  
-Download, install and run K3s (tested with versions 1.16 to 1.18):
+Download, install and run K3s (tested with versions 1.16 to 1.19):
 ``` console
 curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=v1.18.3+k3s1 K3S_KUBECONFIG_MODE="644" sh -s - --no-deploy=traefik
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,8 +9,8 @@ This folder contains docs for developers. If you are looking for the usage docum
   onboarded a service (etc...)
 * Kubernetes Cluster: 
   For testing your changes it is strongly recommended to have access to a (throwaway) Kubernetes Cluster on any of the 
-  supported platforms (e.g., Google Kubernetes Engine, Azure Kubernetes Service). 
-  You can also run Keptn on Minikube and Minishift, which is the recommended way for developing and running integration tests.
+  supported platforms (e.g., K3s, Google Kubernetes Engine). 
+  You can also run Keptn on K3s, Microk8s, KIND, Minikube and Minishift, which is the recommended way for developing and running integration tests.
   You can find more information in [here](integration_tests.md).
 * Kubernetes CLI tool [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 * Docker
@@ -30,7 +30,7 @@ While this is not a requirement, we recommend you to use any of the following
 ## Where to go
 
 Keptn consists of multiple services. We recommend to take a look at the 
-[architecture of keptn](https://keptn.sh/docs/0.5.0/concepts/architecture/).
+[architecture of keptn](https://keptn.sh/docs/concepts/architecture/).
 
 The keptn core implementation as well as the *batteries-included* services are stored within this repository 
 ([keptn/keptn](https://github.com/keptn/keptn)). This includes (but is not limited to):
@@ -47,6 +47,9 @@ The keptn core implementation as well as the *batteries-included* services are s
 
 The `go-utils` package is available in [keptn/go-utils](https://github.com/keptn/go-utils/) and contains several 
  utility functions that we use in many services.
+ 
+Similarly, the `kubernetes-utils` package is available in [keptn/kubernetes-utils](https://github.com/keptn/kubernetes-utils/) and contains several 
+  utility functions that we use in many services.
 
 If you want to contribute to the website or docs provided on the website, the 
  [keptn/keptn.github.io](https://github.com/keptn/keptn.github.io/) is the way to go.
@@ -54,7 +57,9 @@ If you want to contribute to the website or docs provided on the website, the
 In addition, we have a collection of additional services at [github.com/keptn-contrib](https://github.com/keptn-contrib), e.g.:
 * [dynatrace-service](https://github.com/keptn-contrib/dynatrace-service)
 * [dynatrace-sli-service](https://github.com/keptn-contrib/dynatrace-sli-service)
+* [prometheus-service](https://github.com/keptn-contrib/prometheus-service)
 * [prometheus-sli-service](https://github.com/keptn-contrib/prometheus-sli-service)
+* [unleash-service](https://github.com/keptn-contrib/unleash-service)
 
 
 ## Branch Naming Convention

--- a/docs/install_master.md
+++ b/docs/install_master.md
@@ -1,0 +1,41 @@
+# Install master branch
+
+**Attention:** This installs a potentially unstable and unreliable version of Keptn and is not meant to preview features, but for Keptn core/contrib/sandbox developers.
+
+**DO NOT PERFORM THIS ON A PRODUCTION ENVIRONMENT**
+
+1. Create a new cluster (e.g., using k3s)
+1. Download latest CLI based on your platform: [Linux](https://storage.cloud.google.com/keptn-cli/latest/keptn-linux.zip) [Mac OS](https://storage.cloud.google.com/keptn-cli/latest/keptn-macOS.zip) [Windows](https://storage.cloud.google.com/keptn-cli/latest/keptn-windows.zip)
+1. Unpack the binary and move it to a directory of your choice (e.g., `/usr/local/bin/` on Linux and MacOS); Alternatively, use `./keptn` or `./keptn.exe` where appropriate.
+1. Verify that the installation has worked and that the version is correct by running `keptn version` 
+1. Install keptn using `keptn install --chart-repo=https://storage.googleapis.com/keptn-installer/latest/keptn-0.1.0.tgz [--use-case=continuous-delivery]`
+1. Authenticate to the Keptn Installation
+1. Verify the Keptn version you installed by using `keptn version`
+
+## Known Issues
+
+### Docker Image Pull Rate
+As of November 2nd, 2020, Docker introduces an image pull rate-throttling of 100 pulls per 6 hours per IP address for anonymous users. 
+This will result in `ImagePullBackOff` errors in your cluster. There is nothing we can do about this as of right now.
+
+### Old Images
+Depending on your cluster configuration and the used Keptn Version you might end up with a state that's not the current master branch.
+
+We use `imagePullPolicy: IfNotPresent` and as we install images with the `:latest` tag, you might end up with and old version of Keptn on your Kubernetes cluster (in the Docker cache). 
+
+You can verify this by looking at the log output of one of the services, which should print a datetime header on when it was installed, e.g.:
+```
+$> kubectl -n keptn logs deployments/api-service api-service
+
+##########
+branch: release-0.7.2
+repository: https://github.com/keptn/keptn
+commitlink: https://github.com/keptn/keptn/commit/d469876ecfe95d467872921ae6e9ce877f2ccca6
+repolink: https://github.com/keptn/keptn/tree/d469876ecfe95d467872921ae6e9ce877f2ccca6
+travisbuild: https://travis-ci.org/keptn/keptn/jobs/735015708
+timestamp: 20201012.1651
+##########
+
+```
+
+If this is the case for you, you can manually edit the deployments and set image pull policy to always, or alternatively, create a new Kubernetes cluster (which should clear the Docker cache).

--- a/docs/integration_tests.md
+++ b/docs/integration_tests.md
@@ -6,10 +6,7 @@ Several tests are specified in [.travis.yml](../.travis.yml). They usually follo
     stage: Some Integration Test (--platform=kubernetes)
     os: linux
     before_script:
-      # download and install kubectl
-      - curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.17.0/bin/linux/amd64/kubectl && chmod +x ./kubectl && sudo mv ./kubectl /usr/local/bin/kubectl
-      - test/utils/download_and_install_keptn_cli.sh
-      - test/utils/minikube_create_cluster.sh
+      # download and install kubectl and setup cluster
     script:
       - kubectl get nodes || travis_terminate 1
       # finally install keptn quality gates
@@ -18,7 +15,7 @@ Several tests are specified in [.travis.yml](../.travis.yml). They usually follo
       - export PROJECT=musicshop
       - test/test_quality_gates_standalone.sh
     after_success:
-      # delete google kubernetes cluster only on success (in case of an error we want to be able to dig into the cluster)
+      # clean up cluster, etc...
       - echo "Tests were successful, cleaning up the cluster now..."
     after_failure:
       # print some debug info
@@ -26,7 +23,7 @@ Several tests are specified in [.travis.yml](../.travis.yml). They usually follo
       - cat ~/.keptn/keptn-installer.log
 ```
 
-* `before_script`: Set up `kubectl`, `keptn cli` and create a Kubernetes cluster
+* `before_script`: Set up `kubectl`, `keptn` CLI and create a Kubernetes cluster
 * `script`: Verify connection to the kubernetes cluster, install Keptn (e.g., `test/test_install_kubernetes_quality_gates.sh`),
   verify connection to Keptn (`keptn status`) and run the actual test (e.g., `test/test_quality_gates_standalone.sh`)
 * `after_success`: Perform some cleanup (e.g., delete the cluster if necessary)
@@ -40,7 +37,7 @@ There are some caveats when creating a Kubernetes cluster on Travis-CI:
   for the cloud provider to be set on Travis-CI, and accessing those secrets only works for commits that are pushed
   within the current repository. It does **not work** for Pull Requests from forks.
 * It is possible to run docker on Travis-CI.
-* It is not possible to create a virtual-machine on Travis-CI. Therefore setting up Minishift or Minikube on Travis-CI
+* It is not possible to create a virtual-machine on Travis-CI. Therefore, setting up K3s, Minishift or Minikube on Travis-CI
   only works with some specific settings (e.g., `minishift start --vm-driver=generic` or `minikube start --vm-driver=none`).
   With this, `minishift` and `minikube` use the local docker installation of Travis-CI. Please note, with this setup
   we are limited to 2 vCPUs and 4 GB of memory (see [https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system](https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system) for details)
@@ -53,7 +50,22 @@ Above limitations lead to the following setup with Keptn's `.travis.yml`:
 
 ## Prepare your local environment to run integration tests
 
-When running integration tests locally, we recommend using either Minikube or Minishift.
+When running integration tests locally, we recommend using either K3s, Minikube or Minishift.
+
+### Set-up steps for K3s (recommended on Linux)
+
+Starting and setting up K3s is easy:
+
+1. Download, install and run K3s (tested with versions 1.16 to 1.18):
+    ```console
+    curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=v1.18.3+k3s1 K3S_KUBECONFIG_MODE="644" sh -s - --no-deploy=traefik
+    ```
+1. Export the Kubernetes config using:
+    ```console
+    export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+    ```  
+    Please read more about it [here](https://rancher.com/docs/k3s/latest/en/).
+1. Verify that everything has worked using `kubectl get nodes`
 
 ### Set-up steps for Minikube
 
@@ -148,34 +160,40 @@ In case you plan to use Minishift, the following steps are necessary to get Kept
 
 Pre-requesits:
 
-* Minikube (1.4 - 1.10) or Minishift (1.34.2) in a VM
+* A K8s cluster (see above)
+  * 4 GB of free memory (less is possible but you will notice a significant slowdown)
+  * at least 2 CPU cores on your system (less is possible but you will notice a significant slowdown)
 * `kubectl`
-* `keptn` cli
+* `keptn` CLI
 * A local copy of this repository (keptn/keptn)
 * Linux, Mac OS or Linux Subsystem for Windows
 * Bash
 * Dynatrace Tenant with a service that has the tags `FrontEnd` and `testdeploy`
 * Dynatrace API Token that is allowed to read metrics from the Dynatrace Tenant
 * working internet connection
-* 4 GB of free memory (less is possible but you will notice a significant slowdown)
-* at least 4 CPU cores on your system (less is possible but you will notice a significant slowdown)
 
-1. Setup Minikube or Minishift (see above)
-1. Verify `kubectl` is properly configured:
+
+1. Setup your Kubernetes cluster (see above)
+1. `keptn` CLI available
+1. Verify `kubectl` is configured to the right cluster:
    ```console
    kubectl get nodes
    ```
 1. Install Keptn
+   * K3s
+       ```console
+       keptn install --verbose
+       ```
    * Minikube
        ```console
-       keptn install --keptn-installer-image=keptn/installer:latest --platform=kubernetes --gateway=NodePort --verbose
+       keptn install --endpoint-service-type=NodePort --verbose
        ```
-       **Note**: You can skip the `--gateway=NodePort` if you run `minikube tunnel`
+       **Note**: You can use `--endpoint-service-type=LoadBalancer` if you run `minikube tunnel`
    * Minishift
       ```console
-      keptn install --keptn-installer-image=keptn/installer:latest --platform=openshift --verbose
+      keptn install --platform=openshift --verbose
       ```
-   **Note**: Change `--keptn-installer-image=keptn/installer:latest` to the desired installer version you want to use
+   **Note**: Use `--chart-repo=https://storage.googleapis.com/keptn-installer/latest/keptn-0.1.0.tgz` to install the latest master branch, see [master installation docs](install_master.md).
 1. Verify the installation has worked
    ```console
    keptn status
@@ -206,28 +224,37 @@ Pre-requesits:
 
 Pre-requesits:
 
-* Minikube (1.4 - 1.10) or Minishift (1.34.2) in a VM
+* A K8s cluster (see above)
+  * 12 GB of free memory (less is possible but you will notice a significant slowdown)
+  * at least 6 CPU cores on your system (less is possible but you will notice a significant slowdown)
 * `kubectl`
-* `keptn` cli
+* `keptn` CLI
 * A local copy of this repository (keptn/keptn)
 * Linux, Mac OS or Linux Subsystem for Windows
 * Bash
 * working internet connection
-* 12 GB of free memory (less is possible but you will notice a significant slowdown)
-* at least 6 CPU cores on your system (less is possible but you will notice a significant slowdown)
 
-1. Setup Minikube or Minishift (see above)
+1. Setup your Kubernetes cluster (see above)
+1. Verify `kubectl` is configured to the right cluster:
+   ```console
+   kubectl get nodes
+   ```
+1. `keptn` CLI available
 1. Install Keptn
+   * K3s
+       ```console
+       keptn install --use-case=continuous-delivery --verbose
+       ```
    * Minikube
        ```console
-       keptn install --keptn-installer-image=keptn/installer:latest --platform=kubernetes --gateway=NodePort --verbose
+       keptn install --use-case=continuous-delivery --endpoint-service-type=NodePort --verbose
        ```
-       **Note**: You can skip the `--gateway=NodePort` if you run `minikube tunnel`
+       **Note**: You can use `--endpoint-service-type=LoadBalancer` if you run `minikube tunnel`
    * Minishift
       ```console
-      keptn install --keptn-installer-image=keptn/installer:latest --platform=openshift --verbose
+      keptn install --use-case=continuous-delivery --platform=openshift --verbose
       ```
-   **Note**: Change `--keptn-installer-image=keptn/installer:latest` to the desired installer version you want to use
+   **Note**: Use `--chart-repo=https://storage.googleapis.com/keptn-installer/latest/keptn-0.1.0.tgz` to install the latest master branch, see [master installation docs](install_master.md).
 1. Verify the installation has worked
    ```console
    keptn status
@@ -236,11 +263,6 @@ Pre-requesits:
    ```console
    kubectl -n keptn get deployments -owide
    ```
-1. Expose Keptn Bridge for better troubleshooting and debugging
-   ```console
-   keptn configure bridge --action=expose
-   ```
-1. Verify accessing Keptn Bridge works
 1. Configuration for the test:
    ```console
    export PROJECT=sockshop


### PR DESCRIPTION
This PR  adds docs on how to install the current master branch on K8s.
During this task I also noticed that the developer docs need an update regarding k3s and `keptn install`