### PR TITLE
Added a step to upload helm charts

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -771,3 +771,20 @@ jobs:
             dist/keptn-installer/*.tgz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Helm Charts to Google Cloud
+        id: upload_helm_charts
+        env:
+          GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
+          GCLOUD_PROJECT_NAME: ${{ secrets.GCLOUD_PROJECT_NAME }}
+          CLOUDSDK_COMPUTE_ZONE: "us-east1-b"
+          CLOUDSDK_REGION: "us-east1"
+        run: |
+          if [[ "$BRANCH" == "release-"* ]]; then
+            echo "Installing gcloud CLI"
+            export OS_TYPE="linux"
+            ./test/utils/download_and_install_gcloud.sh
+            echo ${GCLOUD_SERVICE_KEY} | base64 --decode > ~/gcloud-service-key.json
+            gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
+            gh-actions-scripts/upload_helm_chart_to_google_cloud.sh dist/keptn-installer/
+          fi

--- a/gh-actions-scripts/build_helm_charts.sh
+++ b/gh-actions-scripts/build_helm_charts.sh
@@ -4,6 +4,11 @@ VERSION=$1
 IMAGE_TAG=$2
 KEPTN_SPEC_VERSION=$3
 
+if [ $# -ne 3 ]; then
+  echo "Usage: $0 VERSION IMAGE_TAG KEPTN_SPEC_VERSION"
+  exit
+fi
+
 if [ -z "$VERSION" ]; then
   echo "No Version set, exiting..."
   exit 1
@@ -37,10 +42,10 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
-mv keptn-${VERSION}.tgz keptn-charts/keptn-installer-${VERSION}.tgz
+mv keptn-${VERSION}.tgz keptn-charts/keptn-${VERSION}.tgz
 
 # verify the chart
-helm template --debug keptn-charts/keptn-installer-${VERSION}.tgz
+helm template --debug keptn-charts/keptn-${VERSION}.tgz
 
 if [ $? -ne 0 ]; then
   echo "::error Helm Chart for installer has templating errors - exiting"
@@ -90,22 +95,7 @@ if [ $? -ne 0 ]; then
 fi
 
 
-
-# download index.yaml chart
-#gsutil cp gs://keptn-installer/index.yaml keptn-charts/index.yaml
-#
-#helm repo index keptn-charts --url https://storage.googleapis.com/keptn-installer/ --merge keptn-charts/index.yaml
-#if [ $? -ne 0 ]; then
-#  echo "Error generating index.yaml, exiting..."
-#  exit 1
-#fi
-#
-## upload to gcloud
-#gsutil cp keptn-charts/index.yaml gs://keptn-installer/index.yaml
-#gsutil cp keptn-charts/keptn-${VERSION}.tgz gs://keptn-installer/keptn-${VERSION}.tgz
-
-
 echo "Generated files:"
-echo " - keptn-charts/keptn-installer-${VERSION}.tgz"
+echo " - keptn-charts/keptn-${VERSION}.tgz"
 echo " - keptn-charts/helm-service-${VERSION}.tgz"
 echo " - keptn-charts/jmeter-service-${VERSION}.tgz"

--- a/gh-actions-scripts/upload_helm_chart_to_google_cloud.sh
+++ b/gh-actions-scripts/upload_helm_chart_to_google_cloud.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# For official releases we want to upload a helm-chart to google cloud bucket
+# This step involves downloading index.yaml and updating it
+# as well as uploading the helm-chart with index.yaml
+
+LOCAL_DIRECTORY=${1:-"keptn-charts"}
+TARGET_BUCKET=${2:-"keptn-installer"}
+
+# download index.yaml
+gsutil cp gs://keptn-installer/index.yaml "${LOCAL_DIRECTORY}/index.yaml"
+
+helm repo index "${LOCAL_DIRECTORY}" --url https://storage.googleapis.com/keptn-installer/ --merge "${LOCAL_DIRECTORY}/index.yaml"
+if [ $? -ne 0 ]; then
+  echo "Error generating index.yaml, exiting..."
+  exit 1
+fi
+
+# upload to gcloud
+gsutil cp "${LOCAL_DIRECTORY}/index.yaml" "gs://${TARGET_BUCKET}/index.yaml"
+gsutil cp "${LOCAL_DIRECTORY}"/* "gs://${TARGET_BUCKET}/"


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

This PR adds a final step for uploading helm charts to google cloud.
In addition, I renamed the packaged helm chart `keptn-installer-${VERSION}.tgz` to `keptn-${VERSION}.tgz`, as this is what we are expecting in the CLI when calling `keptn install`
https://github.com/keptn/keptn/blob/b2ba2f7ecf58b06f13f97a76c65fa43ed9f97121/cli/cmd/install_upgrade_params.go#L15-L26
