### PR TITLE
Added log output of lighthouse service and dynatrace-sli-service 

### DIFF
--- a/test/test_quality_gates_standalone.sh
+++ b/test/test_quality_gates_standalone.sh
@@ -3,10 +3,19 @@
 source test/utils.sh
 
 function cleanup() {
+  # print logs of dynatrace-sli-service
+  echo "Logs from: dynatrace-sli-service"
+  kubectl -n ${KEPTN_NAMESPACE} logs svc/dynatrace-sli-service -c dynatrace-sli-service
+  echo "Logs from: lighthouse-service"
+  kubectl -n ${KEPTN_NAMESPACE} logs svc/lighthouse-service -c lighthouse-service
+
   echo "Executing cleanup..."
 
   echo "Delete lighthouse-config configmap"
   kubectl delete configmap -n ${KEPTN_NAMESPACE} lighthouse-config
+
+  echo "Delete lighthouse-config-$PROJECT configmap"
+  kubectl delete configmap -n ${KEPTN_NAMESPACE} lighthouse-config-${PROJECT}
 
   echo "Deleting project ${PROJECT}"
   keptn delete project $PROJECT
@@ -23,6 +32,7 @@ trap cleanup EXIT SIGINT
 DYNATRACE_SLI_SERVICE_VERSION=${DYNATRACE_SLI_SERVICE_VERSION:-master}
 KEPTN_EXAMPLES_BRANCH=${KEPTN_EXAMPLES_BRANCH:-master}
 PROJECT=${PROJECT:-easytravel}
+SERVICE=${SERVICE:-frontend}
 KEPTN_NAMESPACE=${KEPTN_NAMESPACE:-keptn}
 
 KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n ${KEPTN_NAMESPACE} -ojsonpath={.data.keptn-api-token} | base64 --decode)
@@ -88,7 +98,7 @@ fi
 ###########################################
 # create service frontend                 #
 ###########################################
-SERVICE=frontend
+
 keptn create service $SERVICE --project=$PROJECT
 verify_test_step $? "keptn create service ${SERVICE} - failed"
 
@@ -283,7 +293,6 @@ while [[ $RETRY -lt $RETRY_MAX ]]; do
 done
 
 if [[ $RETRY == $RETRY_MAX ]]; then
-  kubectl -n ${KEPTN_NAMESPACE} logs svc/dynatrace-sli-service -c dynatrace-sli-service
   print_error "evaluation.finished event could not be retrieved"
   # exit 1 - Todo - see below
 fi
@@ -334,11 +343,6 @@ while [[ $RETRY -lt $RETRY_MAX ]]; do
 done
 
 if [[ $RETRY == $RETRY_MAX ]]; then
-  # print logs of dynatrace-sli-service
-  echo "Logs from: dynatrace-sli-service"
-  kubectl -n ${KEPTN_NAMESPACE} logs svc/dynatrace-sli-service -c dynatrace-sli-service
-  echo "Logs from: lighthouse-service"
-  kubectl -n ${KEPTN_NAMESPACE} logs svc/lighthouse-service -c lighthouse-service
   print_error "evaluation.finished event could not be retrieved"
   exit 1
 fi
@@ -416,8 +420,6 @@ while [[ $RETRY -lt $RETRY_MAX ]]; do
 done
 
 if [[ $RETRY == $RETRY_MAX ]]; then
-  # print logs of dynatrace-sli-service
-  kubectl -n ${KEPTN_NAMESPACE} logs svc/dynatrace-sli-service -c dynatrace-sli-service
   print_error "evaluation.finished event could not be retrieved"
   exit 1
 fi
@@ -497,8 +499,6 @@ while [[ $RETRY -lt $RETRY_MAX ]]; do
 done
 
 if [[ $RETRY == $RETRY_MAX ]]; then
-  # print logs of dynatrace-sli-service
-  kubectl -n ${KEPTN_NAMESPACE} logs svc/dynatrace-sli-service -c dynatrace-sli-service
   print_error "evaluation.finished event could not be retrieved"
   exit 1
 fi
@@ -580,8 +580,6 @@ while [[ $RETRY -lt $RETRY_MAX ]]; do
 done
 
 if [[ $RETRY == $RETRY_MAX ]]; then
-  # print logs of dynatrace-sli-service
-  kubectl -n ${KEPTN_NAMESPACE} logs svc/dynatrace-sli-service -c dynatrace-sli-service
   print_error "evaluation.finished event could not be retrieved"
   exit 1
 fi


### PR DESCRIPTION
in the previous PR (#2984), the logs were retrieved after the dynatrace-sli-service has already been deleted. This is fixed with this PR

Signed-off-by: Florian Bacher <florian.bacher@dynatrace.com>