### PR TITLE
Use release versions of contrib services for integration tests

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -412,7 +412,7 @@ jobs:
         continue-on-error: true
         env:
           KEPTN_ENDPOINT: ${{ steps.authenticate_keptn_cli.outputs.KEPTN_ENDPOINT }}
-          UNLEASH_SERVICE_VERSION: "master"
+          UNLEASH_SERVICE_VERSION: "release-0.3.0"
         run: test/test_self_healing.sh
 
       - name: Test Delivery Assistant
@@ -424,7 +424,7 @@ jobs:
         env:
           KEPTN_ENDPOINT: ${{ steps.authenticate_keptn_cli.outputs.KEPTN_ENDPOINT }}
           PROJECT: "musicshop"
-          DYNATRACE_SLI_SERVICE_VERSION: "master"
+          DYNATRACE_SLI_SERVICE_VERSION: "release-0.8.0"
         run: test/test_delivery_assistant.sh
 
       - name: Test Continuous Delivery (with sockshop)

--- a/test/test_self_healing.sh
+++ b/test/test_self_healing.sh
@@ -187,7 +187,6 @@ fi
 echo "Installing unleash-service version ${UNLEASH_SERVICE_VERSION}"
 kubectl apply -f https://raw.githubusercontent.com/keptn-contrib/unleash-service/${UNLEASH_SERVICE_VERSION}/deploy/service.yaml -n ${KEPTN_NAMESPACE}
 
-kubectl -n ${KEPTN_NAMESPACE} set image deployment/unleash-service unleash-service=keptncontrib/unleash-service:0.0.0-master
 
 sleep 10
 


### PR DESCRIPTION
Before merging, check for availability of: 
- [Dynatrace-sli-service 0.8.0](https://hub.docker.com/repository/docker/keptncontrib/dynatrace-sli-service/tags?page=1&ordering=last_updated&name=0.8.0)
- [Unleash-service 0.3.0](https://hub.docker.com/repository/docker/keptncontrib/unleash-service/tags?page=1&ordering=last_updated&name=0.3.0)

Signed-off-by: Florian Bacher <florian.bacher@dynatrace.com>