### PR TITLE
#3418 Sync helm-charts (installer, jmeter-service, helm-service)

### DIFF
--- a/helm-service/.dockerignore
+++ b/helm-service/.dockerignore
@@ -3,3 +3,5 @@
 docs/
 deploy/
 Dockerfile
+chart/
+skaffold.yaml

--- a/helm-service/chart/templates/deployment.yaml
+++ b/helm-service/chart/templates/deployment.yaml
@@ -37,6 +37,10 @@ spec:
           env:
           - name: CONFIGURATION_SERVICE
             value: "http://localhost:8081/configuration"
+          - name: SHIPYARD_CONTROLLER
+            value: 'http://localhost:8081/shipyard'
+          - name: EVENTBROKER
+            value: 'http://localhost:8081/event'
           - name: ENVIRONMENT
             value: 'production'
           - name: INGRESS_HOSTNAME_SUFFIX
@@ -62,6 +66,12 @@ spec:
               configMapKeyRef:
                 name: ingress-config
                 key: istio_gateway
+                optional: true
+          - name: HOSTNAME_TEMPLATE
+            valueFrom:
+              configMapKeyRef:
+                name: ingress-config
+                key: hostname_template
                 optional: true
           livenessProbe:
             httpGet:

--- a/helm-service/chart/templates/deployment.yaml
+++ b/helm-service/chart/templates/deployment.yaml
@@ -30,17 +30,19 @@ spec:
         - name: helm-service
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if .Values.image }}
+          image: {{ .Values.image }} # use image from .Values.image (e.g., when starting via skaffold)
+          {{- else }}
           image: "{{ .Values.helmservice.image.repository }}:{{ .Values.helmservice.image.tag | default .Chart.AppVersion }}"
+          {{ end }}
           imagePullPolicy: {{ .Values.helmservice.image.pullPolicy }}
           ports:
             - containerPort: 80
           env:
           - name: CONFIGURATION_SERVICE
-            value: "http://localhost:8081/configuration"
+            value: "http://localhost:8081/configuration-service"
           - name: SHIPYARD_CONTROLLER
-            value: 'http://localhost:8081/shipyard'
-          - name: EVENTBROKER
-            value: 'http://localhost:8081/event'
+            value: 'http://localhost:8081/controlPlane'
           - name: ENVIRONMENT
             value: 'production'
           - name: INGRESS_HOSTNAME_SUFFIX

--- a/helm-service/skaffold.yaml
+++ b/helm-service/skaffold.yaml
@@ -10,8 +10,13 @@ build:
 
 deploy:
   helm:
+    flags:
+      upgrade: ["--reuse-values"]
     releases:
-      - name: keptn-helm-service
+      - name: helm-service # needs to be the same name as currently used (check via helm ls -n keptn-exec)
+        namespace: keptn-exec # needs to be the same namespace as where the helm-chart is currently deployed
+        # upgradeOnChange: true
+        # recreatePods: false # don't recreate all pods
         artifactOverrides:
           image: keptn/helm-service
         chartPath: chart

--- a/installer/manifests/keptn/charts/continuous-delivery/templates/continuous-deployment.yaml
+++ b/installer/manifests/keptn/charts/continuous-delivery/templates/continuous-deployment.yaml
@@ -80,8 +80,6 @@ spec:
               value: 'http://configuration-service:8080'
             - name: SHIPYARD_CONTROLLER
               value: 'http://shipyard-controller:8080'
-            - name: EVENTBROKER
-              value: 'http://localhost:8081/event'
             - name: ENVIRONMENT
               value: 'production'
             - name: INGRESS_HOSTNAME_SUFFIX
@@ -194,8 +192,6 @@ spec:
           env:
           - name: CONFIGURATION_SERVICE
             value: 'http://configuration-service:8080'
-          - name: EVENTBROKER
-            value: 'http://localhost:8081/event'
         - name: distributor
           image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
           {{- include "continuous-delivery.livenessProbe" . | nindent 10 }}

--- a/installer/manifests/keptn/charts/continuous-delivery/templates/continuous-deployment.yaml
+++ b/installer/manifests/keptn/charts/continuous-delivery/templates/continuous-deployment.yaml
@@ -187,8 +187,8 @@ spec:
             - containerPort: 8080
           resources:
             requests:
-              memory: "64Mi"
-              cpu: "50m"
+              memory: "768Mi"
+              cpu: "1000m"
           env:
           - name: CONFIGURATION_SERVICE
             value: 'http://configuration-service:8080'

--- a/installer/manifests/keptn/charts/continuous-delivery/templates/continuous-deployment.yaml
+++ b/installer/manifests/keptn/charts/continuous-delivery/templates/continuous-deployment.yaml
@@ -84,8 +84,6 @@ spec:
               value: 'http://localhost:8081/event'
             - name: ENVIRONMENT
               value: 'production'
-            - name: CANARY
-              value: 'deployment'
             - name: INGRESS_HOSTNAME_SUFFIX
               valueFrom:
                 configMapKeyRef:

--- a/jmeter-service/chart/templates/deployment.yaml
+++ b/jmeter-service/chart/templates/deployment.yaml
@@ -37,6 +37,8 @@ spec:
           env:
           - name: CONFIGURATION_SERVICE
             value: "http://localhost:8081/configuration"
+          - name: EVENTBROKER
+            value: 'http://localhost:8081/event'
           - name: env
             value: 'production'
           livenessProbe:

