### PR TITLE
#2764 Fix inferring urls

### DIFF
--- a/helm-service/controller/deployment_handler.go
+++ b/helm-service/controller/deployment_handler.go
@@ -3,6 +3,8 @@ package controller
 import (
 	"errors"
 	"fmt"
+	"math"
+
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	keptnevents "github.com/keptn/go-utils/pkg/lib"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
@@ -11,7 +13,6 @@ import (
 	"github.com/keptn/keptn/helm-service/pkg/mesh"
 	"helm.sh/helm/v3/pkg/chart"
 	corev1 "k8s.io/api/core/v1"
-	"math"
 )
 
 // DeploymentHandler is a handler for doing the deployment and
@@ -210,17 +211,17 @@ func (h *DeploymentHandler) getFinishedEventDataForSuccess(inEventData keptnv2.D
 	inEventData.Message = "Successfully deployed"
 
 	var localURIs, publicURIs []string
-	if len(inEventData.Deployment.DeploymentURIsLocal) > 0 || len(inEventData.Deployment.DeploymentURIsPublic) > 0 {
-		h.getKeptnHandler().Logger.Info("Using deployment URIs from deployment.triggered event")
-		localURIs = inEventData.Deployment.DeploymentURIsLocal
-		publicURIs = inEventData.Deployment.DeploymentURIsPublic
-	} else if deploymentStrategy == keptnevents.Direct || deploymentStrategy == keptnevents.Duplicate {
+	if deploymentStrategy == keptnevents.Direct || deploymentStrategy == keptnevents.Duplicate {
 		h.getKeptnHandler().Logger.Info("Inferring deployment URIs")
 		var err error
 		localURIs, publicURIs, err = h.getDeploymentURIs(inEventData.EventData)
 		if err != nil {
 			return nil, fmt.Errorf("Could not determine deployment URIs: %s", err.Error())
 		}
+	} else if len(inEventData.Deployment.DeploymentURIsLocal) > 0 || len(inEventData.Deployment.DeploymentURIsPublic) > 0 {
+		h.getKeptnHandler().Logger.Info("Using deployment URIs from deployment.triggered event")
+		localURIs = inEventData.Deployment.DeploymentURIsLocal
+		publicURIs = inEventData.Deployment.DeploymentURIsPublic
 	} else {
 		h.getKeptnHandler().Logger.Info("No deployment URIs defined in deployment.finished event")
 	}

--- a/helm-service/controller/deployment_handler_test.go
+++ b/helm-service/controller/deployment_handler_test.go
@@ -1,6 +1,8 @@
 package controller
 
 import (
+	"testing"
+
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/golang/mock/gomock"
 	keptn "github.com/keptn/go-utils/pkg/lib"
@@ -9,8 +11,135 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	"testing"
 )
+
+func TestHandleEventWithDeploymentURLAndUserManagedDeploymentStrategy(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockedBaseHandler := NewMockedHandler(createKeptn(), "")
+	mockedOnboarder := mocks.NewMockOnboarder(ctrl)
+	mockedChartGenerator := mocks.NewMockChartGenerator(ctrl)
+
+	deploymentHandler := DeploymentHandler{
+		Handler:               mockedBaseHandler,
+		mesh:                  mocks.NewMockMesh(ctrl),
+		generatedChartHandler: mockedChartGenerator,
+		onboarder:             mockedOnboarder,
+	}
+
+	deploymentTriggeredEventData := keptnv2.DeploymentTriggeredEventData{
+		EventData: keptnv2.EventData{
+			Project: "my-project",
+			Stage:   "production",
+			Service: "my-service",
+		},
+		ConfigurationChange: keptnv2.ConfigurationChange{},
+		Deployment: keptnv2.DeploymentTriggeredData{
+			DeploymentStrategy:   keptn.UserManaged.String(),
+			DeploymentURIsPublic: []string{"https://myurl"},
+		},
+	}
+
+	ce := cloudevents.NewEvent()
+	_ = ce.SetData(cloudevents.ApplicationJSON, deploymentTriggeredEventData)
+	deploymentHandler.HandleEvent(ce)
+
+	expectedDeploymentFinishedEvent := cloudevents.NewEvent()
+	expectedDeploymentFinishedEvent.SetType("sh.keptn.event.deployment.finished")
+	expectedDeploymentFinishedEvent.SetSource("helm-service")
+	expectedDeploymentFinishedEvent.SetDataContentType(cloudevents.ApplicationJSON)
+	expectedDeploymentFinishedEvent.SetExtension("triggeredid", "")
+	expectedDeploymentFinishedEvent.SetExtension("shkeptncontext", "")
+	expectedDeploymentFinishedEvent.SetData(cloudevents.ApplicationJSON, keptnv2.DeploymentFinishedEventData{
+		EventData: keptnv2.EventData{
+			Project: "my-project",
+			Stage:   "production",
+			Service: "my-service",
+			Status:  keptnv2.StatusSucceeded,
+			Result:  keptnv2.ResultPass,
+			Message: "Successfully deployed",
+		},
+		Deployment: keptnv2.DeploymentFinishedData{
+			DeploymentStrategy:   "user_managed",
+			DeploymentURIsPublic: []string{"https://myurl"},
+			DeploymentNames:      []string{"user-managed"},
+			GitCommit:            "USER_CHART_GIT_ID",
+		},
+	})
+
+	require.Equal(t, 2, len(mockedBaseHandler.sentCloudEvents))
+	assert.Equal(t, expectedDeploymentFinishedEvent, mockedBaseHandler.sentCloudEvents[1])
+	require.Equal(t, 2, len(mockedBaseHandler.upgradeChartInvocations))
+	assert.Equal(t, "carts", mockedBaseHandler.upgradeChartInvocations[0].ch.Metadata.Name)
+	assert.Equal(t, deploymentTriggeredEventData.EventData, mockedBaseHandler.upgradeChartInvocations[0].event)
+	assert.Equal(t, keptn.UserManaged, mockedBaseHandler.upgradeChartInvocations[0].strategy)
+}
+
+func TestHandleEventWithDeploymentURLAndDirectDeploymentStrategy(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockedBaseHandler := NewMockedHandler(createKeptn(), "")
+	mockedOnboarder := mocks.NewMockOnboarder(ctrl)
+	mockedChartGenerator := mocks.NewMockChartGenerator(ctrl)
+
+	deploymentHandler := DeploymentHandler{
+		Handler:               mockedBaseHandler,
+		mesh:                  mocks.NewMockMesh(ctrl),
+		generatedChartHandler: mockedChartGenerator,
+		onboarder:             mockedOnboarder,
+	}
+
+	deploymentTriggeredEventData := keptnv2.DeploymentTriggeredEventData{
+		EventData: keptnv2.EventData{
+			Project: "my-project",
+			Stage:   "production",
+			Service: "my-service",
+		},
+		ConfigurationChange: keptnv2.ConfigurationChange{},
+		Deployment: keptnv2.DeploymentTriggeredData{
+			DeploymentStrategy:  keptn.Direct.String(),
+			DeploymentURIsLocal: []string{"http://my-service.my-project-dev:80"},
+		},
+	}
+
+	ce := cloudevents.NewEvent()
+	_ = ce.SetData(cloudevents.ApplicationJSON, deploymentTriggeredEventData)
+	deploymentHandler.HandleEvent(ce)
+
+	expectedDeploymentFinishedEvent := cloudevents.NewEvent()
+	expectedDeploymentFinishedEvent.SetType("sh.keptn.event.deployment.finished")
+	expectedDeploymentFinishedEvent.SetSource("helm-service")
+	expectedDeploymentFinishedEvent.SetDataContentType(cloudevents.ApplicationJSON)
+	expectedDeploymentFinishedEvent.SetExtension("triggeredid", "")
+	expectedDeploymentFinishedEvent.SetExtension("shkeptncontext", "")
+	expectedDeploymentFinishedEvent.SetData(cloudevents.ApplicationJSON, keptnv2.DeploymentFinishedEventData{
+		EventData: keptnv2.EventData{
+			Project: "my-project",
+			Stage:   "production",
+			Service: "my-service",
+			Status:  keptnv2.StatusSucceeded,
+			Result:  keptnv2.ResultPass,
+			Message: "Successfully deployed",
+		},
+		Deployment: keptnv2.DeploymentFinishedData{
+			DeploymentStrategy:   "direct",
+			DeploymentURIsLocal:  []string{"http://my-service.my-project-production:80"},
+			DeploymentURIsPublic: []string{"http://my-service.my-project-production.svc.cluster.local:80"},
+			DeploymentNames:      []string{"direct"},
+			GitCommit:            "USER_CHART_GIT_ID",
+		},
+	})
+
+	require.Equal(t, 2, len(mockedBaseHandler.sentCloudEvents))
+	assert.Equal(t, expectedDeploymentFinishedEvent, mockedBaseHandler.sentCloudEvents[1])
+	require.Equal(t, 2, len(mockedBaseHandler.upgradeChartInvocations))
+	assert.Equal(t, "carts", mockedBaseHandler.upgradeChartInvocations[0].ch.Metadata.Name)
+	assert.Equal(t, deploymentTriggeredEventData.EventData, mockedBaseHandler.upgradeChartInvocations[0].event)
+	assert.Equal(t, keptn.Direct, mockedBaseHandler.upgradeChartInvocations[0].strategy)
+	assert.Equal(t, "carts-generated", mockedBaseHandler.upgradeChartInvocations[1].ch.Metadata.Name)
+	assert.Equal(t, deploymentTriggeredEventData.EventData, mockedBaseHandler.upgradeChartInvocations[1].event)
+	assert.Equal(t, keptn.Direct, mockedBaseHandler.upgradeChartInvocations[1].strategy)
+}
 
 func TestHandleEventWithNoConfigurationChangeAndDirectDeploymentStrategy(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/helm-service/pkg/helm/generated_chart_handler.go
+++ b/helm-service/pkg/helm/generated_chart_handler.go
@@ -3,9 +3,10 @@ package helm
 import (
 	"errors"
 	"fmt"
-	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 	"net/url"
 	"strings"
+
+	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 
 	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
 
@@ -52,7 +53,13 @@ func (c *GeneratedChartGenerator) GenerateDuplicateChart(helmManifest string, pr
 	ch := chart.Chart{Metadata: meta}
 
 	svcs := GetServices(helmManifest)
+	if len(svcs) > 1 {
+		return nil, errors.New("Chart contains multiple Kubernetes services but only 1 is allowed")
+	}
 	depls := GetDeployments(helmManifest)
+	if len(depls) > 1 {
+		return nil, errors.New("Chart contains multiple Kubernetes deployments but only 1 is allowed")
+	}
 
 	for _, svc := range svcs {
 		templates, err := c.generateServices(svc, project, stageName)

--- a/helm-service/pkg/helm/helm_mock_executor.go
+++ b/helm-service/pkg/helm/helm_mock_executor.go
@@ -56,6 +56,31 @@ spec:
         imagePullPolicy: IfNotPresent        
 `
 
+const renderedUserDeployment = `--- 
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: carts
+spec:
+  replicas: 1
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: carts
+  template:
+    metadata:
+      labels:
+        app: carts
+    spec:
+      containers:
+      - name: carts
+        image: "docker.io/keptnexamples/carts:0.8.1"
+        imagePullPolicy: IfNotPresent        
+`
+
 // GeneratedCanaryDestinationRule is a DestinationRule manifest for tests
 const GeneratedCanaryDestinationRule = `---
 apiVersion: networking.istio.io/v1alpha3
@@ -93,7 +118,7 @@ spec:
     targetPort: 8080
   selector:
     app: carts
-  type: ClusterIP
+  type: LoadBalancer
 status:
   loadBalancer: {}
 `
@@ -113,7 +138,7 @@ spec:
     targetPort: 8080
   selector:
     app: carts-primary
-  type: ClusterIP
+  type: LoadBalancer
 status:
   loadBalancer: {}
 `
@@ -130,7 +155,7 @@ spec:
   - public-gateway.istio-system
   - mesh
   hosts:
-  - carts.sockshop-NAMESPACE_PLACEHOLDER.demo.keptn.sh
+  - carts.sockshop-NAMESPACE_PLACEHOLDER.svc.cluster.local
   - carts
   http:
   - route:


### PR DESCRIPTION
Closes #2764 
This PR fixes the inferring of the URL as follows: In case a user uses deployment strategy `direct` or `blue_green_service`, the `DeploymentURIsLocal` and `DeploymentURIsPublic` are always inferred regardless they are already present in the incoming event.

Signed-off-by: agrimmer <andreas.grimmer@dynatrace.com>