### PR TITLE
Helm service: ignore events that have been generated by itself

### DIFF
--- a/helm-service/main.go
+++ b/helm-service/main.go
@@ -46,6 +46,10 @@ func main() {
 
 func gotEvent(ctx context.Context, event cloudevents.Event) error {
 	serviceName := serviceName
+
+	if event.Context.GetSource() == serviceName {
+		return nil
+	}
 	var shkeptncontext string
 	event.Context.ExtensionAs("shkeptncontext", &shkeptncontext)
 


### PR DESCRIPTION
Since the helm-service both listens to, as well as generates `service.delete.finished` events, it needs to ignore its own events. 