### PR TITLE
#3335 update shipyard content of project when receiving event

### DIFF
--- a/shipyard-controller/db/events_operations.go
+++ b/shipyard-controller/db/events_operations.go
@@ -3,4 +3,5 @@ package db
 //go:generate moq --skip-ensure -pkg db_mock -out ./mock/events_operations_mock.go . EventsDbOperations
 type EventsDbOperations interface {
 	UpdateEventOfService(event interface{}, eventType string, keptnContext string, eventID string, triggeredID string) error
+	UpdateShipyard(projectName string, shipyardContent string) error
 }

--- a/shipyard-controller/db/mock/events_operations_mock.go
+++ b/shipyard-controller/db/mock/events_operations_mock.go
@@ -16,6 +16,9 @@ import (
 // 			UpdateEventOfServiceFunc: func(event interface{}, eventType string, keptnContext string, eventID string, triggeredID string) error {
 // 				panic("mock out the UpdateEventOfService method")
 // 			},
+// 			UpdateShipyardFunc: func(projectName string, shipyardContent string) error {
+// 				panic("mock out the UpdateShipyard method")
+// 			},
 // 		}
 //
 // 		// use mockedEventsDbOperations in code that requires db.EventsDbOperations
@@ -25,6 +28,9 @@ import (
 type EventsDbOperationsMock struct {
 	// UpdateEventOfServiceFunc mocks the UpdateEventOfService method.
 	UpdateEventOfServiceFunc func(event interface{}, eventType string, keptnContext string, eventID string, triggeredID string) error
+
+	// UpdateShipyardFunc mocks the UpdateShipyard method.
+	UpdateShipyardFunc func(projectName string, shipyardContent string) error
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -41,8 +47,16 @@ type EventsDbOperationsMock struct {
 			// TriggeredID is the triggeredID argument value.
 			TriggeredID string
 		}
+		// UpdateShipyard holds details about calls to the UpdateShipyard method.
+		UpdateShipyard []struct {
+			// ProjectName is the projectName argument value.
+			ProjectName string
+			// ShipyardContent is the shipyardContent argument value.
+			ShipyardContent string
+		}
 	}
 	lockUpdateEventOfService sync.RWMutex
+	lockUpdateShipyard       sync.RWMutex
 }
 
 // UpdateEventOfService calls UpdateEventOfServiceFunc.
@@ -89,5 +103,40 @@ func (mock *EventsDbOperationsMock) UpdateEventOfServiceCalls() []struct {
 	mock.lockUpdateEventOfService.RLock()
 	calls = mock.calls.UpdateEventOfService
 	mock.lockUpdateEventOfService.RUnlock()
+	return calls
+}
+
+// UpdateShipyard calls UpdateShipyardFunc.
+func (mock *EventsDbOperationsMock) UpdateShipyard(projectName string, shipyardContent string) error {
+	if mock.UpdateShipyardFunc == nil {
+		panic("EventsDbOperationsMock.UpdateShipyardFunc: method is nil but EventsDbOperations.UpdateShipyard was just called")
+	}
+	callInfo := struct {
+		ProjectName     string
+		ShipyardContent string
+	}{
+		ProjectName:     projectName,
+		ShipyardContent: shipyardContent,
+	}
+	mock.lockUpdateShipyard.Lock()
+	mock.calls.UpdateShipyard = append(mock.calls.UpdateShipyard, callInfo)
+	mock.lockUpdateShipyard.Unlock()
+	return mock.UpdateShipyardFunc(projectName, shipyardContent)
+}
+
+// UpdateShipyardCalls gets all the calls that were made to UpdateShipyard.
+// Check the length with:
+//     len(mockedEventsDbOperations.UpdateShipyardCalls())
+func (mock *EventsDbOperationsMock) UpdateShipyardCalls() []struct {
+	ProjectName     string
+	ShipyardContent string
+} {
+	var calls []struct {
+		ProjectName     string
+		ShipyardContent string
+	}
+	mock.lockUpdateShipyard.RLock()
+	calls = mock.calls.UpdateShipyard
+	mock.lockUpdateShipyard.RUnlock()
 	return calls
 }

--- a/shipyard-controller/handler/shipyardcontroller_test.go
+++ b/shipyard-controller/handler/shipyardcontroller_test.go
@@ -948,6 +948,9 @@ func Test_shipyardController_Scenario1(t *testing.T) {
 	eventsDBMock := sc.eventsDbOperations.(*db_mock.EventsDbOperationsMock)
 	// make sure that the UpdateEventOfServiceCalls has been called
 	assert.NotEqual(t, 0, len(eventsDBMock.UpdateEventOfServiceCalls()))
+	assert.NotEqual(t, 0, len(eventsDBMock.UpdateShipyardCalls()))
+	assert.Equal(t, "test-project", eventsDBMock.UpdateShipyardCalls()[0].ProjectName)
+	assert.NotEqual(t, "", eventsDBMock.UpdateShipyardCalls()[0].ShipyardContent)
 }
 
 // Scenario 2: Partial task sequence execution + triggering of next task sequence. Events are received out of order
@@ -1875,6 +1878,9 @@ func getTestShipyardController() *shipyardController {
 		},
 		eventsDbOperations: &db_mock.EventsDbOperationsMock{
 			UpdateEventOfServiceFunc: func(event interface{}, eventType string, keptnContext string, eventID string, triggeredID string) error {
+				return nil
+			},
+			UpdateShipyardFunc: func(projectName string, shipyardContent string) error {
 				return nil
 			},
 		},


### PR DESCRIPTION
Closes #3335 

This PR makes sure to regularly update the shipyard content of a project in the materialized view (whenever an event for that project is received). This makes sure to achieve eventual consistency, between the information stored in the db and the actual state of the shipyard in the git repo.
Signed-off-by: Florian Bacher <florian.bacher@dynatrace.com>