### PR TITLE
Remove payload of received response from distributor logs

### DIFF
--- a/distributor/cmd/main.go
+++ b/distributor/cmd/main.go
@@ -232,7 +232,7 @@ func APIProxyHandler(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	fmt.Println(fmt.Sprintf("Received response from API: Status=%d, Payload=%s", resp.StatusCode, string(respBytes)))
+	fmt.Println(fmt.Sprintf("Received response from API: Status=%d", resp.StatusCode))
 	if _, err := rw.Write(respBytes); err != nil {
 		fmt.Println("could not send response from API: " + err.Error())
 	}


### PR DESCRIPTION
The log output removed in this PR was only used for debugging and was not intended to stay here

Signed-off-by: Florian Bacher <florian.bacher@dynatrace.com>