### PR TITLE
#3489: added trigger for doing docker login at workflow dispatch

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -630,7 +630,7 @@ jobs:
       - id: docker_login
         name: Docker Login
         # only run docker login on pushes; also for PRs, but only if this is not a fork
-        if: (github.event_name == 'push') || (github.event.pull_request.head.repo.full_name == github.repository)
+        if: (github.event_name == 'push') || (github.event_name == 'workflow_dispatch') || (github.event.pull_request.head.repo.full_name == github.repository)
         # note: GH does not allow to access secrets for PRs from a forked repositories due to security reasons
         # that's fine, but it means we can't push images to dockerhub
         env:


### PR DESCRIPTION
With the changes in this PR a `docker login` is also triggered when manually **manually** starting the CI Workflow via the GH UI.
This is necessary for beeing able to push the built Docker image to the Docker registry.

Signed-off-by: warber <bernd.warmuth@dynatrace.com>