### PR TITLE
#2565 Show all core use-cases on integrations page - backport 0.7.3

### DIFF
--- a/bridge/client/app/_services/data.service.ts
+++ b/bridge/client/app/_services/data.service.ts
@@ -21,7 +21,7 @@ export class DataService {
   private _projects = new BehaviorSubject<Project[]>(null);
   private _roots = new BehaviorSubject<Root[]>(null);
   private _openApprovals = new BehaviorSubject<Trace[]>([]);
-  private _keptnInfo = new BehaviorSubject<Object>({});
+  private _keptnInfo = new BehaviorSubject<Object>(null);
   private _rootsLastUpdated: Object = {};
   private _tracesLastUpdated: Object = {};
 

--- a/bridge/client/app/app-header/app-header.component.html
+++ b/bridge/client/app/app-header/app-header.component.html
@@ -37,13 +37,13 @@
     </div>
   </div>
   <hr/>
-  <div class="mt-2 mb-3" fxLayout="row" fxLayoutAlign="flex-start center" *ngIf="keptnInfo?.bridgeInfo?.enableVersionCheckFeature && !keptnInfo.versionCheckEnabled">
+  <div class="mt-2 mb-3" fxLayout="row" fxLayoutAlign="flex-start center" *ngIf="keptnInfo?.bridgeInfo?.enableVersionCheckFeature && !keptnInfo?.versionCheckEnabled">
     <dt-icon class="error" [name]="'criticalevent'"></dt-icon>
     <p class="small m-0">Automatic version and security check disabled</p>
   </div>
   <div class="mt-3 mb-2" fxLayout="column" fxLayoutAlign="flex-end end">
-    <p class="small m-0">Keptn version: <span [textContent]="keptnInfo.keptnVersion"></span><span *ngIf="keptnInfo.keptnVersionInvalid">*</span></p>
-    <p class="small m-0">Bridge version: <span [textContent]="keptnInfo?.bridgeInfo?.bridgeVersion"></span><span *ngIf="keptnInfo.bridgeVersionInvalid">*</span></p>
+    <p class="small m-0">Keptn version: <span [textContent]="keptnInfo?.keptnVersion"></span><span *ngIf="keptnInfo?.keptnVersionInvalid">*</span></p>
+    <p class="small m-0">Bridge version: <span [textContent]="keptnInfo?.bridgeInfo?.bridgeVersion"></span><span *ngIf="keptnInfo?.bridgeVersionInvalid">*</span></p>
   </div>
   <div *ngIf="keptnInfo?.bridgeInfo?.enableVersionCheckFeature">
     <div class="mt-3" fxLayout="row" fxLayoutAlign="flex-start" *ngIf="keptnInfo.keptnVersionInvalid || keptnInfo.bridgeVersionInvalid">
@@ -59,7 +59,7 @@
         <p class="m-0">Version check</p>
       </div>
       <div>
-        <dt-switch (change)="versionCheckClicked($event)" [checked]="keptnInfo.versionCheckEnabled"></dt-switch>
+        <dt-switch (change)="versionCheckClicked($event)" [checked]="keptnInfo?.versionCheckEnabled"></dt-switch>
       </div>
     </div>
     <p class="m-0 mt-2 small">By enabling this feature, Keptn will collect statistical data and notify about new version and security patches for Keptn and Keptn Bridge. Details can be found at <a [href]="versionCheckReference" target="_blank" [textContent]="versionCheckReference"></a></p>

--- a/bridge/client/app/app-header/app-header.component.ts
+++ b/bridge/client/app/app-header/app-header.component.ts
@@ -47,6 +47,7 @@ export class AppHeaderComponent implements OnInit, OnDestroy {
       });
 
     this.dataService.keptnInfo
