### PR TITLE
#2649 Reduce memory and cpu resource requests/limits for distributors in helm-chart

### DIFF
--- a/installer/manifests/keptn/charts/continuous-delivery/charts/openshift/templates/route-service-openshift.yaml
+++ b/installer/manifests/keptn/charts/continuous-delivery/charts/openshift/templates/route-service-openshift.yaml
@@ -102,13 +102,7 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 8080
-        resources:
-          requests:
-            memory: "32Mi"
-            cpu: "50m"
-          limits:
-            memory: "128Mi"
-            cpu: "500m"
+        {{- include "keptn.distributor.resources" . | nindent 8 }}
         env:
           - name: PUBSUB_URL
             value: 'nats://keptn-nats-cluster'

--- a/installer/manifests/keptn/charts/continuous-delivery/templates/continuous-deployment.yaml
+++ b/installer/manifests/keptn/charts/continuous-delivery/templates/continuous-deployment.yaml
@@ -87,13 +87,7 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
-          resources:
-            requests:
-              memory: "32Mi"
-              cpu: "50m"
-            limits:
-              memory: "128Mi"
-              cpu: "500m"
+          {{- include "keptn.distributor.resources" . | nindent 10 }}
           env:
             - name: PUBSUB_URL
               value: 'nats://keptn-nats-cluster'
@@ -206,13 +200,7 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
-          resources:
-            requests:
-              memory: "32Mi"
-              cpu: "50m"
-            limits:
-              memory: "128Mi"
-              cpu: "500m"
+          {{- include "keptn.distributor.resources" . | nindent 10 }}
           env:
             - name: PUBSUB_URL
               value: 'nats://keptn-nats-cluster'
@@ -294,13 +282,7 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
-          resources:
-            requests:
-              memory: "32Mi"
-              cpu: "50m"
-            limits:
-              memory: "128Mi"
-              cpu: "500m"
+          {{- include "keptn.distributor.resources" . | nindent 10 }}
           env:
             - name: PUBSUB_URL
               value: 'nats://keptn-nats-cluster'

--- a/installer/manifests/keptn/charts/control-plane/templates/continuous-operations.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/continuous-operations.yaml
@@ -60,13 +60,7 @@ spec:
         {{- include "control-plane.livenessProbe" . | nindent 8 }}
         ports:
           - containerPort: 8080
-        resources:
-          requests:
-            memory: "32Mi"
-            cpu: "50m"
-          limits:
-            memory: "128Mi"
-            cpu: "500m"
+        {{- include "keptn.distributor.resources" . | nindent 8 }}
         env:
           - name: PUBSUB_URL
             value: 'nats://keptn-nats-cluster'

--- a/installer/manifests/keptn/charts/control-plane/templates/core.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/core.yaml
@@ -117,13 +117,7 @@ spec:
               port: 10999
             initialDelaySeconds: 5
             periodSeconds: 5
-          resources:
-            requests:
-              memory: "32Mi"
-              cpu: "50m"
-            limits:
-              memory: "128Mi"
-              cpu: "500m"
+          {{- include "keptn.distributor.resources" . | nindent 10 }}
           env:
             - name: PUBSUB_URL
               value: 'nats://keptn-nats-cluster'
@@ -327,13 +321,7 @@ spec:
               port: 10999
             initialDelaySeconds: 5
             periodSeconds: 5
-          resources:
-            requests:
-              memory: "32Mi"
-              cpu: "50m"
-            limits:
-              memory: "128Mi"
-              cpu: "500m"
+          {{- include "keptn.distributor.resources" . | nindent 10 }}
           env:
             - name: PUBSUB_URL
               value: 'nats://keptn-nats-cluster'
@@ -463,13 +451,7 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
-          resources:
-            requests:
-              memory: "32Mi"
-              cpu: "50m"
-            limits:
-              memory: "128Mi"
-              cpu: "500m"
+          {{- include "keptn.distributor.resources" . | nindent 10 }}
           env:
             - name: PUBSUB_URL
               value: 'nats://keptn-nats-cluster'

--- a/installer/manifests/keptn/charts/control-plane/templates/mongodb-datastore.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/mongodb-datastore.yaml
@@ -68,13 +68,7 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 8080
-        resources:
-          requests:
-            memory: "32Mi"
-            cpu: "50m"
-          limits:
-            memory: "128Mi"
-            cpu: "500m"
+        {{- include "keptn.distributor.resources" . | nindent 8 }}
         env:
           - name: PUBSUB_IMPL
             value: nats

--- a/installer/manifests/keptn/charts/control-plane/templates/quality-gates.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/quality-gates.yaml
@@ -62,13 +62,7 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
-          resources:
-            requests:
-              memory: "32Mi"
-              cpu: "50m"
-            limits:
-              memory: "128Mi"
-              cpu: "500m"
+          {{- include "keptn.distributor.resources" . | nindent 10 }}
           env:
             - name: PUBSUB_URL
               value: 'nats://keptn-nats-cluster'

--- a/installer/manifests/keptn/templates/_helpers.tpl
+++ b/installer/manifests/keptn/templates/_helpers.tpl
@@ -61,3 +61,13 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{- define "keptn.distributor.resources" -}}
+resources:
+  requests:
+    memory: "16Mi"
+    cpu: "25m"
+  limits:
+    memory: "32Mi"
+    cpu: "250m"
+{{- end }}


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

This PR fixes #2649 by 

* reducing memory and cpu resources limits/requests for distributors,
* adding a helper template function for those limits/requests

**todo: update https://github.com/keptn/keptn.github.io/pull/683**

If you want to test it, here is the helm chart: 
[keptn-0.1.0.zip](https://github.com/keptn/keptn/files/5697186/keptn-0.1.0.zip) (please extract the zip file, and use ``helm upgrade keptn keptn --install -n keptn --create-namespace --wait --repo=./keptn-0.1.0.tgz `` )



Question to @agrimmer 
is it okay to have the function
```
{{- define "keptn.distributor.resources" -}}
resources:
  requests:
    memory: "16Mi"
    cpu: "25m"
  limits:
    memory: "32Mi"
    cpu: "250m"
{{- end }}
```
in helpers.tpl? I opted for this instead of `values.yaml` to reduce redundant entries in our yaml files.

