### PR TITLE
Improve integration tests for new-artifact

### DIFF
--- a/test/utils.sh
+++ b/test/utils.sh
@@ -226,7 +226,7 @@ function verify_test_step() {
 
 function wait_for_url() {
   URL=$1
-  RETRY=0; RETRY_MAX=50;
+  RETRY=0; RETRY_MAX=40;
 
   while [[ $RETRY -lt $RETRY_MAX ]]; do
     curl $URL -k
@@ -262,7 +262,7 @@ function verify_image_of_deployment() {
 
 function wait_for_deployment_in_namespace() {
   DEPLOYMENT=$1; NAMESPACE=$2;
-  RETRY=0; RETRY_MAX=50;
+  RETRY=0; RETRY_MAX=40;
 
   while [[ $RETRY -lt $RETRY_MAX ]]; do
     DEPLOYMENT_LIST=$(eval "kubectl get deployments -n ${NAMESPACE} | awk '/$DEPLOYMENT /'" | awk '{print $1}') # list of multiple deployments when starting with the same name
@@ -293,7 +293,7 @@ function wait_for_deployment_in_namespace() {
 
 function wait_for_deployment_with_image_in_namespace() {
   DEPLOYMENT=$1; NAMESPACE=$2;  IMAGE=$3
-  RETRY=0; RETRY_MAX=50;
+  RETRY=0; RETRY_MAX=40;
 
   while [[ $RETRY -lt $RETRY_MAX ]]; do
     DEPLOYMENT_IMAGE=$(eval kubectl get deployment $DEPLOYMENT -n $NAMESPACE -o=jsonpath='{$.spec.template.spec.containers[:1].image}' --ignore-not-found)
@@ -323,7 +323,7 @@ function wait_for_deployment_with_image_in_namespace() {
 
 function wait_for_pod_number_in_deployment_in_namespace() {
   DEPLOYMENT=$1; POD_COUNT=$2; NAMESPACE=$3;
-  RETRY=0; RETRY_MAX=50;
+  RETRY=0; RETRY_MAX=40;
 
   while [[ $RETRY -lt $RETRY_MAX ]]; do
     DEPLOYMENT_LIST=$(eval "kubectl get deployments -n ${NAMESPACE} | awk '/$DEPLOYMENT /'" | awk '{print $1}') # list of multiple deployments when starting with the same name
@@ -352,7 +352,7 @@ function wait_for_pod_number_in_deployment_in_namespace() {
 
 function wait_for_daemonset_in_namespace() {
   DAEMONSET=$1; NAMESPACE=$2;
-  RETRY=0; RETRY_MAX=50;
+  RETRY=0; RETRY_MAX=40;
 
   while [[ $RETRY -lt $RETRY_MAX ]]; do
     DAEMONSET_LIST=$(eval "kubectl get daemonset -n ${NAMESPACE} | awk '/$DAEMONSET /'" | awk '{print $1}')

--- a/test/utils/send_new_artifact_sockshop.sh
+++ b/test/utils/send_new_artifact_sockshop.sh
@@ -33,11 +33,12 @@ echo "Checking dev deployment"
 echo ""
 
 wait_for_deployment_in_namespace "carts-db" "$PROJECT-dev"
+verify_test_step $? "Deployment carts-db not up in $PROJECT-dev, exiting ..."
 wait_for_deployment_with_image_in_namespace "carts" "$PROJECT-dev" ${ARTIFACT_IMAGE}:$ARTIFACT_IMAGE_TAG
 verify_pod_in_namespace "carts" "$PROJECT-dev"
 verify_test_step $? "Pod carts not found, exiting ..."
 verify_pod_in_namespace "carts-db" "$PROJECT-dev"
-verify_test_step $? "Pod carts-db not found, exiting ..."
+verify_test_step $? "Pod carts-db not found in $PROJECT-dev, exiting ..."
 
 # get URL for that deployment
 DEV_URL=$(echo http://carts.${PROJECT}-dev.$(kubectl get cm ingress-config -n ${KEPTN_NAMESPACE} -o=jsonpath='{.data.ingress_hostname_suffix}'))
@@ -62,13 +63,14 @@ echo "Checking staging deployment"
 echo ""
 
 wait_for_deployment_in_namespace "carts-db" "$PROJECT-staging"
+verify_test_step $? "Deployment carts-db in $PROJECT-staging not up, exiting ..."
 wait_for_deployment_with_image_in_namespace "carts" "$PROJECT-staging" ${ARTIFACT_IMAGE}:$ARTIFACT_IMAGE_TAG
 verify_pod_in_namespace "carts" "$PROJECT-staging"
 verify_test_step $? "Pod carts not found, exiting ..."
 verify_pod_in_namespace "carts-primary" "$PROJECT-staging"
 verify_test_step $? "Pod carts-primary not found, exiting ..."
 verify_pod_in_namespace "carts-db" "$PROJECT-staging"
-verify_test_step $? "Pod carts-db not found, exiting ..."
+verify_test_step $? "Pod carts-db not found in $PROJECT-staging, exiting ..."
 
 # get URL for that deployment
 STAGING_URL=$(echo http://carts.${PROJECT}-staging.$(kubectl get cm ingress-config -n ${KEPTN_NAMESPACE} -o=jsonpath='{.data.ingress_hostname_suffix}'))
@@ -93,13 +95,14 @@ echo "Checking production deployment"
 echo ""
 
 wait_for_deployment_in_namespace "carts-db" "$PROJECT-production"
+verify_test_step $? "Deployment carts-db not up in $PROJECT-production, exiting ..."
 wait_for_deployment_with_image_in_namespace "carts" "$PROJECT-production" ${ARTIFACT_IMAGE}:$ARTIFACT_IMAGE_TAG
 verify_pod_in_namespace "carts" "$PROJECT-production"
 verify_test_step $? "Pod carts not found, exiting ..."
 verify_pod_in_namespace "carts-primary" "$PROJECT-production"
 verify_test_step $? "Pod carts-primary not found, exiting ..."
 verify_pod_in_namespace "carts-db" "$PROJECT-production"
-verify_test_step $? "Pod carts-db not found, exiting ..."
+verify_test_step $? "Pod carts-db not found in $PROJECT-production, exiting ..."
 
 # get URL for that deployment
 PRODUCTION_URL=$(echo http://carts.${PROJECT}-production.$(kubectl get cm ingress-config -n ${KEPTN_NAMESPACE} -o=jsonpath='{.data.ingress_hostname_suffix}'))


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

During log analysis of our integration tests I noticed two things:

1. Our "wait timeouts" are way too high, leading to integration tests that are running for ages
2. While we waited for `carts-db` to be deployed, we never exited

This PR tries to fix both.