### PR TITLE
#2771 Execute self healing and delivery assistant use case in k3s and microkube

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -493,7 +493,8 @@ jobs:
   # Run K3s Standalone on every push on master/release branch
   - &K3sStandaloneTest
     stage: Test K3s Standalone (--platform=kubernetes, --namespace=keptn-test)
-    if: (branch = master or branch =~ ^release.*$) AND (type = cron OR type = push) # run for any change on master/release-* on push as well as cron
+    # TODO: remove filter
+    if: branch = feature/2771/integration-tests #(branch = master or branch =~ ^release.*$) AND (type = cron OR type = push) # run for any change on master/release-* on push as well as cron
     os: linux
     env:
       - K3S_VERSION=v1.16.10+k3s1 # see https://github.com/rancher/k3s/releases
@@ -506,11 +507,14 @@ jobs:
     script:
       - kubectl get nodes || travis_terminate 1
       - export KEPTN_NAMESPACE=keptn-test
+      - export KEPTN_SERVICE_TYPE=NodePort
       - test/test_install_kubernetes_quality_gates.sh
       - keptn status
       - export PROJECT=musicshop
       - export DYNATRACE_SLI_SERVICE_VERSION=master
       - test/test_quality_gates_standalone.sh
+      - test/test_self_healing.sh
+      - test/test_delivery_assistant.sh
     after_success:
       # delete Google Kubernetes cluster only on success (keep cluster in case of an error to dig into the cluster)
       - echo "Tests were successful, cleaning up the cluster now..."

--- a/.travis.yml
+++ b/.travis.yml
@@ -512,9 +512,9 @@ jobs:
       - keptn status
       - export PROJECT=musicshop
       - export DYNATRACE_SLI_SERVICE_VERSION=master
-      - test/test_quality_gates_standalone.sh
+      # - test/test_quality_gates_standalone.sh
       - test/test_self_healing.sh
-      - test/test_delivery_assistant.sh
+      # - test/test_delivery_assistant.sh
     after_success:
       # delete Google Kubernetes cluster only on success (keep cluster in case of an error to dig into the cluster)
       - echo "Tests were successful, cleaning up the cluster now..."

--- a/.travis.yml
+++ b/.travis.yml
@@ -512,9 +512,9 @@ jobs:
       - keptn status
       - export PROJECT=musicshop
       - export DYNATRACE_SLI_SERVICE_VERSION=master
-      # - test/test_quality_gates_standalone.sh
+      - test/test_quality_gates_standalone.sh
       - test/test_self_healing.sh
-      # - test/test_delivery_assistant.sh
+      - test/test_delivery_assistant.sh
     after_success:
       # delete Google Kubernetes cluster only on success (keep cluster in case of an error to dig into the cluster)
       - echo "Tests were successful, cleaning up the cluster now..."

--- a/.travis.yml
+++ b/.travis.yml
@@ -493,8 +493,7 @@ jobs:
   # Run K3s Standalone on every push on master/release branch
   - &K3sStandaloneTest
     stage: Test K3s Standalone (--platform=kubernetes, --namespace=keptn-test)
-    # TODO: remove filter
-    if: branch = feature/2771/integration-tests #(branch = master or branch =~ ^release.*$) AND (type = cron OR type = push) # run for any change on master/release-* on push as well as cron
+    if: (branch = master or branch =~ ^release.*$) AND (type = cron OR type = push) # run for any change on master/release-* on push as well as cron
     os: linux
     env:
       - K3S_VERSION=v1.16.10+k3s1 # see https://github.com/rancher/k3s/releases
@@ -508,7 +507,7 @@ jobs:
       - kubectl get nodes || travis_terminate 1
       - export KEPTN_NAMESPACE=keptn-test
       - export KEPTN_SERVICE_TYPE=NodePort
-      - test/test_install_kubernetes_quality_gates.sh
+      - test/test_install_on_kubernetes.sh
       - keptn status
       - export PROJECT=musicshop
       - export DYNATRACE_SLI_SERVICE_VERSION=master
