### PR TITLE
#2751 Core services: send .finished events when errors occur

### DIFF
--- a/lighthouse-service/event_handler/evaluate_sli_handler.go
+++ b/lighthouse-service/event_handler/evaluate_sli_handler.go
@@ -60,19 +60,20 @@ func (eh *EvaluateSLIHandler) HandleEvent() error {
 	})
 	if err2 != nil {
 		msg := fmt.Sprintf("Could not retrieve evaluation.triggered event for context %s %v", eh.KeptnHandler.KeptnContext, err2)
-		eh.KeptnHandler.Logger.Error(fmt.Sprintf("Could not retrieve evaluation.triggered event for context %s %v", eh.KeptnHandler.KeptnContext, err2))
-		return errors.New(msg)
+		eh.KeptnHandler.Logger.Error(msg)
+		return sendErroredFinishedEventWithMessage(shkeptncontext, "", msg, "", eh.KeptnHandler, e)
 	}
 	if triggeredEvents == nil || len(triggeredEvents) == 0 {
 		msg := "Could not retrieve evaluation.triggered event for context " + eh.KeptnHandler.KeptnContext
 		eh.KeptnHandler.Logger.Error(msg)
-		return errors.New(msg)
+		return sendErroredFinishedEventWithMessage(shkeptncontext, "", msg, "", eh.KeptnHandler, e)
 	}
 	triggeredID := triggeredEvents[0].ID
 
 	if err != nil {
-		eh.KeptnHandler.Logger.Error("Could not parse event payload: " + err.Error())
-		return err
+		msg := "Could not parse event payload: " + err.Error()
+		eh.KeptnHandler.Logger.Error(msg)
+		return sendErroredFinishedEventWithMessage(shkeptncontext, "", msg, "", eh.KeptnHandler, e)
 	}
 
 	eh.KeptnHandler.Logger.Debug("Start to evaluate SLIs")


### PR DESCRIPTION
Closes #2751 
The desired behavior was already mostly implemented by the services. There were some places additional where I have added the functionality to send .finished events to get a better overview in the event trace