### PR TITLE
added alphabetical sorting of projects, services and stages in keptn backend

### DIFF
--- a/configuration-service/handlers/project.go
+++ b/configuration-service/handlers/project.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
 	"os"
+	"sort"
 	"time"
 
 	k8sutils "github.com/keptn/kubernetes-utils/pkg"
@@ -34,6 +35,11 @@ func GetProjectHandlerFunc(params project.GetProjectParams) middleware.Responder
 	mv := common.GetProjectsMaterializedView()
 
 	allProjects, err := mv.GetProjects()
+
+	//sort projects alphabetically
+	sort.Slice(allProjects, func(i, j int) bool {
+		return allProjects[i].ProjectName < allProjects[j].ProjectName
+	})
 
 	if err != nil || allProjects == nil {
 		return project.NewGetProjectDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String(err.Error())})

--- a/configuration-service/handlers/service.go
+++ b/configuration-service/handlers/service.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
 	"os"
+	"sort"
 	"time"
 
 	"github.com/keptn/keptn/configuration-service/restapi/operations/services"
@@ -45,10 +46,15 @@ func GetProjectProjectNameStageStageNameServiceHandlerFunc(params service.GetPro
 
 	for _, stg := range prj.Stages {
 		if stg.StageName == params.StageName {
-			paginationInfo := common.Paginate(len(stg.Services), params.PageSize, params.NextPageKey)
-			totalCount := len(stg.Services)
+			allServicesInStage := stg.Services
+			//sort services alphabetically
+			sort.Slice(allServicesInStage, func(i, j int) bool {
+				return allServicesInStage[i].ServiceName < allServicesInStage[j].ServiceName
+			})
+			paginationInfo := common.Paginate(len(allServicesInStage), params.PageSize, params.NextPageKey)
+			totalCount := len(allServicesInStage)
 			if paginationInfo.NextPageKey < int64(totalCount) {
-				for _, svc := range stg.Services[paginationInfo.NextPageKey:paginationInfo.EndIndex] {
+				for _, svc := range allServicesInStage[paginationInfo.NextPageKey:paginationInfo.EndIndex] {
 					payload.Services = append(payload.Services, svc)
 				}
 			}

--- a/configuration-service/handlers/stage.go
+++ b/configuration-service/handlers/stage.go
@@ -13,6 +13,7 @@ import (
 	"github.com/keptn/keptn/configuration-service/models"
 	"github.com/keptn/keptn/configuration-service/restapi/operations/stage"
 	"io/ioutil"
+	"sort"
 )
 
 func getStages(params stage.GetProjectProjectNameStageParams) ([]*models.Stage, errors.Error) {
@@ -125,9 +126,16 @@ func GetProjectProjectNameStageHandlerFunc(params stage.GetProjectProjectNameSta
 
 	paginationInfo := common.Paginate(len(prj.Stages), params.PageSize, params.NextPageKey)
 
-	totalCount := len(prj.Stages)
+	allStagesOfProject := prj.Stages
+
+	//sort stages alphabetically
+	sort.Slice(allStagesOfProject, func(i, j int) bool {
+		return allStagesOfProject[i].StageName < allStagesOfProject[j].StageName
+	})
+
+	totalCount := len(allStagesOfProject)
 	if paginationInfo.NextPageKey < int64(totalCount) {
-		for _, stg := range prj.Stages[paginationInfo.NextPageKey:paginationInfo.EndIndex] {
+		for _, stg := range allStagesOfProject[paginationInfo.NextPageKey:paginationInfo.EndIndex] {
 			payload.Stages = append(payload.Stages, stg)
 		}
 	}


### PR DESCRIPTION
As part of #2754, this PR changes the configuration-service behavior to return projects, services, and stages in alphabetical order per default.


Signed-off-by: warber <bernd.warmuth@dynatrace.com>