### PR TITLE
#2478 SLI evaluation breakdown as barista table

### DIFF
--- a/bridge/client/app/_components/ktb-sli-breakdown/ktb-sli-breakdown.component.html
+++ b/bridge/client/app/_components/ktb-sli-breakdown/ktb-sli-breakdown.component.html
@@ -1,109 +1,24 @@
 <p class="mb-0">SLI breakdown</p>
-<dt-key-value-list [columns]="1">
-  <ng-container *ngFor="let result of _indicatorResultsFail">
-    <dt-key-value-list-item>
-      <dt-key-value-list-key>
-        <p class="m-0 fail" [class.bold]="result.key_sli" [textContent]="result.value.metric"></p>
-      </dt-key-value-list-key>
-      <dt-key-value-list-value *ngIf="result.value.success && !result.value.message">
-        <span [dtOverlay]="overlay" style="cursor: pointer;" [dtOverlayConfig]="overlayConfig">
-            <span [textContent]="formatNumber(result.value.value)"></span>
-            <span class="small m-0 ml-1" *ngFor="let _target of result.targets" [textContent]="_target.criteria" [class.error]="_target.violated" [class.error-line]="_target.violated"></span>
-        </span>
-        <ng-template #overlay>
-          <span class="small" [textContent]="result.value.value"></span>
-        </ng-template>
-      </dt-key-value-list-value>
-      <dt-key-value-list-value *ngIf="!(result.value.success && !result.value.message)">
-        <span [dtOverlay]="overlay" style="cursor: pointer;" [dtOverlayConfig]="overlayConfig">
-          <dt-icon class="event-icon error" [name]="'criticalevent'"></dt-icon>
-        </span>
-        <ng-template #overlay>
-          <span class="small" [textContent]="result.value.message"></span>
-        </ng-template>
-      </dt-key-value-list-value>
-    </dt-key-value-list-item>
-  </ng-container>
-  <ng-container *ngFor="let result of _indicatorResultsWarning">
-    <dt-key-value-list-item>
-      <dt-key-value-list-key>
-        <p class="m-0 warning" [class.bold]="result.key_sli" [textContent]="result.value.metric"></p>
-      </dt-key-value-list-key>
-      <dt-key-value-list-value *ngIf="result.value.success && !result.value.message">
-        <span [dtOverlay]="overlay" style="cursor: pointer;" [dtOverlayConfig]="overlayConfig">
-            <span [textContent]="formatNumber(result.value.value)"></span>
-            <span class="small m-0 ml-1" *ngFor="let _target of result.targets" [textContent]="_target.criteria" [class.error]="_target.violated" [class.error-line]="_target.violated"></span>
-        </span>
-        <ng-template #overlay>
-          <span class="small" [textContent]="result.value.value"></span>
-        </ng-template>
-      </dt-key-value-list-value>
-      <dt-key-value-list-value *ngIf="!(result.value.success && !result.value.message)">
-        <span [dtOverlay]="overlay" style="cursor: pointer;" [dtOverlayConfig]="overlayConfig">
-          <dt-icon class="event-icon warning" [name]="'criticalevent'"></dt-icon>
-        </span>
-        <ng-template #overlay>
-          <span class="small" [textContent]="result.value.message"></span>
-        </ng-template>
-      </dt-key-value-list-value>
-    </dt-key-value-list-item>
-  </ng-container>
-  <ng-container *ngFor="let result of _indicatorResultsPass; index as i">
-    <dt-key-value-list-item *ngIf="i < (3 - _indicatorResultsFail.length - _indicatorResultsWarning.length)">
-      <dt-key-value-list-key>
-        <p class="m-0" [class.bold]="result.key_sli" [textContent]="result.value.metric"></p>
-      </dt-key-value-list-key>
-      <dt-key-value-list-value *ngIf="result.value.success && !result.value.message">
-        <span [dtOverlay]="overlay" style="cursor: pointer;" [dtOverlayConfig]="overlayConfig">
-            <span [textContent]="formatNumber(result.value.value)"></span>
-            <span class="small m-0 ml-1" *ngFor="let _target of result.targets" [textContent]="_target.criteria" [class.error]="_target.violated" [class.error-line]="_target.violated"></span>
-        </span>
-        <ng-template #overlay>
-          <span class="small" [textContent]="result.value.value"></span>
-        </ng-template>
-      </dt-key-value-list-value>
-      <dt-key-value-list-value *ngIf="!(result.value.success && !result.value.message)">
-        <span [dtOverlay]="overlay" style="cursor: pointer;" [dtOverlayConfig]="overlayConfig">
-          <dt-icon class="event-icon" [name]="'criticalevent'"></dt-icon>
-        </span>
-        <ng-template #overlay>
-          <span class="small" [textContent]="result.value.message"></span>
-        </ng-template>
-      </dt-key-value-list-value>
-    </dt-key-value-list-item>
-  </ng-container>
-</dt-key-value-list>
-<dt-expandable-panel #indicatorResultsPanel>
-  <dt-key-value-list [columns]="1">
-    <ng-container *ngFor="let result of _indicatorResultsPass; index as i">
-      <dt-key-value-list-item *ngIf="i >= (3 - _indicatorResultsFail.length - _indicatorResultsWarning.length)">
-        <dt-key-value-list-key>
-          <p class="m-0" [class.bold]="result.key_sli" [textContent]="result.value.metric"></p>
-        </dt-key-value-list-key>
-        <dt-key-value-list-value *ngIf="result.value.success && !result.value.message">
-          <span [dtOverlay]="overlay" style="cursor: pointer;" [dtOverlayConfig]="overlayConfig">
-              <span [textContent]="formatNumber(result.value.value)"></span>
-              <span class="small m-0 ml-1" *ngFor="let _target of result.targets" [textContent]="_target.criteria" [class.error]="_target.violated" [class.error-line]="_target.violated"></span>
-          </span>
-          <ng-template #overlay>
-            <span class="small" [textContent]="result.value.value"></span>
-          </ng-template>
-        </dt-key-value-list-value>
-        <dt-key-value-list-value *ngIf="!(result.value.success && !result.value.message)">
-        <span [dtOverlay]="overlay" style="cursor: pointer;" [dtOverlayConfig]="overlayConfig">
-          <dt-icon class="event-icon" [name]="'criticalevent'"></dt-icon>
-        </span>
-          <ng-template #overlay>
-            <span class="small" [textContent]="result.value.message"></span>
-          </ng-template>
-        </dt-key-value-list-value>
-      </dt-key-value-list-item>
-    </ng-container>
-  </dt-key-value-list>
-</dt-expandable-panel>
-<p class="m-0 mt-1 mb-1">
-  <a class="dt-link" (click)="$event.stopPropagation();indicatorResultsPanel.toggle();" *ngIf="indicatorResults.length > 3">
-    <span *ngIf="!indicatorResultsPanel.expanded">Show all <span [textContent]="indicatorResults.length"></span> evaluation results</span>
-    <span *ngIf="indicatorResultsPanel.expanded">Collapse evaluation results</span>
-  </a>
-</p>
+<dt-table [dataSource]="tableEntries" dtSort #sortable>
+    <dt-simple-text-column name="name" label="Name"></dt-simple-text-column>
+    <dt-simple-text-column name="result" label="Result"></dt-simple-text-column>
+    <dt-simple-number-column name="value" label="Value"></dt-simple-number-column>
+    <dt-simple-number-column name="score" label="Score"></dt-simple-number-column>
+    <dt-simple-text-column name="criteria" label="Criteria"></dt-simple-text-column>
+
+  <dt-header-row
+    *dtHeaderRowDef="[
+        'name',
+        'result',
+        'value',
+        'score',
+        'criteria'
+      ]"
+  ></dt-header-row>
+  <dt-row
+    *dtRowDef="
+        let row;
+        columns: ['name', 'result', 'value', 'score', 'criteria']
+      "
+  ></dt-row>
+</dt-table>

