### PR TITLE
CI workflow tweaks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ on:
     branches:
       - 'master'
       - 'release-*'
-    type: [labeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch: # run CI when triggered manually
 
 defaults:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   lint_shellscripts:
-    runs-on: [ubuntu-latest]
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Run ShellCheck


### PR DESCRIPTION
1. the `types` field is not spelled `type` -- this could mean that the CI pull_request case has been unintentionally doing something totally out of character. -- per https://github.com/keptn/keptn/pull/3752#discussion_r614576353 we've decided that we want `labeled`, `unlabeled`, and the normal `types` defaults (`opened`,`synchronize`, `reopened`).
2. the `runs-on` field wants either a string for a GH hosted runner, or an array for a self-hosted. But shellcheck was using an array for a GH hosted.