### PR TITLE
#3243 Fix GKE cluster delete, move to another GKE region

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -144,8 +144,8 @@ jobs:
           GKE_VERSION: ${{ matrix.VERSION }}
           GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
           GCLOUD_PROJECT_NAME: ${{ secrets.GCLOUD_PROJECT_NAME }}
-          CLOUDSDK_COMPUTE_ZONE: "us-central1-a"
-          CLOUDSDK_REGION: "us-central1"
+          CLOUDSDK_COMPUTE_ZONE: "us-east1-b"
+          CLOUDSDK_REGION: "us-east1"
           BRANCH: ${{ steps.determine_branch.outputs.BRANCH}}
         id: install_gke
         run: |
@@ -481,14 +481,14 @@ jobs:
         run: kubectl get deployments --all-namespaces -owide
 
       - name: Cleanup GKE cluster
-        if: env.CLOUD_PROVIDER == 'GKE'
+        if: always() && env.CLOUD_PROVIDER == 'GKE' # we always need to cleanup GKE clusters
         timeout-minutes: 5
         env:
           GKE_VERSION: ${{ matrix.VERSION }}
           GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
           GCLOUD_PROJECT_NAME: ${{ secrets.GCLOUD_PROJECT_NAME }}
-          CLOUDSDK_COMPUTE_ZONE: "us-central1-a"
-          CLOUDSDK_REGION: "us-central1"
+          CLOUDSDK_COMPUTE_ZONE: "us-east1-b"
+          CLOUDSDK_REGION: "us-east1"
           CLUSTER_NAME_NIGHTLY: ${{ steps.install_gke.outputs.CLUSTER_NAME_NIGHTLY }}
         run: test/utils/gke_delete_cluster.sh
 


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

Fixes #3243 

With this PR I ensure that a GKE cluster is always deleted (using `if: always()`).
In addition, due to resource constraints within our Google Project, I have moved from us-central1-a to us-east1-b, e.g.:
![image](https://user-images.githubusercontent.com/56065213/108333481-45ea0400-71d1-11eb-8b67-6d0a7d0da7ad.png)
