### PR TITLE
#2759 mongodb performance investigation

### DIFF
--- a/test/assets/evaluation_triggered_event_template.json
+++ b/test/assets/evaluation_triggered_event_template.json
@@ -1,0 +1,14 @@
+{
+  "type": "sh.keptn.event.hardening.evaluation.triggered",
+  "specversion": "1.0",
+  "source": "travis-ci",
+  "contenttype": "application/json",
+  "data": {
+    "project": "$PROJECT",
+    "stage": "$STAGE",
+    "service": "$SERVICE",
+    "deployment": {
+      "deploymentURIsLocal": ["$SERVICE:8080"]
+    }
+  }
+}

--- a/test/assets/mongodb-datastore_evaluation_triggered_template.json
+++ b/test/assets/mongodb-datastore_evaluation_triggered_template.json
@@ -1,0 +1,19 @@
+{
+  "type": "sh.keptn.event.hardening.evaluation.triggered",
+  "specversion": "1.0",
+  "source": "travis-ci",
+  "contenttype": "application/json",
+  "data": {
+    "project": "$PROJECT",
+    "stage": "hardening",
+    "service": "$SERVICE",
+    "deployment": {
+      "deploymentURIsLocal": ["mongodb-datastore:8080"]
+    },
+    "labels": {
+      "nr_projects": "$project_nr",
+      "nr_services_per_project": "$service_nr",
+      "nr_evaluations_per_service": "$NR_NR_EVALUATIONS_PER_SERVICE",
+    }
+  }
+}