--- a/bridge/client/app/_components/ktb-sli-breakdown/ktb-sli-breakdown.component.html
+++ b/bridge/client/app/_components/ktb-sli-breakdown/ktb-sli-breakdown.component.html
@@ -1,10 +1,29 @@
 <p class="mb-0">SLI breakdown</p>
 <dt-table [dataSource]="tableEntries" dtSort #sortable>
-    <dt-simple-text-column name="name" label="Name"></dt-simple-text-column>
-    <dt-simple-text-column name="result" label="Result"></dt-simple-text-column>
-    <dt-simple-number-column name="value" label="Value"></dt-simple-number-column>
-    <dt-simple-number-column name="score" label="Score"></dt-simple-number-column>
-    <dt-simple-text-column name="criteria" label="Criteria"></dt-simple-text-column>
+  <ng-container dtColumnDef="name" dtColumnAlign="text" dtColumnProportion="6">
+    <dt-header-cell *dtHeaderCellDef>Name</dt-header-cell>
+    <dt-cell *dtCellDef="let row">{{ row.name }}</dt-cell>
+  </ng-container>
+
+  <ng-container dtColumnDef="result" dtColumnAlign="text" dtColumnProportion="1">
+    <dt-header-cell *dtHeaderCellDef>Result</dt-header-cell>
+    <dt-cell *dtCellDef="let row">{{ row.result }}</dt-cell>
+  </ng-container>
+
+  <ng-container dtColumnDef="value" dtColumnAlign="number" dtColumnProportion="1">
+    <dt-header-cell *dtHeaderCellDef>Value</dt-header-cell>
+    <dt-cell *dtCellDef="let row">{{ row.value }}</dt-cell>
+  </ng-container>
+
+  <ng-container dtColumnDef="score" dtColumnAlign="number" dtColumnProportion="1">
+    <dt-header-cell *dtHeaderCellDef>Score</dt-header-cell>
+    <dt-cell *dtCellDef="let row">{{ row.score }}</dt-cell>
+  </ng-container>
+
+  <ng-container dtColumnDef="criteria" dtColumnAlign="number"dtColumnProportion="2">
+    <dt-header-cell *dtHeaderCellDef>Criteria</dt-header-cell>
+    <dt-cell *dtCellDef="let row">{{ row.criteria }}</dt-cell>
+  </ng-container>
 
   <dt-header-row
     *dtHeaderRowDef="[

