### PR TITLE
Renamed service name in linking-stages integration test

### DIFF
--- a/test/test_linking_stages.sh
+++ b/test/test_linking_stages.sh
@@ -27,8 +27,8 @@ KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n ${KEPTN_NAMESPACE} -ojso
 echo "KEPTN_ENDPOINT $KEPTN_ENDPOINT"
 
 #test configuration
-PROJECT="linking-stages-project"
-SERVICE="linking-stages-service"
+PROJECT="link-project"
+SERVICE="my-service"
 
 
 # verify that the project does not exist yet via the Keptn API


### PR DESCRIPTION
Due to the introduced limitation regarding the length of a service name (see https://github.com/keptn/keptn/issues/2948), the `linking_stages.sh` integration tests were failing. This PR shortens the name of the service to be compliant with this limitation.

Signed-off-by: Florian Bacher <florian.bacher@dynatrace.com>