### PR TITLE
#3475 Fix CLI builds for platforms that dont have dynamic linking support

### DIFF
--- a/make-scripts/build/build-cli.sh
+++ b/make-scripts/build/build-cli.sh
@@ -9,6 +9,7 @@ cd ./cli/ || return
 
 echo "Building Keptn CLI"
 env go mod download
+export CGO_ENABLED=0
 env go build -v -x -ldflags="-X 'main.Version=$VERSION' -X 'main.KubeServerVersionConstraints=$KUBE_CONSTRAINTS'" -o "${OUTPUT_EXECUTABLE_NAME}"
 
 # shellcheck disable=SC2181


### PR DESCRIPTION
This fixes #3475 by adding CGO_ENABLED=0. I tried using the other approach described in #3475, but it didn't work.