--- a/bridge/client/app/_components/ktb-sli-breakdown/ktb-sli-breakdown.component.ts
+++ b/bridge/client/app/_components/ktb-sli-breakdown/ktb-sli-breakdown.component.ts
@@ -1,5 +1,6 @@
-import {ChangeDetectorRef, Component, Input, OnInit} from '@angular/core';
+import {ChangeDetectorRef, Component, Input, OnInit, ViewChild} from '@angular/core';
 import {DtOverlayConfig} from "@dynatrace/barista-components/overlay";
+import { DtSort, DtTableDataSource } from '@dynatrace/barista-components/table';
 
 @Component({
   selector: 'ktb-sli-breakdown',
@@ -7,6 +8,8 @@ import {DtOverlayConfig} from "@dynatrace/barista-components/overlay";
   styleUrls: ['./ktb-sli-breakdown.component.scss']
 })
 export class KtbSliBreakdownComponent implements OnInit {
+
+  @ViewChild('sortable', { read: DtSort, static: true }) sortable: DtSort;
 
   public _evaluationColor = {
     'pass': '#7dc540',
@@ -30,7 +33,7 @@ export class KtbSliBreakdownComponent implements OnInit {
   public _indicatorResultsFail: any = [];
   public _indicatorResultsWarning: any = [];
   public _indicatorResultsPass: any = [];
-  public tableEntries: any;
+  public tableEntries: DtTableDataSource<object>;
 
   @Input()
   get indicatorResults(): any {
@@ -49,7 +52,10 @@ export class KtbSliBreakdownComponent implements OnInit {
   constructor(private _changeDetectorRef: ChangeDetectorRef) { }
 
   ngOnInit() {
-    this.tableEntries = this.assembleTablesEntries(this.indicatorResults);
+    this.tableEntries = new DtTableDataSource(this.assembleTablesEntries(this.indicatorResults));
+
+    // Set the dtSort reference on the dataSource, so it can react to sorting.
+    this.tableEntries.sort = this.sortable;
   }
 
   formatNumber(number) {

--- a/bridge/client/app/_components/ktb-sli-breakdown/ktb-sli-breakdown.component.ts
+++ b/bridge/client/app/_components/ktb-sli-breakdown/ktb-sli-breakdown.component.ts
@@ -74,12 +74,16 @@ export class KtbSliBreakdownComponent implements OnInit {
 
   assembleTablesEntries(indicatorRestults): any {
     var tableEntries = [];
+
+    let totalscore  = 0;
+    indicatorRestults.forEach(result => totalscore += result.score);
+
     
     for (let indicatorRestult of indicatorRestults) {
       let name = indicatorRestult.value.metric;
       let value = this.formatNumber(indicatorRestult.value.value);
       let result = indicatorRestult.status;
-      let score = indicatorRestult.score;
+      let score = (indicatorRestult.score / totalscore).toFixed(2);
       let criteria = "";
 
       for (let target of indicatorRestult.targets) {

--- a/bridge/client/app/_components/ktb-sli-breakdown/ktb-sli-breakdown.component.ts
+++ b/bridge/client/app/_components/ktb-sli-breakdown/ktb-sli-breakdown.component.ts
@@ -30,6 +30,7 @@ export class KtbSliBreakdownComponent implements OnInit {
   public _indicatorResultsFail: any = [];
   public _indicatorResultsWarning: any = [];
   public _indicatorResultsPass: any = [];
+  public tableEntries: any;
 
   @Input()
   get indicatorResults(): any {
@@ -48,6 +49,7 @@ export class KtbSliBreakdownComponent implements OnInit {
   constructor(private _changeDetectorRef: ChangeDetectorRef) { }
 
   ngOnInit() {
+    this.tableEntries = this.assembleTablesEntries(this.indicatorResults);
   }
 
   formatNumber(number) {
@@ -62,6 +64,34 @@ export class KtbSliBreakdownComponent implements OnInit {
       n = Math.floor(n);
 
     return n;
+  }
+
+  assembleTablesEntries(indicatorRestults): any {
+    var tableEntries = [];
+    
+    for (let indicatorRestult of indicatorRestults) {
+      let name = indicatorRestult.value.metric;
+      let value = this.formatNumber(indicatorRestult.value.value);
+      let result = indicatorRestult.status;
+      let score = indicatorRestult.score;
+      let criteria = "";
+
+      for (let target of indicatorRestult.targets) {
+        criteria += target.criteria + ' '
+      }
+
+      let entry = {
+        name: name,
+        value: value,
+        result: result,
+        score: score,
+        criteria: criteria
+      }
+
+      tableEntries.push(entry);
+    } 
+
+    return tableEntries;
   }
 
 }

--- a/bridge/client/app/app.module.ts
+++ b/bridge/client/app/app.module.ts
@@ -32,6 +32,7 @@ import { DtProgressCircleModule } from '@dynatrace/barista-components/progress-c
 import { DtSelectModule } from '@dynatrace/barista-components/select';
 import { DtShowMoreModule } from '@dynatrace/barista-components/show-more';
 import { DtSwitchModule } from '@dynatrace/barista-components/switch';
+import { DtTableModule } from '@dynatrace/barista-components/table';
 import { DtTagModule } from '@dynatrace/barista-components/tag';
 import { DtTopBarNavigationModule } from "@dynatrace/barista-components/top-bar-navigation";
 import { DtCopyToClipboardModule } from "@dynatrace/barista-components/copy-to-clipboard";
@@ -131,6 +132,7 @@ registerLocaleData(localeEn, 'en');
     DtInfoGroupModule,
     DtProgressBarModule,
     DtLoadingDistractorModule,
+    DtTableModule,
     DtTagModule,
     DtExpandableTextModule,
     DtExpandablePanelModule,


### PR DESCRIPTION
Switched SLI evaluation breadown to a barista table. 
Open issues:

- [ ]  Table does not refresh when clicking on the heatmap
- [x] Fixed size of columns (name 55%, result 10%, value 10%, score 10%, criteria 15%), at least the Name needs more space
- [x]  Column Score shows the weight but should be translated into points between 0 and 100 In the above example, score 1 --> 33.3 points, score 2 --> 66.6 points
- [ ]  Split of criteria in warning/pass (currently just the pass criteria are shown)
- [ ]  show warning criteria
- [ ] Mark criteria as red (or with an icon as an indicator) when criteria failed
- [x]  Sorting the rows according to the header is not possible