### PR TITLE
#2548 allow to invalidate evaluation results from bridge

### DIFF
--- a/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.html
+++ b/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.html
@@ -40,8 +40,9 @@
   <div class="mt-1 mb-1" *ngIf="_selectedEvaluationData" (click)="$event.stopPropagation();">
     <div fxLayout="row" *ngIf="_selectedEvaluationData.data.evaluationdetails.sloFileContentParsed">
       <div fxFlex></div>
-      <div fxLayout="column" fxLayoutAlign="start end">
-        <p class="m-0"><a class="dt-link" (click)="showSloDialog()">Show SLO</a></p>
+      <div fxLayout="row" fxLayoutAlign="start end">
+        <button dt-button variant="nested" (click)="showSloDialog()">Show SLO</button>
+        <button dt-button variant="secondary" (click)="invalidateEvaluationTrigger()">Ignore for comparison</button>
       </div>
     </div>
     <dt-consumption [max]="_selectedEvaluationData.data.evaluationdetails.indicatorResults ? 100 : 0" [value]="_selectedEvaluationData.data.evaluationdetails.score" [color]="_evaluationState[_selectedEvaluationData.data.result]">
@@ -86,4 +87,16 @@
     <button dt-button (click)="closeSloDialog()">Close</button>
   </div>
 </ng-template>
-
+<ng-template #invalidateEvaluationDialog let-data>
+  <h1 mat-dialog-title>Invalidate evaluation</h1>
+  <div mat-dialog-content>
+    <dt-form-field>
+      <dt-label>Reason</dt-label>
+      <input #reasonInput class="wide-input" type="text" dtInput placeholder="Place for a comment why it has been invalidated (optional)" />
+    </dt-form-field>
+  </div>
+  <div mat-dialog-actions>
+    <button dt-button variant="secondary" (click)="invalidateEvaluation(data, reasonInput.value)">Invalidate</button>
+    <button dt-button (click)="closeInvalidateEvaluationDialog()">Close</button>
+  </div>
+</ng-template>

--- a/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.html
+++ b/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.html
@@ -38,10 +38,10 @@
     </dt-chart>
   </div>
   <div class="mt-1 mb-1" *ngIf="_selectedEvaluationData" (click)="$event.stopPropagation();">
-    <div fxLayout="row" *ngIf="_selectedEvaluationData.data.evaluationdetails.sloFileContentParsed">
+    <div fxLayout="row">
       <div fxFlex></div>
       <div fxLayout="row" fxLayoutAlign="start end">
-        <button dt-button variant="nested" (click)="showSloDialog()">Show SLO</button>
+        <button dt-button variant="nested" (click)="showSloDialog()" *ngIf="_selectedEvaluationData.data.evaluationdetails.sloFileContentParsed">Show SLO</button>
         <button dt-button variant="secondary" (click)="invalidateEvaluationTrigger()">Ignore for comparison</button>
       </div>
     </div>

--- a/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.html
+++ b/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.html
@@ -1,5 +1,5 @@
 <div *ngIf="evaluationData">
-  <div class="mt-1 mb-1" *ngIf="showChart">
+  <div class="mt-1 mb-1" *ngIf="showChart && !isInvalidated">
     <div fxLayout="row" class="pr-2">
       <div fxFlex></div>
       <div fxLayout="column" fxLayoutAlign="start end">
@@ -10,7 +10,7 @@
       </div>
     </div>
   </div>
-  <div class="m-0 mr-2" *ngIf="showChart" (click)="$event.stopPropagation();">
+  <div class="m-0 mr-2" *ngIf="showChart && !isInvalidated" (click)="$event.stopPropagation();">
     <dt-chart #heatmapChart *ngIf="showChart && _comparisonView == 'heatmap'"
               [options]="_heatmapOptions"
               [series]="_heatmapSeries"
@@ -37,12 +37,15 @@
       </dt-chart-tooltip>
     </dt-chart>
   </div>
