### PR TITLE
#3223 Load root events per Service

### DIFF
--- a/bridge/client/app/_services/api.service.ts
+++ b/bridge/client/app/_services/api.service.ts
@@ -12,6 +12,7 @@ import {Trace} from "../_models/trace";
 import {ApprovalStates} from "../_models/approval-states";
 import {EventTypes} from "../_models/event-types";
 import {Metadata} from '../_models/metadata';
+import {Project} from "../_models/project";
 
 @Injectable({
   providedIn: 'root'
@@ -80,6 +81,11 @@ export class ApiService {
       url += `&pageSize=${pageSize}`;
     return this.http
       .get<ProjectResult>(url);
+  }
+
+  public getProject(projectName: string): Observable<Project> {
+    let url = `${this._baseUrl}/controlPlane/v1/project/${projectName}`;
+    return this.http.get<Project>(url);
   }
 
   public getMetadata(): Observable<Metadata> {

--- a/bridge/client/app/_views/ktb-service-view/ktb-service-view.component.ts
+++ b/bridge/client/app/_views/ktb-service-view/ktb-service-view.component.ts
@@ -62,7 +62,6 @@ export class KtbServiceViewComponent implements OnInit, OnDestroy {
         this.serviceName = params.serviceName;
         this.currentRoot = null;
         this.selectedStage = null;
-        this.contextId = null;
         this.filterEventTypes = [];
 
         this.project$ = this.dataService.getProject(params.projectName);

--- a/bridge/client/app/project-board/project-board.component.ts
+++ b/bridge/client/app/project-board/project-board.component.ts
@@ -83,7 +83,6 @@ export class ProjectBoardComponent implements OnInit, OnDestroy {
             )
             .pipe(takeUntil(this.unsubscribe$))
             .subscribe(project => {
-              this.dataService.loadServices(project);
               this.dataService.loadRoots(project);
             });
 


### PR DESCRIPTION
Load root events per service to ensure that for each service the latest root events are displayed and take services from GET /project response (actually no separate API calls needed)

Fixes #3223 

Signed-off-by: ermin.muratovic <ermin.muratovic@gmail.com>