### PR TITLE
#2704 Added -y option to keptn auth to automatically apply changed Kubernetes context

### DIFF
--- a/cli/cmd/add_resource.go
+++ b/cli/cmd/add_resource.go
@@ -50,7 +50,7 @@ keptn add-resource --project=rockshop --stage=production --service=shop --resour
 	SilenceUsage: true,
 	Args:         cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
+		endPoint, apiToken, err := credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}

--- a/cli/cmd/auth.go
+++ b/cli/cmd/auth.go
@@ -20,7 +20,7 @@ type authCmdParams struct {
 	endPoint      *string
 	apiToken      *string
 	exportConfig  *bool
-	acceptContext *bool
+	acceptContext bool
 }
 
 var authParams *authCmdParams
@@ -48,7 +48,7 @@ More precisely, the Keptn CLI stores the endpoint and API token using *pass* in 
 		var err error
 		// User wants to print current auth credentials
 		if *authParams.exportConfig {
-			exportEndPoint, exportAPIToken, err = credentialmanager.NewCredentialManager(*authParams.acceptContext).GetCreds(namespace)
+			exportEndPoint, exportAPIToken, err = credentialmanager.NewCredentialManager(authParams.acceptContext).GetCreds(namespace)
 			if err != nil {
 				return err
 			}
@@ -102,7 +102,7 @@ More precisely, the Keptn CLI stores the endpoint and API token using *pass* in 
 			}
 
 			logging.PrintLog("Successfully authenticated against the Keptn cluster "+*authParams.endPoint, logging.InfoLevel)
-			return credentialmanager.NewCredentialManager(false).SetCreds(*url, *authParams.apiToken, namespace)
+			return credentialmanager.NewCredentialManager(authParams.acceptContext).SetCreds(*url, *authParams.apiToken, namespace)
 		}
 
 		fmt.Println("skipping auth due to mocking flag set to true")
@@ -117,7 +117,7 @@ func init() {
 	authParams.endPoint = authCmd.Flags().StringP("endpoint", "e", "", "The endpoint exposed by the Keptn installation (e.g., api.keptn.127.0.0.1.xip.io)")
 	authParams.apiToken = authCmd.Flags().StringP("api-token", "a", "", "The API token to communicate with the Keptn installation")
 	authParams.exportConfig = authCmd.Flags().BoolP("export", "c", false, "To export the current cluster config i.e API token and Endpoint")
-	authParams.acceptContext = authCmd.Flags().BoolP("yes", "y", false, "Automatically accept change of Kubernetes Context")
+	authCmd.Flags().BoolVarP(&authParams.acceptContext, "yes", "y", false, "Automatically accept change of Kubernetes Context")
 }
 
 func verifyAuthParams(authParams *authCmdParams) error {

--- a/cli/cmd/auth.go
+++ b/cli/cmd/auth.go
@@ -17,9 +17,10 @@ import (
 )
 
 type authCmdParams struct {
-	endPoint     *string
-	apiToken     *string
-	exportConfig *bool
+	endPoint      *string
+	apiToken      *string
+	exportConfig  *bool
+	acceptContext *bool
 }
 
 var authParams *authCmdParams
@@ -47,7 +48,7 @@ More precisely, the Keptn CLI stores the endpoint and API token using *pass* in 
 		var err error
 		// User wants to print current auth credentials
 		if *authParams.exportConfig {
-			exportEndPoint, exportAPIToken, err = credentialmanager.NewCredentialManager().GetCreds(namespace)
+			exportEndPoint, exportAPIToken, err = credentialmanager.NewCredentialManager(*authParams.acceptContext).GetCreds(namespace)
 			if err != nil {
 				return err
 			}
@@ -101,7 +102,7 @@ More precisely, the Keptn CLI stores the endpoint and API token using *pass* in 
 			}
 
 			logging.PrintLog("Successfully authenticated against the Keptn cluster "+*authParams.endPoint, logging.InfoLevel)
-			return credentialmanager.NewCredentialManager().SetCreds(*url, *authParams.apiToken, namespace)
+			return credentialmanager.NewCredentialManager(false).SetCreds(*url, *authParams.apiToken, namespace)
 		}
 
 		fmt.Println("skipping auth due to mocking flag set to true")
