### PR TITLE
Show evaluation score for approval-item

### DIFF
--- a/bridge/client/app/_models/project.ts
+++ b/bridge/client/app/_models/project.ts
@@ -94,7 +94,7 @@ export class Project {
   getDeploymentEvaluation(trace: Trace): Trace {
     let service = this.getServices().find(s => s.serviceName == trace.data.service);
     let root = this.getRootEvent(service, trace);
-    return root?.traces.slice().reverse().find(t => t.type == EventTypes.EVALUATION_FINISHED);
+    return root?.traces.slice().reverse().find(t => t.isEvaluation() && t.isFinished())?.getFinishedEvent();
   }
 
   static fromJSON(data: any) {


### PR DESCRIPTION
The score was not displayed, because the evaluation event was not found.
Now it should load the evaluation for approval-item correctly, taking the `.finished` event from the evaluation task:

![image](https://user-images.githubusercontent.com/6098219/108724173-55e14b00-7525-11eb-8cd9-872c0d5b2838.png)

Signed-off-by: ermin.muratovic <ermin.muratovic@gmail.com>