@@ -546,11 +545,13 @@ jobs:
       - export KUBECONFIG=~/kubeconfig
     script:
       - kubectl get nodes || travis_terminate 1 # sanity check that the K8s cluster is available
-      - test/test_install_kubernetes_quality_gates.sh
+      - test/test_install_on_kubernetes.sh
       - keptn status
       - export PROJECT=musicshop
       - export DYNATRACE_SLI_SERVICE_VERSION=master
       - test/test_quality_gates_standalone.sh
+      - test/test_self_healing.sh
+      - test/test_delivery_assistant.sh
     after_success:
       # delete Google Kubernetes cluster only on success (keep cluster in case of an error to dig into the cluster)
       - echo "Tests were successful, cleaning up the cluster now..."

--- a/docs/integration_tests.md
+++ b/docs/integration_tests.md
@@ -10,7 +10,7 @@ Several tests are specified in [.travis.yml](../.travis.yml). They usually follo
     script:
       - kubectl get nodes || travis_terminate 1
       # finally install keptn quality gates
-      - test/test_install_kubernetes_quality_gates.sh
+      - test/test_install_on_kubernetes.sh
       - keptn status
       - export PROJECT=musicshop
       - test/test_quality_gates_standalone.sh

--- a/test/test_delivery_assistant.sh
+++ b/test/test_delivery_assistant.sh
@@ -8,9 +8,17 @@ function cleanup() {
 trap cleanup EXIT
 
 # get keptn API details
-KEPTN_ENDPOINT=http://$(kubectl -n keptn get service api-gateway-nginx -o jsonpath='{.status.loadBalancer.ingress[0].ip}')/api
-KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token} | base64 --decode)
-
+if [[ "$PLATFORM" == "openshift" ]]; then
+  KEPTN_ENDPOINT=http://api.${KEPTN_NAMESPACE}.127.0.0.1.nip.io/api
+else
+  if [[ "$KEPTN_SERVICE_TYPE" == "NodePort" ]]; then
+    API_PORT=$(kubectl get svc api-gateway-nginx -n ${KEPTN_NAMESPACE} -o jsonpath='{.spec.ports[?(@.name=="http")].nodePort}')
+    INTERNAL_NODE_IP=$(kubectl get nodes -o jsonpath='{ $.items[0].status.addresses[?(@.type=="InternalIP")].address }')
+    KEPTN_ENDPOINT="http://${INTERNAL_NODE_IP}:${API_PORT}"/api
+  else
+    KEPTN_ENDPOINT=http://$(kubectl -n ${KEPTN_NAMESPACE} get service api-gateway-nginx -o jsonpath='{.status.loadBalancer.ingress[0].ip}')/api
+  fi
+fi
 # test configuration
 PROJECT="delivery-assistant-project"
 SERVICE="carts"

--- a/test/test_delivery_assistant.sh
+++ b/test/test_delivery_assistant.sh
@@ -19,6 +19,7 @@ else
     KEPTN_ENDPOINT=http://$(kubectl -n ${KEPTN_NAMESPACE} get service api-gateway-nginx -o jsonpath='{.status.loadBalancer.ingress[0].ip}')/api
   fi
 fi
+KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n ${KEPTN_NAMESPACE} -ojsonpath={.data.keptn-api-token} | base64 --decode)
 # test configuration
 PROJECT="delivery-assistant-project"
 SERVICE="carts"

--- a/test/test_install_kubernetes_quality_gates.sh
+++ b/test/test_install_kubernetes_quality_gates.sh
@@ -9,7 +9,7 @@ echo "Installing keptn on cluster"
 echo "{}" > creds.json # empty credentials file
 
 # install Keptn using the develop version, which refers to the :latest docker images