@@ -116,6 +117,7 @@ func init() {
 	authParams.endPoint = authCmd.Flags().StringP("endpoint", "e", "", "The endpoint exposed by the Keptn installation (e.g., api.keptn.127.0.0.1.xip.io)")
 	authParams.apiToken = authCmd.Flags().StringP("api-token", "a", "", "The API token to communicate with the Keptn installation")
 	authParams.exportConfig = authCmd.Flags().BoolP("export", "c", false, "To export the current cluster config i.e API token and Endpoint")
+	authParams.acceptContext = authCmd.Flags().BoolP("yes", "y", false, "Automatically accept change of Kubernetes Context")
 }
 
 func verifyAuthParams(authParams *authCmdParams) error {

--- a/cli/cmd/auth_test.go
+++ b/cli/cmd/auth_test.go
@@ -19,7 +19,7 @@ func TestAuthCmd(t *testing.T) {
 	credentialmanager.MockAuthCreds = true
 	checkEndPointStatusMock = true
 
-	endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
+	endPoint, apiToken, err := credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 	if err != nil {
 		t.Error(err)
 		return

--- a/cli/cmd/configure_bridge.go
+++ b/cli/cmd/configure_bridge.go
@@ -44,7 +44,7 @@ var bridgeCmd = &cobra.Command{
 		return verifyConfigureBridgeParams(configureBridgeParams)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		endpoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
+		endpoint, apiToken, err := credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}

--- a/cli/cmd/configure_monitoring.go
+++ b/cli/cmd/configure_monitoring.go
@@ -61,7 +61,7 @@ keptn configure monitoring prometheus --project=PROJECTNAME --service=SERVICENAM
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
+		endPoint, apiToken, err := credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}

--- a/cli/cmd/create_project.go
+++ b/cli/cmd/create_project.go
@@ -57,7 +57,7 @@ For more information about Shipyard, creating projects, or upstream repositories
 keptn create project PROJECTNAME --shipyard=FILEPATH --git-user=GIT_USER --git-token=GIT_TOKEN --git-remote-url=GIT_REMOTE_URL`,
 	SilenceUsage: true,
 	Args: func(cmd *cobra.Command, args []string) error {
-		_, _, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
+		_, _, err := credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}
@@ -98,7 +98,7 @@ keptn create project PROJECTNAME --shipyard=FILEPATH --git-user=GIT_USER --git-t
 		return checkGitCredentials()
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
+		endPoint, apiToken, err := credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}

--- a/cli/cmd/create_service.go
+++ b/cli/cmd/create_service.go
@@ -30,7 +30,7 @@ var crServiceCmd = &cobra.Command{
 	Example:      `keptn create service carts --project=sockshop`,
 	SilenceUsage: true,
 	Args: func(cmd *cobra.Command, args []string) error {
-		_, _, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
+		_, _, err := credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}
@@ -48,7 +48,7 @@ var crServiceCmd = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
+		endPoint, apiToken, err := credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}

--- a/cli/cmd/delete_project.go
+++ b/cli/cmd/delete_project.go
@@ -32,7 +32,7 @@ var delProjectCmd = &cobra.Command{
 	Example:      `keptn delete project sockshop`,
 	SilenceUsage: true,
 	Args: func(cmd *cobra.Command, args []string) error {
-		_, _, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
+		_, _, err := credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}
@@ -48,7 +48,7 @@ var delProjectCmd = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
+		endPoint, apiToken, err := credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}

--- a/cli/cmd/delete_service.go
+++ b/cli/cmd/delete_service.go
@@ -28,7 +28,7 @@ Furthermore, if Keptn is used for continuous delivery (i.e. services have been o
 	SilenceUsage: true,
 	Args:         cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
+		endPoint, apiToken, err := credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}

--- a/cli/cmd/generate_support_archive.go
+++ b/cli/cmd/generate_support_archive.go
@@ -369,13 +369,13 @@ func newErrorableMetadataResult(result *models.Metadata, err error) *errorableMe
 
 func getKeptnAPIUrl() *errorableStringResult {
 	fmt.Println("Retrieving Keptn API")
-	endPoint, _, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
+	endPoint, _, err := credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 	return newErrorableStringResult(endPoint.String(), err)
 }
 
 func getKeptnAPIReachable() *errorableBoolResult {
 	fmt.Println("Checking availability of Keptn API")
-	endPoint, _, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
+	endPoint, _, err := credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 	if err != nil {
 		return newErrorableBoolResult(false, err)
 	}
@@ -545,7 +545,7 @@ func writePodLogs(namespace, dir string) {
 
 func getProjects() *errorableProjectResult {
 	fmt.Println("Retrieving list of Keptn projects")
-	endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
+	endPoint, apiToken, err := credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 	if err != nil {
 		return newErrorableProjectResult(nil, err)
 	}
@@ -567,7 +567,7 @@ func writeKeptnInstallerLog(logFileName string, dir string) {
 
 func getKeptnMetadata() *errorableMetadataResult {
 	fmt.Println("Retrieving Keptn Metadata from API Service")
-	endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
+	endPoint, apiToken, err := credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 	if err != nil {
 		return newErrorableMetadataResult(nil, err)
 	}

--- a/cli/cmd/get_event.go
+++ b/cli/cmd/get_event.go
@@ -64,7 +64,7 @@ func getEvent(eventStruct GetEventStruct, args []string) error {
 	var apiToken string
 	var err error
 	if !mocking {
-		endPoint, apiToken, err = credentialmanager.NewCredentialManager().GetCreds(namespace)
+		endPoint, apiToken, err = credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 	} else {
 		endPointPtr, _ := url.Parse(os.Getenv("MOCK_SERVER"))
 		endPoint = *endPointPtr

--- a/cli/cmd/get_event_approvalTriggered.go
+++ b/cli/cmd/get_event_approvalTriggered.go
@@ -54,7 +54,7 @@ func getApprovalTriggeredEvents(approvalTriggered approvalTriggeredStruct) error
 	var apiToken string
 	var err error
 	if !mocking {
-		endPoint, apiToken, err = credentialmanager.NewCredentialManager().GetCreds(namespace)
+		endPoint, apiToken, err = credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 	} else {
 		endPointPtr, _ := url.Parse(os.Getenv("MOCK_SERVER"))
 		endPoint = *endPointPtr

--- a/cli/cmd/get_event_evaluationDone.go
+++ b/cli/cmd/get_event_evaluationDone.go
@@ -40,7 +40,7 @@ var evaluationDoneCmd = &cobra.Command{
 	Example:      `keptn get event evaluation-done --keptn-context=1234-5678-90ab-cdef`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
+		endPoint, apiToken, err := credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}

--- a/cli/cmd/get_projects.go
+++ b/cli/cmd/get_projects.go
@@ -61,7 +61,7 @@ keptn get project sockshop -output=json  # Returns project details in JSON forma
 `,
 	SilenceUsage: true,
 	Args: func(cmd *cobra.Command, args []string) error {
-		_, _, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
+		_, _, err := credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}
@@ -84,7 +84,7 @@ keptn get project sockshop -output=json  # Returns project details in JSON forma
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
+		endPoint, apiToken, err := credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}

--- a/cli/cmd/get_services.go
+++ b/cli/cmd/get_services.go
@@ -55,7 +55,7 @@ keptn get services carts --project=sockshop -o=json  # Get details of the carts 
 `,
 	SilenceUsage: true,
 	Args: func(cmd *cobra.Command, args []string) error {
-		_, _, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
+		_, _, err := credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}
@@ -69,7 +69,7 @@ keptn get services carts --project=sockshop -o=json  # Get details of the carts 
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
+		endPoint, apiToken, err := credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}

--- a/cli/cmd/get_stages.go
+++ b/cli/cmd/get_stages.go
@@ -48,7 +48,7 @@ staging        2020-04-06T14:37:45.210Z
 `,
 	SilenceUsage: true,
 	Args: func(cmd *cobra.Command, args []string) error {
-		_, _, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
+		_, _, err := credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}
@@ -57,7 +57,7 @@ staging        2020-04-06T14:37:45.210Z
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 
-		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
+		endPoint, apiToken, err := credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}

