### PR TITLE
Added support for KEPTNCONFIG environment variable

### DIFF
--- a/cli/pkg/credentialmanager/handler.go
+++ b/cli/pkg/credentialmanager/handler.go
@@ -91,7 +91,11 @@ func getCreds(h credentials.Helper, namespace string) (url.URL, string, error) {
 	// Check if creds file is specified in the 'KEPTNCONFIG' environment variable
 	if customCredsLocation, ok := os.LookupEnv("KEPTNCONFIG"); ok {
 		if customCredsLocation != "" {
-			return handleCustomCreds(customCredsLocation, namespace)
+			endPoint, apiToken, err := handleCustomCreds(customCredsLocation, namespace)
+			// If credential is not found in KEPTNCONFIG, use fallback credential manager
+			if apiToken != "" || err != nil {
+				return endPoint, apiToken, err
+			}
 		}
 	}
 	endPointStr, apiToken, err := h.Get(customServerURL)
@@ -126,7 +130,7 @@ func handleCustomCreds(configLocation string, namespace string) (url.URL, string
 			return *parsedURL, context.APIToken, nil
 		}
 	}
-	return url.URL{}, "", errors.New("Credentials against current kubecontext isn't found")
+	return url.URL{}, "", nil
 }
 
 // initChecks needs to be run when credentialManager is called or initilized

--- a/cli/pkg/credentialmanager/handler_linux.go
+++ b/cli/pkg/credentialmanager/handler_linux.go
@@ -62,7 +62,11 @@ func (cm *CredentialManager) GetCreds(namespace string) (url.URL, string, error)
 	// Check if creds file is specified in the 'KEPTNCONFIG' environment variable
 	if customCredsLocation, ok := os.LookupEnv("KEPTNCONFIG"); ok {
 		if customCredsLocation != "" {
-			return handleCustomCreds(customCredsLocation, namespace)
+			endPoint, apiToken, err := handleCustomCreds(customCredsLocation, namespace)
+			// If credential is not found in KEPTNCONFIG, use fallback credential manager
+			if apiToken != "" || err != nil {
+				return endPoint, apiToken, err
+			}
 		}
 	}
 

--- a/cli/pkg/credentialmanager/handler_linux.go
+++ b/cli/pkg/credentialmanager/handler_linux.go
@@ -62,7 +62,7 @@ func (cm *CredentialManager) GetCreds(namespace string) (url.URL, string, error)
 	// Check if creds file is specified in the 'KEPTNCONFIG' environment variable
 	if customCredsLocation, ok := os.LookupEnv("KEPTNCONFIG"); ok {
 		if customCredsLocation != "" {
-			return handleCustomCreds(customCredsLocation)
+			return handleCustomCreds(customCredsLocation, namespace)
 		}
 	}
 


### PR DESCRIPTION
In regards to #2300 

- [x] Added support for defining `KEPTNCONFIG` to access the cluster via keptn CLI
- [x] We can set multiple clusters in the same file as shown below:
   ```
   contexts:
   - api_token: blablabla
     endpoint: http://91.xxx.xx.xx.nip.io/api
     name: keptn-test
  - api_token: blablablah
     endpoint: http://localhost:8080/api
     name: keptn-demo
     namespace: keptn-demo
  ```
- [x] This is enabled for sharing credentials and use them directly, if you are setting up authentication, it won't store in `KEPTNCONFIG` file else it will use good old credential manager.