### PR TITLE
swagger-ui: fixed "get services in stage" endpoint description and title

### DIFF
--- a/shipyard-controller/docs/docs.go
+++ b/shipyard-controller/docs/docs.go
@@ -513,6 +513,74 @@ var doc = `{
                 }
             }
         },
+        "/project/{project}/service/{stage}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Gets all services of a stage in a project",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Services"
+                ],
+                "summary": "Gets all services of a stage in a project",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Project",
+                        "name": "project",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Stage",
+                        "name": "stage",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "The number of items to return",
+                        "name": "pageSize",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Pointer to the next set of items",
+                        "name": "nextPageKey",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "ok",
+                        "schema": {
+                            "$ref": "#/definitions/models.ExpandedServices"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid payload",
+                        "schema": {
+                            "$ref": "#/definitions/models.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "$ref": "#/definitions/models.Error"
+                        }
+                    }
+                }
+            }
+        },
         "/project/{project}/stage": {
             "get": {
                 "security": [
@@ -587,7 +655,7 @@ var doc = `{
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Gets all services of a stage in a project",
+                "description": "Get a stage of a project",
                 "consumes": [
                     "application/json"
                 ],
@@ -595,52 +663,40 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Services"
+                    "Projects"
                 ],
-                "summary": "Gets all services of a stage in a project",
+                "summary": "Get a stage",
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Project",
+                        "description": "The name of the project",
                         "name": "project",
                         "in": "path",
                         "required": true
                     },
                     {
                         "type": "string",
-                        "description": "Stage",
+                        "description": "The name of the stage",
                         "name": "stage",
                         "in": "path",
                         "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "The number of items to return",
-                        "name": "pageSize",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Pointer to the next set of items",
-                        "name": "nextPageKey",
-                        "in": "query"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "ok",
                         "schema": {
-                            "$ref": "#/definitions/models.ExpandedServices"
+                            "$ref": "#/definitions/models.ExpandedStage"
                         }
                     },
