### PR TITLE
Set versions of keptn-contrib services based on tested keptn version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -575,7 +575,6 @@ jobs:
       - keptn status
       - export PROJECT=musicshop
       - export PLATFORM=openshift
-      - export DYNATRACE_SLI_SERVICE_VERSION=master
       - test/test_quality_gates_standalone.sh
     after_success:
       # delete Google Kubernetes cluster only on success (keep cluster in case of an error to dig into the cluster)
@@ -606,7 +605,6 @@ jobs:
       - test/test_install_kubernetes_quality_gates.sh
       - keptn status
       - export PROJECT=musicshop
-      - export DYNATRACE_SLI_SERVICE_VERSION=master
       - test/test_quality_gates_standalone.sh
     after_success:
       # delete Google Kubernetes cluster only on success (keep cluster in case of an error to dig into the cluster)
@@ -649,7 +647,6 @@ jobs:
       - test/test_install_kubernetes_quality_gates.sh
       - keptn status
       - export PROJECT=musicshop
-      - export DYNATRACE_SLI_SERVICE_VERSION=master
       - test/test_quality_gates_standalone.sh
     after_success:
       # delete Google Kubernetes cluster only on success (keep cluster in case of an error to dig into the cluster)
@@ -694,7 +691,6 @@ jobs:
       - test/test_install_kubernetes_quality_gates.sh
       - keptn status
       - export PROJECT=musicshop
-      - export DYNATRACE_SLI_SERVICE_VERSION=master
       - test/test_quality_gates_standalone.sh
     after_success:
       # delete Google Kubernetes cluster only on success (keep cluster in case of an error to dig into the cluster)

--- a/test/test_quality_gates_standalone.sh
+++ b/test/test_quality_gates_standalone.sh
@@ -2,6 +2,8 @@
 
 source test/utils.sh
 
+set_keptn_contrib_service_versions
+
 # test configuration
 DYNATRACE_SLI_SERVICE_VERSION=${DYNATRACE_SLI_SERVICE_VERSION:-master}
 KEPTN_EXAMPLES_BRANCH=${KEPTN_EXAMPLES_BRANCH:-master}
@@ -631,7 +633,7 @@ fi
 ########################################################################################################################
 
 # add SLI file for service
-echo "Adding SLI File: test/assets/quality_gates_standalone_sli_dynatrace_step2.yaml"
+echo "Adding SLI File: test/assets/quality_gates_standalone_sli_dynatrace_step4.yaml"
 keptn add-resource --project=$PROJECT --stage=hardening --service=$SERVICE --resource=test/assets/quality_gates_standalone_slo_step4.yaml --resourceUri=slo.yaml
 verify_test_step $? "keptn add-resource slo.yaml - failed"
 

--- a/test/test_self_healing.sh
+++ b/test/test_self_healing.sh
@@ -2,6 +2,8 @@
 
 source test/utils.sh
 
+set_keptn_contrib_service_versions
+
 # get keptn api details
 KEPTN_ENDPOINT=http://$(kubectl -n keptn get service api-gateway-nginx -o jsonpath='{.status.loadBalancer.ingress[0].ip}')/api
 KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token} | base64 --decode)

--- a/test/test_self_healing_scaling.sh
+++ b/test/test_self_healing_scaling.sh
@@ -2,6 +2,8 @@
 
 source test/utils.sh
 
+set_keptn_contrib_service_versions
+
 function cleanup() {
   kubectl delete namespace loadgen
 }

--- a/test/utils.sh
+++ b/test/utils.sh
@@ -6,6 +6,32 @@ function print_error() {
   echo "[keptn|ERROR] $(timestamp) $1"
 }
 
+# based on the KEPTN_INSTALLER_VERSION, we need to make sure to use versions of the keptn-contrib services that are compatible with this release
+function set_keptn_contrib_service_versions() {
+  echo "Setting version numbers of keptn-services to be compatible with Keptn version ${KEPTN_INSTALLER_VERSION}"
+
+  # use master (=latest) per default
+  export DYNATRACE_SLI_SERVICE_VERSION="master"
+  export DYNATRACE_SERVICE_VERSION="master"
+  export PROMETHEUS_SLI_SERVICE_VERSION="master"
+  export PROMETHEUS_SERVICE_VERSION="master"
+  export UNLEASH_SERVICE_VERSION="master"
+
+  if [[ $KEPTN_INSTALLER_VERSION == "0.7.3" ]]; then
+    export DYNATRACE_SLI_SERVICE_VERSION="release-0.7.0"
+    export DYNATRACE_SERVICE_VERSION="release-0.10.0"
+    export PROMETHEUS_SLI_SERVICE_VERSION="release-0.2.3"
+    export PROMETHEUS_SERVICE_VERSION="release-0.3.6"
+    export UNLEASH_SERVICE_VERSION="release-0.2.0"
+  fi
+
+  echo "using dynatrace-sli-service ${DYNATRACE_SLI_SERVICE_VERSION}"
+  echo "using dynatrace-service ${DYNATRACE_SERVICE_VERSION}"
+  echo "using prometheus-sli-service ${PROMETHEUS_SLI_SERVICE_VERSION}"
+  echo "using prometheus-service ${PROMETHEUS_SERVICE_VERSION}"
+  echo "using unleash-service ${UNLEASH_SERVICE_VERSION}"
+}
+
 function auth_at_keptn() {
   ENDPOINT=$1
   API_TOKEN=$2


### PR DESCRIPTION
This PR makes sure that the versions of the keptn-contrib services used in the integration tests are the ones that are compatible with the respective release