### PR TITLE
Added flag to skip upgrade compatibility check

### DIFF
--- a/cli/cmd/install_upgrade_params.go
+++ b/cli/cmd/install_upgrade_params.go
@@ -9,6 +9,7 @@ type installUpgradeParams struct {
 	ChartRepoURL       *string
 	Namespace          *string
 	PatchNamespace     *bool
+	SkipUpgradeCheck   *bool
 }
 
 func getChartRepoURL(input *string) string {

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -97,6 +97,8 @@ func doUpgradePreRunCheck() error {
 			return fmt.Errorf("No upgrade path exists from Keptn version %s to %s",
 				installedKeptnVerison, getAppVersion(keptnUpgradeChart))
 		}
+	}else{
+		logging.PrintLog("Skipping upgrade compatibility check!",logging.InfoLevel)
 	}
 
 	logging.PrintLog(fmt.Sprintf("Helm Chart used for Keptn upgrade: %s", chartRepoURL), logging.InfoLevel)

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -97,8 +97,8 @@ func doUpgradePreRunCheck() error {
 			return fmt.Errorf("No upgrade path exists from Keptn version %s to %s",
 				installedKeptnVerison, getAppVersion(keptnUpgradeChart))
 		}
-	}else{
-		logging.PrintLog("Skipping upgrade compatibility check!",logging.InfoLevel)
+	} else {
+		logging.PrintLog("Skipping upgrade compatibility check!", logging.InfoLevel)
 	}
 
 	logging.PrintLog(fmt.Sprintf("Helm Chart used for Keptn upgrade: %s", chartRepoURL), logging.InfoLevel)

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -84,17 +84,19 @@ func doUpgradePreRunCheck() error {
 		return err
 	}
 
-	res, err := isUpgradeCompatible()
-	if err != nil {
-		return err
-	}
-	if !res {
-		installedKeptnVerison, err := getInstalledKeptnVersion()
+	if !*upgradeParams.SkipUpgradeCheck {
+		res, err := isUpgradeCompatible()
 		if err != nil {
 			return err
 		}
-		return fmt.Errorf("No upgrade path exists from Keptn version %s to %s",
-			installedKeptnVerison, getAppVersion(keptnUpgradeChart))
+		if !res {
+			installedKeptnVerison, err := getInstalledKeptnVersion()
+			if err != nil {
+				return err
+			}
+			return fmt.Errorf("No upgrade path exists from Keptn version %s to %s",
+				installedKeptnVerison, getAppVersion(keptnUpgradeChart))
+		}
 	}
 
 	logging.PrintLog(fmt.Sprintf("Helm Chart used for Keptn upgrade: %s", chartRepoURL), logging.InfoLevel)
@@ -184,6 +186,7 @@ func init() {
 		"", "URL of the Keptn Helm Chart repository")
 	upgraderCmd.Flags().MarkHidden("chart-repo")
 	upgradeParams.PatchNamespace = upgraderCmd.Flags().BoolP("patch-namespace", "", false, "Patch the namespace with the annotation & label 'keptn.sh/managed-by: keptn'")
+	upgradeParams.SkipUpgradeCheck = upgraderCmd.Flags().BoolP("skip-upgrade-check", "", false, "Skip upgrade compatibility check, useful for nightly version upgrades or upgrades to preview versions")
 }
 
 func doUpgrade() error {

--- a/cli/cmd/upgrade_test.go
+++ b/cli/cmd/upgrade_test.go
@@ -1,0 +1,52 @@
+// Copyright © 2019 NAME HERE <EMAIL ADDRESS>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/keptn/keptn/cli/pkg/credentialmanager"
+)
+
+func TestSkipUpgradeCheck(t *testing.T) {
+	noSkipMsg := "Failed to check if Keptn release is available in namespace keptn: invalid configuration: no configuration has been provided"
+	skipMsg := "Skipping upgrade compatibility check!"
+	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
+	mocking = true
+	cmd := fmt.Sprintf("upgrade --mock")
+
+	r := newRedirector()
+	r.redirectStdOut()
+
+	_, err := executeActionCommandC(cmd)
+	out := r.revertStdOut()
+
+	if !errorContains(err, noSkipMsg) {
+		t.Errorf("upgrade Response did not match [no skip] : \nERROR: %v\nOUT: %v", err, out)
+	}
+
+	cmd = fmt.Sprintf("upgrade --skip-upgrade-check --mock")
+	r = newRedirector()
+	r.redirectStdOut()
+	_, err = executeActionCommandC(cmd)
+	out = r.revertStdOut()
+
+	if !errorContains(err, "EOF") || !strings.Contains(out, skipMsg) {
+		t.Errorf("upgrade Response did not match [skip] : \nERROR: %v\nOUT: %v", err, out)
+	}
+}

--- a/cli/cmd/upgrade_test.go
+++ b/cli/cmd/upgrade_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestSkipUpgradeCheck(t *testing.T) {
-	noSkipMsg := "Failed to check if Keptn release is available in namespace keptn: invalid configuration: no configuration has been provided"
+	noSkipMsg := "Failed to check if Keptn release is available in namespace keptn"
 	skipMsg := "Skipping upgrade compatibility check!"
 	credentialmanager.MockAuthCreds = true
 	checkEndPointStatusMock = true


### PR DESCRIPTION
Signed-off-by: Soumya Ghosh Dastidar <gdsoumya@gmail.com>

This PR adds a new flag to the keptn's cli upgrade command that allows the user to skip the upgrade compatibility check.

closes #2689 