### PR TITLE
#2824 Report Docker Build to PR

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -489,6 +489,12 @@ jobs:
           REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
         run: echo "$REGISTRY_PASSWORD" | docker login --username $REGISTRY_USER --password-stdin
 
+      # Docker Build Report: store successful image builds in docker_build_report/report.txt, so we can report
+      # them to the PR later
+      - id: prepare_docker_build_report
+        run: |
+          mkdir docker_build_report
+
       - id: prepare_manifest
         name: Prepare Build Manifest
         run: |
@@ -605,3 +611,21 @@ jobs:
           FOLDER: ${{ env.MONGODB_DS_FOLDER }}
         run: |
           ./gh-actions-scripts/build_docker_image.sh "${IMAGE}" "${FOLDER}" "${GIT_SHA}" "${VERSION}" "${DATETIME}"
+      
+      - id: create_docker_build_report
+        name: Create Docker Build Report
+        run: |
+          echo "The following Docker Images have been built: " > docker_build_report.txt
+          cat docker_build_report/*.txt >> docker_build_report.txt || echo "* No images have been built or uploaded" >> docker_build_report.txt
+          echo "---"
+          cat docker_build_report.txt
+
+      - id: report_docker_build_to_pr
+        name: Report Docker Build to PR
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          path: docker_build_report.txt
+          recreate: true
+          

--- a/gh-actions-scripts/build_docker_image.sh
+++ b/gh-actions-scripts/build_docker_image.sh
@@ -48,6 +48,9 @@ docker push "${IMAGE}:${VERSION}"
 
 if [[ $? -ne 0 ]]; then
   echo "::warning file=${FOLDER}/Dockerfile::Failed to push ${IMAGE}:${VERSION}.${DATETIME} to DockerHub, continuing anyway"
+  echo "* Failed to push ${IMAGE}:${VERSION}.${DATETIME} and ${IMAGE}:${VERSION} (Source: ${FOLDER})" >> ../docker_build_report/report.txt
+else
+  echo "* Pushed ${IMAGE}:${VERSION}.${DATETIME} and ${IMAGE}:${VERSION} (Source: ${FOLDER})" >> ../docker_build_report/report.txt
 fi
 
 # change back to previous directory


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

This PR adds a feature to our CI build where we post a comment with the updated docker images of the PR.

The comment is updated every time a new commit is built (so the previous comment gets deleted).

If no Docker Images have been updated, it looks like this:
![image](https://user-images.githubusercontent.com/56065213/105473800-cf271d00-5c9d-11eb-8e94-a18e4321feb3.png)

And if an image is built, it looks like this:
![image](https://user-images.githubusercontent.com/56065213/105476611-25498f80-5ca1-11eb-84d4-1e9b7532ebd7.png)
