### PR TITLE
#3199 Shipyard controller: propagate properties of .triggered event

### DIFF
--- a/cli/cmd/send_event_approvalFinished.go
+++ b/cli/cmd/send_event_approvalFinished.go
@@ -356,6 +356,7 @@ func getCommitIDOfConfigurationChangeEvent(eventHandler *apiutils.EventHandler, 
 		return unknownCommitID
 	}
 
+	// TODO: use configurationChange image/tag
 	if deploymentFinishedData.Deployment.GitCommit == "" {
 		return unknownCommitID
 	}

--- a/cli/cmd/send_event_approvalFinished.go
+++ b/cli/cmd/send_event_approvalFinished.go
@@ -293,11 +293,11 @@ func printApprovalOptions(approvals []*apimodels.KeptnContextExtendedCE, eventHa
 
 	defer w.Flush()
 
-	fmt.Fprintf(w, "\n %s\t%s\t%s\t", "OPTION", "GIT COMMIT", "EVALUATION")
+	fmt.Fprintf(w, "\n %s\t%s\t%s\t", "OPTION", "IMAGE", "EVALUATION")
 
 	for index, approval := range approvals {
 		score := getScoreForApprovalTriggeredEvent(eventHandler, approvalFinishedOptions, approval)
-		commitID := getCommitIDOfConfigurationChangeEvent(eventHandler, approvalFinishedOptions, approval)
+		commitID := getApprovalImageEvent(approval)
 		appendOptionToWriter(w, index, commitID, score)
 	}
 	fmt.Fprintf(w, "\n")
@@ -333,34 +333,25 @@ func getScoreForApprovalTriggeredEvent(eventHandler *apiutils.EventHandler, appr
 	return score
 }
 
-func getCommitIDOfConfigurationChangeEvent(eventHandler *apiutils.EventHandler, approvalFinishedOptions sendApprovalFinishedStruct, approval *apimodels.KeptnContextExtendedCE) string {
-	unknownCommitID := "n/a"
-	deploymentFinishedEvents, errorObj := eventHandler.GetEvents(&apiutils.EventFilter{
-		Project:      *approvalFinishedOptions.Project,
-		Stage:        *approvalFinishedOptions.Stage,
-		Service:      *approvalFinishedOptions.Service,
-		EventType:    keptnv2.GetFinishedEventType(keptnv2.DeploymentTaskName),
-		KeptnContext: approval.Shkeptncontext,
-	})
-	if errorObj != nil {
-		return unknownCommitID
-	}
-	if len(deploymentFinishedEvents) == 0 {
-		return unknownCommitID
-	}
-	deploymentFinishedData := &keptnv2.DeploymentFinishedEventData{}
+func getApprovalImageEvent(approval *apimodels.KeptnContextExtendedCE) string {
+	unknownImage := "n/a"
 
-	err := common.DecodeKeptnEventData(deploymentFinishedEvents[0].Data, deploymentFinishedData)
+	// the approval.triggered event should also include the configurationChange property (see https://github.com/keptn/keptn/issues/3199)
+	// therefore, we can cast its data property to a DeploymentTriggeredEventData struct and use the property from this struct
+	deploymentTriggeredData := &keptnv2.DeploymentTriggeredEventData{}
+
+	err := common.DecodeKeptnEventData(deploymentTriggeredData, approval.Data)
 
 	if err != nil {
-		return unknownCommitID
+		return unknownImage
 	}
 
-	// TODO: use configurationChange image/tag
-	if deploymentFinishedData.Deployment.GitCommit == "" {
-		return unknownCommitID
+	if deploymentTriggeredData.ConfigurationChange.Values != nil {
+		if image, ok := deploymentTriggeredData.ConfigurationChange.Values["image"].(string); ok {
+			return image
+		}
 	}
-	return deploymentFinishedData.Deployment.GitCommit
+	return unknownImage
 }
 
 func getApprovalFinishedForID(eventHandler *apiutils.EventHandler, sendApprovalFinishedOptions sendApprovalFinishedStruct) (string,

--- a/shipyard-controller/handler/shipyardcontroller.go
+++ b/shipyard-controller/handler/shipyardcontroller.go
@@ -466,17 +466,13 @@ func (sc *shipyardController) proceedTaskSequence(eventScope *keptnv2.EventData,
 	task, err := sc.getNextTaskOfSequence(taskSequence, previousTask, eventScope)
 	if err != nil && err == errNoFurtherTaskForSequence {
 
-
 		// task sequence completed -> send .finished event and check if a new task sequence should be triggered by the completion
 		err = sc.completeTaskSequence(event.Shkeptncontext, eventScope, taskSequence.Name)
 		if err != nil {
 			sc.logger.Error("Could not complete task sequence " + eventScope.Stage + "." + taskSequence.Name + " with KeptnContext " + event.Shkeptncontext)
 			return err
 		}
-		if eventScope.Result == keptnv2.ResultPass {
-			return sc.triggerNextTaskSequences(event, eventScope, taskSequence, shipyard, previousFinishedEvents, inputEvent)
-		}
-		return nil
+		return sc.triggerNextTaskSequences(event, eventScope, taskSequence, shipyard, previousFinishedEvents, inputEvent)
 	} else if err != nil {
 		sc.logger.Error("Could not get next task of sequence: " + err.Error())
 		return err

--- a/shipyard-controller/handler/shipyardcontroller.go
+++ b/shipyard-controller/handler/shipyardcontroller.go
@@ -472,33 +472,13 @@ func (sc *shipyardController) handleTriggeredEvent(event models.Event) error {
 }
 
 func (sc *shipyardController) proceedTaskSequence(eventScope *keptnv2.EventData, taskSequence *keptnv2.Sequence, event models.Event, shipyard *keptnv2.Shipyard, previousFinishedEvents []interface{}, previousTask string) error {
+	// get the input for the .triggered event that triggered the previous sequence and append it to the list of previous events to gather all required data for the next stage
+	inputEvent, previousFinishedEvents, err := sc.appendTriggerEventProperties(eventScope, taskSequence, event, previousFinishedEvents)
+	if err != nil {
+		return err
+	}
 	task, err := sc.getNextTaskOfSequence(taskSequence, previousTask)
 	if err != nil && err == errNoFurtherTaskForSequence {
-		// get the input for te .triggered event that triggered the previous sequence and append it to the list of previous events to gather all required data for the next stage
-		events, err := sc.eventRepo.GetEvents(eventScope.Project, common.EventFilter{
-			Type:         keptnv2.GetTriggeredEventType(eventScope.Stage + "." + taskSequence.Name),
-			Stage:        &eventScope.Stage,
-			KeptnContext: &event.Shkeptncontext,
-		}, common.TriggeredEvent)
-
-		if err != nil {
-			sc.logger.Error("Could not load event that triggered task sequence " + eventScope.Stage + "." + taskSequence.Name + " with KeptnContext " + event.Shkeptncontext)
-			return err
-		}
-
-		var inputEvent *models.Event
-		if len(events) > 0 {
-			inputEvent = &events[0]
-			marshal, err := json.Marshal(inputEvent.Data)
-			if err != nil {
-				sc.logger.Error("Could not marshal input event: " + err.Error())
-				return err
-			}
-			var tmp interface{}
-			_ = json.Unmarshal(marshal, &tmp)
-			previousFinishedEvents = append(previousFinishedEvents, tmp)
-		}
-
 		// task sequence completed -> send .finished event and check if a new task sequence should be triggered by the completion
 		err = sc.completeTaskSequence(event.Shkeptncontext, eventScope, taskSequence.Name)
 		if err != nil {
@@ -514,6 +494,35 @@ func (sc *shipyardController) proceedTaskSequence(eventScope *keptnv2.EventData,
 		return err
 	}
 	return sc.sendTaskTriggeredEvent(event.Shkeptncontext, eventScope, taskSequence.Name, *task, previousFinishedEvents)
+}
+
+// this function retrieves the .triggered event for the task sequence and appends its properties to the existing .finished events
+// this ensures that all parameters set in the .triggered event are received by all execution plane services, instead of just the first one
+func (sc *shipyardController) appendTriggerEventProperties(eventScope *keptnv2.EventData, taskSequence *keptnv2.Sequence, event models.Event, previousFinishedEvents []interface{}) (*models.Event, []interface{}, error) {
+	events, err := sc.eventRepo.GetEvents(eventScope.Project, common.EventFilter{
+		Type:         keptnv2.GetTriggeredEventType(eventScope.Stage + "." + taskSequence.Name),
+		Stage:        &eventScope.Stage,
+		KeptnContext: &event.Shkeptncontext,
+	}, common.TriggeredEvent)
+
+	if err != nil {
+		sc.logger.Error("Could not load event that triggered task sequence " + eventScope.Stage + "." + taskSequence.Name + " with KeptnContext " + event.Shkeptncontext)
+		return nil, nil, err
+	}
+
+	var inputEvent *models.Event
+	if len(events) > 0 {
+		inputEvent = &events[0]
+		marshal, err := json.Marshal(inputEvent.Data)
+		if err != nil {
+			sc.logger.Error("Could not marshal input event: " + err.Error())
+			return nil, nil, err
+		}
+		var tmp interface{}
+		_ = json.Unmarshal(marshal, &tmp)
+		previousFinishedEvents = append(previousFinishedEvents, tmp)
+	}
+	return inputEvent, previousFinishedEvents, nil
 }
 
 func (sc *shipyardController) triggerNextTaskSequences(event models.Event, eventScope *keptnv2.EventData, completedSequence *keptnv2.Sequence, shipyard *keptnv2.Shipyard, previousFinishedEvents []interface{}, inputEvent *models.Event) error {

--- a/shipyard-controller/handler/shipyardcontroller_test.go
+++ b/shipyard-controller/handler/shipyardcontroller_test.go
@@ -756,6 +756,21 @@ func Test_shipyardController_Scenario1(t *testing.T) {
 				t.Errorf("DeploymentURIsLocal property was not transmitted correctly")
 				return true
 			}
+
+			// also check if the payload of the .triggered event that started the sequence is present
+
+			deploymentEvent := &keptnv2.DeploymentTriggeredEventData{}
+
+			err = json.Unmarshal(marshal, deploymentEvent)
+			if err != nil {
+				t.Errorf("Expected deployment.triggered data but could not convert: %v: %s", e.Data, err.Error())
+				return true
+			}
+
+			if deploymentEvent.ConfigurationChange.Values["image"] != "carts" {
+				t.Errorf("did not receive correct image. Expected 'carts' but got '%s'", deploymentEvent.ConfigurationChange.Values["image"])
+				return true
+			}
 			return false
 		})
 	if done {


### PR DESCRIPTION
Closes #3199 
Additional change: the delivery assistant of the CLI was showing the git commit ID of the deployment.finished event associated with the approval. Since the `configurationChange` property is now included in the approval.triggered event, we can now easily determine the image of the service that should be approved