### PR TITLE
#2362 use HOSTNAME_TEMPLATE in generated VirtualServices

### DIFF
--- a/helm-service/pkg/helm/generated_chart_handler.go
+++ b/helm-service/pkg/helm/generated_chart_handler.go
@@ -1,6 +1,10 @@
 package helm
 
 import (
+	"errors"
+	"fmt"
+	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
+	"net/url"
 	"strings"
 
 	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
@@ -144,11 +148,17 @@ func (c *GeneratedChartGenerator) generateServices(svc *corev1.Service, project 
 	}
 	templates = append(templates, &chart.File{Name: "templates/" + servicePrimary.Name + c.mesh.GetDestinationRuleSuffix(), Data: destinationRulePrimary})
 
+	// get the public hostname based on what has been configured in HOSTNAME_TEMPLATE and INGRESS_HOSTNAME_SUFFIX
+	publicHostName, err := getVirtualServicePublicHost(svc.Name, project, stageName)
+	if err != nil {
+		return nil, err
+	}
+
 	// Generate virtual service
 	gws := []string{mesh.GetIngressGateway(), "mesh"}
 	hosts := []string{
-		svc.Name + "." + c.getNamespace(project, stageName) + "." + mesh.GetIngressHostnameSuffix(), // service_name.dev.123.45.67.89.xip.io
-		svc.Name, // service-name
+		publicHostName, // service_name.dev.123.45.67.89.xip.io
+		svc.Name,       // service-name
 	}
 	destCanary := mesh.HTTPRouteDestination{Host: hostCanary, Weight: 0}
 	destPrimary := mesh.HTTPRouteDestination{Host: hostPrimary, Weight: 100}
@@ -165,6 +175,23 @@ func (c *GeneratedChartGenerator) generateServices(svc *corev1.Service, project 
 	templates = append(templates, &chart.File{Name: "templates/" + svc.Name + c.mesh.GetVirtualServiceSuffix(), Data: vs})
 
 	return templates, nil
+}
+
+func getVirtualServicePublicHost(serviceName, projectName, stageName string) (string, error) {
+	publicURI := mesh.GetPublicDeploymentURI(keptnv2.EventData{
+		Project: projectName,
+		Stage:   stageName,
+		Service: serviceName,
+	})
+
+	if len(publicURI) == 0 {
+		return "", errors.New("could not determine public host name")
+	}
+	url, err := url.Parse(publicURI[0])
+	if err != nil {
+		return "", fmt.Errorf("could not parse hostname: " + err.Error())
+	}
+	return url.Hostname(), nil
 }
 
 func (c *GeneratedChartGenerator) generateDeployment(depl *appsv1.Deployment) (*chart.File, error) {
@@ -208,10 +235,16 @@ func (c *GeneratedChartGenerator) GenerateMeshChart(helmManifest string, project
 	svcs := GetServices(helmManifest)
 
 	for _, svc := range svcs {
+		// get the public hostname based on what has been configured in HOSTNAME_TEMPLATE and INGRESS_HOSTNAME_SUFFIX
+		publicHostName, err := getVirtualServicePublicHost(svc.Name, project, stageName)
+		if err != nil {
+			return nil, err
+		}
+
 		// Generate virtual service for external access
 		gws := []string{mesh.GetIngressGateway(), "mesh"}
 		hosts := []string{
-			svc.Name + "." + c.getNamespace(project, stageName) + "." + mesh.GetIngressHostnameSuffix(),
+			publicHostName,
 			svc.Name,
 		}
 		host := svc.Name + "." + c.getNamespace(project, stageName) + ".svc.cluster.local"

--- a/helm-service/pkg/helm/generated_chart_handler_test.go
+++ b/helm-service/pkg/helm/generated_chart_handler_test.go
@@ -1,0 +1,70 @@
+package helm
+
+import (
+	"os"
+	"testing"
+)
+
+func Test_getVirtualServicePublicHost(t *testing.T) {
+	type args struct {
+		svc       string
+		project   string
+		stageName string
+	}
+	tests := []struct {
+		name             string
+		hostnameTemplate string
+		hostnameSuffix   string
+		args             args
+		want             string
+		wantErr          bool
+	}{
+		{
+			name: "get default hostname",
+			args: args{
+				svc:       "svc",
+				project:   "prj",
+				stageName: "stg",
+			},
+			want:    "svc.prj-stg.svc.cluster.local",
+			wantErr: false,
+		},
+		{
+			name:           "get hostname based on default template and custom INGRESS_HOSTNAME_SUFFIX",
+			hostnameSuffix: "123.xip.io",
+			args: args{
+				svc:       "svc",
+				project:   "prj",
+				stageName: "stg",
+			},
+			want:    "svc.prj-stg.123.xip.io",
+			wantErr: false,
+		},
+		{
+			name:             "get hostname based on custom HOSTNAME_TEMPLATE and custom INGRESS_HOSTNAME_SUFFIX",
+			hostnameTemplate: "${service}-${stage}-${project}.${INGRESS_HOSTNAME_SUFFIX}",
+			hostnameSuffix:   "123.xip.io",
+			args: args{
+				svc:       "svc",
+				project:   "prj",
+				stageName: "stg",
+			},
+			want:    "svc-stg-prj.123.xip.io",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Setenv("HOSTNAME_TEMPLATE", tt.hostnameTemplate)
+			os.Setenv("INGRESS_HOSTNAME_SUFFIX", tt.hostnameSuffix)
+			got, err := getVirtualServicePublicHost(tt.args.svc, tt.args.project, tt.args.stageName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getVirtualServicePublicHost() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("getVirtualServicePublicHost() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/installer/manifests/keptn/charts/continuous-delivery/templates/continuous-deployment.yaml
+++ b/installer/manifests/keptn/charts/continuous-delivery/templates/continuous-deployment.yaml
@@ -194,6 +194,11 @@ spec:
                   name: ingress-config
                   key: istio_gateway
                   optional: true
+            - name: HOSTNAME_TEMPLATE
+              valueFrom:
+                name: ingress-config
+                key: hostname_template
+                optional: true
         - name: distributor
           image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
           {{- include "continuous-delivery.livenessProbe" . | nindent 10 }}


### PR DESCRIPTION
Closes #2362 
In the original PR for this Issue (PR #2882), the hostname template was only used for generating the public deployment URI for the CloudEvent, but not for the actual creation of the rule for the VirtualService. This has been added with this PR