### PR TITLE
#2988 added timeout to helm install

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -244,8 +244,8 @@ func doInstallation() error {
 	}
 
 	if err := helm.NewHelper().UpgradeChart(keptnChart, keptnReleaseName, keptnNamespace, values); err != nil {
-		logging.PrintLog("Could not complete Keptn installation: "+err.Error(), logging.InfoLevel)
-		return err
+		msg := fmt.Sprintf("Could not complete Keptn installation: %s \nFor troubleshooting, please check the status of the keptn deployment by executing the following command: \n\nkubectl get pods -n %s\n", err.Error(), keptnNamespace)
+		return errors.New(msg)
 	}
 
 	logging.PrintLog("Keptn has been successfully set up on your cluster.", logging.InfoLevel)

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -207,8 +208,8 @@ func doUpgrade() error {
 	}
 
 	if err := helm.NewHelper().UpgradeChart(keptnUpgradeChart, keptnReleaseName, keptnNamespace, nil); err != nil {
-		logging.PrintLog("Could not complete Keptn upgrade: "+err.Error(), logging.InfoLevel)
-		return err
+		msg := fmt.Sprintf("Could not complete Keptn upgrade: %s \nFor troubleshooting, please check the status of the keptn deployment by executing the following command: \n\nkubectl get pods -n %s\n", err.Error(), keptnNamespace)
+		return errors.New(msg)
 	}
 
 	logging.PrintLog("Keptn has been successfully upgraded on your cluster.", logging.InfoLevel)

--- a/cli/pkg/helm/helm_helper.go
+++ b/cli/pkg/helm/helm_helper.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
@@ -153,11 +154,13 @@ func (c Helper) UpgradeChart(ch *chart.Chart, releaseName, namespace string, val
 			iCli.Namespace = namespace
 			iCli.ReleaseName = releaseName
 			iCli.Wait = true
+			iCli.Timeout = 10 * time.Minute
 			release, err = iCli.Run(ch, vals)
 		} else {
 			iCli := action.NewUpgrade(cfg)
 			iCli.Namespace = namespace
 			iCli.Wait = true
+			iCli.Timeout = 10 * time.Minute
 			iCli.ReuseValues = true
 			release, err = iCli.Run(releaseName, ch, vals)
 		}


### PR DESCRIPTION
Closes #2988 

Added a timeout of 10minutes to the helm upgrade command - QQ: would it make sense to make this configurable as a parameter to the install command? 

In case of a timeout, added a hint to check the status of the installation via `kubectl get pods -n <keptn-namespace>`. In issue #2988 it was suggested to specifically check for an `ImagePullBackOff` in the deployments, but given that a timeout might have numerous reasons, I was thinking a more general hint might be better suited in this case.

Signed-off-by: Florian Bacher <florian.bacher@dynatrace.com>