### PR TITLE
#2571 Re-add the version check into the root command

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/keptn/keptn/cli/pkg/version"
 	"os"
+	"strings"
 
 	"github.com/keptn/keptn/cli/pkg/logging"
 	homedir "github.com/mitchellh/go-homedir"
@@ -44,7 +45,11 @@ func Execute() {
 	currentLogLevel := logging.LogLevel
 	logging.LogLevel = logging.QuietLevel
 
-	runVersionCheck()
+	containsHelp := strings.Contains(strings.Join(os.Args, " "), "help")
+
+	if !containsHelp {
+		runVersionCheck()
+	}
 
 	// Set LogLevel back to previous state
 	logging.LogLevel = currentLogLevel

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -2,14 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/keptn/keptn/cli/pkg/version"
-	"os"
-	"strings"
-
 	"github.com/keptn/keptn/cli/pkg/logging"
+	"github.com/keptn/keptn/cli/pkg/version"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"os"
 )
 
 var cfgFile string
@@ -45,9 +43,14 @@ func Execute() {
 	currentLogLevel := logging.LogLevel
 	logging.LogLevel = logging.QuietLevel
 
-	containsHelp := strings.Contains(strings.Join(os.Args, " "), "help")
+	isHelp := false
+	for _, n := range os.Args {
+		if n == "--h" || n == "--help" {
+			isHelp = true
+		}
+	}
 
-	if !containsHelp {
+	if !isHelp {
 		runVersionCheck()
 	}
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -45,7 +45,7 @@ func Execute() {
 
 	isHelp := false
 	for _, n := range os.Args {
-		if n == "--h" || n == "--help" {
+		if n == "-h" || n == "--help" {
 			isHelp = true
 		}
 	}


### PR DESCRIPTION
Closes #2571 

I re-added the version check into the root command again. And also added a check if CLI and cluster versions are equal, which fixes #2590 

Signed-off-by: ermin.muratovic <ermin.muratovic@gmail.com>