### PR TITLE
#2715 Remove osx build stage to save credits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -235,7 +235,7 @@ jobs:
 
   - stage: Build CLI (OSX, Windows, Linux)
     if: branch = master AND (type = cron OR type = push)
-    os: osx
+    os: linux # osx
     before_script:
       - source ./travis-scripts/install_gcloud.sh
       - echo ${GCLOUD_SERVICE_KEY} | base64 --decode > ~/gcloud-service-key.json
@@ -266,7 +266,7 @@ jobs:
   ##################################################################################
   - stage: Partial Build for feature/bug/hotfix/patch branches (CLI + Docker Images)
     if: branch =~ ^feature.*$ OR branch =~ ^bug.*$ OR branch =~ ^hotfix.*$ OR branch =~ ^patch.*$
-    os: osx
+    os: linux
     before_script:
       - source ./travis-scripts/install_gcloud.sh
       - echo ${GCLOUD_SERVICE_KEY} | base64 --decode > ~/gcloud-service-key.json
@@ -367,7 +367,7 @@ jobs:
   ##################################################################################
   - stage: Release Build CLI
     if: branch =~ ^release.*$ AND NOT type = pull_request
-    os: osx
+    os: linux # osx
     before_script:
       - source ./travis-scripts/install_gcloud.sh
       - echo ${GCLOUD_SERVICE_KEY} | base64 --decode > ~/gcloud-service-key.json

--- a/travis-scripts/build_cli.sh
+++ b/travis-scripts/build_cli.sh
@@ -6,28 +6,28 @@ KUBE_CONSTRAINTS=$2
 ############################################
 # MAC OS
 ############################################
-echo "Building Keptn CLI for OSX"
-env GOOS=darwin GOARCH=amd64 go mod download
-env GOOS=darwin GOARCH=amd64 go build -v -x  -ldflags="-X 'main.Version=$VERSION' -X 'main.KubeServerVersionConstraints=$KUBE_CONSTRAINTS'" -o keptn
-
-if [ $? -ne 0 ]; then
-  echo "Error compiling Keptn CLI, exiting ..."
-  exit 1
-fi
-
-# create archives
-zip keptn-macOS.zip keptn
-tar -zcvf keptn-macOS.tar.gz keptn
-rm keptn
-
-# upload to gcloud
-if [ -n "$TAG" ]; then
-  gsutil cp keptn-macOS.zip gs://keptn-cli/${TAG}/keptn-macOS.zip
-  gsutil cp keptn-macOS.tar.gz gs://keptn-cli/${TAG}/keptn-macOS.tar.gz
-fi
-
-rm keptn-macOS.zip
-rm keptn-macOS.tar.gz
+#echo "Building Keptn CLI for OSX"
+#env GOOS=darwin GOARCH=amd64 go mod download
+#env GOOS=darwin GOARCH=amd64 go build -v -x  -ldflags="-X 'main.Version=$VERSION' -X 'main.KubeServerVersionConstraints=$KUBE_CONSTRAINTS'" -o keptn
+#
+#if [ $? -ne 0 ]; then
+#  echo "Error compiling Keptn CLI, exiting ..."
+#  exit 1
+#fi
+#
+## create archives
+#zip keptn-macOS.zip keptn
+#tar -zcvf keptn-macOS.tar.gz keptn
+#rm keptn
+#
+## upload to gcloud
+#if [ -n "$TAG" ]; then
+#  gsutil cp keptn-macOS.zip gs://keptn-cli/${TAG}/keptn-macOS.zip
+#  gsutil cp keptn-macOS.tar.gz gs://keptn-cli/${TAG}/keptn-macOS.tar.gz
+#fi
+#
+#rm keptn-macOS.zip
+#rm keptn-macOS.tar.gz
 
 ############################################
 # Linux


### PR DESCRIPTION
We are still consuming too many credits on travis. This PR removes the OSX builds for now.