### PR TITLE
#3290 Invalidation of evaluation

### DIFF
--- a/bridge/client/app/_models/event-types.ts
+++ b/bridge/client/app/_models/event-types.ts
@@ -9,7 +9,7 @@ export enum EventTypes {
   EVALUATION_TRIGGERED = 'sh.keptn.event.evaluation.triggered',
   EVALUATION_STARTED = 'sh.keptn.event.evaluation.started',
   EVALUATION_FINISHED = 'sh.keptn.event.evaluation.finished',
-  EVALUATION_INVALIDATED = 'sh.keptn.events.evaluation.invalidated',
+  EVALUATION_INVALIDATED = 'sh.keptn.event.evaluation.invalidated',
   START_SLI_RETRIEVAL = 'sh.keptn.internal.event.get-sli',
   SLI_RETRIEVAL_DONE = 'sh.keptn.internal.event.get-sli.done',
   DONE = 'sh.keptn.events.done',

--- a/bridge/client/app/_services/api.service.ts
+++ b/bridge/client/app/_services/api.service.ts
@@ -157,7 +157,7 @@ export class ApiService {
       .post<any>(url, {
         "shkeptncontext": evaluation.shkeptncontext,
         "type": EventTypes.EVALUATION_INVALIDATED,
-        "triggeredid": evaluation.id,
+        "triggeredid": evaluation.triggeredid,
         "source": "https://github.com/keptn/keptn/bridge#evaluation.invalidated",
         "data": {
           "project": evaluation.data.project,


### PR DESCRIPTION
Rename `evaluation.invalidated` and set `triggeredid` for `evaluation.invalidated` same as for `evaluation.finished`

Fixes #3290 