-keptn install --namespace=${KEPTN_NAMESPACE} --chart-repo="${KEPTN_INSTALLER_REPO}" --platform=kubernetes --creds=creds.json --endpoint-service-type=NodePort --verbose --hide-sensitive-data
+keptn install --namespace=${KEPTN_NAMESPACE} --chart-repo="${KEPTN_INSTALLER_REPO}" --platform=kubernetes --creds=creds.json --endpoint-service-type=NodePort --use-case=continuous-delivery --verbose --hide-sensitive-data
 verify_test_step $? "keptn install --chart-repo=${KEPTN_INSTALLER_REPO} - failed"
 
 echo "Verifying that services and namespaces have been created"

--- a/test/test_install_on_kubernetes.sh
+++ b/test/test_install_on_kubernetes.sh
@@ -20,6 +20,9 @@ verify_deployment_in_namespace "api-service" ${KEPTN_NAMESPACE}
 verify_deployment_in_namespace "bridge" ${KEPTN_NAMESPACE}
 verify_deployment_in_namespace "configuration-service" ${KEPTN_NAMESPACE}
 verify_deployment_in_namespace "lighthouse-service" ${KEPTN_NAMESPACE}
+verify_deployment_in_namespace "shipyard-controller" ${KEPTN_NAMESPACE}
+verify_deployment_in_namespace "gatekeeper-service" ${KEPTN_NAMESPACE}
+verify_deployment_in_namespace "remediation-service" ${KEPTN_NAMESPACE}
 
 # verify the datastore deployments
 verify_deployment_in_namespace "mongodb" ${KEPTN_NAMESPACE}

--- a/test/test_self_healing.sh
+++ b/test/test_self_healing.sh
@@ -193,7 +193,7 @@ sleep 10
 
 kubectl -n ${KEPTN_NAMESPACE} set image deployment/unleash-service unleash-service=keptncontrib/unleash-service:0.0.0-master
 
-wait_for_deployment_in_namespace "unleash-service" "keptn"
+wait_for_deployment_in_namespace "unleash-service" "${KEPTN_NAMESPACE}"
 
 echo "Sending problem.open event"
 keptn_context_id=$(send_event_json ./test/assets/self_healing_problem_open_event.json)

--- a/test/test_self_healing.sh
+++ b/test/test_self_healing.sh
@@ -190,9 +190,10 @@ fi
 # install unleash service
 echo "Installing unleash-service version ${UNLEASH_SERVICE_VERSION}"
 kubectl apply -f https://raw.githubusercontent.com/keptn-contrib/unleash-service/${UNLEASH_SERVICE_VERSION}/deploy/service.yaml -n ${KEPTN_NAMESPACE}
-sleep 10
 
 kubectl -n ${KEPTN_NAMESPACE} set image deployment/unleash-service unleash-service=keptncontrib/unleash-service:0.0.0-master
+
+sleep 10
 
 wait_for_deployment_in_namespace "unleash-service" "${KEPTN_NAMESPACE}"
 
@@ -241,6 +242,9 @@ fi
 #verify_using_jq "$response" ".data.remediation.message" "Action run-snow-wf triggered but not executed after waiting for 2 minutes."
 
 response=$(curl -X GET "${KEPTN_ENDPOINT}/mongodb-datastore/event?project=${PROJECT}&type=sh.keptn.event.action.finished&keptnContext=${keptn_context_id}" -H  "accept: application/json" -H  "x-token: ${KEPTN_API_TOKEN}" -k 2>/dev/null | jq -r '.events[0]')
+
+echo "Remediation Service logs:"
+kubectl logs -n ${KEPTN_NAMESPACE} svc/remediation-service -c remediation-service
 
 echo "Unleash service logs:"
 kubectl logs -n ${KEPTN_NAMESPACE} svc/unleash-service -c unleash-service

--- a/test/test_self_healing.sh
+++ b/test/test_self_healing.sh
@@ -188,12 +188,15 @@ fi
 ##########################################################################################################################################
 
 # install unleash service
+echo "Installing unleash-service version ${UNLEASH_SERVICE_VERSION}"
 kubectl apply -f https://raw.githubusercontent.com/keptn-contrib/unleash-service/${UNLEASH_SERVICE_VERSION}/deploy/service.yaml -n ${KEPTN_NAMESPACE}
 sleep 10
 
 kubectl -n ${KEPTN_NAMESPACE} set image deployment/unleash-service unleash-service=keptncontrib/unleash-service:0.0.0-master
 
 wait_for_deployment_in_namespace "unleash-service" "${KEPTN_NAMESPACE}"
