### PR TITLE
#2563 Removed livenessProbes from development manifests

### DIFF
--- a/api/deploy/service.yaml
+++ b/api/deploy/service.yaml
@@ -37,12 +37,6 @@ spec:
             limits:
               memory: "256Mi"
               cpu: "500m"
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 10999
-            initialDelaySeconds: 5
-            periodSeconds: 5
           env:
             - name: PREFIX_PATH
               value: ""

--- a/configuration-service/deploy/service.yaml
+++ b/configuration-service/deploy/service.yaml
@@ -55,12 +55,6 @@ spec:
                 fieldPath: metadata.namespace
         ports:
         - containerPort: 8080
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: 10999
-          initialDelaySeconds: 5
-          periodSeconds: 5
         resources:
           requests:
             memory: "256Mi"

--- a/distributor/deploy/distributor.yaml
+++ b/distributor/deploy/distributor.yaml
@@ -29,12 +29,6 @@ spec:
       containers:
       - name: distributor
         image: keptn/distributor:latest
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: 10999
-          initialDelaySeconds: 5
-          periodSeconds: 5
         ports:
         - containerPort: 8080
         resources:

--- a/gatekeeper-service/deploy/service.yaml
+++ b/gatekeeper-service/deploy/service.yaml
@@ -28,12 +28,6 @@ spec:
       containers:
       - name: gatekeeper-service
         image: keptn/gatekeeper-service:latest
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: 10999
-          initialDelaySeconds: 5
-          periodSeconds: 5
         ports:
         - containerPort: 8080
         resources:

--- a/helm-service/deploy/service.yaml
+++ b/helm-service/deploy/service.yaml
@@ -28,12 +28,6 @@ spec:
       containers:
       - name: helm-service
         image: keptn/helm-service:latest
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: 10999
-          initialDelaySeconds: 5
-          periodSeconds: 5
         ports:
         - containerPort: 8080
         resources:

--- a/jmeter-service/deploy/service.yaml
+++ b/jmeter-service/deploy/service.yaml
@@ -27,12 +27,6 @@ spec:
       containers:
       - name: jmeter-service
         image: keptn/jmeter-service:latest
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: 10999
-          initialDelaySeconds: 5
-          periodSeconds: 5
         ports:
         - containerPort: 8080
         env:

--- a/lighthouse-service/deploy/service.yaml
+++ b/lighthouse-service/deploy/service.yaml
@@ -30,12 +30,6 @@ spec:
           image: keptn/lighthouse-service:latest
           ports:
             - containerPort: 8080
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 10999
-            initialDelaySeconds: 5
-            periodSeconds: 5
           resources:
             requests:
               memory: "128Mi"

--- a/mongodb-datastore/deploy/mongodb-datastore.yaml
+++ b/mongodb-datastore/deploy/mongodb-datastore.yaml
@@ -31,12 +31,6 @@ spec:
       containers:
       - name: mongodb-datastore
         image: keptn/mongodb-datastore:latest
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: 10999
-          initialDelaySeconds: 5
-          periodSeconds: 5
         ports:
         - containerPort: 8080
         resources:
@@ -68,12 +62,6 @@ spec:
       - name: distributor
         image: keptn/distributor:latest
         imagePullPolicy: Always
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: 10999
-          initialDelaySeconds: 5
-          periodSeconds: 5
         ports:
           - containerPort: 8080
         resources:

--- a/shipyard-controller/deploy/service.yaml
+++ b/shipyard-controller/deploy/service.yaml
@@ -57,12 +57,6 @@ spec:
             value: 'keptn'
         ports:
         - containerPort: 8080
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: 10999
-          initialDelaySeconds: 5
-          periodSeconds: 5
         resources:
           requests:
             memory: "256Mi"


### PR DESCRIPTION
Closes #2536 

The livenessProbes have been removed from the individual service manifests that are used for developing. The manifests of the installer helm chart have been left untouched.

After removing the livenessProbe from the mongodb-datastore I was able to use the remote debugging feature again with no pod restarts 