### PR TITLE
Abort PR build for releases

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -54,6 +54,16 @@ jobs:
       DATETIME: ${{ steps.get_datetime.outputs.DATETIME }}
 
     steps:
+      - name: Prevent PR Build on Release Branch
+        # if you create a PR from release-* to anything else, there is usually a push-build in action, allowing
+        # us to cancel the PR build
+        if: github.event_name == 'pull_request'
+        run: |
+          if [[ "$GITHUB_HEAD_REF" == "release-"* ]]; then
+            echo "::error::Failing CI Build for Pull Request on purpose, as there is a push build"
+            exit 1
+          fi
+
       - name: Check out code
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

There is still an issue with the latest release-branch we pulled, where the CI workflow is triggered for both, the Pull Request and the Push on the release branch.
https://github.com/keptn/keptn/pull/3428

With this PR I am disabling CI Builds for Pull-Requests if the base-branch is "release-"*.
See https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables for docs regarding GITHUB_HEAD_REF. 