--- a/test/assets/mongodb-performance.jmx
+++ b/test/assets/mongodb-performance.jmx
@@ -1,0 +1,194 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="4.0" jmeter="4.0 r1823414">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Test Plan" enabled="true">
+      <stringProp name="TestPlan.comments"></stringProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+        <collectionProp name="Arguments.arguments">
+          <elementProp name="SERVER_URL" elementType="Argument">
+            <stringProp name="Argument.name">SERVER_URL</stringProp>
+            <stringProp name="Argument.value">mongodb-datastore</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="DefaultThinkTime" elementType="Argument">
+            <stringProp name="Argument.name">DefaultThinkTime</stringProp>
+            <stringProp name="Argument.value">250</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="DT_LTN" elementType="Argument">
+            <stringProp name="Argument.name">DT_LTN</stringProp>
+            <stringProp name="Argument.value">Default</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="SERVER_PORT" elementType="Argument">
+            <stringProp name="Argument.name">SERVER_PORT</stringProp>
+            <stringProp name="Argument.value">8080</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+        </collectionProp>
+      </elementProp>
+      <stringProp name="TestPlan.user_define_classpath"></stringProp>
+    </TestPlan>
+    <hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">${__P(LoopCount,1)}</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">${__P(VUCount,1)}</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+        <longProp name="ThreadGroup.start_time">1536064517000</longProp>
+        <longProp name="ThreadGroup.end_time">1536064517000</longProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+      </ThreadGroup>
+      <hashTree>
+        <CookieManager guiclass="CookiePanel" testclass="CookieManager" testname="HTTP Cookie Manager" enabled="true">
+          <collectionProp name="CookieManager.cookies"/>
+          <boolProp name="CookieManager.clearEachIteration">false</boolProp>
+        </CookieManager>
+        <hashTree/>
+        <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
+          <collectionProp name="HeaderManager.headers">
+            <elementProp name="" elementType="Header">
+              <stringProp name="Header.name">Cache-Control</stringProp>
+              <stringProp name="Header.value">no-cache</stringProp>
+            </elementProp>
+            <elementProp name="" elementType="Header">
+              <stringProp name="Header.name">Content-Type</stringProp>
+              <stringProp name="Header.value">application/json</stringProp>
+            </elementProp>
+            <elementProp name="" elementType="Header">
+              <stringProp name="Header.name">json</stringProp>
+              <stringProp name="Header.value">true</stringProp>
+            </elementProp>
+          </collectionProp>
+        </HeaderManager>
+        <hashTree/>
+        <BeanShellPreProcessor guiclass="TestBeanGUI" testclass="BeanShellPreProcessor" testname="Set Dynatrace Headers" enabled="true">
+          <stringProp name="filename"></stringProp>
+          <stringProp name="parameters"></stringProp>
+          <boolProp name="resetInterpreter">false</boolProp>
+          <stringProp name="script">import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jmeter.protocol.http.control.HeaderManager;
+import java.io;
+import java.util;
+
+// -------------------------------------------------------------------------------------
+// Generate the x-dynatrace-test header based on this best practic
+// -&gt; https://www.dynatrace.com/support/help/integrations/test-automation-frameworks/how-do-i-integrate-dynatrace-into-my-load-testing-process/
+// -------------------------------------------------------------------------------------
+String LTN=JMeterUtils.getProperty(&quot;DT_LTN&quot;);
+if((LTN == null) || (LTN.length() == 0)) {
+	if(vars != null) {
+		LTN = vars.get(&quot;DT_LTN&quot;);
+	}
+}
+if(LTN == null) LTN = &quot;NoTestName&quot;;
+
+String LSN = (bsh.args.length &gt; 0) ? bsh.args[0] : &quot;Test Scenario&quot;;
+String TSN = sampler.getName();
+String VU = ctx.getThreadGroup().getName() + ctx.getThreadNum();
+String headerValue = &quot;LSN=&quot;+ LSN + &quot;;TSN=&quot; + TSN + &quot;;LTN=&quot; + LTN + &quot;;VU=&quot; + VU + &quot;;&quot;;
+
+// -------------------------------------------
+// Set header
+// -------------------------------------------
+HeaderManager hm = sampler.getHeaderManager();
+hm.removeHeaderNamed(&quot;x-dynatrace-test&quot;);
+hm.add(new org.apache.jmeter.protocol.http.control.Header(&quot;x-dynatrace-test&quot;, headerValue));</stringProp>
+        </BeanShellPreProcessor>
+        <hashTree/>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Get events without invalidation" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="limit" elementType="HTTPArgument" enabled="true">
+                  <stringProp name="Argument.name">limit</stringProp>
+                  <stringProp name="Argument.value">1</stringProp>
+                  <stringProp name="Argument.desc">limit</stringProp>
+                  <stringProp name="Argument.metadata">=</stringProp>
+                  <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                  <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                </elementProp>
+                <elementProp name="excludeInvalidated" elementType="HTTPArgument" enabled="true">
+                  <stringProp name="Argument.name">excludeInvalidated</stringProp>
+                  <stringProp name="Argument.value">true</stringProp>
+                  <stringProp name="Argument.desc">excludeInvalidated</stringProp>
+                  <stringProp name="Argument.metadata">=</stringProp>
+                  <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                  <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                </elementProp>
+                <elementProp name="filter" elementType="HTTPArgument" enabled="true">
+                  <stringProp name="Argument.name">filter</stringProp>
+                  <stringProp name="Argument.value">data.project:project=project-0%20AND%20data.service:service-0%20AND%20data.result:pass</stringProp>
+                  <stringProp name="Argument.desc">filter</stringProp>
+                  <stringProp name="Argument.metadata">=</stringProp>
+                  <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                  <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${__P(SERVER_URL,${SERVER_URL})}</stringProp>
+          <stringProp name="HTTPSampler.port">${__P(SERVER_PORT,${SERVER_PORT})}</stringProp>
+          <stringProp name="HTTPSampler.protocol"></stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/event/type/sh.keptn.event.evaluation.finished</stringProp>
+          <stringProp name="HTTPSampler.method">GET</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <boolProp name="HTTPSampler.BROWSER_COMPATIBLE_MULTIPART">true</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+
+
+        <hashTree/>
+        <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Default Think Time" enabled="true">
+          <stringProp name="ConstantTimer.delay">{__P(ThinkTime,${DefaultThinkTime})}</stringProp>
+        </ConstantTimer>
+        <hashTree/>
+      </hashTree>
+      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
+        <boolProp name="ResultCollector.error_logging">false</boolProp>
+        <objProp>
+          <name>saveConfig</name>
+          <value class="SampleSaveConfiguration">
+            <time>true</time>
+            <latency>true</latency>
+            <timestamp>true</timestamp>
+            <success>true</success>
+            <label>true</label>
+            <code>true</code>
+            <message>true</message>
+            <threadName>true</threadName>
+            <dataType>true</dataType>
+            <encoding>false</encoding>
+            <assertions>true</assertions>
+            <subresults>true</subresults>
+            <responseData>false</responseData>
+            <samplerData>false</samplerData>
+            <xml>false</xml>
+            <fieldNames>false</fieldNames>
+            <responseHeaders>false</responseHeaders>
+            <requestHeaders>false</requestHeaders>
+            <responseDataOnError>false</responseDataOnError>
+            <saveAssertionResultsFailureMessage>false</saveAssertionResultsFailureMessage>
+            <assertionsResultsToSave>0</assertionsResultsToSave>
+            <bytes>true</bytes>
+            <threadCounts>true</threadCounts>
+          </value>
+        </objProp>
+        <stringProp name="filename"></stringProp>
+      </ResultCollector>
+      <hashTree/>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>

