### PR TITLE
#2879 delete upstream repo credentials if there was an error

### DIFF
--- a/configuration-service/common/projects_materialized_view.go
+++ b/configuration-service/common/projects_materialized_view.go
@@ -96,6 +96,24 @@ func (mv *projectsMaterializedView) UpdateUpstreamInfo(projectName string, uri, 
 	return nil
 }
 
+// DeleteUpstreamInfo deletes the Upstream Rpository URL and git user of a project
+func (mv *projectsMaterializedView) DeleteUpstreamInfo(projectName string) error {
+	existingProject, err := mv.GetProject(projectName)
+	if err != nil {
+		return err
+	}
+	if existingProject == nil {
+		return nil
+	}
+	existingProject.GitUser = ""
+	existingProject.GitRemoteURI = ""
+	if err := mv.updateProject(existingProject); err != nil {
+		mv.Logger.Error(fmt.Sprintf("could not delete upstream credentials of project %s: %s", projectName, err.Error()))
+		return err
+	}
+	return nil
+}
+
 // GetProjects returns all projects
 func (mv *projectsMaterializedView) GetProjects() ([]*models.ExpandedProject, error) {
 	return mv.ProjectRepo.GetProjects()

--- a/configuration-service/handlers/project.go
+++ b/configuration-service/handlers/project.go
@@ -166,10 +166,24 @@ func PutProjectProjectNameHandlerFunc(params project.PutProjectProjectNameParams
 
 			mv := common.GetProjectsMaterializedView()
 			logger.Debug("Add or update Git origin and push changes for project " + params.ProjectName)
+			projectInfo, err := mv.GetProject(params.Project.ProjectName)
+			if err != nil {
+				msg := "could not read project information: " + err.Error()
+				logger.Error(msg)
+				return project.NewPostProjectDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String(msg)})
+			}
+
+			oldRemoteURL := projectInfo.GitRemoteURI
+			oldRemoteUser := projectInfo.GitUser
+
 			err = common.UpdateOrCreateOrigin(params.Project.ProjectName)
 			if err != nil {
 				logger.Error(fmt.Sprintf("Could not add upstream repository while updating project %s: %v", params.Project.ProjectName, err))
-				if deleteErr := mv.DeleteUpstreamInfo(params.ProjectName); deleteErr != nil {
+				if oldRemoteURL != "" && oldRemoteUser != "" {
+					if restoreErr := mv.UpdateUpstreamInfo(params.ProjectName, oldRemoteURL, oldRemoteUser); restoreErr != nil {
+						logger.Error(fmt.Sprintf("could not restore upstream info in materializer view to previous values: %s", err.Error()))
+					}
+				} else if deleteErr := mv.DeleteUpstreamInfo(params.ProjectName); deleteErr != nil {
 					logger.Error(fmt.Sprintf("Could not delete upstream info from materialized view: %s", err.Error()))
 				}
 				return project.NewPostProjectDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String(err.Error())})

