### PR TITLE
Configure resource request and limit for jmeter-service

### DIFF
--- a/installer/manifests/keptn/charts/continuous-delivery/templates/continuous-deployment.yaml
+++ b/installer/manifests/keptn/charts/continuous-delivery/templates/continuous-deployment.yaml
@@ -283,9 +283,6 @@ spec:
             requests:
               memory: "64Mi"
               cpu: "50m"
-            limits:
-              memory: "128Mi"
-              cpu: "500m
           env:
           - name: CONFIGURATION_SERVICE
             value: 'http://configuration-service:8080'

--- a/installer/manifests/keptn/charts/continuous-delivery/templates/continuous-deployment.yaml
+++ b/installer/manifests/keptn/charts/continuous-delivery/templates/continuous-deployment.yaml
@@ -68,7 +68,7 @@ spec:
           {{- include "continuous-delivery.livenessProbe" . | nindent 10 }}
           imagePullPolicy: IfNotPresent
           ports:
-          - containerPort: 8080
+            - containerPort: 8080
           resources:
             requests:
               memory: "32Mi"
@@ -278,7 +278,14 @@ spec:
           {{- include "continuous-delivery.livenessProbe" . | nindent 10 }}
           imagePullPolicy: IfNotPresent
           ports:
-          - containerPort: 8080
+            - containerPort: 8080
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "128Mi"
+              cpu: "500m
           env:
           - name: CONFIGURATION_SERVICE
             value: 'http://configuration-service:8080'


### PR DESCRIPTION
In reviewing the resource quota of deployments, I recognized that the jmeter-service is missing the resource configuration.

All the other deployments have a resource config. 