### PR TITLE
#3421 Improve debugging experience in configuration-service, shipyard-controller and lighthouse-service

### DIFF
--- a/configuration-service/.dockerignore
+++ b/configuration-service/.dockerignore
@@ -1,0 +1,3 @@
+deploy/
+skaffold.yaml
+README.md

--- a/configuration-service/Dockerfile
+++ b/configuration-service/Dockerfile
@@ -19,21 +19,19 @@ COPY go.mod go.sum ./
 # Download dependencies
 RUN go mod download
 
-ARG debugBuild
-
-# set buildflags for debug build
-RUN if [ ! -z "$debugBuild" ]; then export BUILDFLAGS='-gcflags "all=-N -l"'; fi
-
 # Copy local code to the container image.
 COPY . .
 
 ENV REPLACE="version: ${version}"
 RUN sed -i "s/version: develop/${REPLACE}/g" /go/src/github.com/keptn/keptn/configuration-service/swagger.yaml
 
+# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
+ARG SKAFFOLD_GO_GCFLAGS
+
 # Build the command inside the container. 
 # (You may fetch or manage dependencies here, 
 # either manually or with a tool like "godep".)
-RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v cmd/configuration-service-server/main.go
+RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v cmd/configuration-service-server/main.go
 
 # Use a Docker multi-stage build to create a lean production image.
 FROM alpine:3.11
@@ -67,5 +65,4 @@ ENV GOTRACEBACK=all
 #travis-uncomment ENTRYPOINT ["/entrypoint.sh"]
 
 # Run the web service on container startup.
-
 CMD ["/configuration-service", "--host=0.0.0.0", "--port=8080"]

--- a/configuration-service/deploy/service.yaml
+++ b/configuration-service/deploy/service.yaml
@@ -45,10 +45,12 @@ spec:
         - containerPort: 8080
         resources:
           requests:
-            memory: "256Mi"
-            cpu: "500m"
+            memory: "32Mi"
+            cpu: "50m"
           limits:
-            memory: "1024Mi"
+            # limits is high on purpose to enable Debugging using skaffold
+            # you can monitor memory usage using "kubectl -n keptn top pods"
+            memory: "512Mi"
             cpu: "500m"
         volumeMounts:
         - mountPath: /data/config

--- a/configuration-service/skaffold.yaml
+++ b/configuration-service/skaffold.yaml
@@ -1,13 +1,12 @@
-apiVersion: skaffold/v1beta13
+apiVersion: skaffold/v2beta10
 kind: Config
 build:
   artifacts:
     - image: keptn/configuration-service
-      docker:    # 	beta describes an artifact built from a Dockerfile.
+      docker:
         dockerfile: Dockerfile
-        buildArgs:
-          debugBuild: true
 deploy:
   kubectl:
