### PR TITLE
#2824 Improve integration test workflow, create a pre-release

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -476,7 +476,14 @@ jobs:
 
       - name: Build Helm Charts
         id: build_helm_charts
-        run: ./gh-actions-scripts/build_installer_helm_chart.sh "${VERSION}"
+        run: |
+          if [[ "$BRANCH" == "master" ]]; then
+            # use VERSION.DATETIME for the image tag (e.g., nightly build)
+            ./gh-actions-scripts/build_installer_helm_chart.sh "${VERSION}" "${VERSION}.${DATETIME}"
+          else
+            # just use VERSION for the image tag
+            ./gh-actions-scripts/build_installer_helm_chart.sh "${VERSION}" "${VERSION}"
+          fi
 
       - name: Upload Helm Chart as an artifact
         id: upload_helm_chart

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - 'master'
       - 'release-*'
+    type: [labeled]
 defaults:
   run:
     shell: bash
@@ -70,7 +71,7 @@ jobs:
         continue-on-error: true
 
       - name: Process all artifacts (for push on master/release branches)
-        if: github.event_name == 'push'
+        if: (github.event_name == 'push') || (contains(github.event.pull_request.labels.*.name, 'CI:trigger-build-everything'))
         id: build_everything
         run: |
           BUILD_EVERYTHING=true
@@ -230,6 +231,34 @@ jobs:
           echo "::set-output name=DATE::$(date +'%Y%m%d')"
           echo "::set-output name=TIME::$(date +'%H%M')"
           echo "::set-output name=DATETIME::$(date +'%Y%m%d')$(date +'%H%M')"
+
+  store-output-in-build-config:
+    name: "Store output of last step in build-config.env"
+    needs: prepare_ci_run
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Create build config file
+        env:
+          BRANCH: ${{ needs.prepare_ci_run.outputs.BRANCH }}
+          BRANCH_SLUG: ${{ needs.prepare_ci_run.outputs.BRANCH_SLUG }}
+          BUILD_EVERYTHING: ${{ needs.prepare_ci_run.outputs.BUILD_EVERYTHING }}
+          VERSION: ${{ needs.prepare_ci_run.outputs.VERSION }}
+          DATETIME: ${{ needs.prepare_ci_run.outputs.DATE }}${{ needs.prepare_ci_run.outputs.TIME }}
+          GIT_SHA: ${{ needs.prepare_ci_run.outputs.GIT_SHA }}
+        run: |
+          echo "BRANCH=${BRANCH}" >> build-config.env
+          echo "BRANCH_SLUG=${BRANCH_SLUG}" >> build-config.env
+          echo "BUILD_EVERYTHING=${BUILD_EVERYTHING}" >> build-config.env
+          echo "VERSION=${VERSION}" >> build-config.env
+          echo "DATETIME=${DATETIME}" >> build-config.env
+          echo "GIT_SHA=${GIT_SHA}" >> build-config.env
+
+      - name: Upload build config as artifact
+        id: upload_build_config
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-config
+          path: build-config.env
 
   ############################################################################
   # Unit tests                                                               #
@@ -625,3 +654,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           path: docker_build_report_final.txt
           recreate: true
+
+      - name: Upload Docker Build Report as an artifact
+        id: upload_docker_build_report
+        uses: actions/upload-artifact@v2
+        with:
+          name: docker-build-report
+          path: docker_build_report.txt

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -14,6 +14,10 @@ on:
         description: 'Branch of Keptn examples to use for integration tests (e.g., master, release-x.y.z)'
         required: true
         default: 'master'
+      publish_as_release:
+        description: 'Whether or not to publish the build as a GH release (0=no, 1=yes)'
+        required: true
+        default: 0
 defaults:
   run:
     shell: bash
@@ -510,6 +514,7 @@ jobs:
 
       # Create a pre release
       - name: Create Pre Release
+        if: inputs.publish_as_release == '1'
         id: create_pre_release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -148,7 +148,7 @@ jobs:
         run: kubectl get services --all-namespaces
       - name: Debug - Get Kubernetes Deployments
         run: kubectl get deployments --all-namespaces -owide