+  <div *ngIf="isInvalidated">
+    <p class="m-0 error">This evaluation result has been invalidated.</p>
+  </div>
   <div class="mt-1 mb-1" *ngIf="_selectedEvaluationData" (click)="$event.stopPropagation();">
     <div fxLayout="row">
       <div fxFlex></div>
       <div fxLayout="row" fxLayoutAlign="start end">
         <button dt-button variant="nested" (click)="showSloDialog()" *ngIf="_selectedEvaluationData.data.evaluationdetails.sloFileContentParsed">Show SLO</button>
-        <button dt-button variant="secondary" (click)="invalidateEvaluationTrigger()">Ignore for comparison</button>
+        <button dt-button variant="secondary" (click)="invalidateEvaluationTrigger()" *ngIf="!isInvalidated">Ignore for comparison</button>
       </div>
     </div>
     <dt-consumption [max]="_selectedEvaluationData.data.evaluationdetails.indicatorResults ? 100 : 0" [value]="_selectedEvaluationData.data.evaluationdetails.score" [color]="_evaluationState[_selectedEvaluationData.data.result]">
@@ -70,7 +73,17 @@
       </dt-consumption-count>
       <dt-consumption-label>
         <p class="m-0 small"><span class="bold">Evaluation timeframe: </span><span [textContent]="_selectedEvaluationData.data.evaluationdetails.timeStart | amDateFormat:'YYYY-MM-DD HH:mm'"></span> - <span [textContent]="_selectedEvaluationData.data.evaluationdetails.timeEnd | amDateFormat:'YYYY-MM-DD HH:mm'"></span> (<span [textContent]="getDuration(evaluationData.data.evaluationdetails.timeStart, evaluationData.data.evaluationdetails.timeEnd)"></span>)</p>
-        <p class="m-0" *ngIf="_selectedEvaluationData.data.result == _selectedEvaluationData.data.evaluationdetails.result">Compared with last <span *ngIf="_selectedEvaluationData.data.evaluationdetails.compare_with == 'several_results'" [textContent]="_selectedEvaluationData.data.evaluationdetails.number_of_comparison_results + ' '"></span> <span *ngIf="_selectedEvaluationData.data.evaluationdetails.include_result_with_score == 'pass'">passed</span><span *ngIf="_selectedEvaluationData.data.evaluationdetails.include_result_with_score == 'pass_or_warn'">passed or warned</span> evaluation<span *ngIf="_selectedEvaluationData.data.evaluationdetails.compare_with == 'several_results'">s</span>.</p>
+        <p class="m-0" *ngIf="_selectedEvaluationData.data.result == _selectedEvaluationData.data.evaluationdetails.result && _selectedEvaluationData.data.evaluationdetails.comparedEvents?.length > 0">
+          Compared with last
+          <span *ngIf="_selectedEvaluationData.data.evaluationdetails.compare_with == 'several_results'" [textContent]="_selectedEvaluationData.data.evaluationdetails.comparedEvents?.length + ' '"></span>
+          <span *ngIf="_selectedEvaluationData.data.evaluationdetails.include_result_with_score == 'pass'">passed</span>
+          <span *ngIf="_selectedEvaluationData.data.evaluationdetails.include_result_with_score == 'pass_or_warn'">passed or warned</span>
+          evaluation<span *ngIf="_selectedEvaluationData.data.evaluationdetails.compare_with == 'several_results'">s</span>.
+          <span *ngIf="_selectedEvaluationData.data.evaluationdetails.number_of_missing_comparison_results > 0">
+            <span [textContent]="_selectedEvaluationData.data.evaluationdetails.number_of_missing_comparison_results"></span>
+            results are not showing up in the Heatmap, because they have been either invalidated or are older results.
+          </span>
+        </p>
         <p class="m-0" *ngIf="_selectedEvaluationData.data.result != _selectedEvaluationData.data.evaluationdetails.result" [textContent]="_selectedEvaluationData.data.evaluationdetails.result"></p>
       </dt-consumption-label>
     </dt-consumption>

