### PR TITLE
#2543 Use deployedImage from service

### DIFF
--- a/bridge/client/app/_models/service.ts
+++ b/bridge/client/app/_models/service.ts
@@ -2,7 +2,13 @@ import {Root} from "./root";
 
 export class Service {
   serviceName: string;
+  deployedImage: string;
+
   roots: Root[];
+
+  getShortImageName() {
+    return this.deployedImage.split("/").pop();
+  }
 
   static fromJSON(data: any) {
     return Object.assign(new this, data);

--- a/bridge/client/app/_services/data.service.ts
+++ b/bridge/client/app/_services/data.service.ts
@@ -132,7 +132,8 @@ export class DataService {
   public loadServices(project: Project) {
     from(project.stages).pipe(
       mergeMap(
-        stage => this.apiService.getServices(project.projectName, stage.stageName)
+        // @ts-ignore
+        stage => this.apiService.getServices(project.projectName, stage.stageName, this._keptnInfo.getValue().bridgeInfo.servicesPageSize||50)
           .pipe(
             map(result => result.services),
             map(services => services.map(service => Service.fromJSON(service))),

--- a/bridge/client/app/_services/data.service.ts
+++ b/bridge/client/app/_services/data.service.ts
@@ -129,6 +129,29 @@ export class DataService {
     });
   }
 
+  public loadServices(project: Project) {
+    from(project.stages).pipe(
+      mergeMap(
+        stage => this.apiService.getServices(project.projectName, stage.stageName)
+          .pipe(
+            map(result => result.services),
+            map(services => services.map(service => Service.fromJSON(service))),
+            map(services => ({ ...stage, services}))
+          )
+      ),
+      toArray(),
+      map(stages => stages.map(stage => Stage.fromJSON(stage)))
+    ).subscribe((stages: Stage[]) => {
+      project.stages.forEach((stage: Stage) => {
+        stage.services.forEach((service: Service) => {
+          service.deployedImage = stages.find(s => s.stageName == stage.stageName).services.find(s => s.serviceName == service.serviceName).deployedImage;
+        });
+      });
+    }, (err) => {
+      this._projects.next([]);
+    });
+  }
+
   public loadRoots(project: Project, service: Service) {
     let fromTime: Date = this._rootsLastUpdated[project.projectName+":"+service.serviceName];
     this._rootsLastUpdated[project.projectName+":"+service.serviceName] = new Date();

--- a/bridge/client/app/project-board/project-board.component.html
+++ b/bridge/client/app/project-board/project-board.component.html
@@ -75,7 +75,7 @@
                   <ng-container *ngIf="openApprovals$ | async as openApprovals">
                     <dt-tag-list aria-label="services">
                       <dt-tag *ngFor="let service of stage.services" [class.out-of-sync-service]="countOpenApprovals(openApprovals, project, stage, service) > 0" [class.error]="findProblemEvent(project.getLatestProblemEvents(stage), service)">
-                        <span *ngIf="project.getLatestDeployment(service, stage) as deployment; else noDeploymentOfServiceTag" (click)="selectDeployment(deployment, project)" [textContent]="deployment.getShortImageName()"></span>
+                        <span *ngIf="service.deployedImage; else noDeploymentOfServiceTag" [textContent]="service.getShortImageName()"></span>
                         <ng-template #noDeploymentOfServiceTag>
                           <span class="no-deployment" [textContent]="service.serviceName"></span>
                         </ng-template>

--- a/bridge/client/app/project-board/project-board.component.html
+++ b/bridge/client/app/project-board/project-board.component.html
@@ -140,10 +140,7 @@
                         </ng-container>
                       </div>
                     </dt-info-group-title>
-                    <ng-container *ngIf="project.getLatestSuccessfulArtifact(service, selectedStage) as artifact; else noDeployment">
-                      <p class="m-0 mt-1"><span [textContent]="artifact.data.image"></span>:<span [textContent]="artifact.data.tag"></span></p>
-                      <p class="m-0 mb-1" *ngIf="artifact.isDeployment()"><span class="bold">Deployed at: </span><span [textContent]="artifact.time | amCalendar:getCalendarFormats()"></span></p>
-                    </ng-container>
+                    <p class="m-0 mt-1" *ngIf="service.deployedImage; else noDeployment" [textContent]="service.getShortImageName()"></p>
                   </dt-info-group>
                 </ktb-expandable-tile-header>
                 <ng-container *ngIf="findProblemEvent(problemEvents, service) as problemEvent">

--- a/bridge/client/app/project-board/project-board.component.ts
+++ b/bridge/client/app/project-board/project-board.component.ts
@@ -150,6 +150,7 @@ export class ProjectBoardComponent implements OnInit, OnDestroy {
             .pipe(takeUntil(this.unsubscribe$))
             .subscribe(project => {
               this.updateIntegrations();
+              this.dataService.loadServices(project);
               project.getServices().forEach(service => {
                 this.dataService.loadRoots(project, service);
               });


### PR DESCRIPTION
Closes #2543 

This issue was noticed on the _Services_ screen in the Bridge, but impacted also the _Environments_ screen. On the Environments page the Bridge shows all deployed services on a specific stage.
At initial page load the Bridge loads maximal 20 root events, and if those 20 root events are Problem events or Evaluation events (not Configuration change events), the Bridge looses the information about the last deployment and displayes that the service hasn't been deployed yet. But when retrieving the services from the API, the _deployedImage_ is provided as a separate attribute.

Now the Bridge is not only polling for root events, but also is polling the service details for each stage (only while in the detail view) and uses the `deployedImage` from service details to show currently deployed image in Environments screen.
The logic on the _Services_ screen has not changed, since this shows not the currently deployed image on a specific state, but generally the last processed image of that service on any stage and actually this view will change for Keptn 0.8.0