### PR TITLE
Disable build tasks on macOS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -377,7 +377,7 @@ jobs:
     strategy:
       matrix:
         go-version: [ 1.13.x ]
-        platform: [ ubuntu-20.04, macOS-11.0 ] # , windows-2019
+        platform: [ ubuntu-20.04 ] #[ ubuntu-20.04, macOS-11.0 ] # , windows-2019
     runs-on: ${{ matrix.platform }}
     env:
       KUBE_CONSTRAINTS: ${{ needs.prepare_ci_run.outputs.KUBE_CONSTRAINTS }}
@@ -403,7 +403,7 @@ jobs:
     strategy:
       matrix:
         go-version: [ 1.13.x ]
-        platform: [ ubuntu-20.04, macOS-11.0, windows-2019 ]
+        platform: [ ubuntu-20.04, windows-2019 ] #[ ubuntu-20.04, macOS-11.0, windows-2019 ]
     env:
       KUBE_CONSTRAINTS: ${{ needs.prepare_ci_run.outputs.KUBE_CONSTRAINTS }}
 


### PR DESCRIPTION
Due to a resource shortage on GitHub, our build tasks running on macOS were failing frequently due to running into a timeout. This caused the CLI to not be built and therefore changes made to the CLI were not tested in the integration tests. This PR disables the macOS tasks for now.

Signed-off-by: Florian Bacher <florian.bacher@dynatrace.com>