### PR TITLE
#3546 increase response time thresholds for demo service

### DIFF
--- a/test/assets/quality_gates_standalone_slo_step1.yaml
+++ b/test/assets/quality_gates_standalone_slo_step1.yaml
@@ -12,10 +12,10 @@ objectives:
     pass:             # pass if (relative change <= 75% AND absolute value is < 75ms)
       - criteria:
           - "<=+75%"  # relative values require a prefixed sign (plus or minus)
-          - "<75"     # absolute values only require a logical operator
+          - "<800"     # absolute values only require a logical operator
     warning:          # if the response time is below 200ms, the result should be a warning
       - criteria:
-          - "<=200"
+          - "<=1000"
           - "<=+100%"
     weight: 1
   - sli: "throughput"

--- a/test/assets/quality_gates_standalone_slo_step2.yaml
+++ b/test/assets/quality_gates_standalone_slo_step2.yaml
@@ -12,10 +12,10 @@ objectives:
     pass:             # pass if (relative change <= 75% AND absolute value is < 75ms)
       - criteria:
           - "<=+75%"  # relative values require a prefixed sign (plus or minus)
-          - "<75"     # absolute values only require a logical operator
+          - "<800"     # absolute values only require a logical operator
     warning:          # if the response time is below 200ms, the result should be a warning
       - criteria:
-          - "<=200"
+          - "<=1000"
           - "<=+100%"
     weight: 1
   - sli: "throughput"

--- a/test/assets/quality_gates_standalone_slo_step3.yaml
+++ b/test/assets/quality_gates_standalone_slo_step3.yaml
@@ -12,10 +12,10 @@ objectives:
     pass:             # pass if (relative change <= 75% AND absolute value is < 75ms)
       - criteria:
           - "<=+75%"  # relative values require a prefixed sign (plus or minus)
-          - "<75"     # absolute values only require a logical operator
+          - "<800"     # absolute values only require a logical operator
     warning:          # if the response time is below 200ms, the result should be a warning
       - criteria:
-          - "<=200"
+          - "<=1000"
           - "<=+100%"
     weight: 1
   - sli: "throughput"


### PR DESCRIPTION
Closes #3546 
This PR significantly increases the response time threshold for the demo service we are retrieving the metrics for. Imho the integration tests should not depend on the response time of a demo service.
Signed-off-by: Florian Bacher <florian.bacher@dynatrace.com>