### PR TITLE
#3421 Fix debugging for jmeter and helm-service

### DIFF
--- a/helm-service/Dockerfile
+++ b/helm-service/Dockerfile
@@ -20,17 +20,15 @@ COPY go.mod go.sum ./
 # Download dependencies
 RUN go mod download
 
-ARG debugBuild
-
-# set buildflags for debug build
-RUN if [ ! -z "$debugBuild" ]; then export BUILDFLAGS='-gcflags "all=-N -l"'; fi
-
 # Copy local code to the container image. 
 COPY . .
 
+# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
+ARG SKAFFOLD_GO_GCFLAGS
+
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o helm-service
+RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v -o helm-service
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds

--- a/helm-service/skaffold.yaml
+++ b/helm-service/skaffold.yaml
@@ -3,20 +3,23 @@ kind: Config
 build:
   artifacts:
     - image: keptn/helm-service
-      docker:    # 	beta describes an artifact built from a Dockerfile.
+      docker:
         dockerfile: Dockerfile
-        buildArgs:
-          debugBuild: true
-
+# Before executing this, install helm-service manually:
+# helm install helm-service https://github.com/keptn/keptn/releases/download/0.8.0/helm-service-0.8.0.tgz -n keptn
 deploy:
   helm:
     flags:
       upgrade: ["--reuse-values"]
     releases:
-      - name: helm-service # needs to be the same name as currently used (check via helm ls -n keptn-exec)
-        namespace: keptn-exec # needs to be the same namespace as where the helm-chart is currently deployed
+      - name: helm-service # needs to be the same name as currently used (check via helm ls -n keptn)
+        namespace: keptn # needs to be the same namespace as where the helm-chart is currently deployed
         # upgradeOnChange: true
         # recreatePods: false # don't recreate all pods
         artifactOverrides:
           image: keptn/helm-service
+        overrides:
+          distributor:
+            image:
+              tag: 0.8.0
         chartPath: chart

--- a/jmeter-service/Dockerfile
+++ b/jmeter-service/Dockerfile
@@ -20,17 +20,15 @@ COPY go.mod go.sum ./
 # Download dependencies
 RUN go mod download
 
-ARG debugBuild
-
-# set buildflags for debug build
-RUN if [ ! -z "$debugBuild" ]; then export BUILDFLAGS='-gcflags "all=-N -l"'; fi
-
 # Copy local code to the container image.
 COPY . .
 
+# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
+ARG SKAFFOLD_GO_GCFLAGS
+
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o jmeter-service
+RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v -o jmeter-service
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds

--- a/jmeter-service/skaffold.yaml
+++ b/jmeter-service/skaffold.yaml
@@ -3,20 +3,23 @@ kind: Config
 build:
   artifacts:
     - image: keptn/jmeter-service
-      docker:    # 	beta describes an artifact built from a Dockerfile.
+      docker:
         dockerfile: Dockerfile
-        buildArgs:
-          debugBuild: true
-
+# Before executing this, install jmeter-service manually:
+# helm install jmeter-service https://github.com/keptn/keptn/releases/download/0.8.0/jmeter-service-0.8.0.tgz -n keptn
 deploy:
   helm:
     flags:
       upgrade: ["--reuse-values"]
     releases:
-      - name: jmeter-service # needs to be the same name as currently used (check via helm ls -n keptn-exec)
-        namespace: keptn-exec # needs to be the same namespace as where the helm-chart is currently deployed
+      - name: jmeter-service # needs to be the same name as currently used (check via helm ls -n keptn)
+        namespace: keptn # needs to be the same namespace as where the helm-chart is currently deployed
         # upgradeOnChange: true
         # recreatePods: false # don't recreate all pods
         artifactOverrides:
           image: keptn/jmeter-service
+        overrides:
+          distributor:
+            image:
+              tag: 0.8.0
         chartPath: chart


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

This PR fixes #3421 by performing some changes to skaffold.yaml, which will allow us to debug jmeter and helm service again.

In addition, I have included similar changes as in PR https://github.com/keptn/keptn/pull/3467, e.g.: using `SKAFFOLD_GO_GCFLAGS` instead of `debugBuild`, memory settings for distributor, fixing distributor tag to 0.8.0 