### PR TITLE
#2289 Show services and recent sequence in stage tile as table

### DIFF
--- a/bridge/client/app/_components/ktb-evaluation-info/ktb-evaluation-info.component.html
+++ b/bridge/client/app/_components/ktb-evaluation-info/ktb-evaluation-info.component.html
@@ -1,0 +1,9 @@
+<dt-tag-list aria-label="evaluation-info" *ngIf="evaluation">
+  <dt-tag class="justify-content-center" [dtOverlay]="overlay" [dtOverlayConfig]="overlayConfig" [class.error]="evaluation.isFaulty()" [class.warning]="evaluation.isWarning()" [class.success]="evaluation.isSuccessful()" [textContent]="evaluation.getFinishedEvent().data.evaluation.score | number:'1.0-0'"></dt-tag>
+  <ng-template #overlay>
+    <ktb-evaluation-details [evaluationData]="evaluation.getFinishedEvent()" [showChart]="false"></ktb-evaluation-details>
+  </ng-template>
+</dt-tag-list>
+<dt-tag-list *ngIf="!evaluation">
+  <dt-tag class="justify-content-center">-</dt-tag>
+</dt-tag-list>

--- a/bridge/client/app/_components/ktb-evaluation-info/ktb-evaluation-info.component.html
+++ b/bridge/client/app/_components/ktb-evaluation-info/ktb-evaluation-info.component.html
@@ -1,9 +1,9 @@
-<dt-tag-list aria-label="evaluation-info" *ngIf="evaluation">
+<dt-tag-list aria-label="evaluation-info" *ngIf="evaluation && evaluation.isFinished()">
   <dt-tag class="m-0 justify-content-center" [dtOverlay]="overlay" [dtOverlayConfig]="overlayConfig" [class.error]="evaluation.isFaulty()" [class.warning]="evaluation.isWarning()" [class.success]="evaluation.isSuccessful()" [textContent]="evaluation.getFinishedEvent().data.evaluation.score | number:'1.0-0'"></dt-tag>
   <ng-template #overlay>
     <ktb-evaluation-details [evaluationData]="evaluation.getFinishedEvent()" [showChart]="false"></ktb-evaluation-details>
   </ng-template>
 </dt-tag-list>
-<dt-tag-list *ngIf="!evaluation">
+<dt-tag-list *ngIf="!(evaluation && evaluation.isFinished())">
   <dt-tag class="m-0 justify-content-center" [textContent]="'-'"></dt-tag>
 </dt-tag-list>

--- a/bridge/client/app/_components/ktb-evaluation-info/ktb-evaluation-info.component.html
+++ b/bridge/client/app/_components/ktb-evaluation-info/ktb-evaluation-info.component.html
@@ -1,9 +1,9 @@
 <dt-tag-list aria-label="evaluation-info" *ngIf="evaluation">
-  <dt-tag class="justify-content-center" [dtOverlay]="overlay" [dtOverlayConfig]="overlayConfig" [class.error]="evaluation.isFaulty()" [class.warning]="evaluation.isWarning()" [class.success]="evaluation.isSuccessful()" [textContent]="evaluation.getFinishedEvent().data.evaluation.score | number:'1.0-0'"></dt-tag>
+  <dt-tag class="m-0 justify-content-center" [dtOverlay]="overlay" [dtOverlayConfig]="overlayConfig" [class.error]="evaluation.isFaulty()" [class.warning]="evaluation.isWarning()" [class.success]="evaluation.isSuccessful()" [textContent]="evaluation.getFinishedEvent().data.evaluation.score | number:'1.0-0'"></dt-tag>
   <ng-template #overlay>
     <ktb-evaluation-details [evaluationData]="evaluation.getFinishedEvent()" [showChart]="false"></ktb-evaluation-details>
   </ng-template>
 </dt-tag-list>
 <dt-tag-list *ngIf="!evaluation">
-  <dt-tag class="justify-content-center" [textContent]="'-'"></dt-tag>
+  <dt-tag class="m-0 justify-content-center" [textContent]="'-'"></dt-tag>
 </dt-tag-list>

--- a/bridge/client/app/_components/ktb-evaluation-info/ktb-evaluation-info.component.html
+++ b/bridge/client/app/_components/ktb-evaluation-info/ktb-evaluation-info.component.html
@@ -5,5 +5,5 @@
   </ng-template>
 </dt-tag-list>
 <dt-tag-list *ngIf="!evaluation">
-  <dt-tag class="justify-content-center">-</dt-tag>
+  <dt-tag class="justify-content-center" [textContent]="'-'"></dt-tag>
 </dt-tag-list>

--- a/bridge/client/app/_components/ktb-evaluation-info/ktb-evaluation-info.component.scss
+++ b/bridge/client/app/_components/ktb-evaluation-info/ktb-evaluation-info.component.scss
@@ -1,0 +1,2 @@
+@import '../../../variables';
+@import '~@dynatrace/barista-components/core/src/style/variables';

