### PR TITLE
#2804 Added shipyardVersion property to GET /project response

### DIFF
--- a/configuration-service/common/projects_materialized_view.go
+++ b/configuration-service/common/projects_materialized_view.go
@@ -134,9 +134,11 @@ func (mv *projectsMaterializedView) GetProject(projectName string) (*models.Expa
 	if err != nil {
 		return nil, err
 	}
-	if err := setShipyardVersion(project); err != nil {
-		// log the error but continue
-		mv.Logger.Error(fmt.Sprintf("could not set shipyard version of project %s: %s", project.ProjectName, err.Error()))
+	if project != nil {
+		if err := setShipyardVersion(project); err != nil {
+			// log the error but continue
+			mv.Logger.Error(fmt.Sprintf("could not set shipyard version of project %s: %s", project.ProjectName, err.Error()))
+		}
 	}
 	return project, nil
 }

--- a/configuration-service/common/projects_materialized_view.go
+++ b/configuration-service/common/projects_materialized_view.go
@@ -73,6 +73,9 @@ func (mv *projectsMaterializedView) UpdateShipyard(projectName string, shipyardC
 	}
 
 	existingProject.Shipyard = shipyardContent
+	if err := setShipyardVersion(existingProject); err != nil {
+		mv.Logger.Error(fmt.Sprintf("could not update shipyard version fo project %s: %s"+projectName, err.Error()))
+	}
 
 	return mv.updateProject(existingProject)
 }

--- a/configuration-service/common/projects_materialized_view_test.go
+++ b/configuration-service/common/projects_materialized_view_test.go
@@ -169,6 +169,11 @@ func Test_projectsMaterializedView_CreateProject(t *testing.T) {
 	}
 }
 