--- a/jmeter-service/chart/templates/deployment.yaml
+++ b/jmeter-service/chart/templates/deployment.yaml
@@ -30,15 +30,17 @@ spec:
         - name: jmeter-service
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if .Values.image }}
+          image: {{ .Values.image }} # use image from .Values.image (e.g., when starting via skaffold)
+          {{- else }}
           image: "{{ .Values.jmeterservice.image.repository }}:{{ .Values.jmeterservice.image.tag | default .Chart.AppVersion }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.jmeterservice.image.pullPolicy }}
           ports:
             - containerPort: 80
           env:
           - name: CONFIGURATION_SERVICE
-            value: "http://localhost:8081/configuration"
-          - name: EVENTBROKER
-            value: 'http://localhost:8081/event'
+            value: "http://localhost:8081/configuration-service"
           - name: env
             value: 'production'
           livenessProbe:

--- a/jmeter-service/chart/values.yaml
+++ b/jmeter-service/chart/values.yaml
@@ -40,7 +40,7 @@ securityContext: {}                          # Set the security context (e.g. ru
 #  runAsNonRoot: true
 #  runAsUser: 1000
 
-resources: {}                                 # Resource limits and requests
+resources:                                 # Resource limits and requests
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -48,9 +48,9 @@ resources: {}                                 # Resource limits and requests
   # limits:
   #   cpu: 100m
   #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  requests:
+     cpu: 1000m
+     memory: 768Mi
 
 nodeSelector: {}                                # Node selector configuration
 

--- a/jmeter-service/deploy/service.yaml
+++ b/jmeter-service/deploy/service.yaml
@@ -29,9 +29,6 @@ spec:
         image: keptn/jmeter-service:latest
         ports:
         - containerPort: 8080
-        env:
-        - name: EVENTBROKER
-          value: 'http://localhost:8081/event'
       - name: distributor
         image: keptn/distributor:latest
         livenessProbe:

--- a/jmeter-service/main.go
+++ b/jmeter-service/main.go
@@ -20,7 +20,6 @@ import (
 )
 
 const (
-	eventbroker          = "EVENTBROKER"
 	configurationService = "CONFIGURATION_SERVICE"
 )
 
@@ -329,35 +328,11 @@ func sendEvent(event cloudevents.Event) error {
 		return nil
 	}
 
-	endPoint, err := getServiceEndpoint(eventbroker)
-	if err != nil {
-		return errors.New("Failed to retrieve endpoint of eventbroker. %s" + err.Error())
-	}
-
-	if endPoint.Host == "" {
-		return errors.New("Host of eventbroker not set")
-	}
-	keptnHandler, err := keptnv2.NewKeptn(&event, keptncommon.KeptnOpts{
-		EventBrokerURL: endPoint.String(),
-	})
+	keptnHandler, err := keptnv2.NewKeptn(&event, keptncommon.KeptnOpts{})
 
 	if err != nil {
 		return errors.New("Failed to initialize Keptn handler: " + err.Error())
 	}
 
 	return keptnHandler.SendCloudEvent(event)
-}
-
-// getServiceEndpoint gets an endpoint stored in an environment variable and sets http as default scheme
-func getServiceEndpoint(service string) (url.URL, error) {
-	url, err := url.Parse(os.Getenv(service))
-	if err != nil {
-		return *url, fmt.Errorf("Failed to retrieve value from ENVIRONMENT_VARIABLE: %s", service)
-	}
-
-	if url.Scheme == "" {
-		url.Scheme = "http"
-	}
-
-	return *url, nil
 }

--- a/jmeter-service/skaffold.yaml
+++ b/jmeter-service/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v1beta13
+apiVersion: skaffold/v2beta10
 kind: Config
 build:
   artifacts:
@@ -7,7 +7,16 @@ build:
         dockerfile: Dockerfile
         buildArgs:
           debugBuild: true
+
 deploy:
-  kubectl:
-    manifests:
-      - deploy/service.yaml
+  helm:
+    flags:
+      upgrade: ["--reuse-values"]
+    releases:
+      - name: jmeter-service # needs to be the same name as currently used (check via helm ls -n keptn-exec)
+        namespace: keptn-exec # needs to be the same namespace as where the helm-chart is currently deployed
+        # upgradeOnChange: true
+        # recreatePods: false # don't recreate all pods
+        artifactOverrides:
+          image: keptn/jmeter-service
+        chartPath: chart


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

Fixes #3418

* helm-service/charts
  * added `SHIPYARD_CONTROLLER`, `EVENTBROKER` and `HOSTNAME_TEMPLATE` environment variables
  * Fixed `CONFIGURATION_SERVICE` pointing to the wrong URL
* installer/ continuous-delivery charts: helm-service
  * removed `CANARY` variable as it is not needed nor consumed anywhere 
  * removed `EVENTBROKER`
  * jmeter-service: Properly set resource requests to something that makes sense
* jmeter-service/charts
  * Fixed `CONFIGURATION_SERVICE` pointing to the wrong URL
  * Properly set resource requests to something that makes sense
* jmeter-service
  * removed relevant source code for `EVENTBROKER`
* skaffold related
  * Updated `skaffold.yaml` for helm-service and jmeter-service
  * Updated helm-charts with `image: {{ .Values.Image }}` as this is what's used when deploying using Skaffold

I was able to test my changes using the following commands:
```
helm install helm-service ./helm-service/chart -n keptn-exec --create-namespace --values=values.yaml
helm install jmeter-service ./jmeter-service/chart -n keptn-exec --create-namespace --values=values.yaml
```

Our standard use-case with onboarding and testing carts was running using the above setup, though I'd like to refer to the [Integration Test Issue](https://github.com/keptn/keptn/issues/3214) to get 100% confidence that these changes are working as expected.
