### PR TITLE
#2824 Replace helm-chart appVersion of latest with the actual version

### DIFF
--- a/gh-actions-scripts/build_installer_helm_chart.sh
+++ b/gh-actions-scripts/build_installer_helm_chart.sh
@@ -13,6 +13,7 @@ helm dependency build ${BASE_PATH}/keptn/charts/control-plane
 
 # replace "appVersion: latest" with "appVersion: $VERSION" in all Chart.yaml files
 find -name Chart.yaml -exec sed -i -- "s/appVersion: latest/appVersion: ${VERSION}/g" {} \;
+find -name Chart.yaml -exec sed -i -- "s/version: latest/version: ${VERSION}/g" {} \;
 
 helm package ${BASE_PATH}/keptn --app-version $VERSION --version $VERSION
 if [ $? -ne 0 ]; then

--- a/gh-actions-scripts/build_installer_helm_chart.sh
+++ b/gh-actions-scripts/build_installer_helm_chart.sh
@@ -11,6 +11,9 @@ BASE_PATH=installer/manifests
 helm repo add nats https://nats-io.github.io/k8s/helm/charts/
 helm dependency build ${BASE_PATH}/keptn/charts/control-plane
 
+# replace "appVersion: latest" with "appVersion: $VERSION" in all Chart.yaml files
+find -name Chart.yaml -exec sed -i -- "s/appVersion: latest/appVersion: ${VERSION}/g" {} \;
+
 helm package ${BASE_PATH}/keptn --app-version $VERSION --version $VERSION
 if [ $? -ne 0 ]; then
   echo "Error packing installer, exiting..."


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

This PR replaces `appVersion: latest` with (e.g.) `appVersion: 0.7.4-dev-PR-2824` in the helm-chart that is being built and published as an artifact.

It's a requirement for #2811.