--- a/test/assets/mongodb-performance.jmx
+++ b/test/assets/mongodb-performance.jmx
@@ -171,7 +171,7 @@ hm.add(new org.apache.jmeter.protocol.http.control.Header(&quot;x-dynatrace-test
               </elementProp>
               <elementProp name="project" elementType="HTTPArgument" enabled="true">
                 <stringProp name="Argument.name">project</stringProp>
-                <stringProp name="Argument.value">project-0</stringProp>
+                <stringProp name="Argument.value">project-1</stringProp>
                 <stringProp name="Argument.desc">project</stringProp>
                 <stringProp name="Argument.metadata">=</stringProp>
                 <boolProp name="HTTPArgument.always_encode">false</boolProp>
@@ -179,7 +179,7 @@ hm.add(new org.apache.jmeter.protocol.http.control.Header(&quot;x-dynatrace-test
               </elementProp>
               <elementProp name="service" elementType="HTTPArgument" enabled="true">
                 <stringProp name="Argument.name">service</stringProp>
-                <stringProp name="Argument.value">service-0</stringProp>
+                <stringProp name="Argument.value">service-1</stringProp>
                 <stringProp name="Argument.desc">service</stringProp>
                 <stringProp name="Argument.metadata">=</stringProp>
                 <boolProp name="HTTPArgument.always_encode">false</boolProp>

--- a/test/assets/mongodb-performance.jmx
+++ b/test/assets/mongodb-performance.jmx
@@ -149,6 +149,60 @@ hm.add(new org.apache.jmeter.protocol.http.control.Header(&quot;x-dynatrace-test
           <stringProp name="HTTPSampler.response_timeout"></stringProp>
         </HTTPSamplerProxy>
 
+        <hashTree/>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Get Event Roots for service" enabled="true">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="root" elementType="HTTPArgument" enabled="true">
+                <stringProp name="Argument.name">root</stringProp>
+                <stringProp name="Argument.value">true</stringProp>
+                <stringProp name="Argument.desc">root</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+              </elementProp>
+              <elementProp name="pageSize" elementType="HTTPArgument" enabled="true">
+                <stringProp name="Argument.name">pageSize</stringProp>
+                <stringProp name="Argument.value">20</stringProp>
+                <stringProp name="Argument.desc">pageSize</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+              </elementProp>
+              <elementProp name="project" elementType="HTTPArgument" enabled="true">
+                <stringProp name="Argument.name">project</stringProp>
+                <stringProp name="Argument.value">project-0</stringProp>
+                <stringProp name="Argument.desc">project</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+              </elementProp>
+              <elementProp name="service" elementType="HTTPArgument" enabled="true">
+                <stringProp name="Argument.name">service</stringProp>
+                <stringProp name="Argument.value">service-0</stringProp>
+                <stringProp name="Argument.desc">service</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${__P(SERVER_URL,${SERVER_URL})}</stringProp>
+          <stringProp name="HTTPSampler.port">${__P(SERVER_PORT,${SERVER_PORT})}</stringProp>
+          <stringProp name="HTTPSampler.protocol"></stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/event</stringProp>
+          <stringProp name="HTTPSampler.method">GET</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <boolProp name="HTTPSampler.BROWSER_COMPATIBLE_MULTIPART">true</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+
 
         <hashTree/>
         <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Default Think Time" enabled="true">

--- a/test/assets/self_monitoring_sli.yaml
+++ b/test/assets/self_monitoring_sli.yaml
@@ -1,0 +1,11 @@
+---
+spec_version: '1.0'
+indicators:
+  throughput: "metricSelector=builtin:service.requestCount.total:merge(0):sum&entitySelector=type(SERVICE),tag(keptn_selfmon),tag(keptn_selfmon_service:$SERVICE)"
+  error_rate: "metricSelector=builtin:service.errors.total.count:merge(0):avg&entitySelector=type(SERVICE),tag(keptn_selfmon),tag(keptn_selfmon_service:$SERVICE)"
+  response_time_p50: "metricSelector=builtin:service.response.time:merge(0):percentile(50)&entitySelector=type(SERVICE),tag(keptn_selfmon),tag(keptn_selfmon_service:$SERVICE)"
+  response_time_p90: "metricSelector=builtin:service.response.time:merge(0):percentile(90)&entitySelector=type(SERVICE),tag(keptn_selfmon),tag(keptn_selfmon_service:$SERVICE)"
+  response_time_p95: "metricSelector=builtin:service.response.time:merge(0):percentile(95)&entitySelector=type(SERVICE),tag(keptn_selfmon),tag(keptn_selfmon_service:$SERVICE)"
+  cpu_time: "metricSelector=builtin:service.cpu.time:merge(0):percentile(95)&entitySelector=type(SERVICE),tag(keptn_selfmon),tag(keptn_selfmon_service:$SERVICE)"
+  io_time: "metricSelector=builtin:service.ioTime:merge(0):percentile(95)&entitySelector=type(SERVICE),tag(keptn_selfmon),tag(keptn_selfmon_service:$SERVICE)"
+  memory_usage: "metricSelector=builtin:tech.generic.mem.workingSetSize&entitySelector=type(PROCESS_GROUP_INSTANCE),tag(keptn_selfmon),tag(keptn_selfmon_service:$SERVICE)"

--- a/test/assets/self_monitoring_sli.yaml
+++ b/test/assets/self_monitoring_sli.yaml
@@ -8,4 +8,3 @@ indicators:
   response_time_p95: "metricSelector=builtin:service.response.time:merge(0):percentile(95)&entitySelector=type(SERVICE),tag(keptn_selfmon),tag(keptn_selfmon_service:$SERVICE)"
   cpu_time: "metricSelector=builtin:service.cpu.time:merge(0):percentile(95)&entitySelector=type(SERVICE),tag(keptn_selfmon),tag(keptn_selfmon_service:$SERVICE)"
   io_time: "metricSelector=builtin:service.ioTime:merge(0):percentile(95)&entitySelector=type(SERVICE),tag(keptn_selfmon),tag(keptn_selfmon_service:$SERVICE)"
-  memory_usage: "metricSelector=builtin:tech.generic.mem.workingSetSize&entitySelector=type(PROCESS_GROUP_INSTANCE),tag(keptn_selfmon),tag(keptn_selfmon_service:$SERVICE)"

--- a/test/assets/self_monitoring_slo.yaml
+++ b/test/assets/self_monitoring_slo.yaml
@@ -10,12 +10,10 @@ objectives:
   - sli: "response_time_p95"
     pass:
       - criteria:
-          - "<=+10%"
           - "<250"
     warning:
       - criteria:
           - "<=500"
-          - "<=+100%"
     weight: 1
   - sli: "throughput"
   - sli: "error_rate"

--- a/test/assets/self_monitoring_slo.yaml
+++ b/test/assets/self_monitoring_slo.yaml
@@ -1,0 +1,37 @@
+---
+spec_version: "0.1.1"
+comparison:
+  aggregate_function: "avg"
+  compare_with: "single_result"
+  include_result_with_score: "pass"
+  number_of_comparison_results: 1
+filter:
+objectives:
+  - sli: "response_time_p95"
+    pass:
+      - criteria:
+          - "<=+10%"
+          - "<250"
+    warning:
+      - criteria:
+          - "<=500"
+          - "<=+100%"
+    weight: 1
+  - sli: "throughput"
+  - sli: "error_rate"
+    pass:
+      - criteria:
+          - "<1"
+  - sli: "memory_usage"
+    pass:
+      - criteria:
+          - "<=+10%"
+    warning:
+      - criteria:
+          - "<=+25%"
+  - sli: "throughput"
+  - sli: "cpu_time"
+  - sli: "io_time"
+total_score:
+  pass: "90%"
+  warning: "75%"

--- a/test/assets/self_monitoring_slo.yaml
+++ b/test/assets/self_monitoring_slo.yaml
@@ -22,10 +22,6 @@ objectives:
     pass:
       - criteria:
           - "<1"
-  - sli: "memory_usage"
-    pass:
-      - criteria:
-          - "<=+10%"
     warning:
       - criteria:
           - "<=+25%"

--- a/test/assets/shipyard-quality-gates-self-monitoring.yaml
+++ b/test/assets/shipyard-quality-gates-self-monitoring.yaml
@@ -1,0 +1,14 @@
+apiVersion: "spec.keptn.sh/0.2.0"
+kind: "Shipyard"
+metadata:
+  name: "shipyard-quality-gates"
+spec:
+  stages:
+    - name: "hardening"
+      sequences:
+        - name: "evaluation"
+          tasks:
+            - name: "test"
+              properties:
+                teststrategy: "performance"
+            - name: "evaluation"

--- a/test/test_keptn_performance.sh
+++ b/test/test_keptn_performance.sh
@@ -8,14 +8,14 @@ function cleanup() {
   echo "Delete lighthouse-config configmap"
   kubectl delete configmap -n ${KEPTN_NAMESPACE} lighthouse-config
 
-  echo "Deleting project ${PROJECT}"
-  keptn delete project $PROJECT
+  echo "Deleting project ${SELF_MONITORING_PROJECT}"
+  keptn delete project $SELF_MONITORING_PROJECT
 
   echo "Uninstalling dynatrace-sli-service"
   kubectl -n ${KEPTN_NAMESPACE} delete deployment dynatrace-sli-service
 
-  echo "Removing secret dynatrace-credentials-${PROJECT}"
-  kubectl -n ${KEPTN_NAMESPACE} delete secret dynatrace-credentials-${PROJECT}
+  echo "Removing secret dynatrace-credentials-${SELF_MONITORING_PROJECT}"
+  kubectl -n ${KEPTN_NAMESPACE} delete secret dynatrace-credentials-${SELF_MONITORING_PROJECT}
 
   for project_nr in $(seq 1 ${NR_PROJECTS})
   do
@@ -26,7 +26,7 @@ function cleanup() {
 
 # test configuration
 DYNATRACE_SLI_SERVICE_VERSION=${DYNATRACE_SLI_SERVICE_VERSION:-master}
-PROJECT=${PROJECT:-keptn-selfmonitoring}
+SELF_MONITORING_PROJECT=${SELF_MONITORING_PROJECT:-keptn-selfmonitoring}
 KEPTN_NAMESPACE=${KEPTN_NAMESPACE:-keptn}
 
 NR_PROJECTS=${NR_PROJECTS:-20}
@@ -62,7 +62,7 @@ KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n ${KEPTN_NAMESPACE} -ojso
 
 
 # deploy dynatrace-sli service
-kubectl -n ${KEPTN_NAMESPACE} create secret generic dynatrace-credentials-${PROJECT} --from-literal="DT_TENANT=$QG_INTEGRATION_TEST_DT_TENANT" --from-literal="DT_API_TOKEN=$QG_INTEGRATION_TEST_DT_API_TOKEN"
+kubectl -n ${KEPTN_NAMESPACE} create secret generic dynatrace-credentials-${SELF_MONITORING_PROJECT} --from-literal="DT_TENANT=$QG_INTEGRATION_TEST_DT_TENANT" --from-literal="DT_API_TOKEN=$QG_INTEGRATION_TEST_DT_API_TOKEN"
 
 echo "Install dynatrace-sli-service from: ${DYNATRACE_SLI_SERVICE_VERSION}"
 kubectl apply -f https://raw.githubusercontent.com/keptn-contrib/dynatrace-sli-service/${DYNATRACE_SLI_SERVICE_VERSION}/deploy/service.yaml -n ${KEPTN_NAMESPACE}
@@ -73,13 +73,13 @@ kubectl -n ${KEPTN_NAMESPACE} set image deployment/dynatrace-sli-service dynatra
 sleep 10
 wait_for_deployment_in_namespace "dynatrace-sli-service" ${KEPTN_NAMESPACE}
 
-kubectl create configmap -n ${KEPTN_NAMESPACE} lighthouse-config-${PROJECT} --from-literal=sli-provider=dynatrace
+kubectl create configmap -n ${KEPTN_NAMESPACE} lighthouse-config-${SELF_MONITORING_PROJECT} --from-literal=sli-provider=dynatrace
 
 # create the project
 
-keptn create project $PROJECT --shipyard=./test/assets/shipyard-quality-gates-self-monitoring.yaml
+keptn create project $SELF_MONITORING_PROJECT --shipyard=./test/assets/shipyard-quality-gates-self-monitoring.yaml
 
-keptn add-resource --project=$PROJECT --resource=./test/assets/self_monitoring_sli.yaml --resourceUri=dynatrace/sli.yaml
+keptn add-resource --project=$SELF_MONITORING_PROJECT --resource=./test/assets/self_monitoring_sli.yaml --resourceUri=dynatrace/sli.yaml
 
 # create services
 
@@ -87,19 +87,19 @@ SERVICES=("bridge" "eventbroker-go" "configuration-service" "mongodb-datastore" 
 
 for SERVICE in "${SERVICES[@]}"
 do
-    keptn create service $SERVICE --project=$PROJECT
+    keptn create service $SERVICE --project=$SELF_MONITORING_PROJECT
 done
 
 for SERVICE in "${SERVICES[@]}"
 do
-    keptn add-resource --project=$PROJECT --service=$SERVICE --stage=hardening --resource=./test/assets/self_monitoring_slo.yaml --resourceUri=slo.yaml
+    keptn add-resource --project=$SELF_MONITORING_PROJECT --service=$SERVICE --stage=hardening --resource=./test/assets/self_monitoring_slo.yaml --resourceUri=slo.yaml
 done
 
 # initial evaluation
 
-SERVICE=mongodb-datastore
+SELF_MONITORING_SERVICE=mongodb-datastore
 
-keptn add-resource --project=$PROJECT --service=$SERVICE --stage=hardening --resource=./test/assets/mongodb-performance.jmx --resourceUri=jmeter/load.jmx
+keptn add-resource --project=$SELF_MONITORING_PROJECT --service=$SELF_MONITORING_SERVICE --stage=hardening --resource=./test/assets/mongodb-performance.jmx --resourceUri=jmeter/load.jmx
 
 cat << EOF > ./tmp-trigger-evaluation.json
 {
@@ -108,11 +108,11 @@ cat << EOF > ./tmp-trigger-evaluation.json
   "source": "travis-ci",
   "contenttype": "application/json",
   "data": {
-    "project": "$PROJECT",
+    "project": "$SELF_MONITORING_PROJECT",
     "stage": "hardening",
-    "service": "$SERVICE",
+    "service": "$SELF_MONITORING_SERVICE",
     "deployment": {
-      "deploymentURIsLocal": ["$SERVICE:8080"]
+      "deploymentURIsLocal": ["$SELF_MONITORING_SERVICE:8080"]
     },
     "labels": {
       "nr_projects": "0"
@@ -121,12 +121,14 @@ cat << EOF > ./tmp-trigger-evaluation.json
 }
 EOF
 
+cat tmp-trigger-evaluation.json
+
 keptn_context_id=$(send_event_json ./tmp-trigger-evaluation.json)
 rm tmp-trigger-evaluation.json
 
 # try to fetch a evaluation-done event
 echo "Getting evaluation-done event with context-id: ${keptn_context_id}"
-response=$(get_event_with_retry sh.keptn.event.evaluation.finished ${keptn_context_id} ${PROJECT})
+response=$(get_event_with_retry sh.keptn.event.evaluation.finished ${keptn_context_id} ${SELF_MONITORING_PROJECT})
 
 echo $response | jq .
 
@@ -144,38 +146,37 @@ do
     do
       send_start_evaluation_request project-${project_nr} hardening service-${service_nr}
     done
-  done
-done
 
-# do the evaluation again
-
-cat << EOF > ./tmp-trigger-evaluation.json
-{
-  "type": "sh.keptn.event.hardening.evaluation.triggered",
-  "specversion": "1.0",
-  "source": "travis-ci",
-  "contenttype": "application/json",
-  "data": {
-    "project": "$PROJECT",
-    "stage": "hardening",
-    "service": "$SERVICE",
-    "deployment": {
-      "deploymentURIsLocal": ["$SERVICE:8080"]
-    },
-    "labels": {
-      "nr_projects": "$NR_PROJECTS",
-      "nr_services_per_project": "$NR_SERVICES_PER_PROJECT",
-      "nr_evaluations_per_service": "$NR_NR_EVALUATIONS_PER_SERVICE",
+    # do the evaluation again
+    cat << EOF > ./tmp-trigger-evaluation.json
+    {
+      "type": "sh.keptn.event.hardening.evaluation.triggered",
+      "specversion": "1.0",
+      "source": "travis-ci",
+      "contenttype": "application/json",
+      "data": {
+        "project": "$SELF_MONITORING_PROJECT",
+        "stage": "hardening",
+        "service": "$SELF_MONITORING_SERVICE",
+        "deployment": {
+          "deploymentURIsLocal": ["$SELF_MONITORING_SERVICE:8080"]
+        },
+        "labels": {
+          "nr_projects": "$SELF_MONITORING_PROJECT_nr",
+          "nr_services_per_project": "$service_nr",
+          "nr_evaluations_per_service": "$NR_NR_EVALUATIONS_PER_SERVICE"
+        }
+      }
     }
-  }
-}
 EOF
 
-keptn_context_id=$(send_event_json ./tmp-trigger-evaluation.json)
-rm tmp-trigger-evaluation.json
+    keptn_context_id=$(send_event_json ./tmp-trigger-evaluation.json)
+    rm tmp-trigger-evaluation.json
 
-# try to fetch a evaluation-done event
-echo "Getting evaluation-done event with context-id: ${keptn_context_id}"
-response=$(get_event_with_retry sh.keptn.event.evaluation.finished ${keptn_context_id} ${PROJECT})
+    # try to fetch a evaluation-done event
+    echo "Getting evaluation-done event with context-id: ${keptn_context_id}"
+    response=$(get_event_with_retry sh.keptn.event.evaluation.finished ${keptn_context_id} ${SELF_MONITORING_PROJECT})
 
-echo $response | jq .
+    echo $response | jq .
+  done
+done

--- a/test/test_keptn_performance.sh
+++ b/test/test_keptn_performance.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+
+source test/utils.sh
+
+function cleanup() {
+  echo "Executing cleanup..."
+
+  echo "Delete lighthouse-config configmap"
+  kubectl delete configmap -n ${KEPTN_NAMESPACE} lighthouse-config
+
+  echo "Deleting project ${PROJECT}"
+  keptn delete project $PROJECT
+
+  echo "Uninstalling dynatrace-sli-service"
+  kubectl -n ${KEPTN_NAMESPACE} delete deployment dynatrace-sli-service
+
+  echo "Removing secret dynatrace-credentials-${PROJECT}"
+  kubectl -n ${KEPTN_NAMESPACE} delete secret dynatrace-credentials-${PROJECT}
+
+  for project_nr in $(seq 1 ${NR_PROJECTS})
+  do
+    keptn delete project project-${project_nr}
+  done
+}
+#trap cleanup EXIT SIGINT
+
+# test configuration
+DYNATRACE_SLI_SERVICE_VERSION=${DYNATRACE_SLI_SERVICE_VERSION:-master}
+PROJECT=${PROJECT:-keptn-selfmonitoring}
+KEPTN_NAMESPACE=${KEPTN_NAMESPACE:-keptn}
+
+NR_PROJECTS=${NR_PROJECTS:-20}
+NR_SERVICES_PER_PROJECT=${NR_SERVICES_PER_PROJECT:-15}
+NR_EVALUATIONS_PER_SERVICE=${NR_EVALUATIONS_PER_SERVICE:-100}
+
+if [[ $QG_INTEGRATION_TEST_DT_TENANT == "" ]]; then
+  echo "No DT Tenant env var provided. Exiting."
+  exit 1
+fi
+
+if [[ $QG_INTEGRATION_TEST_DT_API_TOKEN == "" ]]; then
+  echo "No DZ API Token env var provided. Exiting."
+  exit 1
+fi
+
+cleanup
+
+# get keptn API details
+if [[ "$PLATFORM" == "openshift" ]]; then
+  KEPTN_ENDPOINT=http://api.${KEPTN_NAMESPACE}.127.0.0.1.nip.io/api
+else
+  if [[ "$KEPTN_SERVICE_TYPE" == "NodePort" ]]; then
+    API_PORT=$(kubectl get svc api-gateway-nginx -n ${KEPTN_NAMESPACE} -o jsonpath='{.spec.ports[?(@.name=="http")].nodePort}')
+    INTERNAL_NODE_IP=$(kubectl get nodes -o jsonpath='{ $.items[0].status.addresses[?(@.type=="InternalIP")].address }')
+    KEPTN_ENDPOINT="http://${INTERNAL_NODE_IP}:${API_PORT}"/api
+  else
+    KEPTN_ENDPOINT=http://$(kubectl -n ${KEPTN_NAMESPACE} get service api-gateway-nginx -o jsonpath='{.status.loadBalancer.ingress[0].ip}')/api
+  fi
+fi
+
+KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n ${KEPTN_NAMESPACE} -ojsonpath={.data.keptn-api-token} | base64 --decode)
+
+
+# deploy dynatrace-sli service
+kubectl -n ${KEPTN_NAMESPACE} create secret generic dynatrace-credentials-${PROJECT} --from-literal="DT_TENANT=$QG_INTEGRATION_TEST_DT_TENANT" --from-literal="DT_API_TOKEN=$QG_INTEGRATION_TEST_DT_API_TOKEN"
+
+echo "Install dynatrace-sli-service from: ${DYNATRACE_SLI_SERVICE_VERSION}"
+kubectl apply -f https://raw.githubusercontent.com/keptn-contrib/dynatrace-sli-service/${DYNATRACE_SLI_SERVICE_VERSION}/deploy/service.yaml -n ${KEPTN_NAMESPACE}
+sleep 5
+# TODO: delete line below !
+kubectl -n ${KEPTN_NAMESPACE} set image deployment/dynatrace-sli-service dynatrace-sli-service=keptncontrib/dynatrace-sli-service:0.6.0-master
+
+sleep 10
+wait_for_deployment_in_namespace "dynatrace-sli-service" ${KEPTN_NAMESPACE}
+
+kubectl create configmap -n ${KEPTN_NAMESPACE} lighthouse-config-${PROJECT} --from-literal=sli-provider=dynatrace
+
+# create the project
+
+keptn create project $PROJECT --shipyard=./test/assets/shipyard-quality-gates-self-monitoring.yaml
+
+keptn add-resource --project=$PROJECT --resource=./test/assets/self_monitoring_sli.yaml --resourceUri=dynatrace/sli.yaml
+
+# create services
+
+SERVICES=("bridge" "eventbroker-go" "configuration-service" "mongodb-datastore" "gatekeeper-service" "remediation-service" "lighthouse-service" "statistics-service" "gatekeeper-service" "dynatrace-sli-service" "jmeter-service" "dynatrace-service" "api-service" "api-gateway-nginx")
+
+for SERVICE in "${SERVICES[@]}"
+do
+    keptn create service $SERVICE --project=$PROJECT
+done
+
+for SERVICE in "${SERVICES[@]}"
+do
+    keptn add-resource --project=$PROJECT --service=$SERVICE --stage=hardening --resource=./test/assets/self_monitoring_slo.yaml --resourceUri=slo.yaml
+done
+
+# initial evaluation
+
+SERVICE=mongodb-datastore
+
+keptn add-resource --project=$PROJECT --service=$SERVICE --stage=hardening --resource=./test/assets/mongodb-performance.jmx --resourceUri=jmeter/load.jmx
+
+cat << EOF > ./tmp-trigger-evaluation.json
+{
+  "type": "sh.keptn.event.hardening.evaluation.triggered",
+  "specversion": "1.0",
+  "source": "travis-ci",
+  "contenttype": "application/json",
+  "data": {
+    "project": "$PROJECT",
+    "stage": "hardening",
+    "service": "$SERVICE",
+    "deployment": {
+      "deploymentURIsLocal": ["$SERVICE:8080"]
+    }
+  }
+}
+EOF
+
+keptn_context_id=$(send_event_json ./tmp-trigger-evaluation.json)
+rm tmp-trigger-evaluation.json
+
+# try to fetch a evaluation-done event
+echo "Getting evaluation-done event with context-id: ${keptn_context_id}"
+response=$(get_event_with_retry sh.keptn.event.evaluation.finished ${keptn_context_id} ${PROJECT})
+
+echo response
+
+exit
+
+# Create projects, services and evaluations to generate data
+for project_nr in $(seq 1 ${NR_PROJECTS})
+do
+  keptn create project project-${project_nr} --shipyard=./test/assets/shipyard-quality-gates.yaml
+
+  for service_nr in $(seq 1 ${NR_SERVICES_PER_PROJECT})
+  do
+    keptn create service service-${service_nr} --project=project-${project_nr}
+
+    for evaluation_r in $(seq 1 ${NR_EVALUATIONS_PER_SERVICE})
+    do
+      send_start_evaluation_request project-${project_nr} hardening service-${service_nr}
+    done
+  done
+done

--- a/test/utils.sh
+++ b/test/utils.sh
@@ -65,6 +65,33 @@ function get_event() {
   keptn get event $event_type --keptn-context="${keptn_context_id}" --project=${project}
 }
 
+function get_event_with_retry() {
+  event_type=$1
+  keptn_context_id=$2
+  project=$3
+
+  RETRY=0; RETRY_MAX=50;
+
+  while [[ $RETRY -lt $RETRY_MAX ]]; do
+    response=$(keptn get event $event_type --keptn-context="${keptn_context_id}" --project=${project})
+
+    if [[ $response == "No event returned" ]]; then
+      RETRY=$[$RETRY+1]
+      echo "Retry: ${RETRY}/${RETRY_MAX} - Wait 10s for ${event_type} event..."
+      sleep 10
+    else
+      echo $response
+      break
+    fi
+  done
+
+  if [[ $RETRY == $RETRY_MAX ]]; then
+    print_error "URL ${URL} could not be reached"
+    exit 1
+  fi
+
+}
+
 function send_approval_triggered_event() {
   PROJECT=$1
   STAGE=$2


### PR DESCRIPTION
Closes #2759

**Performance Test Setup:**

 - Configured my Keptn installation to be monitored by Dynatrace, and created **keptn-selfmonitoring** project in my Keptn installation.
- Added each core service to the **keptn-selfmonitoring** project. Note: For the sake of this Issue, only the **mongodb-datastore** is needed, but having all services available for doing evaluations does not harm.

**Test protocol**:

1. Created a project
1. Create a service
1. Send 100 evaluation.triggered events
1. Send evaluation.triggered event for the **mongodb-datastore** - This triggers the **evaluation** task sequence which first performs a load tests using the jmeter service, and then evaluates the results using monitoring data from my DT tenant.
1. Send 10 evaluation.invalidated events
1. Trigger another test/evaluation for the **mongodb-datastore**
1. Repeat Steps 2 - 6 until I had 13 services with 1300 evaluations and 130 evaluation invalidations

Note: For this investigation, having one project was sufficient since the mongodb collections are separated for each project, meaning that potential scaling issues can only arise if the number of events for a particular project increases to a certain point. Also, to the best of my knowledge, we do not have a screen where requests for fetching events for multiple projects are sent in parallel in the bridge.

After executing this test, I obtained the following data from my DT tenant:

![response-time](https://user-images.githubusercontent.com/2143586/102233849-fa755a00-3ef0-11eb-9d6f-a637ed4e16e1.png)

The load test script executed the following requests:

`/event/type/sh.keptn.event.evaluation.finished?invalidated=true&filter=data.project:project=project-0%20AND%20data.service:service-0%20AND%20data.result:pass`

`/event?project=project-1&service=service-1&root=true`

Jmeter configuration:

VUsers: 10
LoopCount: 500
ThinkTime: 250
AcceptedErrorRate: 0.1

**Interpretation:**
It clearly shows that an increased number of events leads to an increase of the response time. This is something that could be improved by using **indexes** for the mongodb collections. In my opinion, adding the following indexes could have a benefitial impact:

- Collection **project-rootEvents**: Add an index for `data.service`
- Collection **project**: Add indexes for `data.service` and `shkeptncontext`

On the bridge side, I observed that, when opening a project, all rootEvents, and their correlating event traces are loaded for each service simultaneously - this causes the spike in the response time (see the screenshot above). This could be improved by loading rootEvents and event traces on demand, i.e., when the user clicks on the service, or a particular root event.

