### PR TITLE
Added log output of lighthouse service and dynatrace-sli-service

### DIFF
--- a/test/test_quality_gates_standalone.sh
+++ b/test/test_quality_gates_standalone.sh
@@ -16,6 +16,12 @@ function cleanup() {
 
   echo "Removing secret dynatrace-credentials-${PROJECT}"
   kubectl -n ${KEPTN_NAMESPACE} delete secret dynatrace-credentials-${PROJECT}
+
+  # print logs of dynatrace-sli-service
+  echo "Logs from: dynatrace-sli-service"
+  kubectl -n ${KEPTN_NAMESPACE} logs svc/dynatrace-sli-service -c dynatrace-sli-service
+  echo "Logs from: lighthouse-service"
+  kubectl -n ${KEPTN_NAMESPACE} logs svc/lighthouse-service -c lighthouse-service
 }
 trap cleanup EXIT SIGINT
 
@@ -283,7 +289,6 @@ while [[ $RETRY -lt $RETRY_MAX ]]; do
 done
 
 if [[ $RETRY == $RETRY_MAX ]]; then
-  kubectl -n ${KEPTN_NAMESPACE} logs svc/dynatrace-sli-service -c dynatrace-sli-service
   print_error "evaluation.finished event could not be retrieved"
   # exit 1 - Todo - see below
 fi
@@ -334,11 +339,6 @@ while [[ $RETRY -lt $RETRY_MAX ]]; do
 done
 
 if [[ $RETRY == $RETRY_MAX ]]; then
-  # print logs of dynatrace-sli-service
-  echo "Logs from: dynatrace-sli-service"
-  kubectl -n ${KEPTN_NAMESPACE} logs svc/dynatrace-sli-service -c dynatrace-sli-service
-  echo "Logs from: lighthouse-service"
-  kubectl -n ${KEPTN_NAMESPACE} logs svc/lighthouse-service -c lighthouse-service
   print_error "evaluation.finished event could not be retrieved"
   exit 1
 fi
@@ -416,8 +416,6 @@ while [[ $RETRY -lt $RETRY_MAX ]]; do
 done
 
 if [[ $RETRY == $RETRY_MAX ]]; then
-  # print logs of dynatrace-sli-service
-  kubectl -n ${KEPTN_NAMESPACE} logs svc/dynatrace-sli-service -c dynatrace-sli-service
   print_error "evaluation.finished event could not be retrieved"
   exit 1
 fi
@@ -497,8 +495,6 @@ while [[ $RETRY -lt $RETRY_MAX ]]; do
 done
 
 if [[ $RETRY == $RETRY_MAX ]]; then
-  # print logs of dynatrace-sli-service
-  kubectl -n ${KEPTN_NAMESPACE} logs svc/dynatrace-sli-service -c dynatrace-sli-service
   print_error "evaluation.finished event could not be retrieved"
   exit 1
 fi
@@ -580,8 +576,6 @@ while [[ $RETRY -lt $RETRY_MAX ]]; do
 done
 
 if [[ $RETRY == $RETRY_MAX ]]; then
-  # print logs of dynatrace-sli-service
-  kubectl -n ${KEPTN_NAMESPACE} logs svc/dynatrace-sli-service -c dynatrace-sli-service
   print_error "evaluation.finished event could not be retrieved"
   exit 1
 fi


### PR DESCRIPTION
This will make debugging failing tests (such as https://github.com/keptn/keptn/runs/1759499122?check_suite_focus=true) easier

Signed-off-by: Florian Bacher <florian.bacher@dynatrace.com>