### PR TITLE
#3320 Always restart api-gateway-nginx deployment on changes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -552,7 +552,7 @@ jobs:
   helm_charts_build:
     needs: prepare_ci_run
     name: Build Helm Charts
-    if: (needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') # || (needs.prepare_ci_run.outputs.BUILD_INSTALLER == 'true')
+    if: (needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (needs.prepare_ci_run.outputs.BUILD_INSTALLER == 'true')
     runs-on: ubuntu-20.04
     env:
       BRANCH: ${{ needs.prepare_ci_run.outputs.BRANCH }}

--- a/installer/manifests/keptn/charts/control-plane/templates/api-gateway-nginx.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/api-gateway-nginx.yaml
@@ -254,7 +254,9 @@ spec:
         app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
         app.kubernetes.io/component: {{ include "control-plane.name" . }}
         app.kubernetes.io/version: {{ .Values.apiGatewayNginx.image.tag }}
-        helm.sh/chart: {{ include "control-plane.chart" . }}   
+        helm.sh/chart: {{ include "control-plane.chart" . }}
+      annotations: # add randomizer to restart the deployment if anything changes - see https://github.com/keptn/keptn/issues/3320
+        rollme: {{ randAlphaNum 5 | quote }}
     spec:
       containers:
         - name: api-gateway-nginx
@@ -286,11 +288,11 @@ spec:
               name: api-nginx-config
           resources:
             requests:
-              memory: "32Mi"
+              memory: "64Mi"
               cpu: "50m"
             limits:
               memory: "128Mi"
-              cpu: "500m"
+              cpu: "250m"
       volumes:
         - name: api-nginx-config
           configMap:


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

Fixes #3320.

This PR adds an annotation to the deployment which should lead to a restart every time the helm chart gets applied/installed/upgraded.

In addition, I have fine tuned the resource requirements of the pod according to my current measurements.