### PR TITLE
#2824 Only login to dockerhub if we are on the original repo, not on a fork

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -480,6 +480,10 @@ jobs:
 
       - id: docker_login
         name: Docker Login
+        # only run docker login if this is not a fork
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        # note: GH does not allow to access secrets for PRs from a forked repositories due to security reasons
+        # that's fine, but it means we can't push images to dockerhub
         env:
           REGISTRY_USER: ${{ secrets.REGISTRY_USER }}
           REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}

--- a/gh-actions-scripts/build_docker_image.sh
+++ b/gh-actions-scripts/build_docker_image.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+if [[ "$#" -ne 5 ]]; then
+  echo "Usage: $0 IMAGE FOLDER GIT_SHA VERSION DATETIME"
+  echo "      Example: $0 keptn/api api/ 1234abcd 1.2.3 20210101101210"
+  exit 1
+fi
+
 # ${IMAGE}=$1 ${FOLDER}=$2 ${GIT_SHA}=$3 ${VERSION}=$4 ${DATETIME}=$5
 IMAGE=$1
 FOLDER=$2
@@ -7,8 +13,20 @@ GIT_SHA=$3
 VERSION=$4
 DATETIME=$5
 
-echo "Building Docker Image ${IMAGE}:${VERSION}.${DATETIME}"
+# ensure trailing slash in folder
+if [[ "${FOLDER}" != */ ]]; then
+  echo "Please ensure that FOLDER has a trailing slash, e.g., api/"
+  exit 1
+fi
+
+echo "Building Docker Image ${IMAGE}:${VERSION}.${DATETIME} from ${FOLDER}DOCKERFILE"
 cp MANIFEST ./${FOLDER}MANIFEST #$FOLDER contains / at the end
+
+if [[ $? -ne 0 ]]; then
+  echo "::error file=${FOLDER}/Dockerfile::Could not find MANIFEST. Please create a file called MANIFEST"
+  exit 1
+fi
+
 cp travis-scripts/entrypoint.sh ./${FOLDER}entrypoint.sh #$FOLDER contains / at the end
 
 cd ./${FOLDER}
@@ -24,7 +42,13 @@ if [[ $? -ne 0 ]]; then
   exit 1
 fi
 
-docker push "${IMAGE}"
+# push all tags that we just built
+docker push "${IMAGE}:${VERSION}.${DATETIME}" 
+docker push "${IMAGE}:${VERSION}"
+
+if [[ $? -ne 0 ]]; then
+  echo "::warning file=${FOLDER}/Dockerfile::Failed to push ${IMAGE}:${VERSION}.${DATETIME} to DockerHub, continuing anyway"
+fi
 
 # change back to previous directory
 cd -


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

Based on #2824, this PR enhances the CI workflow, specifically the Docker Build process in the following ways:
* Added some sanity checks for `docker_build.sh`
* Ensured that forked PRs don't run docker login (it's not possible, secrets are not shared with forked PRs by GH action)

