### PR TITLE
Added a workflow to automatically create a release branch

### DIFF
--- a/.github/workflows/create_release_branch.yml
+++ b/.github/workflows/create_release_branch.yml
@@ -1,0 +1,99 @@
+name: Create Release Branch
+# this action helps for release automating by creating a release branch and resp. PRs
+# based on https://riggaroo.dev/using-github-actions-to-automate-our-release-process/
+on:
+  workflow_dispatch:
+    inputs:
+      versionName:
+        description: 'Version (e.g., 0.8.0)'
+        required: true
+      baseBranch:
+        description: 'Which branch to create the release from (e.g., master)'
+        default: 'master'
+        required: false
+jobs:
+  createrelease:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Verify version is semantic
+        env:
+          VERSION: ${{ github.event.inputs.versionName }}
+        run: |
+          SEMVER_REGEX="^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(\\-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+
+          if [[ "$VERSION" =~ $SEMVER_REGEX ]]; then
+            echo "Version $VERSION matches the semver scheme 'X.Y.Z(-PRERELEASE)(+BUILD)'"
+          else
+            echo "::error::Version $VERSION does not match the semver scheme 'X.Y.Z(-PRERELEASE)(+BUILD)'"
+            exit 1
+          fi
+
+      - name: Initialize mandatory git config
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email noreply@github.com
+
+      - name: Export branch name
+        id: export_branch_name
+        run: |
+          RELEASE_BRANCH_NAME=release-${{ github.event.inputs.versionName }}
+          echo "##[set-output name=RELEASE_BRANCH_NAME;]$(echo ${RELEASE_BRANCH_NAME})"
+
+      - name: Check if branch name already exists
+        env:
+          RELEASE_BRANCH_NAME: ${{ steps.export_branch_name.outputs.RELEASE_BRANCH_NAME }}
+        run: |
+          BRANCH_EXISTS_IN_REMOTE=$(git ls-remote --heads origin ${RELEASE_BRANCH_NAME})
+
+          if [[ -z ${BRANCH_EXISTS_IN_REMOTE} ]]; then
+            echo "Branch does not exist, continuing..."
+          else
+            echo "::error::Branch ${RELEASE_BRANCH_NAME} already exists, exiting..."
+            exit 1
+          fi
+
+      - name: Create release branch
+        env:
+          RELEASE_BRANCH_NAME: ${{ steps.export_branch_name.outputs.RELEASE_BRANCH_NAME }}
+          BASE_BRANCH: ${{ github.event.inputs.baseBranch }}
+        run: |
+          git checkout ${BASE_BRANCH}
+          git pull
+          git checkout -b ${RELEASE_BRANCH_NAME}
+
+      - name: Copy release notes develop
+        run: cp releasenotes/releasenotes_develop.md releasenotes_V${{ github.event.inputs.versionName }}.md
+
+      - name: List changed files
+        run: git status
+
+      - name: Commit
+        id: make-commit
+        run: |
+          git add .
+          git commit -s -m "Prepare release ${{ github.event.inputs.versionName }}"
+          echo "::set-output name=commit::$(git rev-parse HEAD)"
+
+      - name: Push new branch
+        env:
+          RELEASE_BRANCH_NAME: ${{ steps.export_branch_name.outputs.RELEASE_BRANCH_NAME }}
+        run: git push origin ${RELEASE_BRANCH_NAME}
+
+      - name: Create PR into master
+        env:
+          VERSION: ${{ github.event.inputs.versionName }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_BRANCH_NAME: ${{ steps.export_branch_name.outputs.RELEASE_BRANCH_NAME }}
+          TARGET_BRANCH: 'master'
+        run: |
+          curl -XPOST -H "Authorization: token $GITHUB_TOKEN" \
+            -d "{\"title\":\"Version ${VERSION} into ${TARGET_BRANCH}\", \
+                 \"base\":\"${TARGET_BRANCH}\", \"head\":\"${RELEASE_BRANCH_NAME}\", \
+                 \"draft\": true, \
+                 \"body\":\":robot: **Beep boop I am a bot**\n\
+                            This is an automatically created PR for version ${VERSION} to merge changes from ${RELEASE_BRANCH_NAME} to ${TARGET_BRANCH}.\n \
+                            \"}" \
+                 https://api.github.com/repos/keptn/keptn/pulls || true


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

This PR adds a workflow to automate the creation of a release branch (and copying of release notes).
In addition, the workflow checks if the release name adheres to semver :) 

FYI: This workflow is not very specific to keptn/keptn itself, it can be copied to our keptn-contrib/sandbox services aswell. Might be worth to extract some functionality as another gh-action.