### PR TITLE
fix apiGroup

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/templates/rbac.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/rbac.yaml
@@ -107,7 +107,7 @@ metadata:
     helm.sh/chart: {{ include "control-plane.chart" . }}
 rules:
   - apiGroups:
-      - ""
+      - rbac.authorization.k8s.io
     resources:
       - roles
     verbs:


### PR DESCRIPTION
apigroup field was missing preventing the secret service from creating roles

Signed-off-by: warber <bernd.warmuth@dynatrace.com>