+const testShipyardContent = `apiVersion: "spec.keptn.sh/0.2.0"
+kind: "Shipyard"
+metadata:
+  name: "shipyard-sockshop"`
+
 func Test_projectsMaterializedView_UpdateShipyard(t *testing.T) {
 	type fields struct {
 		ProjectRepo ProjectRepo
@@ -192,7 +197,7 @@ func Test_projectsMaterializedView_UpdateShipyard(t *testing.T) {
 						return &models.ExpandedProject{ProjectName: "test-project"}, nil
 					},
 					UpdateProjectMock: func(project *models.ExpandedProject) error {
-						if project.Shipyard == "test-content" {
+						if project.Shipyard == testShipyardContent && project.ShipyardVersion == "spec.keptn.sh/0.2.0" {
 							return nil
 						}
 						return errors.New("shipyard content was not updated properly")
@@ -203,7 +208,7 @@ func Test_projectsMaterializedView_UpdateShipyard(t *testing.T) {
 			},
 			args: args{
 				projectName:     "test-project",
-				shipyardContent: "test-content",
+				shipyardContent: testShipyardContent,
 			},
 			wantErr: false,
 		},
@@ -222,7 +227,7 @@ func Test_projectsMaterializedView_UpdateShipyard(t *testing.T) {
 			},
 			args: args{
 				projectName:     "test-project",
-				shipyardContent: "test-content",
+				shipyardContent: testShipyardContent,
 			},
 			wantErr: true,
 		},

--- a/configuration-service/handlers/project_resource.go
+++ b/configuration-service/handlers/project_resource.go
@@ -198,16 +198,6 @@ func GetProjectProjectNameResourceResourceURIHandlerFunc(params project_resource
 		return project_resource.NewGetProjectProjectNameResourceResourceURIDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not read file")})
 	}
 
-	if strings.ToLower(params.ResourceURI) == "shipyard.yaml" {
-		mv := common.GetProjectsMaterializedView()
-		logger.Debug("updating shipyard.yaml content for project " + params.ProjectName + " in mongoDB table")
-		err = mv.UpdateShipyard(params.ProjectName, string(dat))
-		if err != nil {
-			logger.Error("Could not update shipyard.yaml content for project " + params.ProjectName + ": " + err.Error())
-			return project_resource.NewGetProjectProjectNameResourceResourceURIDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String(err.Error())})
-		}
-	}
-
 	resourceContent := base64.StdEncoding.EncodeToString(dat)
 
 	resource := &models.Resource{

--- a/configuration-service/handlers/project_resource.go
+++ b/configuration-service/handlers/project_resource.go
@@ -77,7 +77,11 @@ func PutProjectProjectNameResourceHandlerFunc(params project_resource.PutProject
 		if strings.ToLower(*res.ResourceURI) == "shipyard.yaml" {
 			mv := common.GetProjectsMaterializedView()
 			logger.Debug("updating shipyard.yaml content for project " + params.ProjectName + " in mongoDB table")
-			err := mv.UpdateShipyard(params.ProjectName, res.ResourceContent)
+			decodedShipyard, err := base64.StdEncoding.DecodeString(res.ResourceContent)
+			if err != nil {
+				logger.Error(fmt.Sprintf("could not decode shipyard file content: %s", err.Error()))
+			}
+			err = mv.UpdateShipyard(params.ProjectName, string(decodedShipyard))
 			if err != nil {
 				logger.Error("Could not update shipyard.yaml content for project " + params.ProjectName + ": " + err.Error())
 				return project_resource.NewPutProjectProjectNameResourceBadRequest().WithPayload(&models.Error{Code: 500, Message: swag.String(err.Error())})
@@ -131,6 +135,19 @@ func PostProjectProjectNameResourceHandlerFunc(params project_resource.PostProje
 		filePath := projectConfigPath + "/" + *res.ResourceURI
 		logger.Debug("Adding resource: " + filePath)
 		common.WriteBase64EncodedFile(projectConfigPath+"/"+*res.ResourceURI, res.ResourceContent)
+		if strings.ToLower(*res.ResourceURI) == "shipyard.yaml" {
+			mv := common.GetProjectsMaterializedView()
+			logger.Debug("updating shipyard.yaml content for project " + params.ProjectName + " in mongoDB table")
+			decodedShipyard, err := base64.StdEncoding.DecodeString(res.ResourceContent)
+			if err != nil {
+				logger.Error(fmt.Sprintf("could not decode shipyard file content: %s", err.Error()))
+			}
+			err = mv.UpdateShipyard(params.ProjectName, string(decodedShipyard))
+			if err != nil {
+				logger.Error("Could not update shipyard.yaml content for project " + params.ProjectName + ": " + err.Error())
+				return project_resource.NewPostProjectProjectNameResourceDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String(err.Error())})
+			}
+		}
 	}
 
 	logger.Debug("Staging Changes")
@@ -179,6 +196,16 @@ func GetProjectProjectNameResourceResourceURIHandlerFunc(params project_resource
 	if err != nil {
 		logger.Error(err.Error())
 		return project_resource.NewGetProjectProjectNameResourceResourceURIDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not read file")})
+	}
+
+	if strings.ToLower(params.ResourceURI) == "shipyard.yaml" {
+		mv := common.GetProjectsMaterializedView()
+		logger.Debug("updating shipyard.yaml content for project " + params.ProjectName + " in mongoDB table")
+		err = mv.UpdateShipyard(params.ProjectName, string(dat))
+		if err != nil {
+			logger.Error("Could not update shipyard.yaml content for project " + params.ProjectName + ": " + err.Error())
+			return project_resource.NewGetProjectProjectNameResourceResourceURIDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String(err.Error())})
+		}
 	}
 
 	resourceContent := base64.StdEncoding.EncodeToString(dat)

--- a/configuration-service/models/expanded_project.go
+++ b/configuration-service/models/expanded_project.go
@@ -36,6 +36,9 @@ type ExpandedProject struct {
 	// Shipyard file content
 	Shipyard string `json:"shipyard,omitempty"`
 
+	// Version of the shipyard file
+	ShipyardVersion string `json:"shipyardVersion,omitempty"`
+
 	// stages
 	Stages []*ExpandedStage `json:"stages"`
 }

--- a/configuration-service/restapi/embedded_spec.go
+++ b/configuration-service/restapi/embedded_spec.go
@@ -1689,6 +1689,10 @@ func init() {
           "description": "Shipyard file content",
           "type": "string"
         },
+        "shipyardVersion": {
+          "description": "Version of the shipyard file",
+          "type": "string"
+        },
         "stages": {
           "type": "array",
           "items": {
@@ -4313,6 +4317,10 @@ func init() {
         },
         "shipyard": {
           "description": "Shipyard file content",
+          "type": "string"
+        },
+        "shipyardVersion": {
+          "description": "Version of the shipyard file",
           "type": "string"
         },
         "stages": {

--- a/configuration-service/swagger.yaml
+++ b/configuration-service/swagger.yaml
@@ -70,6 +70,9 @@ definitions:
       shipyard:
         type: string
         description: Shipyard file content
+      shipyardVersion:
+        type: string
+        description: Version of the shipyard file
       creationDate:
         type: string
         description: Creation date of the project


### PR DESCRIPTION
Closes #2804 

It turned out that up until now, the shipyard content was only persisted after updating a shipyard.yaml for a project, but not during the project creation. This has been fixed with this PR. 

Signed-off-by: Florian Bacher <florian.bacher@dynatrace.com>