### PR TITLE
Fixed the patch-namespace flag and also added the error message to run auth  command without upgrade

### DIFF
--- a/cli/cmd/auth.go
+++ b/cli/cmd/auth.go
@@ -247,6 +247,8 @@ func smartKeptnCLIAuth() (string, error) {
 			return "", fmt.Errorf("Please select the correct keptn installation")
 		}
 		return keptnInstallations[inp], nil
+	} else if len(keptnInstallations) == 0 {
+		return "", errors.New("We haven't found any Keptn Installation, Please follow the upgrade guide and patch the namespace with the annotation & label 'keptn.sh/managed-by: keptn'")
 	}
 	return keptnInstallations[0], nil
 }

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -62,6 +62,9 @@ keptn upgrade --platform=kubernetes # upgrades Keptn on the Kubernetes cluster
 			return err
 		}
 		if !mocking {
+			if *upgradeParams.PatchNamespace {
+				return patchNamespace()
+			}
 			return doUpgrade()
 		}
 		fmt.Println("Skipping upgrade due to mocking flag")


### PR DESCRIPTION
The new flag `--patch-namespace` was introduced in the PR #2733 but the calling function was later being removed somehow because of which the CLI was throwing error/crashing as the issue raised in #2912 

This has been fixed and also added the error message while running `keptn auth` without patching the namespace.

Signed-off-by: ankitjain28may <ankitjain28may77@gmail.com>