--- a/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.html
+++ b/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.html
@@ -79,7 +79,11 @@
           <span *ngIf="_selectedEvaluationData.data.evaluationdetails.include_result_with_score == 'pass'">passed</span>
           <span *ngIf="_selectedEvaluationData.data.evaluationdetails.include_result_with_score == 'pass_or_warn'">passed or warned</span>
           evaluation<span *ngIf="_selectedEvaluationData.data.evaluationdetails.compare_with == 'several_results'">s</span>.
-          <span *ngIf="_selectedEvaluationData.data.evaluationdetails.number_of_missing_comparison_results > 0">
+          <span *ngIf="_selectedEvaluationData.data.evaluationdetails.number_of_missing_comparison_results == 1">
+            <span [textContent]="_selectedEvaluationData.data.evaluationdetails.number_of_missing_comparison_results"></span>
+            result is not showing up in the Heatmap, because it has been either invalidated or is older.
+          </span>
+          <span *ngIf="_selectedEvaluationData.data.evaluationdetails.number_of_missing_comparison_results > 1">
             <span [textContent]="_selectedEvaluationData.data.evaluationdetails.number_of_missing_comparison_results"></span>
             results are not showing up in the Heatmap, because they have been either invalidated or are older results.
           </span>

--- a/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.html
+++ b/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.html
@@ -107,10 +107,12 @@
 <ng-template #invalidateEvaluationDialog let-data>
   <h1 mat-dialog-title>Invalidate evaluation</h1>
   <div mat-dialog-content>
-    <dt-form-field>
-      <dt-label>Reason</dt-label>
-      <input #reasonInput class="wide-input" type="text" dtInput placeholder="Place for a comment why it has been invalidated (optional)" />
-    </dt-form-field>
+    <div class="mb-1">
+      <dt-form-field>
+        <dt-label>Reason</dt-label>
+        <input #reasonInput class="wide-input" type="text" dtInput placeholder="Place for a comment why it has been invalidated (optional)" />
+      </dt-form-field>
+    </div>
   </div>
   <div mat-dialog-actions>
     <button dt-button variant="secondary" (click)="invalidateEvaluation(data, reasonInput.value)">Invalidate</button>

--- a/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.scss
+++ b/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.scss
@@ -16,3 +16,7 @@
 .dt-button + .dt-button {
   fill: $cta-color-active;	  margin-left: $gap-normal;
 }
+
+.wide-input {
+  min-width: 440px;
+}

--- a/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
+++ b/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
@@ -37,6 +37,7 @@ export class KtbEvaluationDetailsComponent implements OnInit, OnDestroy {
 
   private readonly unsubscribe$ = new Subject<void>();
   @Input() public showChart = true;
+  @Input() public isInvalidated = false;
 
   @ViewChild('sloDialog')
   public sloDialog: TemplateRef<any>;
@@ -178,7 +179,9 @@ export class KtbEvaluationDetailsComponent implements OnInit, OnDestroy {
   ngOnInit() {
     if(this._evaluationData) {
       this.dataService.loadEvaluationResults(this._evaluationData);
-      if (!this._selectedEvaluationData && this._evaluationData.data.evaluationHistory)
+      if (this.isInvalidated)
+        this.selectEvaluationData(this._evaluationData);
+      else if (!this._selectedEvaluationData && this._evaluationData.data.evaluationHistory)
         this.selectEvaluationData(this._evaluationData.data.evaluationHistory.find(h => h.shkeptncontext === this._evaluationData.shkeptncontext));
     }
     this.dataService.evaluationResults
@@ -400,8 +403,10 @@ export class KtbEvaluationDetailsComponent implements OnInit, OnDestroy {
           });
       });
       this._heatmapOptions.xAxis[0].plotBands = plotBands;
+      this._selectedEvaluationData?.data.evaluationdetails.number_of_missing_comparison_results = this._selectedEvaluationData?.data.evaluationdetails.comparedEvents?.length - (this._heatmapOptions.xAxis[0].plotBands?.length - 1);
     } else {
       this._heatmapOptions.xAxis[0].plotBands = [];
+      this._selectedEvaluationData?.data.evaluationdetails.number_of_missing_comparison_results = 0;
     }
     this.heatmapChart?._update();
     this._changeDetectorRef.markForCheck();

