### PR TITLE
#2824 Fix stale images script

### DIFF
--- a/.github/workflows/cleanup_images.yml
+++ b/.github/workflows/cleanup_images.yml
@@ -20,6 +20,4 @@ jobs:
           REGISTRY_USER: ${{ secrets.REGISTRY_USER }}
           REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
           DOCKER_ORG: ${{ env.DOCKER_ORGANIZATION }}
-        run: |
-          # sudo apt-get update && sudo apt-get install jq -y
-          ./gh-actions-scripts/cleanup_docker_images.sh
+        run: ./gh-actions-scripts/cleanup_docker_images.sh

--- a/.github/workflows/cleanup_images.yml
+++ b/.github/workflows/cleanup_images.yml
@@ -6,13 +6,20 @@ on:
 jobs:
   cleanup:
     name: Clean up
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out code.
         uses: actions/checkout@v2
+      - name: Load CI Environemnt from .ci_env
+        id: load_ci_env
+        uses: c-py/action-dotenv-to-setenv@v2
+        with:
+          env-file: .ci_env
       - name: Clean up outdated images
         env:
           REGISTRY_USER: ${{ secrets.REGISTRY_USER }}
           REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+          DOCKER_ORG: ${{ env.DOCKER_ORGANIZATION }}
         run: |
-          apt-get update && apt-get install jq -y && ./gh-actions-scripts/cleanup_docker_images.sh
+          # sudo apt-get update && sudo apt-get install jq -y
+          ./gh-actions-scripts/cleanup_docker_images.sh

--- a/.github/workflows/detect_stale_images.yml
+++ b/.github/workflows/detect_stale_images.yml
@@ -20,6 +20,4 @@ jobs:
           REGISTRY_USER: ${{ secrets.REGISTRY_USER }}
           REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
           DOCKER_ORG: ${{ env.DOCKER_ORGANIZATION }}
-        run: |
-          # sudo apt-get update && sudo apt-get install jq -y
-          ./gh-actions-scripts/detect_stale_images.sh
+        run: ./gh-actions-scripts/detect_stale_images.sh

--- a/.github/workflows/detect_stale_images.yml
+++ b/.github/workflows/detect_stale_images.yml
@@ -10,9 +10,16 @@ jobs:
     steps:
       - name: Check out code.
         uses: actions/checkout@v2
+      - name: Load CI Environemnt from .ci_env
+        id: load_ci_env
+        uses: c-py/action-dotenv-to-setenv@v2
+        with:
+          env-file: .ci_env
       - name: Detect stale images on DockerHub
         env:
           REGISTRY_USER: ${{ secrets.REGISTRY_USER }}
           REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+          DOCKER_ORG: ${{ env.DOCKER_ORGANIZATION }}
         run: |
-          apt-get update && apt-get install jq -y && ./gh-actions-scripts/detect_stale_images.sh
+          # sudo apt-get update && sudo apt-get install jq -y
+          ./gh-actions-scripts/detect_stale_images.sh

