### PR TITLE
Fix wrong URL parameter in shipyard-controllers swagger

### DIFF
--- a/shipyard-controller/docs/docs.go
+++ b/shipyard-controller/docs/docs.go
@@ -521,7 +521,7 @@ var doc = `{
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Gets all services of a stage in a project",
+                "description": "Gets a service by its name",
                 "consumes": [
                     "application/json"
                 ],
@@ -531,7 +531,7 @@ var doc = `{
                 "tags": [
                     "Services"
                 ],
-                "summary": "Gets all services of a stage in a project",
+                "summary": "Gets a service by its name",
                 "parameters": [
                     {
                         "type": "string",
@@ -548,23 +548,18 @@ var doc = `{
                         "required": true
                     },
                     {
-                        "type": "integer",
-                        "description": "The number of items to return",
-                        "name": "pageSize",
-                        "in": "query"
-                    },
-                    {
                         "type": "string",
-                        "description": "Pointer to the next set of items",
-                        "name": "nextPageKey",
-                        "in": "query"
+                        "description": "Service",
+                        "name": "service",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "ok",
                         "schema": {
-                            "$ref": "#/definitions/models.ExpandedServices"
+                            "$ref": "#/definitions/models.ExpandedService"
                         }
                     },
                     "400": {
@@ -619,6 +614,74 @@ var doc = `{
                         "description": "ok",
                         "schema": {
                             "$ref": "#/definitions/operations.DeleteServiceResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid payload",
+                        "schema": {
+                            "$ref": "#/definitions/models.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "$ref": "#/definitions/models.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/project/{project}/service/{stage}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Gets all services of a stage in a project",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Services"
+                ],
+                "summary": "Gets all services of a stage in a project",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Project",
+                        "name": "project",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Stage",
+                        "name": "stage",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "The number of items to return",
+                        "name": "pageSize",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Pointer to the next set of items",
+                        "name": "nextPageKey",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "ok",
+                        "schema": {
+                            "$ref": "#/definitions/models.ExpandedServices"
                         }
                     },
                     "400": {

--- a/shipyard-controller/docs/swagger.json
+++ b/shipyard-controller/docs/swagger.json
@@ -505,7 +505,7 @@
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Gets all services of a stage in a project",
+                "description": "Gets a service by its name",
                 "consumes": [
                     "application/json"
                 ],
@@ -515,7 +515,7 @@
                 "tags": [
                     "Services"
                 ],
-                "summary": "Gets all services of a stage in a project",
+                "summary": "Gets a service by its name",
                 "parameters": [
                     {
                         "type": "string",
@@ -532,23 +532,18 @@
                         "required": true
                     },
                     {
-                        "type": "integer",
-                        "description": "The number of items to return",
-                        "name": "pageSize",
-                        "in": "query"
-                    },
-                    {
                         "type": "string",
-                        "description": "Pointer to the next set of items",
-                        "name": "nextPageKey",
-                        "in": "query"
+                        "description": "Service",
+                        "name": "service",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "ok",
                         "schema": {
-                            "$ref": "#/definitions/models.ExpandedServices"
+                            "$ref": "#/definitions/models.ExpandedService"
                         }
                     },
                     "400": {
@@ -603,6 +598,74 @@
                         "description": "ok",
                         "schema": {
                             "$ref": "#/definitions/operations.DeleteServiceResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid payload",
+                        "schema": {
+                            "$ref": "#/definitions/models.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "$ref": "#/definitions/models.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/project/{project}/service/{stage}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Gets all services of a stage in a project",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Services"
+                ],
+                "summary": "Gets all services of a stage in a project",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Project",
+                        "name": "project",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Stage",
+                        "name": "stage",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "The number of items to return",
+                        "name": "pageSize",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Pointer to the next set of items",
+                        "name": "nextPageKey",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "ok",
+                        "schema": {
+                            "$ref": "#/definitions/models.ExpandedServices"
                         }
                     },
                     "400": {

--- a/shipyard-controller/docs/swagger.yaml
+++ b/shipyard-controller/docs/swagger.yaml
@@ -617,6 +617,47 @@ paths:
     get:
       consumes:
       - application/json
+      description: Gets a service by its name
+      parameters:
+      - description: Project
+        in: path
+        name: project
+        required: true
+        type: string
+      - description: Stage
+        in: path
+        name: stage
+        required: true
+        type: string
+      - description: Service
+        in: path
+        name: service
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: ok
+          schema:
+            $ref: '#/definitions/models.ExpandedService'
+        "400":
+          description: Invalid payload
+          schema:
+            $ref: '#/definitions/models.Error'
+        "500":
+          description: Internal error
+          schema:
+            $ref: '#/definitions/models.Error'
+      security:
+      - ApiKeyAuth: []
+      summary: Gets a service by its name
+      tags:
+      - Services
+  /project/{project}/service/{stage}:
+    get:
+      consumes:
+      - application/json
       description: Gets all services of a stage in a project
       parameters:
       - description: Project

--- a/shipyard-controller/handler/servicehandler.go
+++ b/shipyard-controller/handler/servicehandler.go
@@ -179,7 +179,7 @@ func (sh *ServiceHandler) GetService(c *gin.Context) {
 // @Success 200 {object} models.ExpandedServices	"ok"
 // @Failure 400 {object} models.Error "Invalid payload"
 // @Failure 500 {object} models.Error "Internal error"
-// @Router /project/{project}/service/{service} [get]
+// @Router /project/{project}/service/{stage} [get]
 func (sh *ServiceHandler) GetServices(c *gin.Context) {
 	projectName := c.Param("project")
 	stageName := c.Param("stage")


### PR DESCRIPTION
Fixed #3456 by

* changing `/project/{project}/service/{service}` URL to `/project/{project}/service/{stage}` in  shipyard-controller/handler/servicehandler.go (please note: the remaining changes are automatically generated using `swag init`)

This not only fixes the endpoint description in swagger UI, but also makes a new endpoint visible:
![image](https://user-images.githubusercontent.com/56065213/110305045-91d3e000-7ffc-11eb-8bb6-7f99b9888380.png)