--- a/cli/cmd/onboard_service.go
+++ b/cli/cmd/onboard_service.go
@@ -49,7 +49,7 @@ keptn onboard service SERVICENAME --project=PROJECTNAME --chart=HELM_CHART.tgz
 	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 
-		_, _, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
+		_, _, err := credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}
@@ -78,7 +78,7 @@ keptn onboard service SERVICENAME --project=PROJECTNAME --chart=HELM_CHART.tgz
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
+		endPoint, apiToken, err := credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}

--- a/cli/cmd/send_event.go
+++ b/cli/cmd/send_event.go
@@ -52,7 +52,7 @@ In addition, the payload of the CloudEvent needs to follow the Keptn spec (https
 		return json.Unmarshal([]byte(eventString), &body)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
+		endPoint, apiToken, err := credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}

--- a/cli/cmd/send_event_approvalFinished.go
+++ b/cli/cmd/send_event_approvalFinished.go
@@ -64,7 +64,7 @@ func sendApprovalFinishedEvent(sendApprovalFinishedOptions sendApprovalFinishedS
 	var apiToken string
 	var err error
 	if !mocking {
-		endPoint, apiToken, err = credentialmanager.NewCredentialManager().GetCreds(namespace)
+		endPoint, apiToken, err = credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 	} else {
 		endPointPtr, _ := url.Parse(os.Getenv("MOCK_SERVER"))
 		endPoint = *endPointPtr

--- a/cli/cmd/send_event_evaluationStart.go
+++ b/cli/cmd/send_event_evaluationStart.go
@@ -63,7 +63,7 @@ keptn send event start-evaluation --project=sockshop --stage=hardening --service
 `,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
+		endPoint, apiToken, err := credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}

--- a/cli/cmd/send_event_newArtifact.go
+++ b/cli/cmd/send_event_newArtifact.go
@@ -80,7 +80,7 @@ For pulling an image from a private registry, we would like to refer to the Kube
 		var apiToken string
 		var err error
 		if !mocking {
-			endPoint, apiToken, err = credentialmanager.NewCredentialManager().GetCreds(namespace)
+			endPoint, apiToken, err = credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 		} else {
 			endPointPtr, _ := url.Parse(os.Getenv("MOCK_SERVER"))
 			endPoint = *endPointPtr

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -17,7 +17,7 @@ var statusCmd = &cobra.Command{
 	Example:      `keptn status`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
+		endPoint, apiToken, err := credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 		if err != nil || endPoint.String() == "" || apiToken == "" {
 			fmt.Println("CLI is not authenticated against any Keptn cluster.  For authenticating your CLI use \"keptn auth\"")
 			return nil

--- a/cli/cmd/update_project.go
+++ b/cli/cmd/update_project.go
@@ -37,7 +37,7 @@ For more information about updating projects or upstream repositories, please go
 	Example:      `keptn update project PROJECTNAME --git-user=GIT_USER --git-token=GIT_TOKEN --git-remote-url=GIT_REMOTE_URL`,
 	SilenceUsage: true,
 	Args: func(cmd *cobra.Command, args []string) error {
-		_, _, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
+		_, _, err := credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}
@@ -57,7 +57,7 @@ For more information about updating projects or upstream repositories, please go
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
+		endPoint, apiToken, err := credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 		if err != nil {
 			return errors.New(authErrorMsg)
 		}

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -141,7 +141,7 @@ func updateLastVersionCheck() {
 }
 
 func getKeptnServerVersion() (string, error) {
-	endPoint, apiToken, err := credentialmanager.NewCredentialManager().GetCreds(namespace)
+	endPoint, apiToken, err := credentialmanager.NewCredentialManager(false).GetCreds(namespace)
 	if err != nil {
 		return "", errors.New(authErrorMsg)
 	}

--- a/cli/pkg/credentialmanager/handler.go
+++ b/cli/pkg/credentialmanager/handler.go
@@ -133,14 +133,14 @@ func handleCustomCreds(configLocation string, namespace string) (url.URL, string
 	return url.URL{}, "", nil
 }
 
-// initChecks needs to be run when credentialManager is called or initilized
-func initChecks() {
+// initChecks needs to be run when credentialManager is called or initialized
+func initChecks(autoApplyNewContext bool) {
 	cliConfigManager := config.NewCLIConfigManager()
 	currentContext, err := getCurrentContextFromKubeConfig()
 	if err != nil {
 		log.Fatal(err)
 	}
-	checkForContextChange(currentContext, cliConfigManager)
+	checkForContextChange(currentContext, cliConfigManager, autoApplyNewContext)
 }
 
 func getCurrentContextFromKubeConfig() (string, error) {
@@ -171,7 +171,7 @@ func getCurrentContextFromKubeConfig() (string, error) {
 	return kubeConfigFile.CurrentContext, nil
 }
 
-func checkForContextChange(currentContext string, cliConfigManager *config.CLIConfigManager) error {
+func checkForContextChange(currentContext string, cliConfigManager *config.CLIConfigManager, autoApplyNewContext bool) error {
 
 	if MockAuthCreds || MockKubeConfigCheck {
 		// Do nothing
@@ -181,19 +181,21 @@ func checkForContextChange(currentContext string, cliConfigManager *config.CLICo
 	if err != nil {
 		log.Fatal(err)
 	}
-	if cliConfig.CurrentContext != currentContext {
+	if cliConfig.CurrentContext != "" && cliConfig.CurrentContext != currentContext {
 		fmt.Printf("Kube context has been changed to %s", currentContext)
 		fmt.Println()
-		fmt.Println("Do you want to continue with this? (y/n)")
-		reader := bufio.NewReader(os.Stdin)
-		in, err := reader.ReadString('\n')
-		if err != nil {
-			return err
-		}
-		in = strings.ToLower(strings.TrimSpace(in))
-		if !(in == "y" || in == "yes") {
-			err := errors.New("stopping installation")
-			log.Fatal(err)
+		if !autoApplyNewContext {
+			fmt.Println("Do you want to continue with this? (y/n)")
+			reader := bufio.NewReader(os.Stdin)
+			in, err := reader.ReadString('\n')
+			if err != nil {
+				return err
+			}
+			in = strings.ToLower(strings.TrimSpace(in))
+			if !(in == "y" || in == "yes") {
+				err := errors.New("stopping installation")
+				log.Fatal(err)
+			}
 		}
 		cliConfig.CurrentContext = currentContext
 		err = cliConfigManager.StoreCLIConfig(cliConfig)

--- a/cli/pkg/credentialmanager/handler.go
+++ b/cli/pkg/credentialmanager/handler.go
@@ -181,10 +181,10 @@ func checkForContextChange(currentContext string, cliConfigManager *config.CLICo
 	if err != nil {
 		log.Fatal(err)
 	}
-	if cliConfig.CurrentContext != "" && cliConfig.CurrentContext != currentContext {
+	if cliConfig.CurrentContext != currentContext {
 		fmt.Printf("Kube context has been changed to %s", currentContext)
 		fmt.Println()
-		if !autoApplyNewContext {
+		if !autoApplyNewContext && cliConfig.CurrentContext != "" {
 			fmt.Println("Do you want to continue with this? (y/n)")
 			reader := bufio.NewReader(os.Stdin)
 			in, err := reader.ReadString('\n')

--- a/cli/pkg/credentialmanager/handler_darwin.go
+++ b/cli/pkg/credentialmanager/handler_darwin.go
@@ -9,6 +9,7 @@ import (
 type CredentialManager struct {
 }
 
+// NewCredentialManager creates a new credential manager
 func NewCredentialManager(autoApplyNewContext bool) (cm *CredentialManager) {
 	initChecks(autoApplyNewContext)
 	return &CredentialManager{}

--- a/cli/pkg/credentialmanager/handler_darwin.go
+++ b/cli/pkg/credentialmanager/handler_darwin.go
@@ -9,8 +9,8 @@ import (
 type CredentialManager struct {
 }
 
-func NewCredentialManager() (cm *CredentialManager) {
-	initChecks()
+func NewCredentialManager(autoApplyNewContext bool) (cm *CredentialManager) {
+	initChecks(autoApplyNewContext)
 	return &CredentialManager{}
 }
 

--- a/cli/pkg/credentialmanager/handler_darwin_test.go
+++ b/cli/pkg/credentialmanager/handler_darwin_test.go
@@ -13,7 +13,7 @@ func init() {
 
 func TestSetAndGetCreds(t *testing.T) {
 	MockKubeConfigCheck = true
-	cm := NewCredentialManager()
+	cm := NewCredentialManager(false)
 	if err := cm.SetCreds(testEndPoint, testAPIToken, testNamespace); err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +29,7 @@ func TestSetAndGetCreds(t *testing.T) {
 
 func TestOverwriteCreds(t *testing.T) {
 	MockKubeConfigCheck = true
-	cm := NewCredentialManager()
+	cm := NewCredentialManager(false)
 	if err := cm.SetCreds(testEndPoint, "old-secret", testNamespace); err != nil {
 		t.Fatal(err)
 	}

--- a/cli/pkg/credentialmanager/handler_linux.go
+++ b/cli/pkg/credentialmanager/handler_linux.go
@@ -31,13 +31,13 @@ type CredentialManager struct {
 	credsFile    string
 }
 
-func NewCredentialManager() (cm *CredentialManager) {
+func NewCredentialManager(autoApplyNewContext bool) (cm *CredentialManager) {
 
 	dir, err := keptnutils.GetKeptnDirectory()
 	if err != nil {
 		log.Fatal(err)
 	}
-	initChecks()
+	initChecks(autoApplyNewContext)
 	return &CredentialManager{apiTokenFile: dir + ".keptn", credsFile: dir + ".keptn-creds"}
 }
 

--- a/cli/pkg/credentialmanager/handler_linux.go
+++ b/cli/pkg/credentialmanager/handler_linux.go
@@ -31,6 +31,7 @@ type CredentialManager struct {
 	credsFile    string
 }
 
+// NewCredentialManager creates a new credential manager
 func NewCredentialManager(autoApplyNewContext bool) (cm *CredentialManager) {
 
 	dir, err := keptnutils.GetKeptnDirectory()

--- a/cli/pkg/credentialmanager/handler_linux_test.go
+++ b/cli/pkg/credentialmanager/handler_linux_test.go
@@ -15,7 +15,7 @@ func init() {
 
 func TestSetAndGetCreds(t *testing.T) {
 	MockKubeConfigCheck = true
-	cm := NewCredentialManager()
+	cm := NewCredentialManager(false)
 	if err := cm.SetCreds(testEndPoint, testAPIToken, testNamespace); err != nil {
 		t.Fatal(err)
 	}
@@ -46,7 +46,7 @@ func TestGetCredsFromFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cm := NewCredentialManager()
+	cm := NewCredentialManager(false)
 	tempFileName := strings.Split(file.Name(), "__")[0]
 	cm.apiTokenFile = tempFileName
 

--- a/cli/pkg/credentialmanager/handler_windows.go
+++ b/cli/pkg/credentialmanager/handler_windows.go
@@ -9,6 +9,7 @@ import (
 type CredentialManager struct {
 }
 
+// NewCredentialManager creates a new credential manager
 func NewCredentialManager(autoApplyNewContext bool) (cm *CredentialManager) {
 	initChecks(autoApplyNewContext)
 	return &CredentialManager{}

--- a/cli/pkg/credentialmanager/handler_windows.go
+++ b/cli/pkg/credentialmanager/handler_windows.go
@@ -9,8 +9,8 @@ import (
 type CredentialManager struct {
 }
 
-func NewCredentialManager() (cm *CredentialManager) {
-	initChecks()
+func NewCredentialManager(autoApplyNewContext bool) (cm *CredentialManager) {
+	initChecks(autoApplyNewContext)
 	return &CredentialManager{}
 }
 

--- a/cli/pkg/credentialmanager/handler_windows_test.go
+++ b/cli/pkg/credentialmanager/handler_windows_test.go
@@ -13,7 +13,7 @@ func init() {
 
 func TestSetAndGetCreds(t *testing.T) {
 	MockKubeConfigCheck = true
-	cm := NewCredentialManager()
+	cm := NewCredentialManager(false)
 	if err := cm.SetCreds(testEndPoint, testAPIToken, testNamespace); err != nil {
 		t.Fatal(err)
 	}

--- a/cli/pkg/platform/platform_manager.go
+++ b/cli/pkg/platform/platform_manager.go
@@ -67,7 +67,7 @@ func (mng PlatformManager) ParseConfig(configFile string) error {
 // ReadCreds reads the credentials for the platform
 func (mng PlatformManager) ReadCreds() error {
 
-	cm := credentialmanager.NewCredentialManager()
+	cm := credentialmanager.NewCredentialManager(false)
 	credsStr, err := cm.GetInstallCreds()
 	if err != nil {
 		credsStr = ""


### PR DESCRIPTION
Closes #2704

Also, when no context has been set in the first place, it will automatically applied and the user will be informed