-                    "400": {
-                        "description": "Invalid payload",
+                    "404": {
+                        "description": "Not found",
                         "schema": {
                             "$ref": "#/definitions/models.Error"
                         }
                     },
                     "500": {
-                        "description": "Internal error",
+                        "description": "Internal Error)",
                         "schema": {
                             "$ref": "#/definitions/models.Error"
                         }
@@ -1217,7 +1273,7 @@ var SwaggerInfo = swaggerInfo{
 	Host:        "",
 	BasePath:    "/v1",
 	Schemes:     []string{},
-	Title:       "Shipyard Controller API",
+	Title:       "Control Plane API",
 	Description: "This is the API documentation of the Shipyard Controller.",
 }
 

--- a/shipyard-controller/docs/docs.go
+++ b/shipyard-controller/docs/docs.go
@@ -513,74 +513,6 @@ var doc = `{
                 }
             }
         },
-        "/project/{project}/service/{stage}": {
-            "get": {
-                "security": [
-                    {
-                        "ApiKeyAuth": []
-                    }
-                ],
-                "description": "Gets all services of a stage in a project",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Services"
-                ],
-                "summary": "Gets all services of a stage in a project",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Project",
-                        "name": "project",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Stage",
-                        "name": "stage",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "The number of items to return",
-                        "name": "pageSize",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Pointer to the next set of items",
-                        "name": "nextPageKey",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "ok",
-                        "schema": {
-                            "$ref": "#/definitions/models.ExpandedServices"
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid payload",
-                        "schema": {
-                            "$ref": "#/definitions/models.Error"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal error",
-                        "schema": {
-                            "$ref": "#/definitions/models.Error"
-                        }
-                    }
-                }
-            }
-        },
         "/project/{project}/stage": {
             "get": {
                 "security": [
@@ -697,6 +629,74 @@ var doc = `{
                     },
                     "500": {
                         "description": "Internal Error)",
+                        "schema": {
+                            "$ref": "#/definitions/models.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/project/{project}/stage/{stage}/service": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Gets all services of a stage in a project",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Services"
+                ],
+                "summary": "Gets all services of a stage in a project",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Project",
+                        "name": "project",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Stage",
+                        "name": "stage",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "The number of items to return",
+                        "name": "pageSize",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Pointer to the next set of items",
+                        "name": "nextPageKey",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "ok",
+                        "schema": {
+                            "$ref": "#/definitions/models.ExpandedServices"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid payload",
+                        "schema": {
+                            "$ref": "#/definitions/models.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
                         "schema": {
                             "$ref": "#/definitions/models.Error"
                         }

--- a/shipyard-controller/docs/swagger.json
+++ b/shipyard-controller/docs/swagger.json
@@ -498,74 +498,6 @@
                 }
             }
         },
-        "/project/{project}/service/{stage}": {
-            "get": {
-                "security": [
-                    {
-                        "ApiKeyAuth": []
-                    }
-                ],
-                "description": "Gets all services of a stage in a project",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Services"
-                ],
-                "summary": "Gets all services of a stage in a project",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Project",
-                        "name": "project",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Stage",
-                        "name": "stage",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "The number of items to return",
-                        "name": "pageSize",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Pointer to the next set of items",
-                        "name": "nextPageKey",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "ok",
-                        "schema": {
-                            "$ref": "#/definitions/models.ExpandedServices"
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid payload",
-                        "schema": {
-                            "$ref": "#/definitions/models.Error"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal error",
-                        "schema": {
-                            "$ref": "#/definitions/models.Error"
-                        }
-                    }
-                }
-            }
-        },
         "/project/{project}/stage": {
             "get": {
                 "security": [
@@ -682,6 +614,74 @@
                     },
                     "500": {
                         "description": "Internal Error)",
+                        "schema": {
+                            "$ref": "#/definitions/models.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/project/{project}/stage/{stage}/service": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Gets all services of a stage in a project",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Services"
+                ],
+                "summary": "Gets all services of a stage in a project",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Project",
+                        "name": "project",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Stage",
+                        "name": "stage",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "The number of items to return",
+                        "name": "pageSize",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Pointer to the next set of items",
+                        "name": "nextPageKey",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "ok",
+                        "schema": {
+                            "$ref": "#/definitions/models.ExpandedServices"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid payload",
+                        "schema": {
+                            "$ref": "#/definitions/models.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
                         "schema": {
                             "$ref": "#/definitions/models.Error"
                         }

--- a/shipyard-controller/docs/swagger.json
+++ b/shipyard-controller/docs/swagger.json
@@ -2,7 +2,7 @@
     "swagger": "2.0",
     "info": {
         "description": "This is the API documentation of the Shipyard Controller.",
-        "title": "Shipyard Controller API",
+        "title": "Control Plane API",
         "contact": {
             "name": "Keptn Team",
             "url": "http://www.keptn.sh"
@@ -498,6 +498,74 @@
                 }
             }
         },
+        "/project/{project}/service/{stage}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Gets all services of a stage in a project",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Services"
+                ],
+                "summary": "Gets all services of a stage in a project",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Project",
+                        "name": "project",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Stage",
+                        "name": "stage",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "The number of items to return",
+                        "name": "pageSize",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Pointer to the next set of items",
+                        "name": "nextPageKey",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "ok",
+                        "schema": {
+                            "$ref": "#/definitions/models.ExpandedServices"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid payload",
+                        "schema": {
+                            "$ref": "#/definitions/models.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "$ref": "#/definitions/models.Error"
+                        }
+                    }
+                }
+            }
+        },
         "/project/{project}/stage": {
             "get": {
                 "security": [
@@ -572,7 +640,7 @@
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Gets all services of a stage in a project",
+                "description": "Get a stage of a project",
                 "consumes": [
                     "application/json"
                 ],
@@ -580,52 +648,40 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Services"
+                    "Projects"
                 ],
-                "summary": "Gets all services of a stage in a project",
+                "summary": "Get a stage",
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Project",
+                        "description": "The name of the project",
                         "name": "project",
                         "in": "path",
                         "required": true
                     },
                     {
                         "type": "string",
-                        "description": "Stage",
+                        "description": "The name of the stage",
                         "name": "stage",
                         "in": "path",
                         "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "The number of items to return",
-                        "name": "pageSize",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Pointer to the next set of items",
-                        "name": "nextPageKey",
-                        "in": "query"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "ok",
                         "schema": {
-                            "$ref": "#/definitions/models.ExpandedServices"
+                            "$ref": "#/definitions/models.ExpandedStage"
                         }
                     },
-                    "400": {
-                        "description": "Invalid payload",
+                    "404": {
+                        "description": "Not found",
                         "schema": {
                             "$ref": "#/definitions/models.Error"
                         }
                     },
                     "500": {
-                        "description": "Internal error",
+                        "description": "Internal Error)",
                         "schema": {
                             "$ref": "#/definitions/models.Error"
                         }

--- a/shipyard-controller/docs/swagger.yaml
+++ b/shipyard-controller/docs/swagger.yaml
@@ -305,7 +305,7 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
-  title: Shipyard Controller API
+  title: Control Plane API
   version: "1.0"
 paths:
   /event:
@@ -615,6 +615,50 @@ paths:
       summary: Delete a service
       tags:
       - Services
+  /project/{project}/service/{stage}:
+    get:
+      consumes:
+      - application/json
+      description: Gets all services of a stage in a project
+      parameters:
+      - description: Project
+        in: path
+        name: project
+        required: true
+        type: string
+      - description: Stage
+        in: path
+        name: stage
+        required: true
+        type: string
+      - description: The number of items to return
+        in: query
+        name: pageSize
+        type: integer
+      - description: Pointer to the next set of items
+        in: query
+        name: nextPageKey
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: ok
+          schema:
+            $ref: '#/definitions/models.ExpandedServices'
+        "400":
+          description: Invalid payload
+          schema:
+            $ref: '#/definitions/models.Error'
+        "500":
+          description: Internal error
+          schema:
+            $ref: '#/definitions/models.Error'
+      security:
+      - ApiKeyAuth: []
+      summary: Gets all services of a stage in a project
+      tags:
+      - Services
   /project/{project}/stage:
     get:
       consumes:
@@ -662,25 +706,17 @@ paths:
     get:
       consumes:
       - application/json
-      description: Gets all services of a stage in a project
+      description: Get a stage of a project
       parameters:
-      - description: Project
+      - description: The name of the project
         in: path
         name: project
         required: true
         type: string
-      - description: Stage
+      - description: The name of the stage
         in: path
         name: stage
         required: true
-        type: string
-      - description: The number of items to return
-        in: query
-        name: pageSize
-        type: integer
-      - description: Pointer to the next set of items
-        in: query
-        name: nextPageKey
         type: string
       produces:
       - application/json
@@ -688,20 +724,20 @@ paths:
         "200":
           description: ok
           schema:
-            $ref: '#/definitions/models.ExpandedServices'
-        "400":
-          description: Invalid payload
+            $ref: '#/definitions/models.ExpandedStage'
+        "404":
+          description: Not found
           schema:
             $ref: '#/definitions/models.Error'
         "500":
-          description: Internal error
+          description: Internal Error)
           schema:
             $ref: '#/definitions/models.Error'
       security:
       - ApiKeyAuth: []
-      summary: Gets all services of a stage in a project
+      summary: Get a stage
       tags:
-      - Services
+      - Projects
   /project/{project}/stage/{stage}/service/{service}:
     get:
       consumes:

--- a/shipyard-controller/docs/swagger.yaml
+++ b/shipyard-controller/docs/swagger.yaml
@@ -615,50 +615,6 @@ paths:
       summary: Delete a service
       tags:
       - Services
-  /project/{project}/service/{stage}:
-    get:
-      consumes:
-      - application/json
-      description: Gets all services of a stage in a project
-      parameters:
-      - description: Project
-        in: path
-        name: project
-        required: true
-        type: string
-      - description: Stage
-        in: path
-        name: stage
-        required: true
-        type: string
-      - description: The number of items to return
-        in: query
-        name: pageSize
-        type: integer
-      - description: Pointer to the next set of items
-        in: query
-        name: nextPageKey
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: ok
-          schema:
-            $ref: '#/definitions/models.ExpandedServices'
-        "400":
-          description: Invalid payload
-          schema:
-            $ref: '#/definitions/models.Error'
-        "500":
-          description: Internal error
-          schema:
-            $ref: '#/definitions/models.Error'
-      security:
-      - ApiKeyAuth: []
-      summary: Gets all services of a stage in a project
-      tags:
-      - Services
   /project/{project}/stage:
     get:
       consumes:
@@ -738,6 +694,50 @@ paths:
       summary: Get a stage
       tags:
       - Projects
+  /project/{project}/stage/{stage}/service:
+    get:
+      consumes:
+      - application/json
+      description: Gets all services of a stage in a project
+      parameters:
+      - description: Project
+        in: path
+        name: project
+        required: true
+        type: string
+      - description: Stage
+        in: path
+        name: stage
+        required: true
+        type: string
+      - description: The number of items to return
+        in: query
+        name: pageSize
+        type: integer
+      - description: Pointer to the next set of items
+        in: query
+        name: nextPageKey
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: ok
+          schema:
+            $ref: '#/definitions/models.ExpandedServices'
+        "400":
+          description: Invalid payload
+          schema:
+            $ref: '#/definitions/models.Error'
+        "500":
+          description: Internal error
+          schema:
+            $ref: '#/definitions/models.Error'
+      security:
+      - ApiKeyAuth: []
+      summary: Gets all services of a stage in a project
+      tags:
+      - Services
   /project/{project}/stage/{stage}/service/{service}:
     get:
       consumes:

--- a/shipyard-controller/handler/servicehandler.go
+++ b/shipyard-controller/handler/servicehandler.go
@@ -179,7 +179,7 @@ func (sh *ServiceHandler) GetService(c *gin.Context) {
 // @Success 200 {object} models.ExpandedServices	"ok"
 // @Failure 400 {object} models.Error "Invalid payload"
 // @Failure 500 {object} models.Error "Internal error"
-// @Router /project/{project}/service/{stage} [get]
+// @Router /project/{project}/stage/{stage}/service [get]
 func (sh *ServiceHandler) GetServices(c *gin.Context) {
 	projectName := c.Param("project")
 	stageName := c.Param("stage")

--- a/shipyard-controller/handler/servicehandler.go
+++ b/shipyard-controller/handler/servicehandler.go
@@ -179,7 +179,7 @@ func (sh *ServiceHandler) GetService(c *gin.Context) {
 // @Success 200 {object} models.ExpandedServices	"ok"
 // @Failure 400 {object} models.Error "Invalid payload"
 // @Failure 500 {object} models.Error "Internal error"
-// @Router /project/{project}/stage/{stage} [get]
+// @Router /project/{project}/service/{stage} [get]
 func (sh *ServiceHandler) GetServices(c *gin.Context) {
 	projectName := c.Param("project")
 	stageName := c.Param("stage")

--- a/shipyard-controller/main.go
+++ b/shipyard-controller/main.go
@@ -15,7 +15,7 @@ import (
 	"os"
 )
 
-// @title Shipyard Controller API
+// @title Control Plane API
 // @version 1.0
 // @description This is the API documentation of the Shipyard Controller.
 


### PR DESCRIPTION
This PR fises the API path for _getting all services in a stage of a project_.
Also it fixes the swagger API title.

Changes in: 
* servicehandler.go
* main.go


Signed-off-by: warber <bernd.warmuth@dynatrace.com>