### PR TITLE
Stop deleting draft releases

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -713,7 +713,7 @@ jobs:
             console.log(`Trying to fetch DRAFT release by tag '${tag}'...`);
 
             try {
-              let draftRelease;
+              // get all releases (including drafts)
               let releases = await github.repos.listReleases({
                 owner: context.repo.owner,
                 repo: context.repo.repo
@@ -725,12 +725,20 @@ jobs:
                 if (release.draft) {
                   // found a draft release
                   console.log(`🥳 Found a draft release with id ${release.id}, deleting it`);
+                  console.log(`Release Tag Name: ${release.tag_name}`);
+                  console.log(`Release Draft: ${release.draft}`);
+                  console.log(`Release URL: ${release.html_url}`);
 
-                  github.repos.deleteRelease({
+                  console.log(`::error::Draft release found, please delete it manually!`);
+
+                  return 1;
+                  // ToDo: Commenetd out as there seems to be a problem with deleting releases
+
+                  /*github.repos.deleteRelease({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     release_id: release.id
-                  });
+                  });*/
 
                   console.log("Deleted! -> okay");
                 } else {


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

I'm not sure what's going on, but it seems that *draft* releases that I have published are being deleted after some time, e.g., https://github.com/keptn/keptn/releases/tag/0.8.0-dev.202102221215

Either there is an error in GitHub UI (when I delete draft releases manually), or there is a problem with our CI job.

For the sake of sanity, I've commented out the part where it should delete the draft release in the CI job.