### PR TITLE
Forward query parameters and headers

### DIFF
--- a/distributor/cmd/main.go
+++ b/distributor/cmd/main.go
@@ -206,6 +206,7 @@ func APIProxyHandler(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	forwardReq.URL = parsedProxyURL
+	forwardReq.URL.RawQuery = req.URL.RawQuery
 
 	fmt.Println(fmt.Sprintf("Forwarding request to host=%s, path=%s, URL=%s", proxyHost, proxyPath, forwardReq.URL.String()))
 
@@ -222,6 +223,13 @@ func APIProxyHandler(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+
+	for name, headers := range resp.Header {
+		for _, h := range headers {
+			rw.Header().Set(name, h)
+		}
+	}
+
 	rw.WriteHeader(resp.StatusCode)
 
 	defer resp.Body.Close()


### PR DESCRIPTION
This PR fixes bugs when the distributor is used as a proxy.
More precisely, it forwards the query parameters when sending the request and returns the headers.

Unit tests require a refactoring of the function `APIProxyHandler`. A contribution would be more than welcome! 

Signed-off-by: agrimmer <andreas.grimmer@dynatrace.com>