### PR TITLE
fixed errors in swagger definition of shipyard controller

### DIFF
--- a/shipyard-controller/docs/docs.go
+++ b/shipyard-controller/docs/docs.go
@@ -513,74 +513,6 @@ var doc = `{
                 }
             }
         },
-        "/project/{project}/service/{stage}": {
-            "get": {
-                "security": [
-                    {
-                        "ApiKeyAuth": []
-                    }
-                ],
-                "description": "Gets all services of a stage in a project",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Services"
-                ],
-                "summary": "Gets all services of a stage in a project",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Project",
-                        "name": "project",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Stage",
-                        "name": "stage",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "The number of items to return",
-                        "name": "pageSize",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Pointer to the next set of items",
-                        "name": "nextPageKey",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "ok",
-                        "schema": {
-                            "$ref": "#/definitions/models.ExpandedServices"
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid payload",
-                        "schema": {
-                            "$ref": "#/definitions/models.Error"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal error",
-                        "schema": {
-                            "$ref": "#/definitions/models.Error"
-                        }
-                    }
-                }
-            }
-        },
         "/project/{project}/stage": {
             "get": {
                 "security": [
@@ -600,6 +532,13 @@ var doc = `{
                 ],
                 "summary": "Get all stages of a project",
                 "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The name of the project",
+                        "name": "project",
+                        "in": "path",
+                        "required": true
+                    },
                     {
                         "type": "integer",
                         "description": "The number of items to return",
@@ -764,7 +703,7 @@ var doc = `{
             "post": {
                 "security": [
                     {
-                        "ApiKeyAutth": []
+                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Trigger a new evaluation for a service within a project",

--- a/shipyard-controller/docs/docs.go
+++ b/shipyard-controller/docs/docs.go
@@ -587,7 +587,7 @@ var doc = `{
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Get a stage of a project",
+                "description": "Gets all services of a stage in a project",
                 "consumes": [
                     "application/json"
                 ],
@@ -595,40 +595,52 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Projects"
+                    "Services"
                 ],
-                "summary": "Get a stage",
+                "summary": "Gets all services of a stage in a project",
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The name of the project",
+                        "description": "Project",
                         "name": "project",
                         "in": "path",
                         "required": true
                     },
                     {
                         "type": "string",
-                        "description": "The name of the stage",
+                        "description": "Stage",
                         "name": "stage",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "The number of items to return",
+                        "name": "pageSize",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Pointer to the next set of items",
+                        "name": "nextPageKey",
+                        "in": "query"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "ok",
                         "schema": {
-                            "$ref": "#/definitions/models.ExpandedStage"
+                            "$ref": "#/definitions/models.ExpandedServices"
                         }
                     },
-                    "404": {
-                        "description": "Not found",
+                    "400": {
+                        "description": "Invalid payload",
                         "schema": {
                             "$ref": "#/definitions/models.Error"
                         }
                     },
                     "500": {
-                        "description": "Internal Error)",
+                        "description": "Internal error",
                         "schema": {
                             "$ref": "#/definitions/models.Error"
                         }

--- a/shipyard-controller/docs/swagger.json
+++ b/shipyard-controller/docs/swagger.json
@@ -498,74 +498,6 @@
                 }
             }
         },