-      - name: Download CLI artifact from master branch
+      - name: Download CLI artifact from specified branch
         uses: dawidd6/action-download-artifact@v2
         with:
           # Optional, GitHub token
@@ -432,7 +432,7 @@ jobs:
           path: test-report-*.txt
 
 
-  report-to-pr:
+  create-draft-release-for-master:
     needs: integration-test
     if: always() # run report-to-pr always, even if the previous required job fails
     runs-on: ubuntu-20.04
@@ -441,6 +441,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: test-report
+          
       - name: Print Test Report
         id: print_test_report
         run: |
@@ -461,4 +462,61 @@ jobs:
           name: test-report
           path: final-test-report.txt
 
-      # ToDo: Report to slack, E-mail, PR, or whatever
+      - name: Download all artifacts from previous build and specified branch
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          # Optional, GitHub token
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          # Required, workflow file name or ID
+          workflow: CI.yml
+          # Optional, the status or conclusion of a completed workflow to search for
+          # Can be one of a workflow conculsion::
+          # "failure", "success", "neutral", "cancelled", "skipped", "timed_out", "action_required"
+          # Or a workflow status:
+          # "completed", "in_progress", "queued"
+          # Default: "completed"
+          workflow_conclusion: success
+          # Use the branch
+          branch: ${{ github.event.inputs.branch }}
+          # Optional, directory where to extract artifact
+          path: ./dist
+
+      - name: Show content of dist folder
+        run: ls -la ./dist
+      
+      - name: Show build-config.env
+        run: cat ./dist/build-config.env
+
+      - name: Load Build-Config Environemnt from ./dist/build-config.env
+        id: load_ci_env
+        uses: c-py/action-dotenv-to-setenv@v2
+        with:
+          env-file: ./dist/build-config.env
+
+      - name: DEBUG Build-Config
+        run: |
+          echo VERSION=${VERSION}
+          echo BRANCH=${BRANCH}
+       
+      - name: Create a Release message
+        run: |
+          echo "# DEV BUILD ${VERSION} ON ${BRANCH}" > release-notes.txt
+          echo "This is a developer build, please use with caution." >> release-notes.txt
+          echo "## Docker Images" >> release-notes.txt
+          cat dist/docker_build_report.txt  >> release-notes.txt || echo "Failed to open dist/docker_build_report.txt" >> release-notes.txt
+          echo "## Integration Tests" >> release-notes.txt
+          cat final-test-report.txt >> release-notes.txt
+
+      # Create a pre release
+      - name: Create Pre Release
+        id: create_pre_release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: ${{ env.VERSION }}
+          prerelease: true
+          body_path: release-notes.txt # ${{ github.workflow }}-CHANGELOG.txt
+          files: |
+            dist/keptn-cli/keptn-*.tar.gz
+            dist/keptn-installer/keptn*.tgz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -113,10 +113,11 @@ jobs:
           GCLOUD_PROJECT_NAME: ${{ secrets.GCLOUD_PROJECT_NAME }}
           CLOUDSDK_COMPUTE_ZONE: "us-central1-a"
           CLOUDSDK_REGION: "us-central1"
+          BRANCH: ${{ steps.determine_branch.outputs.BRANCH}}
         id: install_gke
         run: |
           CLUSTER_NAME_NIGHTLY=gh-nightly
