### PR TITLE
#2719 Create GH Action for building the CLI

### DIFF
--- a/.github/workflows/cli-pipeline.yml
+++ b/.github/workflows/cli-pipeline.yml
@@ -1,0 +1,129 @@
+name: Keptn CLI Pipeline
+on:
+  # always execute CLI Pipeline when something is pushed to master or release-* branches
+  push:
+    branches:
+      - 'master'
+      - 'release-*'
+  # in addition, execute for pull requests to those branches if anything was changed in the CLI folder
+  pull_request:
+    branches:
+      - 'master'
+      - 'release-*'
+    paths:
+      - 'cli/**' # only execute if there are changes to the cli folder
+defaults:
+  run:
+    shell: bash
+jobs:
+  build-cli:
+    env:
+      VERSION: "dev"
+      KUBE_CONSTRAINTS: ">= 1.14, <= 1.19" # don't forget to udpate the defaults in cli/main.go
+    strategy:
+      matrix:
+        go-version: [ 1.13.x ]
+        platform: [ ubuntu-20.04, macOS-11.0, windows-2019 ]
+    name: Build Keptn CLI
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Test cli
+        run: echo "skipping tests for now" # ToDo: Enable tests: go test -race -v ./...
+        working-directory: ./cli
+      - name: Build cli
+        env:
+          PLATFORM: "${{ matrix.platform }}"
+          GOARCH: "amd64"
+        working-directory: ./cli
+        run: |
+          FILE_ENDING=""
+          CPU_ARCHITECTURE=amd64
+
+          if [[ "$OSTYPE" == "linux-gnu" ]]; then
+            DISTR="linux"
+          elif [[ "$OSTYPE" == "darwin"* ]]; then
+            DISTR="darwin"
+          elif [[ "$PLATFORM" == "windows-2019" ]]; then
+            DISTR="windows"
+            FILE_ENDING=".exe"
+          else
+            echo "Unknown Operating System; PlATFORM=${PLATFORM},OSTYPE=${OSTYPE}"
+            exit 1
+          fi
+
+          # determine version
+          GIT_LAST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1) || echo "0.0.0")
+          BRANCH=${GITHUB_REF##*/}
+          BRANCH_SLUG=$(echo $BRANCH | iconv -t ascii//TRANSLIT | sed -r s/[^a-zA-Z0-9]+/-/g | sed -r s/^-+\|-+$//g | tr A-Z a-z)
+
+          if [[ "$BRANCH" == "release-"* ]]; then
+            # Release Branch: extract version from branch name
+            VERSION=${BRANCH#"release-"}
+          else
+            if [[ "$BRANCH" == "master" ]]; then
+              # master branch = latest
+              VERSION=latest
+            else
+              # Feature/Development Branch - use last tag with branch slug
+              VERSION="${GIT_LAST_TAG}-${BRANCH_SLUG}"
+            fi
+          fi
+
+          # determine output file name based on version, distribution, architecture
+          OUTPUT_FILENAME="keptn-${VERSION}-${DISTR}-${GOARCH}${FILE_ENDING}"
+
+          mkdir dist
+
+          go build -v -x -ldflags="-X 'main.Version=$VERSION' -X 'main.KubeServerVersionConstraints=$KUBE_CONSTRAINTS'" -o "${OUTPUT_FILENAME}"
+          tar -zcvf dist/${OUTPUT_FILENAME}.tar.gz ${OUTPUT_FILENAME}
+      - name: Upload Keptn CLI as an artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: keptn-cli
+          path: cli/dist/
+
+
+  upload-cli:
+    # Attach Keptn CLI to a release draft
+    name: Upload Keptn CLI to Release
+    needs: "build-cli"
+    # only run this for release-* and master branch
+    if: contains('refs/heads/release-', github.head_ref) || github.head_ref == 'refs/heads/master'
+    runs-on: "ubuntu-20.04"
+    steps:
+      - name: Extract branch name
+        id: extract_branch
+        shell: bash
+        run: echo "##[set-output name=BRANCH;]$(echo ${GITHUB_REF#refs/heads/})"
+      - name: Get the version of the release based on branch name
+        id: get_version
+        env:
+          BRANCH: ${{ steps.extract_branch.outputs.BRANCH }}
+        # For BRANCH=release-*, output the version number; else, output the branch name
+        run: |
+          if [[ "$BRANCH" == "release-"* ]]; then
+            echo "##[set-output name=VERSION;]$(echo ${BRANCH#"release-"})"
+          else
+            if [[ "$BRANCH" == "master" ]]; then
+              echo "##[set-output name=VERSION;]$(echo latest)"
+            else
+              echo "##[set-output name=VERSION;]$(echo ${BRANCH})"
+            fi
+          fi
+      - name: Debug step
+        env:
+          BRANCH: ${{ steps.extract_branch.outputs.BRANCH }}
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
+        run: echo "::debug::Version=${VERSION}, Branch=${BRANCH}"
+      - name: Download Keptn CLI Artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: keptn-cli
+          path: cli/dist/
+      # ToDo: Create Draft Release and upload Release Assets

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,7 +1,15 @@
 name: Unit Tests
 on:
+  # always execute unit tests when something is pushed to master or release-* branches
+  push:
+    branches:
+      - 'master'
+      - 'release-*'
+  # in addition, execute for pull requests to those branches
   pull_request:
-    branches: [ master ]
+    branches:
+      - 'master'
+      - 'release-*'
 jobs:
   unit-tests-go:
     name: Unit-Tests-Go

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ before_install:
 - VERSION="unknownversion"
 - DATE="$(date +'%Y%m%d.%H%M')"
 - GIT_SHA="$(git rev-parse --short HEAD)"
-- KUBE_CONSTRAINTS=">= 1.14, <= 1.19" # don't forget to udpate the defaults in cli/main.go
 
 # store all changed files from this commit in files.txt (note: Travis commit range might fail)
 - git diff --name-only $TRAVIS_COMMIT_RANGE > files.txt || echo ""
@@ -54,7 +53,6 @@ before_install:
 - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, BRANCH=$BRANCH"
 
 # configure folders and image names
-- CLI_FOLDER="cli/"
 - API_IMAGE="keptn/api"
 - API_FOLDER="api/"
 - OS_ROUTE_SVC_IMAGE="keptn/openshift-route-service"
@@ -233,22 +231,6 @@ jobs:
       - echo "The following images have been built and pushed to dockerhub:"
       - docker images | grep keptn
 
-  - stage: Build CLI (OSX, Windows, Linux)
-    if: branch = master AND (type = cron OR type = push)
-    os: linux # osx
-    before_script:
-      - source ./travis-scripts/install_gcloud.sh
-      - echo ${GCLOUD_SERVICE_KEY} | base64 --decode > ~/gcloud-service-key.json
-      - gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
-    script:
-      - export VERSION="master+${DATE}"
-      - export TAG="latest"
-      - echo "Build keptn cli"
-      - cd ./cli
-      - go test ./...
-      - source ../travis-scripts/build_cli.sh "${VERSION}" "${KUBE_CONSTRAINTS}"
-      - cd ..
-
   - stage: Build Installer
     if: branch = master AND (type = cron OR type = push)
     os: linux
@@ -264,25 +246,6 @@ jobs:
   ##################################################################################
   # feature/bug/hotfix/patch branches build jobs
   ##################################################################################
-  - stage: Partial Build for feature/bug/hotfix/patch branches (CLI + Docker Images)
-    if: branch =~ ^feature.*$ OR branch =~ ^bug.*$ OR branch =~ ^hotfix.*$ OR branch =~ ^patch.*$
-    os: linux
-    before_script:
-      - source ./travis-scripts/install_gcloud.sh
-      - echo ${GCLOUD_SERVICE_KEY} | base64 --decode > ~/gcloud-service-key.json
-      - gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
-    script:
-    - TYPE="$(echo $TRAVIS_BRANCH | cut -d'/' -f1)"
-    - NUMBER="$(echo $TRAVIS_BRANCH | cut -d'/' -f2)"
-    - |
-      if [[ $CHANGED_FILES == *"${CLI_FOLDER}"*  ]]; then
-        echo "Build keptn cli"
-        cd ./cli
-        go test ./...
-        TAG="${TYPE}-${NUMBER}+${DATE}"
-        source ../travis-scripts/build_cli.sh "${TAG}" "${KUBE_CONSTRAINTS}"
-        cd ..
-      fi
   - if: branch =~ ^feature.*$ OR branch =~ ^bug.*$ OR branch =~ ^hotfix.*$ OR branch =~ ^patch.*$
     os: linux
     before_script:
@@ -365,22 +328,6 @@ jobs:
   ##################################################################################
   # Release specific jobs
   ##################################################################################
-  - stage: Release Build CLI
-    if: branch =~ ^release.*$ AND NOT type = pull_request
-    os: linux # osx
-    before_script:
-      - source ./travis-scripts/install_gcloud.sh
-      - echo ${GCLOUD_SERVICE_KEY} | base64 --decode > ~/gcloud-service-key.json
-      - gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
-    script:
-      - export VERSION=${BRANCH#"release-"} # overwrite version for release branches based on the branch name
-      - echo "Build keptn cli"
-      - cd ./cli
-      - go test ./...
-      - TAG="${VERSION}"
-      - source ../travis-scripts/build_cli.sh "${VERSION}" "${KUBE_CONSTRAINTS}"
-      - cd ..
-
   - stage: Release Build Installer
     if: branch =~ ^release.*$ AND NOT type = pull_request
     os: linux

--- a/cli/main.go
+++ b/cli/main.go
@@ -12,7 +12,7 @@ var (
 	Version = "develop"
 
 	// DefaultKubeServerVersionConstraints is used when no version is passed by ldflags
-	DefaultKubeServerVersionConstraints = ">= 1.14, <= 1.19"
+	DefaultKubeServerVersionConstraints = ">= 1.14, <= 1.19" // double check versions in .github/workflows/cli-pipeline.yml
 
 	//KubeServerVersionConstraints the Kubernetes Cluster version's constraints is passed by ldflags
 	KubeServerVersionConstraints = ""

--- a/gh-actions-scripts/detect_stale_images.sh
+++ b/gh-actions-scripts/detect_stale_images.sh
@@ -43,7 +43,7 @@ function check_if_stale() {
   TARGET_DATE=$(date -d "-${MAX_AGE_DAYS} days" +%s)
 
   # for each tag, check if the tag is stale
-  for TAG in ${RELEASE_TAGS[@]}; do
+  for TAG in ${TAGS[@]}; do
     HTTP_RESPONSE=$(curl -s -H "Authorization: JWT ${DOCKER_API_TOKEN}" --write-out "HTTPSTATUS:%{http_code}" "https://hub.docker.com/v2/repositories/${DOCKER_ORG}/${REPO}/tags/${TAG}/")
 
     # extract body and status


### PR DESCRIPTION
This PR introduces a GitHub Action/Workflow that builds the CLI and uploads it as an artifact to the action itself (not to gcloud for now).

*Note*: The release step is not fully implemented yet. CLI  is currently uploaded to GH actions instead of google cloud, but I guess that's a good thing.

In addition, I've removed all scripts that were used to build the CLI via travis-ci previously.

# New Features

- Build CLI on the operating system it is meant for (windows, linux, macos)
- Upload CLI build artifacts via GH actions

# GH Actions

Looks as follows:
![gh-action-step1-wip](https://user-images.githubusercontent.com/56065213/101924264-bf151b80-3bd0-11eb-8533-8b612aab20f7.png)


## Build CLI on {Linux, Windows, MacOS}

This builds the cli on the target platform, and uploads an artifact to GitHub.

## Release Keptn

**Not implemented yet, but here is the idea**

![image](https://user-images.githubusercontent.com/56065213/101924729-4bbfd980-3bd1-11eb-822a-28d51424428f.png)

This is only triggered for release branches (e.g., release-0.8.0).
It downloads the previously built artifact, creates a draft release, and uploads the CLI assets to the draft release.

The end result of this step is a draft release with up2date CLI binaries (packed as .tar.gz):
![image](https://user-images.githubusercontent.com/56065213/101924771-5aa68c00-3bd1-11eb-8f28-115e81d46ba6.png)

