### PR TITLE
#2925 add indexes to mongodb collections

### DIFF
--- a/mongodb-datastore/handlers/events.go
+++ b/mongodb-datastore/handlers/events.go
@@ -314,6 +314,7 @@ func dropProjectEvents(logger *keptncommon.Logger, event *models.KeptnContextExt
 
 	logger.Debug(fmt.Sprintf("Delete all root events of project %s", projectName))
 	createdIndexes[rootEventsCollection.Name()+"-data.service"] = false
+	createdIndexes[rootEventsCollection.Name()+"-time"] = false
 	err = rootEventsCollection.Drop(ctx)
 	if err != nil {
 		err := fmt.Errorf("failed to drop collection %s: %v", rootEventsCollection.Name(), err)
@@ -514,6 +515,13 @@ func findInDB(collectionName string, pageSize int64, nextPageKeyStr *string, onl
 			ctx,
 			collection,
 			"type",
+			logger,
+		)
+	} else {
+		ensureIndexExistsOnCollection(
+			ctx,
+			collection,
+			"time",
 			logger,
 		)
 	}

--- a/mongodb-datastore/handlers/events.go
+++ b/mongodb-datastore/handlers/events.go
@@ -303,6 +303,7 @@ func dropProjectEvents(logger *keptncommon.Logger, event *models.KeptnContextExt
 	logger.Debug(fmt.Sprintf("Delete all events of project %s", projectName))
 
 	createdIndexes[projectCollection.Name()+"-shkeptncontext"] = false
+	createdIndexes[projectCollection.Name()+"-type"] = false
 	createdIndexes[projectCollection.Name()+"-data.service"] = false
 	err := projectCollection.Drop(ctx)
 	if err != nil {
@@ -507,6 +508,12 @@ func findInDB(collectionName string, pageSize int64, nextPageKeyStr *string, onl
 			ctx,
 			collection,
 			"shkeptncontext",
+			logger,
+		)
+		ensureIndexExistsOnCollection(
+			ctx,
+			collection,
+			"type",
 			logger,
 		)
 	}

--- a/mongodb-datastore/handlers/events.go
+++ b/mongodb-datastore/handlers/events.go
@@ -32,6 +32,7 @@ var mutex sync.Mutex
 
 var projectLocks = map[string]*sync.Mutex{}
 
+// define the indexes that should be created for each collection
 var rootEventsIndexes = []string{"data.service", "time"}
 var projectEventsIndexes = []string{"data.service", "shkeptncontext", "type"}
 var invalidatedEventsIndexes = []string{"triggeredid"}


### PR DESCRIPTION
Closes #2925

So far the results seem promising. I executed the same test as described in #2812, and the response time pretty much stays constant at a median of 100ms, and 95th percentile of 200ms:

In addition to the indexes mentioned in #2925, adding an index for the property `type` in the collections containing a project's events proved to be beneficial (e.g. for loading the evaluation heatmap which queries a specific event type)

![Screenshot 2021-01-22 at 08 05 56](https://user-images.githubusercontent.com/2143586/105459698-fa544100-5c8a-11eb-8b1e-591afc135638.png)


Signed-off-by: Florian Bacher <florian.bacher@dynatrace.com>