+
+kubectl get deployment -n ${KEPTN_NAMESPACE} unleash-service -oyaml
 
 echo "Sending problem.open event"
 keptn_context_id=$(send_event_json ./test/assets/self_healing_problem_open_event.json)
@@ -238,6 +241,8 @@ fi
 #verify_using_jq "$response" ".data.remediation.message" "Action run-snow-wf triggered but not executed after waiting for 2 minutes."
 
 response=$(curl -X GET "${KEPTN_ENDPOINT}/mongodb-datastore/event?project=${PROJECT}&type=sh.keptn.event.action.finished&keptnContext=${keptn_context_id}" -H  "accept: application/json" -H  "x-token: ${KEPTN_API_TOKEN}" -k 2>/dev/null | jq -r '.events[0]')
+
+kubectl logs -n ${KEPTN_NAMESPACE} svc/unleash-service
 
 # print the response
 echo $response | jq .

--- a/test/test_self_healing.sh
+++ b/test/test_self_healing.sh
@@ -242,7 +242,11 @@ fi
 
 response=$(curl -X GET "${KEPTN_ENDPOINT}/mongodb-datastore/event?project=${PROJECT}&type=sh.keptn.event.action.finished&keptnContext=${keptn_context_id}" -H  "accept: application/json" -H  "x-token: ${KEPTN_API_TOKEN}" -k 2>/dev/null | jq -r '.events[0]')
 
-kubectl logs -n ${KEPTN_NAMESPACE} svc/unleash-service
+echo "Unleash service logs:"
+kubectl logs -n ${KEPTN_NAMESPACE} svc/unleash-service -c unleash-service
+
+echo "Unleash service distributor logs:"
+kubectl logs -n ${KEPTN_NAMESPACE} svc/unleash-service -c distributor
 
 # print the response
 echo $response | jq .

--- a/test/test_self_healing.sh
+++ b/test/test_self_healing.sh
@@ -2,9 +2,20 @@
 
 source test/utils.sh
 
-# get keptn api details
-KEPTN_ENDPOINT=http://$(kubectl -n keptn get service api-gateway-nginx -o jsonpath='{.status.loadBalancer.ingress[0].ip}')/api
-KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n keptn -ojsonpath={.data.keptn-api-token} | base64 --decode)
+# get keptn API details
+if [[ "$PLATFORM" == "openshift" ]]; then
+  KEPTN_ENDPOINT=http://api.${KEPTN_NAMESPACE}.127.0.0.1.nip.io/api
+else
+  if [[ "$KEPTN_SERVICE_TYPE" == "NodePort" ]]; then
+    API_PORT=$(kubectl get svc api-gateway-nginx -n ${KEPTN_NAMESPACE} -o jsonpath='{.spec.ports[?(@.name=="http")].nodePort}')
+    INTERNAL_NODE_IP=$(kubectl get nodes -o jsonpath='{ $.items[0].status.addresses[?(@.type=="InternalIP")].address }')
+    KEPTN_ENDPOINT="http://${INTERNAL_NODE_IP}:${API_PORT}"/api
+  else
+    KEPTN_ENDPOINT=http://$(kubectl -n ${KEPTN_NAMESPACE} get service api-gateway-nginx -o jsonpath='{.status.loadBalancer.ingress[0].ip}')/api
+  fi
+fi
+
+KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n ${KEPTN_NAMESPACE} -ojsonpath={.data.keptn-api-token} | base64 --decode)
 
 # test configuration
 UNLEASH_SERVICE_VERSION=${UNLEASH_SERVICE_VERSION:-master}
@@ -16,11 +27,11 @@ SERVICE="frontend"
 ########################################################################################################################
 
 # ensure unleash-service is not installed yet