--- a/shipyard-controller/api/project.go
+++ b/shipyard-controller/api/project.go
@@ -315,7 +315,7 @@ func (pm *projectManager) updateProject(params *operations.CreateProjectParams) 
 	})
 
 	if errObj != nil {
-		msg := fmt.Sprintf("Could not update upstream repository of project %s: %s", *params.Name, errObj.Message)
+		msg := fmt.Sprintf("Could not update upstream repository of project %s: %s", *params.Name, *errObj.Message)
 
 		if delErr := pm.deleteUpstreamRepoCredentials(params); delErr != nil {
 			pm.logger.Error(fmt.Sprintf("Could not delete upstream repo credentials: %s", delErr.Error()))

--- a/shipyard-controller/api/project.go
+++ b/shipyard-controller/api/project.go
@@ -332,6 +332,16 @@ func (pm *projectManager) updateProject(params *operations.CreateProjectParams) 
 				Name:         params.Name,
 			}); createErr != nil {
 				pm.logger.Error(fmt.Sprintf("Could not restore previous upstream repo credentials: %s", createErr.Error()))
+			} else {
+				// restore the upstream on the configuration service
+				if _, restoreErrObj := pm.projectAPI.UpdateConfigurationServiceProject(keptnapimodels.Project{
+					GitRemoteURI: oldSecret.RemoteURI,
+					GitToken:     oldSecret.Token,
+					GitUser:      oldSecret.User,
+					ProjectName:  *params.Name,
+				}); restoreErrObj != nil {
+					pm.logger.Error(fmt.Sprintf("Could not restore previous upstream on configuration service: %s", *restoreErrObj.Message))
+				}
 			}
 		} else {
 			if delErr := pm.deleteUpstreamRepoCredentials(params); delErr != nil {

--- a/shipyard-controller/api/project.go
+++ b/shipyard-controller/api/project.go
@@ -301,6 +301,12 @@ func (pm *projectManager) updateProject(params *operations.CreateProjectParams) 
 		pm.logger.Error(msg)
 		return errors.New(msg)
 	}
+	oldSecret, getSecretErr := pm.getUpstreamRepoCredentials(*params.Name)
+	if getSecretErr != nil {
+		// log the error but continue
+		pm.logger.Error(fmt.Sprintf("could not read previous secret of project %s: %s", *params.Name, getSecretErr.Error()))
+	}
+
 	if params.GitRemoteURL != "" && params.GitUser != "" && params.GitToken != "" {
 		if err := pm.createUpstreamRepoCredentials(params); err != nil {
 			return pm.logAndReturnError(err.Error())
@@ -317,8 +323,20 @@ func (pm *projectManager) updateProject(params *operations.CreateProjectParams) 
 	if errObj != nil {
 		msg := fmt.Sprintf("Could not update upstream repository of project %s: %s", *params.Name, *errObj.Message)
 
-		if delErr := pm.deleteUpstreamRepoCredentials(params); delErr != nil {
-			pm.logger.Error(fmt.Sprintf("Could not delete upstream repo credentials: %s", delErr.Error()))
+		if oldSecret != nil {
+			// restore previous secret
+			if createErr := pm.createUpstreamRepoCredentials(&operations.CreateProjectParams{
+				GitRemoteURL: oldSecret.RemoteURI,
+				GitToken:     oldSecret.Token,
+				GitUser:      oldSecret.User,
+				Name:         params.Name,
+			}); createErr != nil {
+				pm.logger.Error(fmt.Sprintf("Could not restore previous upstream repo credentials: %s", createErr.Error()))
+			}
+		} else {
+			if delErr := pm.deleteUpstreamRepoCredentials(params); delErr != nil {
+				pm.logger.Error(fmt.Sprintf("Could not delete upstream repo credentials: %s", delErr.Error()))
+			}
 		}
 		return pm.logAndReturnError(msg)
 	}
@@ -449,6 +467,25 @@ func (pm *projectManager) sendProjectCreateSuccessFinishedEvent(keptnContext str
 		return errors.New("could not send create.project.finished event: " + err.Error())
 	}
 	return nil
+}
+
+func (pm *projectManager) getUpstreamRepoCredentials(projectName string) (*gitCredentials, error) {
+	secret, err := pm.secretStore.GetSecret(getUpstreamRepoCredsSecretName(projectName))
+	if err != nil {
+		return nil, err
+	}
+	if secret == nil {
+		return nil, nil
+	}
+
+	if marshalledSecret, ok := secret["git-credentials"]; ok {
+		secretObj := &gitCredentials{}
+		if err := json.Unmarshal(marshalledSecret, secretObj); err != nil {
+			return nil, err
+		}
+		return secretObj, nil
+	}
+	return nil, nil
 }
 
 func (pm *projectManager) createUpstreamRepoCredentials(params *operations.CreateProjectParams) error {


### PR DESCRIPTION
Closes #2879 

In case there already was an upstream repository defined before updating the project with the wrong one, the previous credentials will be restored.
Signed-off-by: Florian Bacher <florian.bacher@dynatrace.com>