--- a/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
+++ b/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
@@ -403,10 +403,10 @@ export class KtbEvaluationDetailsComponent implements OnInit, OnDestroy {
           });
       });
       this._heatmapOptions.xAxis[0].plotBands = plotBands;
-      this._selectedEvaluationData?.data.evaluationdetails.number_of_missing_comparison_results = this._selectedEvaluationData?.data.evaluationdetails.comparedEvents?.length - (this._heatmapOptions.xAxis[0].plotBands?.length - 1);
+      this._selectedEvaluationData.data.evaluationdetails.number_of_missing_comparison_results = this._selectedEvaluationData?.data.evaluationdetails.comparedEvents?.length - (this._heatmapOptions.xAxis[0].plotBands?.length - 1);
     } else {
       this._heatmapOptions.xAxis[0].plotBands = [];
-      this._selectedEvaluationData?.data.evaluationdetails.number_of_missing_comparison_results = 0;
+      this._selectedEvaluationData.data.evaluationdetails.number_of_missing_comparison_results = 0;
     }
     this.heatmapChart?._update();
     this._changeDetectorRef.markForCheck();

--- a/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
+++ b/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
@@ -201,7 +201,7 @@ export class KtbEvaluationDetailsComponent implements OnInit, OnDestroy {
   }
 
   private parseSloFile(evaluationData) {
-    if(evaluationData.data && evaluationData.data.evaluationdetails.sloFileContent && !evaluationData.data.evaluationdetails.sloFileContentParsed) {
+    if(evaluationData && evaluationData.data && evaluationData.data.evaluationdetails.sloFileContent && !evaluationData.data.evaluationdetails.sloFileContentParsed) {
       evaluationData.data.evaluationdetails.sloFileContentParsed = atob(evaluationData.data.evaluationdetails.sloFileContent);
       evaluationData.data.evaluationdetails.score_pass = evaluationData.data.evaluationdetails.sloFileContentParsed.split("total_score:")[1]?.split("pass:")[1]?.split("\"")[1]?.split("%")[0];
       evaluationData.data.evaluationdetails.score_warning = evaluationData.data.evaluationdetails.sloFileContentParsed.split("total_score:")[1]?.split("warning:")[1]?.split("\"")[1]?.split("%")[0];
@@ -370,35 +370,39 @@ export class KtbEvaluationDetailsComponent implements OnInit, OnDestroy {
   }
 
   highlightHeatmap() {
-    let _this = this;
-    let highlightIndex = this._heatmapOptions.xAxis[0].categories.indexOf(this._selectedEvaluationData.getHeatmapLabel());
-    let secondaryHighlightIndexes = this._selectedEvaluationData?.data.evaluationdetails.comparedEvents?.map(eventId => this._heatmapSeries[0]?.data.findIndex(e => e['evaluation'].id == eventId));
-    let plotBands = [];
-    if(highlightIndex >= 0)
-      plotBands.push({
-        className: 'highlight-primary',
-        from: highlightIndex-0.5,
-        to: highlightIndex+0.5,
-        zIndex: 100
-      });
-    secondaryHighlightIndexes?.forEach(highlightIndex => {
+    if(this._selectedEvaluationData) {
+      let _this = this;
+      let highlightIndex = this._heatmapOptions.xAxis[0].categories.indexOf(this._selectedEvaluationData.getHeatmapLabel());
+      let secondaryHighlightIndexes = this._selectedEvaluationData?.data.evaluationdetails.comparedEvents?.map(eventId => this._heatmapSeries[0]?.data.findIndex(e => e['evaluation'].id == eventId));
+      let plotBands = [];
       if(highlightIndex >= 0)
         plotBands.push({
-          className: 'highlight-secondary',
+          className: 'highlight-primary',
           from: highlightIndex-0.5,
           to: highlightIndex+0.5,
-          zIndex: 100,
-          events: {
-            click: function () {
-              let index = this.options.from+0.5;
-              setTimeout(() => {
-                _this.selectEvaluationData(_this._heatmapSeries[0].data[index]['evaluation']);
-              });
-            }
-          }
+          zIndex: 100
         });
-    });
-    this._heatmapOptions.xAxis[0].plotBands = plotBands;
+      secondaryHighlightIndexes?.forEach(highlightIndex => {
+        if(highlightIndex >= 0)
+          plotBands.push({
+            className: 'highlight-secondary',
+            from: highlightIndex-0.5,
+            to: highlightIndex+0.5,
+            zIndex: 100,
+            events: {
+              click: function () {
+                let index = this.options.from+0.5;
+                setTimeout(() => {
+                  _this.selectEvaluationData(_this._heatmapSeries[0].data[index]['evaluation']);
+                });
+              }
+            }
+          });
+      });
+      this._heatmapOptions.xAxis[0].plotBands = plotBands;
+    } else {
+      this._heatmapOptions.xAxis[0].plotBands = [];
+    }
     this.heatmapChart?._update();
     this._changeDetectorRef.markForCheck();
   }

--- a/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
+++ b/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
@@ -373,7 +373,7 @@ export class KtbEvaluationDetailsComponent implements OnInit, OnDestroy {
   }
 
   highlightHeatmap() {
-    if(this._selectedEvaluationData) {
+    if(this._selectedEvaluationData && !this.isInvalidated) {
       let _this = this;
       let highlightIndex = this._heatmapOptions.xAxis[0].categories.indexOf(this._selectedEvaluationData.getHeatmapLabel());
       let secondaryHighlightIndexes = this._selectedEvaluationData?.data.evaluationdetails.comparedEvents?.map(eventId => this._heatmapSeries[0]?.data.findIndex(e => e['evaluation'].id == eventId));

--- a/bridge/client/app/_components/ktb-events-list/ktb-events-list.component.html
+++ b/bridge/client/app/_components/ktb-events-list/ktb-events-list.component.html
@@ -5,7 +5,7 @@
     </ktb-horizontal-separator>
     <ktb-event-item [event]="event" [class.focused]="event.id == focusedEventId && scrollIntoView(eventRef)" (click)="focusEvent(event)">
       <ktb-event-item-detail>
-        <ktb-evaluation-details *ngIf="event.data.evaluationdetails" [evaluationData]="event"></ktb-evaluation-details>
+        <ktb-evaluation-details *ngIf="event.data.evaluationdetails" [evaluationData]="event" [isInvalidated]="isInvalidated(event)"></ktb-evaluation-details>
       </ktb-event-item-detail>
     </ktb-event-item>
   </div>

--- a/bridge/client/app/_components/ktb-events-list/ktb-events-list.component.ts
+++ b/bridge/client/app/_components/ktb-events-list/ktb-events-list.component.ts
@@ -73,4 +73,8 @@ export class KtbEventsListComponent implements OnInit {
     }
   }
 
+  isInvalidated(event) {
+    return !!this.events.find(e => e.isEvaluationInvalidation() && e.triggeredid == event.id);
+  }
+
 }

--- a/bridge/client/app/_models/event-labels.ts
+++ b/bridge/client/app/_models/event-labels.ts
@@ -9,6 +9,7 @@ export const EVENT_LABELS = {
   [EventTypes.TESTS_FINISHED]: "Tests finished",
   [EventTypes.START_EVALUATION]: "Evaluation started",
   [EventTypes.EVALUATION_DONE]: "Evaluation done",
+  [EventTypes.EVALUATION_INVALIDATED]: "Evaluation invalidated",
   [EventTypes.START_SLI_RETRIEVAL]: "SLI retrieval started",
   [EventTypes.SLI_RETRIEVAL_DONE]: "SLI retrieval done",
   [EventTypes.DONE]: "Done",

--- a/bridge/client/app/_models/event-types.ts
+++ b/bridge/client/app/_models/event-types.ts
@@ -6,6 +6,7 @@ export enum EventTypes {
   TESTS_FINISHED = 'sh.keptn.events.tests-finished',
   START_EVALUATION = 'sh.keptn.event.start-evaluation',
   EVALUATION_DONE = 'sh.keptn.events.evaluation-done',
+  EVALUATION_INVALIDATED = 'sh.keptn.events.evaluation.invalidated',
   START_SLI_RETRIEVAL = 'sh.keptn.internal.event.get-sli',
   SLI_RETRIEVAL_DONE = 'sh.keptn.internal.event.get-sli.done',
   DONE = 'sh.keptn.events.done',

--- a/bridge/client/app/_models/trace.ts
+++ b/bridge/client/app/_models/trace.ts
@@ -13,6 +13,7 @@ const DEFAULT_ICON = "information";
 class Trace {
   id: string;
   shkeptncontext: string;
+  triggeredid: string;
   source: string;
   time: Date;
   type: string;
@@ -66,6 +67,7 @@ class Trace {
       compare_with: string;
       include_result_with_score: string;
       number_of_comparison_results: number;
+      number_of_missing_comparison_results: number;
       sloFileContentParsed: string;
     };
 
@@ -177,6 +179,10 @@ class Trace {
 
   public isEvaluation(): string {
     return this.type === EventTypes.START_EVALUATION ? this.data.stage : null;
+  }
+
+  public isEvaluationInvalidation(): boolean {
+    return this.type === EventTypes.EVALUATION_INVALIDATED;
   }
 
   hasLabels(): boolean {

--- a/bridge/client/app/_services/api.service.ts
+++ b/bridge/client/app/_services/api.service.ts
@@ -116,7 +116,7 @@ export class ApiService {
   }
 
   public getEvaluationResults(projectName: string, serviceName: string, stageName: string, source: string, fromTime?: string) {
-    let url = `${this._baseUrl}/mongodb-datastore/event?type=sh.keptn.events.evaluation-done&project=${projectName}&service=${serviceName}&stage=${stageName}&source=${source}&pageSize=50`;
+    let url = `${this._baseUrl}/mongodb-datastore/event/type/sh.keptn.events.evaluation-done?filter=data.project:${projectName}%20AND%20data.service:${serviceName}%20AND%20data.stage:${stageName}&excludeInvalidated=true&limit=50`;
     if(fromTime)
       url += `&fromTime=${fromTime}`;
     return this.http
@@ -138,6 +138,26 @@ export class ApiService {
             "status": "succeeded"
           }
         })
+      });
+  }
+
+  public sendEvaluationInvalidated(evaluation: Trace, reason: string) {
+    let url = `${this._baseUrl}/v1/event`;
+
+    return this.http
+      .post<any>(url, {
+        "shkeptncontext": evaluation.shkeptncontext,
+        "type": EventTypes.EVALUATION_INVALIDATED,
+        "triggeredid": evaluation.id,
+        "source": "https://github.com/keptn/keptn/bridge#evaluation.invalidated",
+        "data": {
+          "project": evaluation.data.project,
+          "stage": evaluation.data.stage,
+          "service": evaluation.data.service,
+          "evaluation": {
+            "reason": reason
+          }
+        }
       });
   }
 

--- a/bridge/client/app/app.module.ts
+++ b/bridge/client/app/app.module.ts
@@ -2,6 +2,7 @@ import { registerLocaleData } from '@angular/common';
 import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
 import localeEn from '@angular/common/locales/en';
 import { NgModule } from '@angular/core';
+import { FormsModule } from "@angular/forms";
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { MatDialogModule } from '@angular/material/dialog';
 import { BrowserModule } from '@angular/platform-browser';
@@ -109,6 +110,7 @@ registerLocaleData(localeEn, 'en');
   ],
   imports: [
     BrowserModule,
+    FormsModule,
     BrowserAnimationsModule,
     HttpClientModule,
     AppRouting,


### PR DESCRIPTION
The evaluation tile now allows to invalidate evaluation results from the bridge by clicking on the "Ignore for comparison"-Button.

![image](https://user-images.githubusercontent.com/6098219/97560336-cf858400-19de-11eb-8b16-fbdef9c667c9.png)

It will ask the user for confirmation and allow to provide a reason as well.

![image](https://user-images.githubusercontent.com/6098219/97560416-eb892580-19de-11eb-8c17-8bb15d99c8d0.png)