+      .pipe(filter(keptnInfo => !!keptnInfo))
       .pipe(takeUntil(this.unsubscribe$))
       .subscribe(keptnInfo => {
         this.keptnInfo = keptnInfo;

--- a/bridge/client/app/project-board/project-board.component.html
+++ b/bridge/client/app/project-board/project-board.component.html
@@ -279,9 +279,10 @@
       </ol>
       <p class="bold mt-2">Use Cases:</p>
       <ul class="list-style-none">
-        <li><a href="javascript:void(0);" (click)="exampleTriggerQualityGateCli.toggle()"><button class="inline small mr-2" dt-show-more [showLess]="exampleTriggerQualityGateCli.expanded"></button> Trigger a quality gate evaluation</a>
-          <dt-expandable-panel #exampleTriggerQualityGateCli>
-            <pre class="code"><code class="lang-console" [innerHtml]="triggerQualityGateEvaluationViaCli"></code></pre>
+        <li *ngFor="let example of useCaseExamples['cli']">
+          <a href="javascript:void(0);" (click)="exampleCode.toggle()"><button class="inline small mr-2" dt-show-more [showLess]="exampleCode.expanded"></button> <span [textContent]="example.label"></span></a>
+          <dt-expandable-panel #exampleCode>
+            <pre class="code"><code class="lang-console" [innerHtml]="example.code"></code></pre>
           </dt-expandable-panel>
         </li>
       </ul>
@@ -298,9 +299,10 @@
       </ol>
       <p class="bold mt-2">Use Cases:</p>
       <ul class="list-style-none">
-        <li><a href="javascript:void(0);" (click)="exampleTriggerQualityGateApi.toggle()"><button class="inline small mr-2" dt-show-more [showLess]="exampleTriggerQualityGateApi.expanded"></button> Trigger a quality gate evaluation</a>
-          <dt-expandable-panel #exampleTriggerQualityGateApi>
-            <pre class="code"><code class="lang-console" [innerHtml]="triggerQualityGateEvaluationViaApi"></code></pre>
+        <li *ngFor="let example of useCaseExamples['api']">
+          <a href="javascript:void(0);" (click)="exampleCode.toggle()"><button class="inline small mr-2" dt-show-more [showLess]="exampleCode.expanded"></button> <span [textContent]="example.label"></span></a>
+          <dt-expandable-panel #exampleCode>
+            <pre class="code"><code class="lang-console" [innerHtml]="example.code"></code></pre>
           </dt-expandable-panel>
         </li>
       </ul>

--- a/bridge/client/app/project-board/project-board.component.html
+++ b/bridge/client/app/project-board/project-board.component.html
@@ -277,7 +277,7 @@
         <li><a *ngIf="keptnInfo?.bridgeInfo?.cliDownloadLink" [attr.href]="keptnInfo.bridgeInfo.cliDownloadLink" rel="noopener noreferrer" target="_blank">Download Keptn CLI</a></li>
         <li>Authenticate CLI with: <a href="https://keptn.sh/docs/0.7.x/reference/cli/commands/keptn_auth/" rel="noopener noreferrer" target="_blank">keptn auth</a></li>
       </ol>
-      <p class="bold mt-2">Use Cases:</p>
+      <p class="bold mt-2" *ngIf="useCaseExamples['cli'].length > 0">Use Cases:</p>
       <ul class="list-style-none">
         <li *ngFor="let example of useCaseExamples['cli']">
           <a href="javascript:void(0);" (click)="exampleCode.toggle()"><button class="inline small mr-2" dt-show-more [showLess]="exampleCode.expanded"></button> <span [textContent]="example.label"></span></a>
@@ -297,7 +297,7 @@
           <li>Access Keptn API</li>
         </ng-template>
       </ol>
-      <p class="bold mt-2">Use Cases:</p>
+      <p class="bold mt-2" *ngIf="useCaseExamples['api'].length > 0">Use Cases:</p>
       <ul class="list-style-none">
         <li *ngFor="let example of useCaseExamples['api']">
           <a href="javascript:void(0);" (click)="exampleCode.toggle()"><button class="inline small mr-2" dt-show-more [showLess]="exampleCode.expanded"></button> <span [textContent]="example.label"></span></a>

--- a/bridge/client/app/project-board/project-board.component.ts
+++ b/bridge/client/app/project-board/project-board.component.ts
@@ -162,20 +162,23 @@ export class ProjectBoardComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this.unsubscribe$))
       .subscribe(keptnInfo => {
         this.keptnInfo = keptnInfo;
-        if(this.keptnInfo.bridgeInfo.keptnInstallationType.indexOf("CONTINUOUS_DELIVERY") != -1) {
-          this.addDeploymentUseCaseToIntegrations();
-        }
-        if(this.keptnInfo.bridgeInfo.keptnInstallationType.indexOf("QUALITY_GATES_ONLY") != -1) {
-          this.addEvaluationUseCaseToIntegrations();
-        }
-        if(this.keptnInfo.bridgeInfo.keptnInstallationType.indexOf("CONTINUOUS_OPERATIONS") != -1) {
-          this.addRemediationUseCaseToIntegrations();
+        if(this.keptnInfo.bridgeInfo.keptnInstallationType) {
+          if(this.keptnInfo.bridgeInfo.keptnInstallationType.indexOf("CONTINUOUS_DELIVERY") != -1) {
+            this.addDeploymentUseCaseToIntegrations();
+          }
+          if(this.keptnInfo.bridgeInfo.keptnInstallationType.indexOf("QUALITY_GATES_ONLY") != -1) {
+            this.addEvaluationUseCaseToIntegrations();
+          }
+          if(this.keptnInfo.bridgeInfo.keptnInstallationType.indexOf("CONTINUOUS_OPERATIONS") != -1) {
+            this.addRemediationUseCaseToIntegrations();
+          }
+          this.updateIntegrations();
         }
       });
   }
 
   updateIntegrations() {
-    if(this.keptnInfo.bridgeInfo.keptnInstallationType.indexOf("QUALITY_GATES_ONLY") != -1) {
+    if(this.keptnInfo && this.keptnInfo.bridgeInfo.keptnInstallationType && this.keptnInfo.bridgeInfo.keptnInstallationType.indexOf("QUALITY_GATES_ONLY") != -1) {
       this.currentTime = moment.utc().startOf('minute').format("YYYY-MM-DDTHH:mm:ss");
       this.useCaseExamples['cli'].find(e => e.label == 'Trigger a quality gate evaluation').code = `keptn send event start-evaluation --project=\${PROJECT} --stage=\${STAGE} --service=\${SERVICE} --start=${this.currentTime} --timeframe=5m`;
       this.useCaseExamples['api'].find(e => e.label == 'Trigger a quality gate evaluation').code = `curl -X POST "\${KEPTN_API_ENDPOINT}/v1/project/\${PROJECT}/stage/\${STAGE}/service/\${SERVICE}/evaluation" \\

--- a/bridge/client/app/project-board/project-board.component.ts
+++ b/bridge/client/app/project-board/project-board.component.ts
@@ -166,7 +166,7 @@ export class ProjectBoardComponent implements OnInit, OnDestroy {
           if(this.keptnInfo.bridgeInfo.keptnInstallationType.indexOf("CONTINUOUS_DELIVERY") != -1) {
             this.addDeploymentUseCaseToIntegrations();
           }
-          if(this.keptnInfo.bridgeInfo.keptnInstallationType.indexOf("QUALITY_GATES_ONLY") != -1) {
+          if(this.keptnInfo.bridgeInfo.keptnInstallationType.indexOf("QUALITY_GATES") != -1) {
             this.addEvaluationUseCaseToIntegrations();
           }
           if(this.keptnInfo.bridgeInfo.keptnInstallationType.indexOf("CONTINUOUS_OPERATIONS") != -1) {
@@ -178,7 +178,7 @@ export class ProjectBoardComponent implements OnInit, OnDestroy {
   }
 
   updateIntegrations() {
-    if(this.keptnInfo && this.keptnInfo.bridgeInfo.keptnInstallationType && this.keptnInfo.bridgeInfo.keptnInstallationType.indexOf("QUALITY_GATES_ONLY") != -1) {
+    if(this.keptnInfo && this.keptnInfo.bridgeInfo.keptnInstallationType && this.keptnInfo.bridgeInfo.keptnInstallationType.indexOf("QUALITY_GATES") != -1) {
       this.currentTime = moment.utc().startOf('minute').format("YYYY-MM-DDTHH:mm:ss");
       this.useCaseExamples['cli'].find(e => e.label == 'Trigger a quality gate evaluation').code = `keptn send event start-evaluation --project=\${PROJECT} --stage=\${STAGE} --service=\${SERVICE} --start=${this.currentTime} --timeframe=5m`;
       this.useCaseExamples['api'].find(e => e.label == 'Trigger a quality gate evaluation').code = `curl -X POST "\${KEPTN_API_ENDPOINT}/v1/project/\${PROJECT}/stage/\${STAGE}/service/\${SERVICE}/evaluation" \\

--- a/bridge/client/app/project-board/project-board.component.ts
+++ b/bridge/client/app/project-board/project-board.component.ts
@@ -56,14 +56,8 @@ export class ProjectBoardComponent implements OnInit, OnDestroy {
   public integrationsExternalDetails = null;
 
   public useCaseExamples = {
-    'cli': [{
-      label: 'Trigger a quality gate evaluation',
-      code: ''
-    }],
-    'api': [{
-      label: 'Trigger a quality gate evaluation',
-      code: ''
-    }]
+    'cli': [],
+    'api': []
   };
 
   public keptnInfo: any;
@@ -168,29 +162,47 @@ export class ProjectBoardComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this.unsubscribe$))
       .subscribe(keptnInfo => {
         this.keptnInfo = keptnInfo;
-        if(this.keptnInfo.bridgeInfo.keptnInstallationType != "QUALITY_GATES_ONLY") {
+        if(this.keptnInfo.bridgeInfo.keptnInstallationType.indexOf("CONTINUOUS_DELIVERY") != -1) {
           this.addDeploymentUseCaseToIntegrations();
+        }
+        if(this.keptnInfo.bridgeInfo.keptnInstallationType.indexOf("QUALITY_GATES_ONLY") != -1) {
+          this.addEvaluationUseCaseToIntegrations();
+        }
+        if(this.keptnInfo.bridgeInfo.keptnInstallationType.indexOf("CONTINUOUS_OPERATIONS") != -1) {
           this.addRemediationUseCaseToIntegrations();
         }
       });
   }
 
   updateIntegrations() {
-    this.currentTime = moment.utc().startOf('minute').format("YYYY-MM-DDTHH:mm:ss");
-    this.useCaseExamples['cli'].find(e => e.label == 'Trigger a quality gate evaluation').code = `keptn send event start-evaluation --project=\${PROJECT} --stage=\${STAGE} --service=\${SERVICE} --start=${this.currentTime} --timeframe=5m`;
-    this.useCaseExamples['api'].find(e => e.label == 'Trigger a quality gate evaluation').code = `curl -X POST "\${KEPTN_API_ENDPOINT}/v1/project/\${PROJECT}/stage/\${STAGE}/service/\${SERVICE}/evaluation" \\
+    if(this.keptnInfo.bridgeInfo.keptnInstallationType.indexOf("QUALITY_GATES_ONLY") != -1) {
+      this.currentTime = moment.utc().startOf('minute').format("YYYY-MM-DDTHH:mm:ss");
+      this.useCaseExamples['cli'].find(e => e.label == 'Trigger a quality gate evaluation').code = `keptn send event start-evaluation --project=\${PROJECT} --stage=\${STAGE} --service=\${SERVICE} --start=${this.currentTime} --timeframe=5m`;
+      this.useCaseExamples['api'].find(e => e.label == 'Trigger a quality gate evaluation').code = `curl -X POST "\${KEPTN_API_ENDPOINT}/v1/project/\${PROJECT}/stage/\${STAGE}/service/\${SERVICE}/evaluation" \\
     -H "accept: application/json; charset=utf-8" \\
     -H "x-token: \${KEPTN_API_TOKEN}" \\
     -H "Content-Type: application/json; charset=utf-8" \\
     -d "{"start": "${this.currentTime}", "timeframe": "5m", "labels":{"buildId":"build-17","owner":"JohnDoe","testNo":"47-11"}"`;
+    }
+  }
+
+  addEvaluationUseCaseToIntegrations() {
+    this.useCaseExamples['cli'].push({
+      label: 'Trigger a quality gate evaluation',
+      code: ''
+    });
+    this.useCaseExamples['api'].push({
+      label: 'Trigger a quality gate evaluation',
+      code: ''
+    });
   }
 
   addDeploymentUseCaseToIntegrations() {
-    this.useCaseExamples['cli'].unshift({
+    this.useCaseExamples['cli'].push({
       label: 'Trigger deployment with a new artifact',
       code: `keptn send event new-artifact --project=\${PROJECT} --service=\${SERVICE}--image=\${IMAGE} --tag=\${TAG}`
     });
-    this.useCaseExamples['api'].unshift({
+    this.useCaseExamples['api'].push({
       label: 'Trigger deployment with a new artifact',
       code: `curl -X POST "\${KEPTN_API_ENDPOINT}/v1/event" \\
       -H "accept: application/json; charset=utf-8" -H "x-token: \${KEPTN_API_TOKEN}" -H "Content-Type: application/json; charset=utf-8" \\

--- a/bridge/deploy/bridge.yaml
+++ b/bridge/deploy/bridge.yaml
@@ -47,9 +47,9 @@ spec:
          - name: SHOW_API_TOKEN
            value: "true"
          - name: KEPTN_INSTALLATION_TYPE
-           value: "FULL"
+           value: "QUALITY_GATES,CONTINUOUS_OPERATIONS,CONTINUOUS_DELIVERY"
            Description: >
-             Should be "FULL" or "QUALITY_GATES_ONLY". In case of "QUALITY_GATES_ONLY" the bridge will not show all use-case examples in the Integrations page.
+             Should contain the supported use cases as comma-separated string. "QUALITY_GATES", "CONTINUOUS_OPERATIONS" and "CONTINUOUS_DELIVERY" are valid values.
         envFrom:
           - secretRef:
               name: bridge-credentials

--- a/bridge/deploy/bridge.yaml
+++ b/bridge/deploy/bridge.yaml
@@ -46,6 +46,10 @@ spec:
            value: "true"
          - name: SHOW_API_TOKEN
            value: "true"
+         - name: KEPTN_INSTALLATION_TYPE
+           value: "FULL"
+           Description: >
+             Should be "FULL" or "QUALITY_GATES_ONLY". In case of "QUALITY_GATES_ONLY" the bridge will not show all use-case examples in the Integrations page.
         envFrom:
           - secretRef:
               name: bridge-credentials

--- a/bridge/server/api/index.js
+++ b/bridge/server/api/index.js
@@ -11,6 +11,7 @@ module.exports = (params) => {
   const enableVersionCheckFeature = process.env.ENABLE_VERSION_CHECK !== "false";
   const showApiToken = process.env.SHOW_API_TOKEN !== "false";
   const bridgeVersion = process.env.VERSION;
+  const keptnInstallationType = process.env.KEPTN_INSTALLATION_TYPE;
 
   // accepts self-signed ssl certificate
   const agent = new https.Agent({
@@ -20,7 +21,7 @@ module.exports = (params) => {
   // bridgeInfo endpoint: Provide certain metadata for Bridge
   router.get('/bridgeInfo', async (req, res, next) => {
     try {
-      return res.json({ bridgeVersion, apiUrl, ...showApiToken && { apiToken }, cliDownloadLink, enableVersionCheckFeature, showApiToken });
+      return res.json({ bridgeVersion, keptnInstallationType, apiUrl, ...showApiToken && { apiToken }, cliDownloadLink, enableVersionCheckFeature, showApiToken });
     } catch (err) {
       return next(err);
     }


### PR DESCRIPTION
If keptn is not used as "quality gates only" installation, the bridge shows all core use-cases on integrations page.
The installation type is configured by providing `KEPTN_INSTALLATION_TYPE` environment variable, see _bridge/deploy/bridge.yaml_

![image](https://user-images.githubusercontent.com/6098219/97575164-9ce28800-19ec-11eb-83ef-c76a71be74b9.png)
