### PR TITLE
#2976 #2973 Upgrade istio, enable GKE shielded nodes

### DIFF
--- a/test/utils/gke_create_cluster.sh
+++ b/test/utils/gke_create_cluster.sh
@@ -17,8 +17,7 @@ else
     echo "No nightly cluster need to be deleted"
 fi
 
-ISTIO_CONFIG="--istio-config=auth=MTLS_PERMISSIVE"
-ADDONS="Istio,HorizontalPodAutoscaling,HttpLoadBalancing"
+ADDONS="HorizontalPodAutoscaling,HttpLoadBalancing"
 
 echo "Creating nightly cluster ${CLUSTER_NAME_NIGHTLY}"
 
@@ -32,9 +31,10 @@ gcloud beta container --project "$GCLOUD_PROJECT_NAME" clusters create "$CLUSTER
  --enable-stackdriver-kubernetes --enable-ip-alias \
  --network "projects/$GCLOUD_PROJECT_NAME/global/networks/default" --subnetwork "projects/$GCLOUD_PROJECT_NAME/regions/$CLOUDSDK_REGION/subnetworks/default" \
  --no-enable-master-authorized-networks \
- --addons $ADDONS $ISTIO_CONFIG \
+ --addons $ADDONS \
  --no-enable-autoupgrade --no-enable-autorepair \
- --labels owner=travis,expiry=auto-delete
+ --enable-shielded-nodes \
+ --labels owner=CI,expiry=auto-delete
 
 if [[ $? != '0' ]]; then
     echo "gcloud cluster create failed"

--- a/test/utils/install_istio.sh
+++ b/test/utils/install_istio.sh
@@ -3,7 +3,7 @@
 source test/utils.sh
 
 # install istio
-curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.6.14 sh -
+curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.8.2 sh -
 cd istio-*
 export PATH=$PWD/bin:$PATH
 istioctl install --set profile=demo


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

This PR addresses the first parts of #2976 and #2973:

* Upgrade Istio to 1.8.2 in integration tests
* Use GKE Shielded Nodes in integration tests
* In addition, I used the time to remove the istio addon from our GKE installation (we don't want to be forced to use the old version of istio)

We still need to adapt our docs.