--- a/gh-actions-scripts/cleanup_docker_images.sh
+++ b/gh-actions-scripts/cleanup_docker_images.sh
@@ -48,7 +48,7 @@ fi
 
 function get_outdated_commit_hash_tags() {
   REPO=$1
-  MAX_AGE_DAYS=$3
+  MAX_AGE_DAYS=$2
 
   # Target-Date = Current Date Minus $MAX_AGE_DAYS
   TARGET_DATE=$(date -d "-${MAX_AGE_DAYS} days" +%s)
@@ -61,6 +61,26 @@ function get_outdated_commit_hash_tags() {
   # get all tags, ordered by last_update (get the newest), and filter with jq based on TARGET_DATE
   response=$(curl -s -H "Authorization: JWT ${DOCKER_API_TOKEN}" "https://hub.docker.com/v2/repositories/${DOCKER_ORG}/${REPO}/tags/?ordering=-last_updated&page_size=${COUNT}" | \
      jq -r --argjson date "$TARGET_DATE" '.results|.[]|select (.last_updated | sub(".[0-9]+Z$"; "Z") | fromdate < $date)|select(.name | match("\\b[0-9a-f]{7}\\b"))|.name')
+  echo $response
+}
+
+
+function get_outdated_datetime_tags() {
+  REPO=$1
+  TAG_FILTER=$2
+  MAX_AGE_DAYS=$3
+
+  # Target-Date = Current Date Minus $MAX_AGE_DAYS
+  TARGET_DATE=$(date -d "-${MAX_AGE_DAYS} days" +%s)
+
+  # Count number of tags based on the tag filter
+  COUNT=$(curl -s -H "Authorization: JWT ${DOCKER_API_TOKEN}" "https://hub.docker.com/v2/repositories/${DOCKER_ORG}/${REPO}/tags/?name=${TAG_FILTER}&page_size=1" | jq -r '.count')
+  # unfortunately, anything above 100 doesn't work for pagination with docker hub api; leaving it in for debug purposes
+  >&2 echo "Found $COUNT tags for $REPO (filter $TAG_FILTER)"
+
+  # get all tags, ordered by last_update (get the newest), and filter with jq based on TARGET_DATE
+  response=$(curl -s -H "Authorization: JWT ${DOCKER_API_TOKEN}" "https://hub.docker.com/v2/repositories/${DOCKER_ORG}/${REPO}/tags/?name=${TAG_FILTER}&ordering=-last_updated&page_size=${COUNT}" | \
+    jq -r --argjson date "$TARGET_DATE" '.results|.[]|select (.last_updated | sub(".[0-9]+Z$"; "Z") | fromdate < $date)|select(.name | match("^\\b[0-9]{8}\\b"))|.name')
   echo $response
 }
 
@@ -108,18 +128,25 @@ for s in ${IMAGES[@]}; do
   echo "deleting outdated images for service ${s}"
 
   # get all outdated commit hash tags
-  # outdated_commit_hash_tags=$(get_outdated_commit_hash_tags $s $MAX_AGE)
+  outdated_commit_hash_tags=$(get_outdated_commit_hash_tags $s $MAX_AGE)
 
-  # get all outdated tag where tag contains "feature"
-  outdated_feature_tags=$(get_outdated_images $s "feature" $MAX_AGE)
-  # get all outdated tag where tag contains "bug"
-  outdated_bug_tags=$(get_outdated_images $s "bug" $MAX_AGE)
-  # get all outdated tag where tag contains "patch"
-  outdated_patch_tags=$(get_outdated_images $s "patch" $MAX_AGE)
+  outdated_datetime_tags=$(get_outdated_datetime_tags $s "202003" $MAX_AGE)
+
+#  # get all outdated tag where tag contains "feature"
+#  outdated_feature_tags=$(get_outdated_images $s "feature" $MAX_AGE)
+#  # get all outdated tag where tag contains "bug"
+#  outdated_bug_tags=$(get_outdated_images $s "bug" $MAX_AGE)
+#  # get all outdated tag where tag contains "patch"
+#  outdated_patch_tags=$(get_outdated_images $s "patch" $MAX_AGE)
+
   # get all outdated tag where tag contains "dirty"
   outdated_dirty_tags=$(get_outdated_images $s "dirty" $MAX_AGE)
 
   for tag in ${outdated_commit_hash_tags}; do
+    delete_tag $s $tag
+  done
+
+  for tag in ${outdated_datetime_tags}; do
     delete_tag $s $tag
   done
 

--- a/gh-actions-scripts/cleanup_docker_images.sh
+++ b/gh-actions-scripts/cleanup_docker_images.sh
@@ -14,7 +14,7 @@
 
 # max age that images should have before they are marked as outdated
 MAX_AGE=30
-IMAGES=("api" "bridge2" "configuration-service" "openshift-route-service" "distributor" "gatekeeper-service" "helm-service" "jmeter-service" "lighthouse-service" "mongodb-datastore" "remediation-service" "shipyard-controller" "shipyard-service")
+IMAGES=("api" "bridge2" "configuration-service" "openshift-route-service" "distributor" "gatekeeper-service" "helm-service" "jmeter-service" "lighthouse-service" "mongodb-datastore" "remediation-service" "shipyard-controller")
 
 # ensure the params/variables are set
 if [ -z "$REGISTRY_USER" ]; then
@@ -130,14 +130,20 @@ for s in ${IMAGES[@]}; do
   # get all outdated commit hash tags
   outdated_commit_hash_tags=$(get_outdated_commit_hash_tags $s $MAX_AGE)
 
-  outdated_datetime_tags=$(get_outdated_datetime_tags $s "202003" $MAX_AGE)
+  outdated_datetime_tags=$(get_outdated_datetime_tags $s "2020" $MAX_AGE)
 
-#  # get all outdated tag where tag contains "feature"
-#  outdated_feature_tags=$(get_outdated_images $s "feature" $MAX_AGE)
-#  # get all outdated tag where tag contains "bug"
-#  outdated_bug_tags=$(get_outdated_images $s "bug" $MAX_AGE)
-#  # get all outdated tag where tag contains "patch"
-#  outdated_patch_tags=$(get_outdated_images $s "patch" $MAX_AGE)
+  # get all outdated tag where tag contains "dev-PR"
+  # outdated_dev_pr_tags=$(get_outdated_images $s "dev-PR" $MAX_AGE)
+
+  # ToDo: Also Check for "x.y.z-dev.20" tags (e.g., 0.8.0-dev.20210101)
+  # outdated_dev_tags=$(get_outdated_images $s "dev.20" $MAX_AGE)
+
+  # get all outdated tag where tag contains "feature"
+  outdated_feature_tags=$(get_outdated_images $s "feature" $MAX_AGE)
+  # get all outdated tag where tag contains "bug"
+  outdated_bug_tags=$(get_outdated_images $s "bug" $MAX_AGE)
+  # get all outdated tag where tag contains "patch"
+  outdated_patch_tags=$(get_outdated_images $s "patch" $MAX_AGE)
 
   # get all outdated tag where tag contains "dirty"
   outdated_dirty_tags=$(get_outdated_images $s "dirty" $MAX_AGE)
@@ -148,6 +154,14 @@ for s in ${IMAGES[@]}; do
 
   for tag in ${outdated_datetime_tags}; do
     delete_tag $s $tag
+  done
+
+  for tag in ${outdated_dev_pr_tags}; do
+    echo "dummy" $s $tag
+  done
+
+  for tag in ${outdated_dev_tags}; do
+    echo "dummy" $s $tag
   done
 
   for tag in ${outdated_feature_tags}; do

--- a/gh-actions-scripts/cleanup_docker_images.sh
+++ b/gh-actions-scripts/cleanup_docker_images.sh
@@ -5,17 +5,17 @@
 # Required secrets/params:                                       #
 # - REGISTRY_USER                                                #
 # - REGISTRY_PASSWORD                                            #
+# - DOCKER_ORG                                                   #
+# - IMAGES                                                       #
 ##################################################################
 
 ##################################################################
 # Configuration                                                  #
 ##################################################################
 
-# list all images that should be checked
-IMAGES=("api" "bridge2" "configuration-service" "openshift-route-service" "distributor" "gatekeeper-service" "helm-service" "jmeter-service" "lighthouse-service" "mongodb-datastore" "remediation-service" "shipyard-controller" "shipyard-service")
 # max age that images should have before they are marked as outdated
 MAX_AGE=30
-
+IMAGES=("api" "bridge2" "configuration-service" "openshift-route-service" "distributor" "gatekeeper-service" "helm-service" "jmeter-service" "lighthouse-service" "mongodb-datastore" "remediation-service" "shipyard-controller" "shipyard-service")
 
 ##################################################################
 # Actual Job                                                     #
@@ -34,10 +34,10 @@ function get_outdated_images() {
   TOKEN=$(curl -s -H "Content-Type: application/json" -X POST -d '{"username": "'${REGISTRY_USER}'", "password": "'${REGISTRY_PASSWORD}'"}' https://hub.docker.com/v2/users/login/ | jq -r .token)
 
   # Count number of tags based on the tag filter
-  COUNT=$(curl -s -H "Authorization: JWT ${TOKEN}" "https://hub.docker.com/v2/repositories/keptn/${REPO}/tags/?name=${TAG_FILTER}&page_size=1" | jq -r '.count')
+  COUNT=$(curl -s -H "Authorization: JWT ${TOKEN}" "https://hub.docker.com/v2/repositories/${DOCKER_ORG}/${REPO}/tags/?name=${TAG_FILTER}&page_size=1" | jq -r '.count')
 
   # get all tags, ordered by last_update (get the newest), and filter with jq based on TARGET_DATE
-  response=$(curl -s -H "Authorization: JWT ${TOKEN}" "https://hub.docker.com/v2/repositories/keptn/${REPO}/tags/?name=${TAG_FILTER}&ordering=-last_updated&page_size=${COUNT}" | jq -r --argjson date "$TARGET_DATE" '.results|.[]|select (.last_updated | sub(".[0-9]+Z$"; "Z") | fromdate < $date)|.name')
+  response=$(curl -s -H "Authorization: JWT ${TOKEN}" "https://hub.docker.com/v2/repositories/${DOCKER_ORG}/${REPO}/tags/?name=${TAG_FILTER}&ordering=-last_updated&page_size=${COUNT}" | jq -r --argjson date "$TARGET_DATE" '.results|.[]|select (.last_updated | sub(".[0-9]+Z$"; "Z") | fromdate < $date)|.name')
   echo $response
 }
 

--- a/gh-actions-scripts/detect_stale_images.sh
+++ b/gh-actions-scripts/detect_stale_images.sh
@@ -5,6 +5,7 @@
 # Required secrets/params:                                       #
 # - REGISTRY_USER                                                #
 # - REGISTRY_PASSWORD                                            #
+# - DOCKER_ORG                                                   #
 ##################################################################
 
 ##################################################################
@@ -12,11 +13,10 @@
 ##################################################################
 
 # list all images that should be checked
-DOCKER_ORG="keptn"
 MAX_AGE_DAYS=30
-IMAGES=("api" "bridge2" "configuration-service" "openshift-route-service" "distributor" "gatekeeper-service" "helm-service" "jmeter-service" "lighthouse-service" "mongodb-datastore" "remediation-service" "shipyard-controller" "shipyard-service")
-# Todo: The list of images should be somehow configured in the repo
 
+# list of images to be checked
+IMAGES=("api" "bridge2" "configuration-service" "openshift-route-service" "distributor" "gatekeeper-service" "helm-service" "jmeter-service" "lighthouse-service" "mongodb-datastore" "remediation-service" "shipyard-controller" "shipyard-service")
 # additional old images that we want to keep
 ADDITIONAL_OLD_IMAGES=("installer" "bridge" "upgrader")
 
@@ -43,7 +43,7 @@ function check_if_stale() {
   TARGET_DATE=$(date -d "-${MAX_AGE_DAYS} days" +%s)
 
   # for each tag, check if the tag is stale
-  for TAG in ${RELEASE_TAGS[@]}; do
+  for TAG in ${TAGS[@]}; do
     HTTP_RESPONSE=$(curl -s -H "Authorization: JWT ${DOCKER_API_TOKEN}" --write-out "HTTPSTATUS:%{http_code}" "https://hub.docker.com/v2/repositories/${DOCKER_ORG}/${REPO}/tags/${TAG}/")
 
     # extract body and status

--- a/gh-actions-scripts/detect_stale_images.sh
+++ b/gh-actions-scripts/detect_stale_images.sh
@@ -33,12 +33,15 @@ fi
 
 
 # list of images to be checked
-IMAGES=("api" "bridge2" "configuration-service" "openshift-route-service" "distributor" "gatekeeper-service" "helm-service" "jmeter-service" "lighthouse-service" "mongodb-datastore" "remediation-service" "shipyard-controller" "shipyard-service")
+IMAGES=("api" "bridge2" "configuration-service" "openshift-route-service" "distributor" "gatekeeper-service" "helm-service" "jmeter-service" "lighthouse-service" "mongodb-datastore" "remediation-service" "shipyard-controller")
 # additional old images that we want to keep
-ADDITIONAL_OLD_IMAGES=("installer" "bridge" "upgrader" "wait-service")
+ADDITIONAL_OLD_IMAGES=("installer" "bridge" "upgrader" "shipyard-service" "wait-service" "pitometer-service")
+# Older than version 0.5
+ADDITIONAL_VERY_OLD_IMAGES=("keptn-authenticator" "keptn-control" "keptn-event-broker" "keptn-event-broker-ext" "slack-service" "control" "eventbroker" "eventbroker-ext" "github-service")
 
 # merge IMAGES and ADDITIONAL_OLD_IMAGES
 IMAGES=("${IMAGES[@]}" "${ADDITIONAL_OLD_IMAGES[@]}")
+IMAGES=("${IMAGES[@]}" "${ADDITIONAL_VERY_OLD_IMAGES[@]}")
 
 
 # Authenticate against DockerHub API

--- a/gh-actions-scripts/detect_stale_images.sh
+++ b/gh-actions-scripts/detect_stale_images.sh
@@ -15,10 +15,27 @@
 # list all images that should be checked
 MAX_AGE_DAYS=30
 
+# ensure the params/variables are set
+if [ -z "$REGISTRY_USER" ]; then
+  echo "REGISTRY_USER is not set. Please set REGISTRY_USER to the username of your container registry."
+  exit 1
+fi
+
+if [ -z "$REGISTRY_PASSWORD" ]; then
+  echo "REGISTRY_PASSWORD is not set. Please set REGISTRY_PASSWORD to the password of your container registry."
+  exit 1
+fi
+
+if [ -z "$DOCKER_ORG" ]; then
+  echo "DOCKER_ORG is not set. Please set DOCKER_ORG to the organization that you want to check stale images for."
+  exit 1
+fi
+
+
 # list of images to be checked
 IMAGES=("api" "bridge2" "configuration-service" "openshift-route-service" "distributor" "gatekeeper-service" "helm-service" "jmeter-service" "lighthouse-service" "mongodb-datastore" "remediation-service" "shipyard-controller" "shipyard-service")
 # additional old images that we want to keep
-ADDITIONAL_OLD_IMAGES=("installer" "bridge" "upgrader")
+ADDITIONAL_OLD_IMAGES=("installer" "bridge" "upgrader" "wait-service")
 
 # merge IMAGES and ADDITIONAL_OLD_IMAGES
 IMAGES=("${IMAGES[@]}" "${ADDITIONAL_OLD_IMAGES[@]}")
@@ -26,6 +43,11 @@ IMAGES=("${IMAGES[@]}" "${ADDITIONAL_OLD_IMAGES[@]}")
 
 # Authenticate against DockerHub API
 DOCKER_API_TOKEN=$(curl -s -H "Content-Type: application/json" -X POST -d '{"username": "'${REGISTRY_USER}'", "password": "'${REGISTRY_PASSWORD}'"}' https://hub.docker.com/v2/users/login/ | jq -r .token)
+
+if [[ "$DOCKER_API_TOKEN" == "null" ]]; then
+  echo "Failed to authenticate on DockerHub Api."
+  exit 1
+fi
 
 
 # get all github release tags


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

* This PR fixes the failed workflows for stale and outdated images
* Set OS to ubuntu-20.04 (instead of `ubuntu-latest`)
* added c-py/action-dotenv-to-setenv@v2 for loading .ci_env
* added more (older) services for outdated tag check
* added a check for images/tags based on commit hashes that are outdated
* added some more debug messages
* added sanity checks

In addition, I've ran the script locally and cleaned up old/outdated-images on `keptn` organization on hub.docker.com.

