### PR TITLE
Revert typo fix for perfromance in bridge

### DIFF
--- a/bridge/client/app/_models/event-icons.ts
+++ b/bridge/client/app/_models/event-icons.ts
@@ -1,7 +1,7 @@
 export const EVENT_ICONS = {
   "artifact-delivery": "duplicate",
   "deployment": "deploy",
-  "test": "performance-health",
+  "test": "perfromance-health",
   "evaluation": "traffic-light",
   "problem": "criticalevent",
   "release": "hops",


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

This PR reverts the typo fix for `perfromance-health`, which is a legimatimate icon in barista:  https://barista.dynatrace.com/resources/icons/perfromance-health