### PR TITLE
Fixed missing spaces in logging output in shipyard-controller

### DIFF
--- a/shipyard-controller/api/event.go
+++ b/shipyard-controller/api/event.go
@@ -440,7 +440,7 @@ func (sc *shipyardController) getEvents(project string, filter db.EventFilter, s
 	for i := 0; i <= nrRetries; i++ {
 		startedEvents, err := sc.eventRepo.GetEvents(project, filter, status)
 		if err != nil && err == db.ErrNoEventFound {
-			sc.logger.Info(string("No matching" + status + " events found. Retrying in 2s."))
+			sc.logger.Info(string("No matching " + status + " events found. Retrying in 2s."))
 			<-time.After(2 * time.Second)
 		} else {
 			return startedEvents, err
@@ -539,10 +539,10 @@ func (sc *shipyardController) handleTriggeredEvent(event models.Event) error {
 
 	taskSequence, err := sc.getTaskSequenceInStage(stageName, taskSequenceName, shipyard)
 	if err != nil && err == errNoTaskSequence {
-		sc.logger.Info("no task sequence with name " + taskSequenceName + "found in stage " + stageName)
+		sc.logger.Info("no task sequence with name " + taskSequenceName + " found in stage " + stageName)
 		return err
 	} else if err != nil && err == errNoStage {
-		sc.logger.Info("no stage with name " + stageName + "found in project " + eventScope.Project)
+		sc.logger.Info("no stage with name " + stageName + " found in project " + eventScope.Project)
 		return err
 	}
 

--- a/shipyard-controller/deploy/service.yaml
+++ b/shipyard-controller/deploy/service.yaml
@@ -65,7 +65,7 @@ spec:
             memory: "256Mi"
             cpu: "500m"
       - name: distributor
-        image: keptn/distributor:latest
+        image: keptn/distributor:0.8.0-alpha
         ports:
           - containerPort: 8080
         livenessProbe:


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

I just went through the logs of shipyard-controller and saw that there are missing spaces, which I hereby fixed.
Also, I've set the distributor image to 0.8.0-alpha so we can use skaffold again to test it.