### PR TITLE
Load bridgeInfo first and then projects

### DIFF
--- a/bridge/client/app/_services/data.service.ts
+++ b/bridge/client/app/_services/data.service.ts
@@ -1,7 +1,7 @@
 import {Injectable} from '@angular/core';
 import {HttpClient} from "@angular/common/http";
 import {BehaviorSubject, forkJoin, from, Observable, Subject, timer, of} from "rxjs";
-import {debounce, map, mergeMap, take, takeUntil, toArray} from "rxjs/operators";
+import {debounce, filter, map, mergeMap, take, toArray} from "rxjs/operators";
 
 import {Root} from "../_models/root";
 import {Trace} from "../_models/trace";
@@ -30,6 +30,7 @@ export class DataService {
   constructor(private http: HttpClient, private apiService: ApiService) {
     this.loadKeptnInfo();
     this.keptnInfo
+      .pipe(filter(keptnInfo => !!keptnInfo))
       .pipe(take(1))
       .subscribe(keptnInfo => {
         this.loadProjects();


### PR DESCRIPTION
When merging the feature https://github.com/keptn/keptn/commit/7dea4c95dc4abc4feb4f8de7db12f862ede1436d#diff-b63bb8da34d1fc6e6a5e1114fe4faa39aed2ddf2ff0369cffe5595cae4d1f68b to master, some lines where dropped. The Bridge should load the bridgeInfo first and then projects.

Signed-off-by: ermin.muratovic <ermin.muratovic@gmail.com>