### PR TITLE
#2625 Heatmap not showing up in Bridge

### DIFF
--- a/bridge/client/app/_components/ktb-events-list/ktb-events-list.component.html
+++ b/bridge/client/app/_components/ktb-events-list/ktb-events-list.component.html
@@ -5,8 +5,7 @@
     </ktb-horizontal-separator>
     <ktb-event-item [event]="event" [class.focused]="event.id == focusedEventId && scrollIntoView(eventRef)" (click)="focusEvent(event)">
       <ktb-event-item-detail>
-
-        <ktb-evaluation-details *ngIf="event.data.evaluation && isFinished(event.type)" [evaluationData]="event" [isInvalidated]="isInvalidated(event)">
+        <ktb-evaluation-details *ngIf="event.isEvaluation() && event.isFinished()" [evaluationData]="event.getFinishedEvent()" [isInvalidated]="isInvalidated(event)">
         </ktb-evaluation-details>
       </ktb-event-item-detail>
     </ktb-event-item>

--- a/bridge/client/app/_components/ktb-events-list/ktb-events-list.component.ts
+++ b/bridge/client/app/_components/ktb-events-list/ktb-events-list.component.ts
@@ -77,8 +77,4 @@ export class KtbEventsListComponent implements OnInit {
   isInvalidated(event) {
     return !!this.events.find(e => e.isEvaluationInvalidation() && e.triggeredid == event.id);
   }
-
-  isFinished(type: string) {
-    return type === EventTypes.EVALUATION_FINISHED;
-  }
 }

--- a/bridge/client/app/_models/event-types.ts
+++ b/bridge/client/app/_models/event-types.ts
@@ -5,6 +5,8 @@ export enum EventTypes {
   DEPLOYMENT_FINISHED = 'sh.keptn.events.deployment-finished',
   TESTS_FINISHED = 'sh.keptn.events.tests-finished',
   START_EVALUATION = 'sh.keptn.event.start-evaluation',
+  EVALUATION_TRIGGERED = 'sh.keptn.event.evaluation.triggered',
+  EVALUATION_STARTED = 'sh.keptn.event.evaluation.started',
   EVALUATION_FINISHED = 'sh.keptn.event.evaluation.finished',
   EVALUATION_INVALIDATED = 'sh.keptn.events.evaluation.invalidated',
   START_SLI_RETRIEVAL = 'sh.keptn.internal.event.get-sli',

--- a/bridge/client/app/_models/trace.ts
+++ b/bridge/client/app/_models/trace.ts
@@ -181,7 +181,7 @@ class Trace {
   }
 
   public isEvaluation(): string {
-    return this.type === EventTypes.START_EVALUATION ? this.data.stage : null;
+    return this.type === EventTypes.EVALUATION_TRIGGERED ? this.data.stage : null;
   }
 
   public isEvaluationInvalidation(): boolean {
@@ -270,6 +270,10 @@ class Trace {
     }
 
     return this.finished;
+  }
+
+  getFinishedEvent() {
+    return this.traces.find(t => t.type.includes(".finished"));
   }
 
   static fromJSON(data: any) {

--- a/bridge/client/app/_models/trace.ts
+++ b/bridge/client/app/_models/trace.ts
@@ -273,6 +273,9 @@ class Trace {
   }
 
   static fromJSON(data: any) {
+    if(data instanceof Trace)
+      return data;
+
     const plainEvent = JSON.parse(JSON.stringify(data));
     return Object.assign(new this, data, { plainEvent });
   }


### PR DESCRIPTION
Since the `.triggered`, `.started` and `.finished` events of any type are now "merged" in the Bridge into one `Trace`, the heatmap was not showing up, since the results are provided with the `.finished` event, which now is not showing up as a separate tile anymore. 

This makes it easier to read the tasks that were executed, but also had to be considered for showing the evaluation results correctly.