### PR TITLE
Slow down dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,59 +4,71 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 3
+    rebase-strategy: "disabled"
   - package-ecosystem: gomod
     directory: "/cli"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 3
+    rebase-strategy: "disabled"
   - package-ecosystem: gomod
     directory: "/api"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 3
+    rebase-strategy: "disabled"
   - package-ecosystem: gomod
     directory: "/distributor"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 3
+    rebase-strategy: "disabled"
   - package-ecosystem: gomod
     directory: "/configuration-service"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 3
+    rebase-strategy: "disabled"
   - package-ecosystem: gomod
     directory: "/helm-service"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 3
+    rebase-strategy: "disabled"
   - package-ecosystem: gomod
     directory: "/jmeter-service"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 3
+    rebase-strategy: "disabled"
   - package-ecosystem: gomod
     directory: "/lighthouse-service"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 3
+    rebase-strategy: "disabled"
   - package-ecosystem: gomod
     directory: "/mongodb-datastore"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 3
+    rebase-strategy: "disabled"
   - package-ecosystem: gomod
     directory: "/remediation-service"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 3
+    rebase-strategy: "disabled"
   - package-ecosystem: gomod
     directory: "/shipyard-controller"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 3
+    rebase-strategy: "disabled"
   - package-ecosystem: gomod
     directory: "/statistics-service"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 3
+    rebase-strategy: "disabled"


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

Dependabot is creating roughly 100 PRs as we have some dependencies that we could update... This PR tries to lower the amount of PRs and disables rebase strategy for now (to lower the strain on our CI).