-kubectl -n keptn get deployment unleash-service 2> /dev/null
+kubectl -n ${KEPTN_NAMESPACE} get deployment unleash-service 2> /dev/null
 
 if [[ $? -eq 0 ]]; then
   echo "Found unleash-service. Please uninstall it using:"
-  echo "kubectl -n keptn delete deployment unleash-service"
+  echo "kubectl -n ${KEPTN_NAMESPACE} delete deployment unleash-service"
   exit 1
 fi
 
@@ -177,10 +188,10 @@ fi
 ##########################################################################################################################################
 
 # install unleash service
-kubectl apply -f https://raw.githubusercontent.com/keptn-contrib/unleash-service/${UNLEASH_SERVICE_VERSION}/deploy/service.yaml -n keptn
+kubectl apply -f https://raw.githubusercontent.com/keptn-contrib/unleash-service/${UNLEASH_SERVICE_VERSION}/deploy/service.yaml -n ${KEPTN_NAMESPACE}
 sleep 10
 
-kubectl -n keptn set image deployment/unleash-service unleash-service=keptncontrib/unleash-service:0.0.0-master
+kubectl -n ${KEPTN_NAMESPACE} set image deployment/unleash-service unleash-service=keptncontrib/unleash-service:0.0.0-master
 
 wait_for_deployment_in_namespace "unleash-service" "keptn"
 

--- a/test/utils.sh
+++ b/test/utils.sh
@@ -256,7 +256,7 @@ function wait_for_deployment_in_namespace() {
       READY_REPLICAS=$(eval kubectl get deployments $DEPLOYMENT -n $NAMESPACE -o=jsonpath='{$.status.availableReplicas}')
       WANTED_REPLICAS=$(eval kubectl get deployments $DEPLOYMENT  -n $NAMESPACE -o=jsonpath='{$.spec.replicas}')
       UNAVAILABLE_REPLICAS=$(eval kubectl get deployments $DEPLOYMENT  -n $NAMESPACE -o=jsonpath='{$.status.unavailableReplicas}')
-      if [[ "$READY_REPLICAS" = "$WANTED_REPLICAS" && "$UNAVAILABLE_REPLICAS" = "0" ]]; then
+      if [[ "$READY_REPLICAS" = "$WANTED_REPLICAS" && "$UNAVAILABLE_REPLICAS" = "" ]]; then
         echo "Found deployment ${DEPLOYMENT} in namespace ${NAMESPACE}: ${DEPLOYMENT_LIST}"
         break
       else

--- a/test/utils.sh
+++ b/test/utils.sh
@@ -255,7 +255,8 @@ function wait_for_deployment_in_namespace() {
     else
       READY_REPLICAS=$(eval kubectl get deployments $DEPLOYMENT -n $NAMESPACE -o=jsonpath='{$.status.availableReplicas}')
       WANTED_REPLICAS=$(eval kubectl get deployments $DEPLOYMENT  -n $NAMESPACE -o=jsonpath='{$.spec.replicas}')
-      if [[ "$READY_REPLICAS" = "$WANTED_REPLICAS" ]]; then
+      UNAVAILABLE_REPLICAS=$(eval kubectl get deployments $DEPLOYMENT  -n $NAMESPACE -o=jsonpath='{$.status.unavailableReplicas}')
+      if [[ "$READY_REPLICAS" = "$WANTED_REPLICAS" && "$UNAVAILABLE_REPLICAS" = "0" ]]; then
         echo "Found deployment ${DEPLOYMENT} in namespace ${NAMESPACE}: ${DEPLOYMENT_LIST}"
         break
       else


### PR DESCRIPTION
Closes #2771

This PR adds the integration tests for the self healing use case, as well as for the delivery assistant to the tests executed in K3s/Minikube. 
Open questions: Those two tests do add 5min to the execution time. Do we want to execute those additional tests both on Microk8s and K3s, or should we add those tests to only one platform, i.e. K3s?

Further changes: To be able to test the delivery assistant, I added the `--use-case=continuous delivery` flag to the installation command and renamed the containing script accordingly.