-        "/project/{project}/service/{stage}": {
-            "get": {
-                "security": [
-                    {
-                        "ApiKeyAuth": []
-                    }
-                ],
-                "description": "Gets all services of a stage in a project",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Services"
-                ],
-                "summary": "Gets all services of a stage in a project",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Project",
-                        "name": "project",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Stage",
-                        "name": "stage",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "The number of items to return",
-                        "name": "pageSize",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Pointer to the next set of items",
-                        "name": "nextPageKey",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "ok",
-                        "schema": {
-                            "$ref": "#/definitions/models.ExpandedServices"
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid payload",
-                        "schema": {
-                            "$ref": "#/definitions/models.Error"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal error",
-                        "schema": {
-                            "$ref": "#/definitions/models.Error"
-                        }
-                    }
-                }
-            }
-        },
         "/project/{project}/stage": {
             "get": {
                 "security": [
@@ -585,6 +517,13 @@
                 ],
                 "summary": "Get all stages of a project",
                 "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The name of the project",
+                        "name": "project",
+                        "in": "path",
+                        "required": true
+                    },
                     {
                         "type": "integer",
                         "description": "The number of items to return",
@@ -749,7 +688,7 @@
             "post": {
                 "security": [
                     {
-                        "ApiKeyAutth": []
+                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Trigger a new evaluation for a service within a project",

--- a/shipyard-controller/docs/swagger.json
+++ b/shipyard-controller/docs/swagger.json
@@ -572,7 +572,7 @@
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Get a stage of a project",
+                "description": "Gets all services of a stage in a project",
                 "consumes": [
                     "application/json"
                 ],
@@ -580,40 +580,52 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Projects"
+                    "Services"
                 ],
-                "summary": "Get a stage",
+                "summary": "Gets all services of a stage in a project",
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The name of the project",
+                        "description": "Project",
                         "name": "project",
                         "in": "path",
                         "required": true
                     },
                     {
                         "type": "string",
-                        "description": "The name of the stage",
+                        "description": "Stage",
                         "name": "stage",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "The number of items to return",
+                        "name": "pageSize",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Pointer to the next set of items",
+                        "name": "nextPageKey",
+                        "in": "query"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "ok",
                         "schema": {
-                            "$ref": "#/definitions/models.ExpandedStage"
+                            "$ref": "#/definitions/models.ExpandedServices"
                         }
                     },
-                    "404": {
-                        "description": "Not found",
+                    "400": {
+                        "description": "Invalid payload",
                         "schema": {
                             "$ref": "#/definitions/models.Error"
                         }
                     },
                     "500": {
-                        "description": "Internal Error)",
+                        "description": "Internal error",
                         "schema": {
                             "$ref": "#/definitions/models.Error"
                         }

--- a/shipyard-controller/docs/swagger.yaml
+++ b/shipyard-controller/docs/swagger.yaml
@@ -615,56 +615,17 @@ paths:
       summary: Delete a service
       tags:
       - Services
-  /project/{project}/service/{stage}:
-    get:
-      consumes:
-      - application/json
-      description: Gets all services of a stage in a project
-      parameters:
-      - description: Project
-        in: path
-        name: project
-        required: true
-        type: string
-      - description: Stage
-        in: path
-        name: stage
-        required: true
-        type: string
-      - description: The number of items to return
-        in: query
-        name: pageSize
-        type: integer
-      - description: Pointer to the next set of items
-        in: query
-        name: nextPageKey
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: ok
-          schema:
-            $ref: '#/definitions/models.ExpandedServices'
-        "400":
-          description: Invalid payload
-          schema:
-            $ref: '#/definitions/models.Error'
-        "500":
-          description: Internal error
-          schema:
-            $ref: '#/definitions/models.Error'
-      security:
-      - ApiKeyAuth: []
-      summary: Gets all services of a stage in a project
-      tags:
-      - Services
   /project/{project}/stage:
     get:
       consumes:
       - application/json
       description: Get the list of stages of a project
       parameters:
+      - description: The name of the project
+        in: path
+        name: project
+        required: true
+        type: string
       - description: The number of items to return
         in: query
         name: pageSize
@@ -817,7 +778,7 @@ paths:
           schema:
             $ref: '#/definitions/models.Error'
       security:
-      - ApiKeyAutth: []
+      - ApiKeyAuth: []
       summary: Trigger a new evaluation
       tags:
       - Evaluation

--- a/shipyard-controller/docs/swagger.yaml
+++ b/shipyard-controller/docs/swagger.yaml
@@ -662,17 +662,25 @@ paths:
     get:
       consumes:
       - application/json
-      description: Get a stage of a project
+      description: Gets all services of a stage in a project
       parameters:
-      - description: The name of the project
+      - description: Project
         in: path
         name: project
         required: true
         type: string
-      - description: The name of the stage
+      - description: Stage
         in: path
         name: stage
         required: true
+        type: string
+      - description: The number of items to return
+        in: query
+        name: pageSize
+        type: integer
+      - description: Pointer to the next set of items
+        in: query
+        name: nextPageKey
         type: string
       produces:
       - application/json
@@ -680,20 +688,20 @@ paths:
         "200":
           description: ok
           schema:
-            $ref: '#/definitions/models.ExpandedStage'
-        "404":
-          description: Not found
+            $ref: '#/definitions/models.ExpandedServices'
+        "400":
+          description: Invalid payload
           schema:
             $ref: '#/definitions/models.Error'
         "500":
-          description: Internal Error)
+          description: Internal error
           schema:
             $ref: '#/definitions/models.Error'
       security:
       - ApiKeyAuth: []
-      summary: Get a stage
+      summary: Gets all services of a stage in a project
       tags:
-      - Projects
+      - Services
   /project/{project}/stage/{stage}/service/{service}:
     get:
       consumes:

--- a/shipyard-controller/handler/evaluationhandler.go
+++ b/shipyard-controller/handler/evaluationhandler.go
@@ -24,7 +24,7 @@ func NewEvaluationHandler(evaluationManager IEvaluationManager) *EvaluationHandl
 // @Summary Trigger a new evaluation
 // @Description Trigger a new evaluation for a service within a project
 // @Tags Evaluation
-// @Security ApiKeyAutth
+// @Security ApiKeyAuth
 // @Accept json
 // @Produce json
 // @Param project path string true "Project"

--- a/shipyard-controller/handler/servicehandler.go
+++ b/shipyard-controller/handler/servicehandler.go
@@ -179,7 +179,7 @@ func (sh *ServiceHandler) GetService(c *gin.Context) {
 // @Success 200 {object} models.ExpandedServices	"ok"
 // @Failure 400 {object} models.Error "Invalid payload"
 // @Failure 500 {object} models.Error "Internal error"
-// @Router /project/{project}/service/{stage} [get]
+// @Router /project/{project}/stage/{stage} [get]
 func (sh *ServiceHandler) GetServices(c *gin.Context) {
 	projectName := c.Param("project")
 	stageName := c.Param("stage")

--- a/shipyard-controller/handler/stagehandler.go
+++ b/shipyard-controller/handler/stagehandler.go
@@ -31,6 +31,7 @@ func NewStageHandler(stageManager IStageManager) *StageHandler {
 // @Security ApiKeyAuth
 // @Accept	json
 // @Produce  json
+// @Param	project				path	string	true	"The name of the project"
 // @Param	pageSize			query		int			false	"The number of items to return"
 // @Param   nextPageKey     	query    	string     	false	"Pointer to the next set of items"
 // @Param   disableUpstreamSync	query		boolean		false	"Disable sync of upstream repo before reading content"


### PR DESCRIPTION
The swagger def of the shipyard controller is invalid.
![image](https://user-images.githubusercontent.com/72415058/111118913-b6363c00-8569-11eb-9d00-9b1afb85ff2a.png)

Fix in `*.go` files.