+    defaultNamespace: keptn
     manifests:
       - deploy/service.yaml

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -5,8 +5,8 @@
 * GoLand IDE (VSCode might work too, this guide was written for GoLand however)
 * [Cloud Code](https://plugins.jetbrains.com/plugin/8079-cloud-code/) Plugin for GoLand
 * skaffold (see https://skaffold.dev/docs/install/ for details)
-* Kubernetes cluster with keptn installed and running
-* Container registry (e.g., dockerhub)
+* Kubernetes cluster with keptn installed and running (e.g., K3s)
+* Authenticated against a container registry (e.g., dockerhub)
 
 ## Repo-Setup
 
@@ -19,7 +19,7 @@ Most of our services should already have a working setup. But just in case the s
 1. Do not use ENTRYPOINT scripts in Dockerfile
 1. Make sure CMD in Dockerfile refers to the go-binary that you want to debug. Here is an example Dockerfile:
     ```dockerfile
-    FROM golang:1.12 as builder
+    FROM golang:1.13 as builder
     
     WORKDIR /go/src/github.com/keptn-contrib/some-go-service
     
@@ -83,6 +83,14 @@ To verify that the installation has worked you should see the **Kubernetes Explo
   ![GoLand Cloud Code Configuration](assets/goland_cloud_code_select.png "GoLand Cloud Code Configurations")
 1. Give this configuration a self-explanatory name and select your **skaffold.yaml** configuration file.
 1. Save your configuration and close the dialog.
+
+### Configure Container Registry
+
+It's recommended to configure a container registry other than the default one (`docker.io/keptn`). For instance, you
+can set it to `docker.io/username` where `username` is your username on DockerHub:
+```console
+skaffold config set default-repo docker.io/username
+```
 
 ### Debug now!
 

--- a/lighthouse-service/Dockerfile
+++ b/lighthouse-service/Dockerfile
@@ -21,16 +21,14 @@ COPY go.mod go.sum ./
 # Download dependencies
 RUN go mod download
 
-ARG debugBuild
-
-# set buildflags for debug build
-RUN if [ ! -z "$debugBuild" ]; then export BUILDFLAGS='-gcflags "all=-N -l"'; fi
-
 COPY . .
+
+# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
+ARG SKAFFOLD_GO_GCFLAGS
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o lighthouse-service
+RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v -o lighthouse-service
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds

--- a/lighthouse-service/deploy/service.yaml
+++ b/lighthouse-service/deploy/service.yaml
@@ -32,10 +32,12 @@ spec:
             - containerPort: 8080
           resources:
             requests:
-              memory: "128Mi"
+              memory: "32Mi"
               cpu: "50m"
             limits:
-              memory: "1024Mi"
+              # limits is high on purpose to enable Debugging using skaffold
+              # you can monitor memory usage using "kubectl -n keptn top pods"
+              memory: "512Mi"
               cpu: "500m"
           env:
             - name: EVENTBROKER
@@ -51,16 +53,16 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
         - name: distributor
-          image: keptn/distributor:latest
+          image: keptn/distributor:0.8.0
           ports:
             - containerPort: 8080
           resources:
             requests:
+              memory: "16Mi"
+              cpu: "25m"
+            limits:
               memory: "32Mi"
               cpu: "50m"
-            limits:
-              memory: "128Mi"
-              cpu: "500m"
           livenessProbe:
             httpGet:
               path: /health

--- a/lighthouse-service/skaffold.yaml
+++ b/lighthouse-service/skaffold.yaml
@@ -1,13 +1,12 @@
-apiVersion: skaffold/v1beta13
+apiVersion: skaffold/v2beta10
 kind: Config
 build:
   artifacts:
     - image: keptn/lighthouse-service
-      docker:    # 	beta describes an artifact built from a Dockerfile.
+      docker:
         dockerfile: Dockerfile
-        buildArgs:
-          debugBuild: true
 deploy:
   kubectl:
+    defaultNamespace: keptn
     manifests:
       - deploy/service.yaml

--- a/shipyard-controller/.dockerignore
+++ b/shipyard-controller/.dockerignore
@@ -1,0 +1,3 @@
+deploy/
+skaffold.yaml
+README.md

--- a/shipyard-controller/Dockerfile
+++ b/shipyard-controller/Dockerfile
@@ -19,20 +19,18 @@ COPY go.mod go.sum ./
 # Download dependencies
 RUN go mod download
 
-ARG debugBuild
-
-# set buildflags for debug build
-RUN if [ ! -z "$debugBuild" ]; then export BUILDFLAGS='-gcflags "all=-N -l"'; fi
-
 # Copy local code to the container image.
 COPY . .
 
 ENV REPLACE="version: ${version}"
 
+# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
+ARG SKAFFOLD_GO_GCFLAGS
+
 # Build the command inside the container. 
 # (You may fetch or manage dependencies here, 
 # either manually or with a tool like "godep".)
-RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v main.go
+RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v main.go
 
 # Use a Docker multi-stage build to create a lean production image.
 FROM alpine:3.11
@@ -66,4 +64,3 @@ ENV GOTRACEBACK=all
 # Run the web service on container startup.
 ENV GIN_MODE=release
 CMD ["/shipyard-controller"]
-#CMD ["/shipyard-controller", "--host=0.0.0.0", "--port=8080"]

--- a/shipyard-controller/deploy/service.yaml
+++ b/shipyard-controller/deploy/service.yaml
@@ -61,13 +61,15 @@ spec:
         - containerPort: 8080
         resources:
           requests:
-            memory: "256Mi"
-            cpu: "500m"
+            memory: "32Mi"
+            cpu: "50m"
           limits:
+            # limits is high on purpose to enable Debugging using skaffold
+            # you can monitor memory usage using "kubectl -n keptn top pods"
             memory: "256Mi"
             cpu: "500m"
       - name: distributor
-        image: keptn/distributor:0.8.0-alpha
+        image: keptn/distributor:0.8.0
         ports:
           - containerPort: 8080
         livenessProbe:
@@ -78,16 +80,16 @@ spec:
           periodSeconds: 5
         resources:
           requests:
+            memory: "16Mi"
+            cpu: "25m"
+          limits:
             memory: "32Mi"
             cpu: "50m"
-          limits:
-            memory: "128Mi"
-            cpu: "500m"
         env:
           - name: PUBSUB_URL
             value: 'nats://keptn-nats-cluster'
           - name: PUBSUB_TOPIC
-            value: 'sh.keptn.event.problem.open,sh.keptn.event.evaluation.finished,sh.keptn.event.action.finished'
+            value: 'sh.keptn.>'
           - name: PUBSUB_RECIPIENT
             value: '127.0.0.1'
           - name: PUBSUB_RECIPIENT_PATH

--- a/shipyard-controller/skaffold.yaml
+++ b/shipyard-controller/skaffold.yaml
@@ -3,10 +3,8 @@ kind: Config
 build:
   artifacts:
     - image: keptn/shipyard-controller
-      docker:    # 	beta describes an artifact built from a Dockerfile.
+      docker:
         dockerfile: Dockerfile
-        buildArgs:
-          debugBuild: 'true'
 deploy:
   kubectl:
     defaultNamespace: keptn


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

While investigating issue #3421 I noticed several smaller issues with our skaffold setup, which I addressed for the following microservices:
* shipyard-controller
* lighthouse-service
* configuration-service

Mainly:
* Add a `.dockerignore` to speed up the build while using `skaffold dev`
* Added `SKAFFOLD_GO_GCFLAGS` in favor of `debugBuild` (see https://github.com/GoogleContainerTools/skaffold/blob/master/examples/getting-started/Dockerfile for an example)
* Set distributor to use 0.8.0
* Improve memory request/limits (limits is set to 512 Megabytes on those containers, it should be more than enough; requests does not need to be that high)
* Upgraded skaffold version in skaffold.yaml (you might require a newer skaffold version locally; if you're using Cloud Code plugin, it should be on auto-update anyway)
* Set `defaultNamespace` in skaffold.yaml


