### PR TITLE
#2929 Improve CodeCoverage reporting

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -290,66 +290,88 @@ jobs:
 
       - name: Test api
         if: (needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (needs.prepare_ci_run.outputs.BUILD_API == 'true')
-        run: go test -coverprofile=coverage.txt -covermode=atomic -v ./handlers/... ./utils/...
+        run: |
+          go test -coverprofile=coverage.txt -covermode=atomic -v ./handlers/... ./utils/...
+          bash <(curl -s https://codecov.io/bash) -c -F api
         working-directory: ./api
 
       - name: Test os route svc
         if: (needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (needs.prepare_ci_run.outputs.BUILD_OS_ROUTE_SVC == 'true')
-        run: go test -race -v -coverprofile=coverage.txt -covermode=atomic ./...
+        run: |
+          go test -race -v -coverprofile=coverage.txt -covermode=atomic ./...
+          bash <(curl -s https://codecov.io/bash) -c -F openshift-route-service
         working-directory: ./platform-support/openshift-route-service
 
       - name: Test jmeter svc
         if: (needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (needs.prepare_ci_run.outputs.BUILD_JMETER == 'true')
-        run: go test -race -v -coverprofile=coverage.txt -covermode=atomic ./...
+        run: |
+          go test -race -v -coverprofile=coverage.txt -covermode=atomic ./...
+          bash <(curl -s https://codecov.io/bash) -c -F jmeter-service
         working-directory: ./jmeter-service
 
       - name: Test helm svc
         if: (needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (needs.prepare_ci_run.outputs.BUILD_HELM_SVC == 'true')
-        run: go test -race -v -coverprofile=coverage.txt -covermode=atomic ./...
+        run: |
+          go test -race -v -coverprofile=coverage.txt -covermode=atomic ./...
+          bash <(curl -s https://codecov.io/bash) -c -F helm-service
         working-directory: ./helm-service
 
       - name: Test gatekeeper svc
         if: (needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (needs.prepare_ci_run.outputs.BUILD_GATEKEEPER_SVC == 'true')
-        run: go test -race -v -coverprofile=coverage.txt -covermode=atomic ./...
+        run: |
+          go test -race -v -coverprofile=coverage.txt -covermode=atomic ./...
+          bash <(curl -s https://codecov.io/bash) -c -F gatekeeper-service
         working-directory: ./gatekeeper-service
 
       - name: Test distributor svc
         if: (needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (needs.prepare_ci_run.outputs.BUILD_DISTRIBUTOR == 'true')
-        run: go test -v -coverprofile=coverage.txt -covermode=atomic ./...
+        run: |
+          go test -v -coverprofile=coverage.txt -covermode=atomic ./...
+          bash <(curl -s https://codecov.io/bash) -c -F distributor-service
         working-directory: ./distributor
 
       - name: Test shipyard controller svc
         if: (needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (needs.prepare_ci_run.outputs.BUILD_SHIPYARD_CONTROLLER == 'true')
-        run: go test -v -coverprofile=coverage.txt -covermode=atomic ./...
+        run: |
+          go test -v -coverprofile=coverage.txt -covermode=atomic ./...
+          bash <(curl -s https://codecov.io/bash) -c -F shipyard-controller
         working-directory: ./shipyard-controller
 
       - name: Test configuration svc
         if: (needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (needs.prepare_ci_run.outputs.BUILD_CONFIGURATION_SVC == 'true')
-        run: go test -v -coverprofile=coverage.txt -covermode=atomic ./...
+        run: |
+          go test -v -coverprofile=coverage.txt -covermode=atomic ./...
+          bash <(curl -s https://codecov.io/bash) -c -F configuration-service
         working-directory: ./configuration-service
 
       - name: Test remediation svc
         if: (needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (needs.prepare_ci_run.outputs.BUILD_REMEDIATION_SVC == 'true')
-        run: go test -race -v -coverprofile=coverage.txt -covermode=atomic ./...
+        run: |
+          go test -race -v -coverprofile=coverage.txt -covermode=atomic ./...
+          bash <(curl -s https://codecov.io/bash) -c -F remediation-service
         working-directory: ./remediation-service
 
       - name: Test lighthouse svc
         if: (needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (needs.prepare_ci_run.outputs.BUILD_LIGHTHOUSE_SVC == 'true')
-        run: go test -v -coverprofile=coverage.txt -covermode=atomic ./...
+        run: |
+          go test -v -coverprofile=coverage.txt -covermode=atomic ./...
+          bash <(curl -s https://codecov.io/bash) -c -F lighthouse-service
         working-directory: ./lighthouse-service
 
       - name: Test mongodb datastore svc
         if: (needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (needs.prepare_ci_run.outputs.BUILD_MONGODB_DS == 'true')
-        run: go test -race -v -coverprofile=coverage.txt -covermode=atomic ./...
+        run: |
+          go test -race -v -coverprofile=coverage.txt -covermode=atomic ./...
+          bash <(curl -s https://codecov.io/bash) -c -F mongodb-datastore
         working-directory: ./mongodb-datastore
 
       - name: Test statistics svc
         if: (needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (needs.prepare_ci_run.outputs.BUILD_STATISTICS_SVC == 'true')
-        run: go test -race -v -coverprofile=coverage.txt -covermode=atomic ./...
+        run: |
+          go test -race -v -coverprofile=coverage.txt -covermode=atomic ./...
+          bash <(curl -s https://codecov.io/bash) -c -F statistics-service
         working-directory: ./statistics-service
 
-      - name: Coverage report
-        run: bash <(curl -s https://codecov.io/bash)
 
   unit-tests-node:
     needs: prepare_ci_run
@@ -379,7 +401,7 @@ jobs:
         working-directory: ./bridge
       - name: Coverage report
         if: (needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (needs.prepare_ci_run.outputs.BUILD_BRIDGE == 'true')
-        run: bash <(curl -s https://codecov.io/bash) -F moduleA
+        run: bash <(curl -s https://codecov.io/bash) -c -F bridge
 
 
   unit-tests-cli:
@@ -402,8 +424,11 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Test cli
-        run: go test -race -v ./...
+        run: go test -race -v  -coverprofile=coverage.txt -covermode=atomic ./...
         working-directory: ./cli
+
+      - name: Coverage report
+        run: bash <(curl -s https://codecov.io/bash) -c -F cli
 
   ############################################################################
   # Build CLI                                                                #

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ cli/onboarding-carts/*
 configuration-service/cmd/configuration-service-server/__debug_bin
 keptn-charts/
 
+# ignore coverage reports
+*/coverage.txt
+
 # IDE files
 .vscode/
 *.iml

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,7 +5,14 @@ coverage:
         # basic
         target: auto
         threshold: 2% # allow cov to drop by 2% (just in case)
+      microservices:
+        # basic
+        target: auto
+        threshold: 2% # allow cov to drop by 2% (just in case)
       bridge:
+        target: auto
+        threshold: 2% # allow cov to drop by 2% (just in case)
+      cli:
         target: auto
         threshold: 2% # allow cov to drop by 2% (just in case)
     patch:
@@ -18,3 +25,38 @@ ignore:
   - "**/*.md"         # ignore all markdown files, those are not relevant for building/testing
   - "**/Dockerfile"   # ignore Dockerfiles, those are build with travis
   - "**/*.sh"         # ignore shell scripts
+
+comment:
+  show_carryforward_flags: true # see https://docs.codecov.io/docs/carryforward-flags
+
+flags:
+  microservices:
+    carryforward: true # see https://docs.codecov.io/docs/carryforward-flags
+  api:
+    carryforward: true # see https://docs.codecov.io/docs/carryforward-flags
+  bridge:
+    carryforward: true # see https://docs.codecov.io/docs/carryforward-flags
+  cli:
+    carryforward: true # see https://docs.codecov.io/docs/carryforward-flags
+  configuration-service:
+    carryforward: true # see https://docs.codecov.io/docs/carryforward-flags
+  distributor:
+    carryforward: true # see https://docs.codecov.io/docs/carryforward-flags
+  gatekeeper-service:
+    carryforward: true # see https://docs.codecov.io/docs/carryforward-flags
+  helm-service:
+    carryforward: true # see https://docs.codecov.io/docs/carryforward-flags
+  jmeter-service:
+    carryforward: true # see https://docs.codecov.io/docs/carryforward-flags
+  lighthouse-service:
+    carryforward: true # see https://docs.codecov.io/docs/carryforward-flags
+  mongodb-datastore:
+    carryforward: true # see https://docs.codecov.io/docs/carryforward-flags
+  openshift-route-service:
+    carryforward: true # see https://docs.codecov.io/docs/carryforward-flags
+  remediation-service:
+    carryforward: true # see https://docs.codecov.io/docs/carryforward-flags
+  shipyard-controller:
+    carryforward: true # see https://docs.codecov.io/docs/carryforward-flags
+  statistics-service:
+    carryforward: true # see https://docs.codecov.io/docs/carryforward-flags


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

This PR tries to fix #2929 by doing the following:

* Added codecov reporting to CLI tests
* Added codecov call to every unit test (instead of a single call for all of them)
* Added a flag (`-F flagname`) when running codecov to split tests and codecov by directory
* Added `-c` flag to cleanup after sending the report (to avoid having a mix of reports)
* Added `coverage.txt` to .gitignore
* Added the `carryforward` flag for all directories, such that it *should* carry over the coverage from the last build (e.g., master branch) - this is recommended for monorepos, but it remains to be seen if it also works as expected.

Whether those changes have the desired effect or not can not be seen within this PR, but after it has been merged to master and builds are running for a week or so.