-          BRANCH_SLUG=master
+          BRANCH_SLUG=$(echo $BRANCH | iconv -t ascii//TRANSLIT | sed -r s/[^a-zA-Z0-9]+/-/g | sed -r s/^-+\|-+$//g | tr A-Z a-z)
           export CLUSTER_NAME_NIGHTLY=${CLUSTER_NAME_NIGHTLY}-${BRANCH_SLUG:0:15}-gke${GKE_VERSION//./}
           echo $CLUSTER_NAME_NIGHTLY
           echo "Installing gcloud CLI"
@@ -432,7 +433,7 @@ jobs:
           path: test-report-*.txt
 
 
-  create-draft-release-for-master:
+  publish-artifacts-as-pre-release:
     needs: integration-test
     if: always() # run report-to-pr always, even if the previous required job fails
     runs-on: ubuntu-20.04
@@ -482,16 +483,16 @@ jobs:
           path: ./dist
 
       - name: Show content of dist folder
-        run: ls -la ./dist
+        run: ls -la ./dist/*
       
       - name: Show build-config.env
-        run: cat ./dist/build-config.env
+        run: cat ./dist/build-config/build-config.env
 
-      - name: Load Build-Config Environemnt from ./dist/build-config.env
+      - name: Load Build-Config Environemnt from ./dist/build-config/build-config.env
         id: load_ci_env
         uses: c-py/action-dotenv-to-setenv@v2
         with:
-          env-file: ./dist/build-config.env
+          env-file: ./dist/build-config/build-config.env
 
       - name: DEBUG Build-Config
         run: |
@@ -503,7 +504,7 @@ jobs:
           echo "# DEV BUILD ${VERSION} ON ${BRANCH}" > release-notes.txt
           echo "This is a developer build, please use with caution." >> release-notes.txt
           echo "## Docker Images" >> release-notes.txt
-          cat dist/docker_build_report.txt  >> release-notes.txt || echo "Failed to open dist/docker_build_report.txt" >> release-notes.txt
+          cat dist/docker-build-report/docker_build_report.txt  >> release-notes.txt || echo "Failed to open dist/docker-build-report/docker_build_report.txt" >> release-notes.txt
           echo "## Integration Tests" >> release-notes.txt
           cat final-test-report.txt >> release-notes.txt
 
@@ -513,6 +514,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           name: ${{ env.VERSION }}
+          tag_name: ${{ env.VERSION }}
           prerelease: true
           body_path: release-notes.txt # ${{ github.workflow }}-CHANGELOG.txt
           files: |

--- a/gh-actions-scripts/build_installer_helm_chart.sh
+++ b/gh-actions-scripts/build_installer_helm_chart.sh
@@ -1,9 +1,16 @@
 #!/bin/bash
 
 VERSION=$1
+IMAGE_TAG=$2
+
 if [ -z "$VERSION" ]; then
   echo "No Version set, exiting..."
   exit 1
+fi
+
+if [ -z "$IMAGE_TAG" ]; then
+  echo "No Image Tag set, defaulting to version"
+  IMAGE_TAG=$VERSION
 fi
 
 BASE_PATH=installer/manifests
@@ -12,7 +19,7 @@ helm repo add nats https://nats-io.github.io/k8s/helm/charts/
 helm dependency build ${BASE_PATH}/keptn/charts/control-plane
 
 # replace "appVersion: latest" with "appVersion: $VERSION" in all Chart.yaml files
-find -name Chart.yaml -exec sed -i -- "s/appVersion: latest/appVersion: ${VERSION}/g" {} \;
+find -name Chart.yaml -exec sed -i -- "s/appVersion: latest/appVersion: ${IMAGE_TAG}/g" {} \;
 find -name Chart.yaml -exec sed -i -- "s/version: latest/version: ${VERSION}/g" {} \;
 
 helm package ${BASE_PATH}/keptn --app-version $VERSION --version $VERSION


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

This PR partially implements #2824, by doing the following:
* CI: When setting the label `CI:trigger-build-everything` on a PR, we are forcing the CI to build all docker images and the CLI
* CI: Export build-environment/build-config as an artifact, such that it can be re-used in the integration-test workflow
* CI: Add option for installer helm-chart to contain datetime for docker image tags
* Integration Tests: Create a Pre-Release (if `inputs.publish_as_release` is set to 1 - it defaults to 0 atm), including build reports, CLI and helm-chart artifacts

Example Release: https://github.com/keptn/keptn/releases/tag/0.8.1-dev-PR-2965

You can actually use this as follows:
```console
curl -sL https://get.keptn.sh | KEPTN_VERSION=0.8.1-dev-PR-2965 bash
keptn version
keptn install --chart-repo=https://github.com/keptn/keptn/releases/download/0.8.1-dev-PR-2965/keptn-installer-0.8.1-dev-PR-2965.tgz
```

![image](https://user-images.githubusercontent.com/56065213/105532257-e3ddd200-5cea-11eb-9d4b-2be40509f448.png)


