### PR TITLE
#2824 Fix Building of helm-charts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ examples/
 *.exe
 cli/onboarding-carts/*
 configuration-service/cmd/configuration-service-server/__debug_bin
+keptn-charts/
 
 # IDE files
 .vscode/

--- a/gh-actions-scripts/build_installer_helm_chart.sh
+++ b/gh-actions-scripts/build_installer_helm_chart.sh
@@ -22,7 +22,7 @@ if [ $? -ne 0 ]; then
 fi
 
 mkdir keptn-charts/
-mv keptn-${VERSION}.tgz keptn-charts/
+mv keptn-${VERSION}.tgz keptn-charts/keptn-installer-${VERSION}.tgz
 
 # verify the chart
 helm template --debug keptn-charts/keptn-installer-${VERSION}.tgz
@@ -48,6 +48,6 @@ fi
 
 
 echo "Generated files:"
-echo " - keptn-charts/keptn-${VERSION}.tgz"
+echo " - keptn-charts/keptn-installer-${VERSION}.tgz"
 
 

--- a/installer/.gitignore
+++ b/installer/.gitignore
@@ -1,1 +1,4 @@
 .DS_Store
+# ignore generated files
+manifests/keptn/charts/control-plane/Chart.lock
+manifests/keptn/charts/control-plane/charts/nats-*.tgz


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

In https://github.com/keptn/keptn/pull/2858 I introduced the new helm-chart name `keptn-installer-${VERSION}`. Unfortunately there are some more places where this is needed, which I fixed with this PR.

In addition I improved our `.gitignore` file to ignore files when generating the installer helm chart locally.