### PR TITLE
Print warning in case of non-admin rights in helm-service

### DIFF
--- a/helm-service/main.go
+++ b/helm-service/main.go
@@ -168,7 +168,7 @@ func _main(args []string, env envConfig) int {
 		log.Fatal(fmt.Sprintf("failed to check whether helm-service has admin right: %v", err))
 	}
 	if !adminRights {
-		log.Fatal("helm-service has insufficient RBAC rights.")
+		log.Println("Warning: helm-service is running without admin RBAC rights. See #3511 for details.")
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
This commit prevents that the helm-service exists after discovering that
it does not have admin access when checking the available RBAC. Instead,
it logs a warning and continues to operate.

This is a temporary workaround for supporting fine-granular RBAC in the
helm-service to deploy kubernetes workloads (#3511).