--- a/bridge/client/app/_components/ktb-evaluation-info/ktb-evaluation-info.component.spec.ts
+++ b/bridge/client/app/_components/ktb-evaluation-info/ktb-evaluation-info.component.spec.ts
@@ -1,0 +1,27 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { KtbEvaluationInfoComponent } from './ktb-evaluation-info.component';
+import {AppModule} from "../../app.module";
+import {HttpClientTestingModule} from "@angular/common/http/testing";
+
+describe('KtbEvaluationDetailsComponent', () => {
+  let component: KtbEvaluationInfoComponent;
+  let fixture: ComponentFixture<KtbEvaluationInfoComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [],
+      imports: [
+        AppModule,
+        HttpClientTestingModule,
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(KtbEvaluationInfoComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+});

--- a/bridge/client/app/_components/ktb-evaluation-info/ktb-evaluation-info.component.ts
+++ b/bridge/client/app/_components/ktb-evaluation-info/ktb-evaluation-info.component.ts
@@ -1,0 +1,27 @@
+import {Component, Input, OnDestroy, OnInit} from '@angular/core';
+import {DtOverlayConfig} from "@dynatrace/barista-components/overlay";
+
+import {Trace} from "../../_models/trace";
+
+@Component({
+  selector: 'ktb-evaluation-info',
+  templateUrl: './ktb-evaluation-info.component.html',
+  styleUrls: ['./ktb-evaluation-info.component.scss']
+})
+export class KtbEvaluationInfoComponent implements OnInit, OnDestroy {
+
+  @Input() public evaluation: Trace;
+
+  public overlayConfig: DtOverlayConfig = {
+    pinnable: true
+  };
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+  ngOnDestroy(): void {
+  }
+
+}

--- a/bridge/client/app/_components/ktb-services-list/ktb-services-list.component.html
+++ b/bridge/client/app/_components/ktb-services-list/ktb-services-list.component.html
@@ -3,7 +3,10 @@
     <dt-table [dataSource]="dataSource">
       <ng-container dtColumnDef="serviceName" [dtColumnProportion]="2">
         <dt-cell *dtCellDef="let row">
-          <p [class.highlight]="row.getOpenApprovals().length > 0" [class.error]="row.getOpenProblems().length > 0" class="m-0" [textContent]="row.getShortImageName()"></p>
+          <p [class.highlight]="row.getOpenApprovals().length > 0" [class.error]="row.getOpenProblems().length > 0" class="m-0">
+            <span *ngIf="row.getShortImageName()" [textContent]="row.getShortImageName()"></span>
+            <span *ngIf="!row.getShortImageName()" class="italic" [textContent]="row.serviceName"></span>
+          </p>
         </dt-cell>
       </ng-container>
       <ng-container dtColumnDef="recentSequence" [dtColumnProportion]="2">
@@ -28,6 +31,8 @@
       </ng-container>
       <dt-row *dtRowDef="let row; columns: ['serviceName', 'recentSequence', 'recentEvaluation']"></dt-row>
     </dt-table>
+    <a *ngIf="services.length > pageSize" (click)="pageSize = services.length">Show all <span [textContent]="services.length"></span> services</a>
+    <a *ngIf="pageSize > DEFAULT_PAGE_SIZE" (click)="pageSize = DEFAULT_PAGE_SIZE">Show only <span [textContent]="DEFAULT_PAGE_SIZE"></span> services</a>
   </ng-container>
 </div>
 <ng-template #noService>

--- a/bridge/client/app/_components/ktb-services-list/ktb-services-list.component.html
+++ b/bridge/client/app/_components/ktb-services-list/ktb-services-list.component.html
@@ -31,8 +31,7 @@
       </ng-container>
       <dt-row *dtRowDef="let row; columns: ['serviceName', 'recentSequence', 'recentEvaluation']"></dt-row>
     </dt-table>
-    <a *ngIf="services.length > pageSize" (click)="pageSize = services.length">Show all <span [textContent]="services.length"></span> services</a>
-    <a *ngIf="pageSize > DEFAULT_PAGE_SIZE" (click)="pageSize = DEFAULT_PAGE_SIZE">Show only <span [textContent]="DEFAULT_PAGE_SIZE"></span> services</a>
+    <button *ngIf="services.length > DEFAULT_PAGE_SIZE" dt-show-more [showLess]="pageSize > DEFAULT_PAGE_SIZE" (click)="toggleAllServices()">Show all <span [textContent]="services.length"></span> services</button>
   </ng-container>
 </div>
 <ng-template #noService>

--- a/bridge/client/app/_components/ktb-services-list/ktb-services-list.component.html
+++ b/bridge/client/app/_components/ktb-services-list/ktb-services-list.component.html
@@ -1,0 +1,39 @@
+<div fxLayout="column" fxLayoutGap="5px">
+  <ng-container *ngIf="services && services.length > 0; else noService">
+    <dt-table [dataSource]="dataSource">
+      <ng-container dtColumnDef="serviceName" [dtColumnProportion]="2">
+        <dt-cell *dtCellDef="let row">
+          <p [class.highlight]="row.getOpenApprovals().length > 0" [class.error]="row.getOpenProblems().length > 0" class="m-0" [textContent]="row.getShortImageName()"></p>
+        </dt-cell>
+      </ng-container>
+      <ng-container dtColumnDef="recentSequence" [dtColumnProportion]="2">
+        <dt-cell *dtCellDef="let row">
+          <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px" *ngIf="row.getRecentSequence() as currentSequence">
+            <dt-icon *ngIf="!currentSequence.getLastTraceOfStage(row.stage).isLoading()" class="event-icon" [name]="currentSequence.getFirstTraceOfStage(row.stage).isFinished() ? currentSequence.getIcon() : currentSequence.getLastTrace().getIcon()" [class.error]="row.stage === currentSequence.isFaulty()" [class.success]="currentSequence.getFirstTraceOfStage(row.stage).isFinished() && row.stage !== currentSequence.isFaulty()" [class.highlight]="currentSequence.hasPendingApproval(row.stage)"></dt-icon>
+            <button *ngIf="currentSequence.getLastTraceOfStage(row.stage).isLoading()" class="m-0 p-0" dt-button disabled variant="nested">
+              <dt-loading-spinner aria-label="Task is running..."></dt-loading-spinner>
+            </button>
+            <p class="m-0" [class.error]="currentSequence.isProblem() && currentSequence.isFaulty() && !currentSequence.isSuccessful()" [textContent]="currentSequence.getLabel()"></p>
+          </div>
+          <p class="m-0" *ngIf="!row.roots">-</p>
+        </dt-cell>
+      </ng-container>
+      <ng-container dtColumnDef="recentEvaluation" dtColumnAlign="number">
+        <dt-cell *dtCellDef="let row">
+          <div *ngIf="row.roots">
+            <ktb-evaluation-info [evaluation]="row.getRecentEvaluation()"></ktb-evaluation-info>
+          </div>
+          <p class="m-0" *ngIf="!row.roots">-</p>
+        </dt-cell>
+      </ng-container>
+      <dt-row *dtRowDef="let row; columns: ['serviceName', 'recentSequence', 'recentEvaluation']"></dt-row>
+    </dt-table>
+  </ng-container>
+</div>
+<ng-template #noService>
+  <div fxLayout="row" fxLayoutAlign="start center">
+    <dt-icon class="icon" name="information"></dt-icon>
+    <p class="m-0">No service onboarded yet.</p>
+  </div>
+  <p class="m-0">Follow the instructions to <a [href]="'/manage/service/#onboard-a-service' | keptnUrl" target="_blank" rel="noopener noreferrer">onboard a service</a>.</p>
+</ng-template>

--- a/bridge/client/app/_components/ktb-services-list/ktb-services-list.component.scss
+++ b/bridge/client/app/_components/ktb-services-list/ktb-services-list.component.scss
@@ -1,0 +1,2 @@
+@import '../../../variables';
+@import '~@dynatrace/barista-components/core/src/style/variables';

--- a/bridge/client/app/_components/ktb-services-list/ktb-services-list.component.spec.ts
+++ b/bridge/client/app/_components/ktb-services-list/ktb-services-list.component.spec.ts
@@ -1,0 +1,28 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { KtbServicesListComponent } from './ktb-services-list.component';
+import {HttpClientTestingModule} from "@angular/common/http/testing";
+import {AppModule} from "../../app.module";
+
+describe('KtbServicesListComponent', () => {
+  let component: KtbServicesListComponent;
+  let fixture: ComponentFixture<KtbServicesListComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+      ],
+      imports: [
+        AppModule,
+        HttpClientTestingModule,
+      ],
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(KtbServicesListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+});

--- a/bridge/client/app/_components/ktb-services-list/ktb-services-list.component.ts
+++ b/bridge/client/app/_components/ktb-services-list/ktb-services-list.component.ts
@@ -15,6 +15,8 @@ import {DateUtil} from "../../_utils/date.utils";
 import {DataService} from "../../_services/data.service";
 import {takeUntil} from "rxjs/operators";
 
+const DEFAULT_PAGE_SIZE = 3;
+
 @Component({
   selector: 'ktb-services-list',
   templateUrl: './ktb-services-list.component.html',
@@ -31,6 +33,7 @@ export class KtbServicesListComponent implements OnInit, OnDestroy {
   private readonly unsubscribe$ = new Subject<void>();
 
   public _services: Service[] = [];
+  public _pageSize: number = DEFAULT_PAGE_SIZE;
   public dataSource: DtTableDataSource<Service>;
 
   @Input()
@@ -40,19 +43,47 @@ export class KtbServicesListComponent implements OnInit, OnDestroy {
   set services(value: Service[]) {
     if (this._services !== value) {
       this._services = value;
+      this.updateDataSource();
       this._changeDetectorRef.markForCheck();
     }
+  }
+
+  get pageSize(): number {
+    return this._pageSize;
+  }
+  set pageSize(value: number) {
+    if (this._pageSize !== value) {
+      this._pageSize = value;
+      this.updateDataSource();
+      this._changeDetectorRef.markForCheck();
+    }
+  }
+
+  get DEFAULT_PAGE_SIZE(): number {
+    return DEFAULT_PAGE_SIZE;
   }
 
   constructor(private _changeDetectorRef: ChangeDetectorRef, public dataService: DataService, public dateUtil: DateUtil) { }
 
   ngOnInit() {
-    this.dataSource = new DtTableDataSource(this.services);
     this.dataService.roots
       .pipe(takeUntil(this.unsubscribe$))
       .subscribe(roots => {
+        this.updateDataSource();
         this._changeDetectorRef.markForCheck();
       });
+  }
+
+  updateDataSource() {
+    let data = this.services.sort((a, b) => {
+      if(!a.getRecentSequence())
+        return 1;
+      else if(!b.getRecentSequence())
+        return -1;
+      else
+        return DateUtil.compareTraceTimesAsc(a.getRecentSequence().getLastTrace(), b.getRecentSequence().getLastTrace());
+    });
+    this.dataSource = new DtTableDataSource(data.slice(0, this.pageSize));
   }
 
   ngOnDestroy(): void {

--- a/bridge/client/app/_components/ktb-services-list/ktb-services-list.component.ts
+++ b/bridge/client/app/_components/ktb-services-list/ktb-services-list.component.ts
@@ -86,6 +86,14 @@ export class KtbServicesListComponent implements OnInit, OnDestroy {
     this.dataSource = new DtTableDataSource(data.slice(0, this.pageSize));
   }
 
+  toggleAllServices() {
+    if(this.services.length > this.pageSize) {
+      this.pageSize = this.services.length;
+    } else if(this.pageSize > DEFAULT_PAGE_SIZE) {
+      this.pageSize = DEFAULT_PAGE_SIZE;
+    }
+  }
+
   ngOnDestroy(): void {
     this.unsubscribe$.next();
   }

--- a/bridge/client/app/_components/ktb-services-list/ktb-services-list.component.ts
+++ b/bridge/client/app/_components/ktb-services-list/ktb-services-list.component.ts
@@ -1,0 +1,62 @@
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  Input,
+  OnDestroy,
+  OnInit,
+  ViewEncapsulation
+} from '@angular/core';
+import {DtTableDataSource} from "@dynatrace/barista-components/table";
+import {Subject} from "rxjs";
+
+import {Service} from "../../_models/service";
+import {DateUtil} from "../../_utils/date.utils";
+import {DataService} from "../../_services/data.service";
+import {takeUntil} from "rxjs/operators";
+
+@Component({
+  selector: 'ktb-services-list',
+  templateUrl: './ktb-services-list.component.html',
+  styleUrls: ['./ktb-services-list.component.scss'],
+  host: {
+    class: 'ktb-services-list'
+  },
+  encapsulation: ViewEncapsulation.None,
+  preserveWhitespaces: false,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class KtbServicesListComponent implements OnInit, OnDestroy {
+
+  private readonly unsubscribe$ = new Subject<void>();
+
+  public _services: Service[] = [];
+  public dataSource: DtTableDataSource<Service>;
+
+  @Input()
+  get services(): Service[] {
+    return this._services;
+  }
+  set services(value: Service[]) {
+    if (this._services !== value) {
+      this._services = value;
+      this._changeDetectorRef.markForCheck();
+    }
+  }
+
+  constructor(private _changeDetectorRef: ChangeDetectorRef, public dataService: DataService, public dateUtil: DateUtil) { }
+
+  ngOnInit() {
+    this.dataSource = new DtTableDataSource(this.services);
+    this.dataService.roots
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe(roots => {
+        this._changeDetectorRef.markForCheck();
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.unsubscribe$.next();
+  }
+
+}

--- a/bridge/client/app/_components/ktb-stage-details/ktb-stage-details.component.html
+++ b/bridge/client/app/_components/ktb-stage-details/ktb-stage-details.component.html
@@ -16,11 +16,11 @@
             </dt-toggle-button-item-icon>
             <p class="m-0"><span [textContent]="failedRootEvents.length"></span> Quality gate<span *ngIf="failedRootEvents.length != 1">s</span> failed</p>
           </button>
-          <button #approvalFilterEventButton dt-toggle-button-item class="default" [value]="'approval'" [class.highlight]="selectedStage.getOpenApprovals().length > 0" [disabled]="selectedStage.getOpenApprovals().length == 0" [selected]="filterEventType == 'approval'">
+          <button #approvalFilterEventButton dt-toggle-button-item class="default" [value]="'approval'" [class.highlight]="selectedstage.servicesWithOpenApprovals().length > 0" [disabled]="selectedstage.servicesWithOpenApprovals().length == 0" [selected]="filterEventType == 'approval'">
             <dt-toggle-button-item-icon>
               <dt-icon class="stage-state-icon" name="deploy"></dt-icon>
             </dt-toggle-button-item-icon>
-            <p class="m-0"><span [textContent]="selectedStage.getOpenApprovals().length"></span> Service<span *ngIf="selectedStage.getOpenApprovals().length != 1">s</span> out-of-sync</p>
+            <p class="m-0"><span [textContent]="selectedstage.servicesWithOpenApprovals().length"></span> Service<span *ngIf="selectedstage.servicesWithOpenApprovals().length != 1">s</span> out-of-sync</p>
           </button>
         </dt-toggle-button-group>
         <div fxLayout="row" fxLayoutAlign="start center" *ngIf="selectedStage.services.length == 0">

--- a/bridge/client/app/_components/ktb-stage-details/ktb-stage-details.component.html
+++ b/bridge/client/app/_components/ktb-stage-details/ktb-stage-details.component.html
@@ -16,11 +16,11 @@
             </dt-toggle-button-item-icon>
             <p class="m-0"><span [textContent]="failedRootEvents.length"></span> Quality gate<span *ngIf="failedRootEvents.length != 1">s</span> failed</p>
           </button>
-          <button #approvalFilterEventButton dt-toggle-button-item class="default" [value]="'approval'" [class.highlight]="selectedstage.servicesWithOpenApprovals().length > 0" [disabled]="selectedstage.servicesWithOpenApprovals().length == 0" [selected]="filterEventType == 'approval'">
+          <button #approvalFilterEventButton dt-toggle-button-item class="default" [value]="'approval'" [class.highlight]="selectedStage.servicesWithOpenApprovals().length > 0" [disabled]="selectedStage.servicesWithOpenApprovals().length == 0" [selected]="filterEventType == 'approval'">
             <dt-toggle-button-item-icon>
               <dt-icon class="stage-state-icon" name="deploy"></dt-icon>
             </dt-toggle-button-item-icon>
-            <p class="m-0"><span [textContent]="selectedstage.servicesWithOpenApprovals().length"></span> Service<span *ngIf="selectedstage.servicesWithOpenApprovals().length != 1">s</span> out-of-sync</p>
+            <p class="m-0"><span [textContent]="selectedStage.servicesWithOpenApprovals().length"></span> Service<span *ngIf="selectedStage.servicesWithOpenApprovals().length != 1">s</span> out-of-sync</p>
           </button>
         </dt-toggle-button-group>
         <div fxLayout="row" fxLayoutAlign="start center" *ngIf="selectedStage.services.length == 0">

--- a/bridge/client/app/_components/ktb-stage-details/ktb-stage-details.component.html
+++ b/bridge/client/app/_components/ktb-stage-details/ktb-stage-details.component.html
@@ -1,7 +1,7 @@
-<ng-container *ngIf="selectedStage">
-  <ng-container *ngIf="project.getLatestFailedRootEvents(selectedStage) as failedRootEvents">
-    <ng-container *ngIf="project.getLatestProblemEvents(selectedStage) as problemEvents">
-      <ng-container *ngIf="openApprovals$ | async as openApprovals">
+<div fxLayout="column" fxLayoutGap="15px">
+  <ng-container *ngIf="selectedStage">
+    <ng-container *ngIf="project.getLatestFailedRootEvents(selectedStage) as failedRootEvents">
+      <ng-container *ngIf="project.getLatestProblemEvents(selectedStage) as problemEvents">
         <h2 [textContent]="selectedStage.stageName"></h2>
         <dt-toggle-button-group (change)="selectFilterEvent($event)">
           <button #problemFilterEventButton dt-toggle-button-item class="default" [value]="'problem'" [class.error]="problemEvents.length > 0" [disabled]="problemEvents.length == 0" [selected]="filterEventType == 'problem'">
@@ -16,11 +16,11 @@
             </dt-toggle-button-item-icon>
             <p class="m-0"><span [textContent]="failedRootEvents.length"></span> Quality gate<span *ngIf="failedRootEvents.length != 1">s</span> failed</p>
           </button>
-          <button #approvalFilterEventButton dt-toggle-button-item class="default" [value]="'approval'" [class.highlight]="countOpenApprovals(project, selectedStage) > 0" [disabled]="countOpenApprovals(project, selectedStage) == 0" [selected]="filterEventType == 'approval'">
+          <button #approvalFilterEventButton dt-toggle-button-item class="default" [value]="'approval'" [class.highlight]="selectedStage.getOpenApprovals().length > 0" [disabled]="selectedStage.getOpenApprovals().length == 0" [selected]="filterEventType == 'approval'">
             <dt-toggle-button-item-icon>
               <dt-icon class="stage-state-icon" name="deploy"></dt-icon>
             </dt-toggle-button-item-icon>
-            <p class="m-0"><span [textContent]="countOpenApprovals(project, selectedStage)"></span> Service<span *ngIf="countOpenApprovals(project, selectedStage) != 1">s</span> out-of-sync</p>
+            <p class="m-0"><span [textContent]="selectedStage.getOpenApprovals().length"></span> Service<span *ngIf="selectedStage.getOpenApprovals().length != 1">s</span> out-of-sync</p>
           </button>
         </dt-toggle-button-group>
         <div fxLayout="row" fxLayoutAlign="start center" *ngIf="selectedStage.services.length == 0">
@@ -28,8 +28,8 @@
           <p class="m-0">No service onboarded yet. Follow the instructions to <a [href]="'/manage/service/#onboard-a-service' | keptnUrl" target="_blank" rel="noopener noreferrer">onboard a service</a>.</p>
         </div>
         <ng-container *ngFor="let service of selectedStage.services">
-          <ktb-expandable-tile [expanded]="countOpenApprovals(project, selectedStage, service) > 0"
-                               *ngIf="!filterEventType || filterEventType == 'problem' && findProblemEvent(problemEvents, service) || filterEventType == 'evaluation' && findFailedRootEvent(failedRootEvents, service) || filterEventType == 'approval' && countOpenApprovals(project, selectedStage, service) > 0">
+          <ktb-expandable-tile class="mt-1" [expanded]="service.getOpenApprovals().length > 0"
+                               *ngIf="!filterEventType || filterEventType == 'problem' && findProblemEvent(problemEvents, service) || filterEventType == 'evaluation' && findFailedRootEvent(failedRootEvents, service) || filterEventType == 'approval' && service.getOpenApprovals().length > 0">
             <ktb-expandable-tile-header>
               <dt-info-group>
                 <dt-info-group-title>
@@ -41,9 +41,7 @@
                     <ng-container *ngIf="findProblemEvent(problemEvents, service) as problemEvent">
                       <dt-icon class="stage-state-icon event-icon error" name="criticalevent"></dt-icon>
                     </ng-container>
-                    <ng-container *ngIf="openApprovals$ | async as openApprovals">
-                      <dt-icon class="stage-state-icon highlight" *ngIf="countOpenApprovals(project, selectedStage, service) > 0" name="deploy"></dt-icon>
-                    </ng-container>
+                    <dt-icon class="stage-state-icon highlight" *ngIf="service.getOpenApprovals().length > 0" name="deploy"></dt-icon>
                     <ng-container *ngIf="project.getLatestDeployment(service, selectedStage) as deployment">
                       <a *ngIf="deployment.data.deploymentURIPublic" [href]="deployment.data.deploymentURIPublic" target="_blank"><button dt-icon-button variant="nested"><dt-icon name="externallink"></dt-icon></button></a>
                     </ng-container>
@@ -79,9 +77,9 @@
               <p class="m-0" *ngIf="failedRootEvent?.isDeployment() && !failedRootEvent.getDeploymentDetails(selectedStage)?.isDirectDeployment()">Rollback to <span *ngIf="project.getLatestDeployment(service, selectedStage) as deployment" [textContent]="deployment.getShortImageName()"></span> performed.</p>
               <hr />
             </ng-container>
-            <div *ngIf="countOpenApprovals(project, selectedStage, service) > 0; else noOutOfSyncDeployments">
+            <div *ngIf="service.getOpenApprovals().length > 0; else noOutOfSyncDeployments">
               <p class="m-0">Deployable artifacts for <span [textContent]="service.serviceName"></span> service</p>
-              <ktb-approval-item class="mt-1" *ngFor="let approval of getOpenApprovals(project, selectedStage, service)" [event]="approval"></ktb-approval-item>
+              <ktb-approval-item class="mt-1" *ngFor="let approval of service.getOpenApprovals()" [event]="approval"></ktb-approval-item>
             </div>
             <ng-template #noOutOfSyncDeployments>No pending deployments for this stage available.</ng-template>
           </ktb-expandable-tile>
@@ -89,7 +87,7 @@
       </ng-container>
     </ng-container>
   </ng-container>
-</ng-container>
+</div>
 <ng-template #noDeployment>
   <p class="m-0">Service not deployed yet. Use <a [href]="'/reference/cli/commands/keptn_trigger_delivery/' | keptnUrl" target="_blank" rel="noopener noreferrer">keptn trigger delivery</a> to trigger a deployment.</p>
 </ng-template>

--- a/bridge/client/app/_components/ktb-stage-details/ktb-stage-details.component.ts
+++ b/bridge/client/app/_components/ktb-stage-details/ktb-stage-details.component.ts
@@ -1,13 +1,13 @@
-import {ChangeDetectorRef, Component, EventEmitter, Input, OnInit, Output, ViewChild} from '@angular/core';
-import {Project} from '../../_models/project';
-import {Stage} from '../../_models/stage';
-import {Observable} from 'rxjs';
-import {Trace} from '../../_models/trace';
-import {DataService} from '../../_services/data.service';
+import {ChangeDetectorRef, Component, Input, OnInit, ViewChild} from '@angular/core';
 import {DtToggleButtonItem} from '@dynatrace/barista-components/toggle-button-group';
 import {DtOverlayConfig} from '@dynatrace/barista-components/overlay';
+
+import {Project} from '../../_models/project';
+import {Stage} from '../../_models/stage';
 import {Service} from '../../_models/service';
 import {Root} from '../../_models/root';
+
+import {DataService} from '../../_services/data.service';
 
 @Component({
   selector: 'ktb-stage-details',
@@ -17,7 +17,6 @@ import {Root} from '../../_models/root';
 export class KtbStageDetailsComponent implements OnInit {
   public _project: Project;
   public selectedStage: Stage = null;
-  public openApprovals$: Observable<Trace[]>;
   public filterEventType: string = null;
   public overlayConfig: DtOverlayConfig = {
     pinnable: true
@@ -43,7 +42,6 @@ export class KtbStageDetailsComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.openApprovals$ = this.dataService.openApprovals;
   }
 
   selectStage($event) {
@@ -58,14 +56,6 @@ export class KtbStageDetailsComponent implements OnInit {
     if ($event.isUserInput) {
       this.filterEventType = $event.source.selected ? $event.value : null;
     }
-  }
-
-  countOpenApprovals(project: Project, stage: Stage, service?: Service): number {
-    return this.getOpenApprovals(project, stage, service).length;
-  }
-
-  getOpenApprovals(project: Project, stage: Stage, service?: Service): Trace[] {
-    return this.dataService.getOpenApprovals(project, stage, service);
   }
 
   findProblemEvent(problemEvents: Root[], service: Service): Root {

--- a/bridge/client/app/_components/ktb-stage-overview/ktb-stage-overview.component.html
+++ b/bridge/client/app/_components/ktb-stage-overview/ktb-stage-overview.component.html
@@ -11,42 +11,21 @@
         <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px"
              *ngIf="project.getLatestProblemEvents(stage) as problemEvents"
              (click)="problemEvents.length > 0 && selectStage($event, stage, 'problem')">
-          <dt-icon class="stage-state-icon event-icon" name="criticalevent" [class.error]="problemEvents.length > 0"></dt-icon>
+          <dt-icon class="stage-state-icon" name="criticalevent" [class.error]="problemEvents.length > 0"></dt-icon>
           <span [textContent]="problemEvents.length"></span>
         </div>
         <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px"
              *ngIf="project.getLatestFailedRootEvents(stage) as failedRootEvents"
              (click)="failedRootEvents.length > 0 && selectStage($event, stage, 'evaluation')">
-          <dt-icon class="stage-state-icon event-icon" name="traffic-light" [class.error]="failedRootEvents.length > 0"></dt-icon>
+          <dt-icon class="stage-state-icon" name="traffic-light" [class.error]="failedRootEvents.length > 0"></dt-icon>
           <span [textContent]="failedRootEvents.length"></span>
         </div>
-        <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px"
-             *ngIf="openApprovals$ | async as openApprovals"
-             (click)="countOpenApprovals(project, stage) > 0 && selectStage($event, stage, 'approval')">
-          <dt-icon class="stage-state-icon" name="deploy" [class.highlight]="countOpenApprovals(project, stage) > 0"></dt-icon>
-          <span [textContent]="countOpenApprovals(project, stage)"></span>
+        <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px" (click)="stage.getOpenApprovals().length > 0 && selectStage($event, stage, 'approval')">
+          <dt-icon class="stage-state-icon" name="deploy" [class.highlight]="stage.getOpenApprovals().length > 0"></dt-icon>
+          <span [textContent]="stage.getOpenApprovals().length"></span>
         </div>
       </div>
-      <ng-container *ngIf="stage.services && stage.services.length > 0; else noService">
-        <ng-container *ngIf="openApprovals$ | async as openApprovals">
-          <dt-tag-list aria-label="services">
-            <dt-tag *ngFor="let service of stage.services" [class.highlight]="countOpenApprovals(project, stage, service) > 0" [class.error]="findProblemEvent(project.getLatestProblemEvents(stage), service)">
-              <span *ngIf="service.deployedImage; else noDeploymentOfServiceTag" [textContent]="service.getShortImageName()"></span>
-              <ng-template #noDeploymentOfServiceTag>
-                <span class="no-deployment" [textContent]="service.serviceName"></span>
-              </ng-template>
-            </dt-tag>
-          </dt-tag-list>
-        </ng-container>
-      </ng-container>
+      <ktb-services-list [services]="stage.services"></ktb-services-list>
     </ktb-selectable-tile>
   </div>
 </dt-info-group>
-
-<ng-template #noService>
-  <div fxLayout="row" fxLayoutAlign="start center">
-    <dt-icon class="icon" name="information"></dt-icon>
-    <p class="m-0">No service onboarded yet.</p>
-  </div>
-  <p class="m-0">Follow the instructions to <a [href]="'/manage/service/#onboard-a-service' | keptnUrl" target="_blank" rel="noopener noreferrer">onboard a service</a>.</p>
-</ng-template>

--- a/bridge/client/app/_components/ktb-stage-overview/ktb-stage-overview.component.html
+++ b/bridge/client/app/_components/ktb-stage-overview/ktb-stage-overview.component.html
@@ -20,9 +20,9 @@
           <dt-icon class="stage-state-icon" name="traffic-light" [class.error]="failedRootEvents.length > 0"></dt-icon>
           <span [textContent]="failedRootEvents.length"></span>
         </div>
-        <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px" (click)="stage.getOpenApprovals().length > 0 && selectStage($event, stage, 'approval')">
-          <dt-icon class="stage-state-icon" name="deploy" [class.highlight]="stage.getOpenApprovals().length > 0"></dt-icon>
-          <span [textContent]="stage.getOpenApprovals().length"></span>
+        <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px" (click)="stage.servicesWithOpenApprovals().length > 0 && selectStage($event, stage, 'approval')">
+          <dt-icon class="stage-state-icon" name="deploy" [class.highlight]="stage.servicesWithOpenApprovals().length > 0"></dt-icon>
+          <span [textContent]="stage.servicesWithOpenApprovals().length"></span>
         </div>
       </div>
       <ktb-services-list [services]="stage.services"></ktb-services-list>

--- a/bridge/client/app/_components/ktb-stage-overview/ktb-stage-overview.component.ts
+++ b/bridge/client/app/_components/ktb-stage-overview/ktb-stage-overview.component.ts
@@ -2,10 +2,6 @@ import {ChangeDetectorRef, Component, EventEmitter, Input, OnInit, Output} from 
 import {Project} from '../../_models/project';
 import {Stage} from '../../_models/stage';
 import {DataService} from '../../_services/data.service';
-import {Observable} from 'rxjs';
-import {Trace} from '../../_models/trace';
-import {Service} from '../../_models/service';
-import {Root} from '../../_models/root';
 
 @Component({
   selector: 'ktb-stage-overview',
@@ -15,7 +11,6 @@ import {Root} from '../../_models/root';
 export class KtbStageOverviewComponent implements OnInit {
   public _project: Project;
   public selectedStage: Stage = null;
-  public openApprovals$: Observable<Trace[]>;
 
   @Output() selectedStageChange: EventEmitter<any> = new EventEmitter();
 
@@ -35,7 +30,6 @@ export class KtbStageOverviewComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.openApprovals$ = this.dataService.openApprovals;
   }
 
   trackStage(index: number, stage: Stage): string {
@@ -46,14 +40,6 @@ export class KtbStageOverviewComponent implements OnInit {
     this.selectedStage = stage;
     $event.stopPropagation();
     this.selectedStageChange.emit({stage, filterType});
-  }
-
-  countOpenApprovals(project: Project, stage: Stage, service?: Service): number {
-    return this.dataService.getOpenApprovals(project, stage, service).length;
-  }
-
-  findProblemEvent(problemEvents: Root[], service: Service): Root {
-    return problemEvents.find(root => root?.data.service === service.serviceName);
   }
 
 }

--- a/bridge/client/app/_models/event-icons.ts
+++ b/bridge/client/app/_models/event-icons.ts
@@ -1,5 +1,6 @@
 export const EVENT_ICONS = {
   "artifact-delivery": "duplicate",
+  "delivery": "duplicate",
   "deployment": "deploy",
   "test": "perfromance-health",
   "evaluation": "traffic-light",

--- a/bridge/client/app/_models/project.ts
+++ b/bridge/client/app/_models/project.ts
@@ -2,7 +2,6 @@ import semver from 'semver';
 import {Stage} from "./stage";
 import {Service} from "./service";
 import {Trace} from "./trace";
-import {EventTypes} from "./event-types";
 import {Root} from "./root";
 
 export class Project {
@@ -84,7 +83,7 @@ export class Project {
   }
 
   getLatestProblemEvents(stage: Stage): Root[] {
-    return this.getServices().map(service => service.roots?.find(root => root.traces.some(trace => trace.data.stage === stage.stageName))).filter(root => root && root?.isProblem() && !root?.isProblemResolvedOrClosed());
+    return stage.getOpenProblems();
   }
 
   getRootEvent(service: Service, event: Trace): Root {

--- a/bridge/client/app/_models/service.ts
+++ b/bridge/client/app/_models/service.ts
@@ -1,13 +1,32 @@
 import {Root} from "./root";
+import {Trace} from "./trace";
 
 export class Service {
   serviceName: string;
   deployedImage: string;
+  stage: string;
 
-  roots: Root[];
+  roots: Root[] = [];
+  openApprovals: Trace[] = [];
 
-  getShortImageName() {
+  getShortImageName(): string {
     return this.deployedImage.split("/").pop();
+  }
+
+  getOpenApprovals(): Trace[] {
+    return this.openApprovals || [];
+  }
+
+  getOpenProblems(): Trace[] {
+    return this.roots?.filter(root => root.isProblem() && !root.isProblemResolvedOrClosed()) || [];
+  }
+
+  getRecentSequence(): Root {
+    return this.roots[0];
+  }
+
+  getRecentEvaluation(): Trace {
+    return this.getRecentSequence()?.getEvaluation(this.stage);
   }
 
   static fromJSON(data: any) {

--- a/bridge/client/app/_models/service.ts
+++ b/bridge/client/app/_models/service.ts
@@ -10,7 +10,7 @@ export class Service {
   openApprovals: Trace[] = [];
 
   getShortImageName(): string {
-    return this.deployedImage.split("/").pop();
+    return this.deployedImage?.split("/").pop();
   }
 
   getOpenApprovals(): Trace[] {

--- a/bridge/client/app/_models/stage.ts
+++ b/bridge/client/app/_models/stage.ts
@@ -4,8 +4,15 @@ export class Stage {
   stageName: string;
   services: Service[];
 
+  public getOpenApprovals() {
+    return this.services.reduce((openApprovals, service) => [...openApprovals, ...service.getOpenApprovals()], []);
+  }
+
+  public getOpenProblems() {
+    return this.services.reduce((openProblems, service) => [...openProblems, ...service.getOpenProblems()], []);
+  }
+
   static fromJSON(data: any) {
     return Object.assign(new this, data);
   }
-
 }

--- a/bridge/client/app/_models/stage.ts
+++ b/bridge/client/app/_models/stage.ts
@@ -8,6 +8,10 @@ export class Stage {
     return this.services.reduce((openApprovals, service) => [...openApprovals, ...service.getOpenApprovals()], []);
   }
 
+  public servicesWithOpenApprovals() {
+    return this.services.filter(s => s.getOpenApprovals().length > 0);
+  }
+
   public getOpenProblems() {
     return this.services.reduce((openProblems, service) => [...openProblems, ...service.getOpenProblems()], []);
   }

--- a/bridge/client/app/_views/ktb-environment-view/ktb-environment-view.component.html
+++ b/bridge/client/app/_views/ktb-environment-view/ktb-environment-view.component.html
@@ -1,8 +1,8 @@
-<div class="container" fxFlex="64" fxLayout="row" fxLayoutGap="15px">
-  <div fxFlex fxLayout="column" fxLayoutGap="15px">
+<ng-container *ngIf="project$ | async as project">
+  <div class="container" fxFlex="64">
     <ktb-stage-overview [project]="project" (selectedStageChange)="stageDetails.selectStage($event)"></ktb-stage-overview>
   </div>
-</div>
-<div class="container dark" fxFlex="36" fxLayout="column" fxLayoutGap="15px">
-  <ktb-stage-details #stageDetails [project]="project"></ktb-stage-details>
-</div>
+  <div class="container dark" fxFlex="36">
+    <ktb-stage-details #stageDetails [project]="project"></ktb-stage-details>
+  </div>
+</ng-container>

--- a/bridge/client/app/_views/ktb-environment-view/ktb-environment-view.component.ts
+++ b/bridge/client/app/_views/ktb-environment-view/ktb-environment-view.component.ts
@@ -1,27 +1,38 @@
-import {Component, Input, OnInit} from '@angular/core';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnInit} from '@angular/core';
+import {takeUntil} from "rxjs/operators";
+import {Observable, Subject} from "rxjs";
+import {ActivatedRoute} from "@angular/router";
+
 import {Project} from '../../_models/project';
+import {DataService} from "../../_services/data.service";
 
 @Component({
   selector: 'ktb-environment-view',
   templateUrl: './ktb-environment-view.component.html',
-  styleUrls: ['./ktb-environment-view.component.scss']
+  styleUrls: ['./ktb-environment-view.component.scss'],
+  host: {
+    class: 'ktb-environment-view'
+  },
+  preserveWhitespaces: false,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class KtbEnvironmentViewComponent implements OnInit {
-  private _project: Project;
+export class KtbEnvironmentViewComponent implements OnInit, OnDestroy {
 
-  @Input()
-  get project() {
-    return this._project;
-  }
-  set project(project: Project) {
-    if (this._project !== project) {
-      this._project = project;
-    }
-  }
+  private readonly unsubscribe$ = new Subject<void>();
+  public project$: Observable<Project>;
 
-  constructor() {
+  constructor(private _changeDetectorRef: ChangeDetectorRef, private dataService: DataService, private route: ActivatedRoute) {
   }
 
   ngOnInit(): void {
+    this.route.params
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe(params => {
+        this.project$ = this.dataService.getProject(params.projectName);
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.unsubscribe$.next();
   }
 }

--- a/bridge/client/app/app.module.ts
+++ b/bridge/client/app/app.module.ts
@@ -62,6 +62,7 @@ import { KtbApprovalItemComponent } from "./_components/ktb-approval-item/ktb-ap
 import { KtbCopyToClipboardComponent } from "./_components/ktb-copy-to-clipboard/ktb-copy-to-clipboard.component";
 import { KtbMarkdownComponent } from "./_components/ktb-markdown/ktb-markdown.component";
 import { KtbEvaluationDetailsComponent } from './_components/ktb-evaluation-details/ktb-evaluation-details.component';
+import { KtbEvaluationInfoComponent } from "./_components/ktb-evaluation-info/ktb-evaluation-info.component";
 import { KtbEventItemComponent, KtbEventItemDetail } from './_components/ktb-event-item/ktb-event-item.component';
 import { KtbTaskItemComponent, KtbTaskItemDetail } from "./_components/ktb-task-item/ktb-task-item.component";
 import { KtbSequenceTasksListComponent } from "./_components/ktb-sequence-tasks-list/ktb-sequence-tasks-list.component";
@@ -84,7 +85,8 @@ import { KtbStageDetailsComponent } from './_components/ktb-stage-details/ktb-st
 import { KtbSequenceViewComponent } from "./_views/ktb-sequence-view/ktb-sequence-view.component";
 import { KtbServiceViewComponent } from "./_views/ktb-service-view/ktb-service-view.component";
 import { KeptnUrlPipe } from './_pipes/keptn-url.pipe';
-import {KtbSliBreakdownCriteriaItemComponent} from './_components/ktb-sli-breakdown-criteria-item/ktb-sli-breakdown-criteria-item.component';
+import { KtbSliBreakdownCriteriaItemComponent } from './_components/ktb-sli-breakdown-criteria-item/ktb-sli-breakdown-criteria-item.component';
+import { KtbServicesListComponent } from "./_components/ktb-services-list/ktb-services-list.component";
 
 registerLocaleData(localeEn, 'en');
 
@@ -116,6 +118,7 @@ registerLocaleData(localeEn, 'en');
     KtbTaskItemComponent,
     KtbTaskItemDetail,
     KtbEvaluationDetailsComponent,
+    KtbEvaluationInfoComponent,
     KtbSliBreakdownComponent,
     KtbNotificationBarComponent,
     KtbApprovalItemComponent,
@@ -128,6 +131,7 @@ registerLocaleData(localeEn, 'en');
     KtbStageDetailsComponent,
     KeptnUrlPipe,
     KtbSliBreakdownCriteriaItemComponent,
+    KtbServicesListComponent,
   ],
   imports: [
     BrowserModule,

--- a/bridge/client/app/project-board/project-board.component.html
+++ b/bridge/client/app/project-board/project-board.component.html
@@ -40,7 +40,7 @@
     </dt-menu-group>
   </dt-menu>
   <ng-container [ngSwitch]="view">
-    <ktb-environment-view *ngSwitchCase="'environment'" fxFlex="calc(100% - 150px)" [project]="project"></ktb-environment-view>
+    <ktb-environment-view *ngSwitchCase="'environment'" fxFlex="calc(100% - 150px)"></ktb-environment-view>
     <ktb-service-view *ngSwitchCase="'service'" fxFlex="calc(100% - 150px)"></ktb-service-view>
     <ktb-sequence-view *ngSwitchCase="'sequence'" fxFlex="calc(100% - 150px)"></ktb-sequence-view>
     <ktb-integration-view *ngSwitchCase="'integration'" fxFlex="calc(100% - 150px)"></ktb-integration-view>


### PR DESCRIPTION
Services are shown in the stage tile in the environments screen as table, also showing the recent sequence and the status of that sequence and if available also the evaluation result for that sequence on that stage.

![image](https://user-images.githubusercontent.com/6098219/110623088-a353ee00-819c-11eb-80db-719dac86112c.png)

closes #2289