### PR TITLE
Several smaller fixes for integration test workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -201,7 +201,7 @@ jobs:
         uses: "WyriHaximus/github-action-get-previous-tag@1.0.0"
       - name: 'Get next patch version'
         id: get_next_semver_tag
-        uses: "WyriHaximus/github-action-next-semvers@v1"
+        uses: "WyriHaximus/github-action-next-semvers@v1.1.0"
         with:
           version: ${{ steps.get_previous_tag.outputs.tag }}
       - name: Get the version

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -457,6 +457,7 @@ jobs:
         env:
           PLATFORM: "${{ matrix.platform }}"
           GOARCH: "amd64"
+          BRANCH: ${{ needs.prepare_ci_run.outputs.BRANCH }}
           VERSION: ${{ needs.prepare_ci_run.outputs.VERSION }}
           DATETIME: ${{ needs.prepare_ci_run.outputs.DATE }}${{ needs.prepare_ci_run.outputs.TIME }}
           GIT_SHA: ${{ needs.prepare_ci_run.outputs.GIT_SHA }}
@@ -480,6 +481,12 @@ jobs:
           OUTPUT_EXECUTEABLE_NAME="keptn-${VERSION}-${DISTR}-${GOARCH}${FILE_ENDING}"
           OUTPUT_ARCHIVE_NAME="keptn-${VERSION}-${DISTR}-${GOARCH}" # no need for file-ending in the archive name
           mkdir dist
+
+          if [[ "$BRANCH" == "master" ]]; then
+            # use VERSION.DATETIME for the cli version (e.g., nightly build)
+            VERSION=${VERSION}.${DATETIME}
+          fi
+
           go build -v -x -ldflags="-X 'main.Version=$VERSION' -X 'main.KubeServerVersionConstraints=$KUBE_CONSTRAINTS'" -o "${OUTPUT_EXECUTEABLE_NAME}"
           tar -zcvf dist/${OUTPUT_ARCHIVE_NAME}.tar.gz ${OUTPUT_EXECUTEABLE_NAME}
       - name: Upload Keptn CLI as an artifact

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -553,6 +553,15 @@ jobs:
         with:
           env-file: ./dist/build-config/build-config.env
 
+      - name: Overwrite VERSION String for nightly builds
+        run: |
+          if [[ "$BRANCH" == "master" ]]; then
+            # use VERSION.DATETIME for the cli version (e.g., nightly build)
+            VERSION=${VERSION}.${DATETIME}
+            # overwrite VERSION
+            echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          fi
+
       - name: DEBUG Build-Config
         run: |
           echo VERSION=${VERSION}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -69,6 +69,8 @@ jobs:
       RUN_CONTINUOUS_DELIVERY_TEST: ${{ matrix.RUN_CONTINUOUS_DELIVERY_TEST }}
       KEPTN_EXAMPLES_BRANCH: ${{ github.event.inputs.examples_branch }}
       COLLECT_RESOURCE_LIMITS: ${{ matrix.COLLECT_RESOURCE_LIMITS }}
+    outputs:
+      BRANCH: ${{ steps.determine_branch.outputs.BRANCH }}
     steps:
       - name: Check out code.
         uses: actions/checkout@v2
@@ -485,9 +487,14 @@ jobs:
     needs: integration-test
     if: always() # always run, regardless of the outcome of the last job
     runs-on: ubuntu-20.04
+    env:
+      BRANCH: ${{ needs.integration-test.outputs.BRANCH }}
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+
+      - name: Debug - Output Branch
+        run: echo $BRANCH
 
       - name: Load CI Environment from .ci_env
         id: load_ci_env
@@ -536,7 +543,7 @@ jobs:
           workflow: CI.yml
           workflow_conclusion: success
           # Use the branch
-          branch: ${{ github.event.inputs.branch }}
+          branch: ${{ env.BRANCH}}
           # Optional, directory where to extract artifact
           path: ./dist
 
@@ -612,7 +619,7 @@ jobs:
               release = await github.repos.getReleaseByTag({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                tag: "${{ steps.get_version.outputs.VERSION }}"
+                tag: tag
               });
               console.log("::error Release already exists... Aborting!");
               core.setFailed("Release already exists... Aborting!");

--- a/test/utils/k8s_collect_resources.sh
+++ b/test/utils/k8s_collect_resources.sh
@@ -3,13 +3,13 @@
 NAMESPACE=${1:-"keptn"}
 
 # Gathers resource limits by deployment for keptn namespace
-
+# | Deployment                          	| Memory (requested) 	| CPU (requested) 	| Memory (limit) 	| CPU (limit)
 KUBE_GET_DEPS="kubectl get deployments -n $NAMESPACE"
 echo -e ""
-echo -e "| Pod | Container | lim.cpu | lim.mem | req.cpu | req.mem | Images |"
-echo -e "|-----|-----------|---------|---------|---------|---------|--------|"
+echo -e "| Pod | Container | Memory (requested) | CPU (requested) | Memory (limit) | CPU (limit) | Images |"
+echo -e "|-----|-----------|--------------------|-----------------|----------------|-------------|--------|"
 $KUBE_GET_DEPS | sed '1d' | awk '{print $1}' | sort | while read DEPLOYMENT; do
-  $KUBE_GET_DEPS $DEPLOYMENT -o jsonpath='{range .spec.template.spec.containers[*]}{"| "}{"'$DEPLOYMENT'"}{" | "}{.name}{" | "}--{.resources.limits.cpu}{" | "}--{.resources.limits.memory}{" | "}--{.resources.requests.cpu}{" | "}--{.resources.requests.memory}{" | "}{.image}{" | "}{"\n"}{end}' | sed -E -e 's/--([0-9])/\1/g' -e 's/--/-/g'
+  $KUBE_GET_DEPS $DEPLOYMENT -o jsonpath='{range .spec.template.spec.containers[*]}{"| "}{"'$DEPLOYMENT'"}{" | "}{.name}{" | "}--{.resources.requests.memory}{" | "}--{.resources.requests.cpu}{" | "}--{.resources.limits.memory}{" | "}--{.resources.limits.cpu}{" | "}{.image}{" | "}{"\n"}{end}' | sed -E -e 's/--([0-9])/\1/g' -e 's/--/-/g'
 done
 
 echo -e ""


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

Last improvement based on #2824 (upgrading to the latest get-next-semver action).

Plus: I found that our master builds are always using builds from PRs, e.g.:
![image](https://user-images.githubusercontent.com/56065213/106476510-6ca4fc80-64a7-11eb-8387-5de0be5ed85c.png)
![image](https://user-images.githubusercontent.com/56065213/106476549-7595ce00-64a7-11eb-8d23-93f338a5d3f8.png)



In addition, I found that existing release were not detected properly, e.g.:
![image](https://user-images.githubusercontent.com/56065213/106483156-8433b380-64ae-11eb-834d-4b495e86ac91.png)

With this PR I am using the `extract_branch` steps output `BRANCH` in the download-artifact step for publishing the release. Also, I fixed the problem with the release-check.