### PR TITLE
#2710 Detect stale release images and pull them

### DIFF
--- a/.github/workflows/detect_stale_images.yml
+++ b/.github/workflows/detect_stale_images.yml
@@ -1,0 +1,18 @@
+name: Detect Stale Images
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '0 0 * * 0'
+jobs:
+  cleanup:
+    name: Detect Stale Images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code.
+        uses: actions/checkout@v2
+      - name: Detect stale images on DockerHub
+        env:
+          REGISTRY_USER: ${{ secrets.REGISTRY_USER }}
+          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+        run: |
+          apt-get update && apt-get install jq -y && ./gh-actions-scripts/detect_stale_images.sh

--- a/gh-actions-scripts/detect_stale_images.sh
+++ b/gh-actions-scripts/detect_stale_images.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+##################################################################
+# This script deletes outdated images from DockerHub             #
+# Required secrets/params:                                       #
+# - REGISTRY_USER                                                #
+# - REGISTRY_PASSWORD                                            #
+##################################################################
+
+##################################################################
+# Configuration                                                  #
+##################################################################
+
+# list all images that should be checked
+DOCKER_ORG="keptn"
+MAX_AGE_DAYS=30
+IMAGES=("api" "bridge2" "configuration-service" "openshift-route-service" "distributor" "gatekeeper-service" "helm-service" "jmeter-service" "lighthouse-service" "mongodb-datastore" "remediation-service" "shipyard-controller" "shipyard-service")
+# Todo: The list of images should be somehow configured in the repo
+
+# additional old images that we want to keep
+ADDITIONAL_OLD_IMAGES=("installer" "bridge" "upgrader")
+
+# merge IMAGES and ADDITIONAL_OLD_IMAGES
+IMAGES=("${IMAGES[@]}" "${ADDITIONAL_OLD_IMAGES[@]}")
+
+
+# Authenticate against DockerHub API
+DOCKER_API_TOKEN=$(curl -s -H "Content-Type: application/json" -X POST -d '{"username": "'${REGISTRY_USER}'", "password": "'${REGISTRY_PASSWORD}'"}' https://hub.docker.com/v2/users/login/ | jq -r .token)
+
+
+# get all github release tags
+function get_releases() {
+  REPO=$1
+  curl --silent https://api.github.com/repos/$1/releases | jq -r '.[].tag_name'
+}
+
+# check if a repo + tag is stale
+function check_if_stale() {
+  REPO=$1
+  TAGS=$2
+
+  # Target-Date = Current Date Minus $MAX_AGE_DAYS
+  TARGET_DATE=$(date -d "-${MAX_AGE_DAYS} days" +%s)
+
+  # for each tag, check if the tag is stale
+  for TAG in ${RELEASE_TAGS[@]}; do
+    HTTP_RESPONSE=$(curl -s -H "Authorization: JWT ${DOCKER_API_TOKEN}" --write-out "HTTPSTATUS:%{http_code}" "https://hub.docker.com/v2/repositories/${DOCKER_ORG}/${REPO}/tags/${TAG}/")
+
+    # extract body and status
+    HTTP_BODY=$(echo "$HTTP_RESPONSE" | sed -E 's/HTTPSTATUS\:[0-9]{3}$//')
+    HTTP_STATUS=$(echo "$HTTP_RESPONSE" | tr -d '\n' | sed -E 's/.*HTTPSTATUS:([0-9]{3})$/\1/')
+
+    if [ "$HTTP_STATUS" == "200" ]; then
+      # extract TAG_LAST_PULLED
+      TAG_LAST_PULLED=$(echo $HTTP_BODY | jq -r '.tag_last_pulled')
+      # and check if it is null (e.g., not tracked yet)
+      if [ "$TAG_LAST_PULLED" == "null" ]; then
+        echo "$TAG"
+      else
+        # if it's != null, we need to compare it to TARGET_DATE
+        echo "$HTTP_BODY" | jq -r --argjson date "$TARGET_DATE" 'select (.tag_last_pulled | sub(".[0-9]+Z$"; "Z") | fromdate < $date)|.name'
+      fi
+    fi
+  done
+}
+
+# query all releases from current repo
+RELEASE_TAGS=$(get_releases "keptn/keptn")
+
+
+for IMAGE in "${IMAGES[@]}"; do
+  echo "Detecting stale images for ${DOCKER_ORG}/${IMAGE} for all release tags"
+  STALE_TAGS=$(check_if_stale "${IMAGE}" "${RELEASE_TAGS}")
+
+  # pull each stale tag
+  if [[ -n "$STALE_TAGS" ]]; then
+    for TAG in ${STALE_TAGS[@]}; do
+      echo "Pulling ${DOCKER_ORG}/${IMAGE}:${TAG} to ensure images are not stale..."
+      docker pull "${DOCKER_ORG}/${IMAGE}:${TAG}"
+    done
+  else
+    echo "All images are fine."
+  fi
+done


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

This PR introduces a new action that checks for stale images based on Github release tags.

FYI, I've executed the script locally and for now all release images should be "not stale".