### PR TITLE
Run containers as non-root

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -192,7 +192,6 @@ dvcm
 dynatrace
 dynatraceheader
 dynatracelabs
-EAP
 easytravel
 eb
 ebe
@@ -302,7 +301,6 @@ GOTRACEBACK
 goutils
 goutilsmodels
 gpg
-gpu
 grabnerandi
 grep
 grpc
@@ -534,7 +532,6 @@ Nano
 nats
 natsbox
 nbsp
-nc
 nch
 netutil
 Neue
@@ -553,6 +550,7 @@ nodemon
 nodeport
 nokubectl
 noname
+nonroot
 noopener
 Nop
 noreferrer
@@ -760,7 +758,7 @@ strconv
 stretchr
 strfmt
 stringify
-stringp
+Stringp
 structs
 stylesheet
 subdomain

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -37,7 +37,8 @@ RUN sed -i "s/version: develop/${REPLACE}/g" /go/src/github.com/keptn/keptn/api/
 RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v cmd/api-server/main.go
 
 # Use a Docker multi-stage build to create a lean production image.
-FROM alpine:3.11
+FROM alpine:3.13
+
 # we need to install ca-certificates and libc6-compat for go programs to work properly
 RUN apk add --no-cache ca-certificates libc6-compat
 
@@ -57,6 +58,9 @@ ENV GOTRACEBACK=all
 #travis-uncomment ADD MANIFEST /
 #travis-uncomment COPY entrypoint.sh /
 #travis-uncomment ENTRYPOINT ["/entrypoint.sh"]
+
+RUN adduser -D nonroot -u 65532
+USER nonroot
 
 # Run the web service on container startup.
 CMD ["/api", "--host=0.0.0.0", "--port=8080"]

--- a/approval-service/Dockerfile
+++ b/approval-service/Dockerfile
@@ -34,7 +34,7 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o approval
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM alpine:3.11
+FROM alpine:3.13
 # we need to install ca-certificates and libc6-compat for go programs to work properly
 RUN apk add --no-cache ca-certificates libc6-compat
 
@@ -50,6 +50,9 @@ ENV GOTRACEBACK=all
 #travis-uncomment ADD MANIFEST /
 #travis-uncomment COPY entrypoint.sh /
 #travis-uncomment ENTRYPOINT ["/entrypoint.sh"]
+
+RUN adduser -D nonroot -u 65532
+USER nonroot
 
 # Run the web service on container startup.
 CMD ["/approval-service"]

--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -47,4 +47,7 @@ USER myuser
 #travis-uncomment COPY entrypoint.sh /
 #travis-uncomment ENTRYPOINT ["/entrypoint.sh"]
 
+RUN adduser -D nonroot -u 65532
+USER nonroot
+
 CMD ["/usr/local/bin/npm", "start"]

--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -37,7 +37,7 @@ WORKDIR /usr/src/app/server
 RUN npm install
 WORKDIR /usr/src/app
 
-RUN addgroup mygroup && adduser -D -G mygroup myuser && mkdir -p /usr/src/app && chown -R myuser /usr/src/app
+RUN addgroup mygroup --gid 65532 && adduser -D -G mygroup myuser --uid 65532 && mkdir -p /usr/src/app && chown -R myuser /usr/src/app
 
 # Set user
 USER myuser
@@ -46,8 +46,5 @@ USER myuser
 #travis-uncomment ADD MANIFEST /
 #travis-uncomment COPY entrypoint.sh /
 #travis-uncomment ENTRYPOINT ["/entrypoint.sh"]
-
-RUN adduser -D nonroot -u 65532
-USER nonroot
 
 CMD ["/usr/local/bin/npm", "start"]

--- a/configuration-service/Dockerfile
+++ b/configuration-service/Dockerfile
@@ -64,5 +64,8 @@ ENV GOTRACEBACK=all
 #travis-uncomment COPY entrypoint.sh /
 #travis-uncomment ENTRYPOINT ["/entrypoint.sh"]
 
+RUN adduser -D nonroot -u 65532
+USER nonroot
+
 # Run the web service on container startup.
 CMD ["/configuration-service", "--host=0.0.0.0", "--port=8080"]

--- a/configuration-service/restapi/configure_configuration_service.go
+++ b/configuration-service/restapi/configure_configuration_service.go
@@ -122,7 +122,7 @@ func configureTLS(tlsConfig *tls.Config) {
 	// Make all necessary changes to the TLS configuration here.
 }
 
-// As soon as server is initialized but not run yet, this function will be called.
+// As soon as the server is initialized but not run yet, this function will be called.
 // If you need to modify a config, store server instance to stop it individually later, this is the place.
 // This function can be called multiple times, depending on the number of serving schemes.
 // scheme value will be set accordingly: "http", "https" or "unix"

--- a/distributor/Dockerfile
+++ b/distributor/Dockerfile
@@ -35,7 +35,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS 
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM alpine:3.11
+FROM alpine:3.13
 RUN apk add --no-cache ca-certificates libc6-compat
 
 # Copy the binary to the production image from the builder stage.
@@ -49,6 +49,9 @@ ENV GOTRACEBACK=all
 #travis-uncomment ADD MANIFEST /
 #travis-uncomment COPY entrypoint.sh /
 #travis-uncomment ENTRYPOINT ["/entrypoint.sh"]
+
+RUN adduser -D nonroot -u 65532
+USER nonroot
 
 # Run the web service on container startup.
 CMD ["/distributor"]

--- a/installer/manifests/keptn/charts/control-plane/charts/mongodb/templates/deployment.yaml
+++ b/installer/manifests/keptn/charts/control-plane/charts/mongodb/templates/deployment.yaml
@@ -65,6 +65,11 @@ spec:
           volumeMounts:
             - mountPath: /var/lib/mongodb/data
               name: mongodata
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 184
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
       restartPolicy: Always
       volumes:
         - name: mongodata

--- a/installer/manifests/keptn/charts/control-plane/charts/mongodb/templates/deployment.yaml
+++ b/installer/manifests/keptn/charts/control-plane/charts/mongodb/templates/deployment.yaml
@@ -68,7 +68,7 @@ spec:
           securityContext:
             runAsNonRoot: true
             runAsUser: 184
-            readOnlyRootFilesystem: true
+            readOnlyRootFilesystem: false
             allowPrivilegeEscalation: false
       restartPolicy: Always
       volumes:

--- a/installer/manifests/keptn/charts/control-plane/templates/api-gateway-nginx.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/api-gateway-nginx.yaml
@@ -294,6 +294,8 @@ spec:
       annotations: # add randomizer to restart the deployment if anything changes - see https://github.com/keptn/keptn/issues/3320
         rollme: {{ randAlphaNum 5 | quote }}
     spec:
+      securityContext:
+        fsGroup: 101
       containers:
         - name: api-gateway-nginx
           image: {{ .Values.apiGatewayNginx.image.repository }}:{{ .Values.apiGatewayNginx.image.tag }}
@@ -329,6 +331,11 @@ spec:
             limits:
               memory: "128Mi"
               cpu: "250m"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 101
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
       volumes:
         - name: api-nginx-config
           configMap:

--- a/installer/manifests/keptn/charts/control-plane/templates/api-gateway-nginx.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/api-gateway-nginx.yaml
@@ -334,7 +334,7 @@ spec:
           securityContext:
             runAsNonRoot: true
             runAsUser: 101
-            readOnlyRootFilesystem: true
+            readOnlyRootFilesystem: false
             allowPrivilegeEscalation: false
       volumes:
         - name: api-nginx-config

--- a/installer/manifests/keptn/charts/control-plane/templates/continuous-operations.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/continuous-operations.yaml
@@ -29,6 +29,8 @@ spec:
         app.kubernetes.io/version: {{ .Values.remediationService.image.tag | default .Chart.AppVersion }}
         helm.sh/chart: {{ include "control-plane.chart" . }}                   
     spec:
+      securityContext:
+        fsGroup: 65532
       containers:
       - name: remediation-service
         image: {{ .Values.remediationService.image.repository }}:{{ .Values.remediationService.image.tag | default .Chart.AppVersion }}
@@ -68,6 +70,11 @@ spec:
                 key: password
           - name: MONGO_DB_NAME
             value: 'keptn'
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 65532
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
       - name: distributor
         image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
         imagePullPolicy: IfNotPresent
@@ -82,6 +89,11 @@ spec:
             value: 'sh.keptn.event.problem.open,sh.keptn.event.evaluation.finished,sh.keptn.event.action.finished'
           - name: PUBSUB_RECIPIENT
             value: '127.0.0.1'
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 65532
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
       serviceAccountName: keptn-default
 ---
 apiVersion: v1

--- a/installer/manifests/keptn/charts/control-plane/templates/core.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/core.yaml
@@ -73,6 +73,8 @@ spec:
         app.kubernetes.io/version: {{ .Values.apiService.image.tag | default .Chart.AppVersion }}
         helm.sh/chart: {{ include "control-plane.chart" . }}    
     spec:
+      securityContext:
+        fsGroup: 65532
       containers:
         - name: api-service
           image: {{ .Values.apiService.image.repository }}:{{ .Values.apiService.image.tag | default .Chart.AppVersion }}
@@ -105,6 +107,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
         - name: distributor
           image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
           {{- include "control-plane.livenessProbe" . | nindent 10 }}
@@ -121,6 +128,11 @@ spec:
           env:
             - name: PUBSUB_URL
               value: 'nats://keptn-nats-cluster'
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
       serviceAccountName: keptn-api-service
 ---
 apiVersion: v1
@@ -174,6 +186,8 @@ spec:
         app.kubernetes.io/version: {{ .Values.bridge.image.tag | default .Chart.AppVersion }}
         helm.sh/chart: {{ include "control-plane.chart" . }}      
     spec:
+      securityContext:
+        fsGroup: 65532
       containers:
         - name: bridge
           image: {{ .Values.bridge.image.repository }}:{{ .Values.bridge.image.tag | default .Chart.AppVersion }}
@@ -209,6 +223,11 @@ spec:
             limits:
               memory: "128Mi"
               cpu: "500m"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
       serviceAccountName: keptn-default
 
 ---
@@ -265,6 +284,8 @@ spec:
         app.kubernetes.io/version: {{ .Values.shipyardController.image.tag | default .Chart.AppVersion }}
         helm.sh/chart: {{ include "control-plane.chart" . }}
     spec:
+      securityContext:
+        fsGroup: 65532
       serviceAccountName: keptn-shipyard-controller
       containers:
         - name: shipyard-controller
@@ -311,6 +332,11 @@ spec:
             limits:
               memory: "128Mi"
               cpu: "500m"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
         - name: distributor
           image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
           {{- include "control-plane.livenessProbe" . | nindent 10 }}
@@ -333,6 +359,11 @@ spec:
               value: '127.0.0.1'
             - name: PUBSUB_RECIPIENT_PATH
               value: '/v1/event'
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
 ---
 apiVersion: v1
 kind: Service
@@ -407,6 +438,8 @@ spec:
         app.kubernetes.io/version: {{ .Values.secretService.image.tag | default .Chart.AppVersion }}
         helm.sh/chart: {{ include "control-plane.chart" . }}
     spec:
+      securityContext:
+        fsGroup: 65532
       serviceAccountName: keptn-secret-service
       containers:
         - name: secret-service
@@ -436,6 +469,11 @@ spec:
           volumeMounts:
             - mountPath: /data
               name: secret-service-configmap-volume
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
       volumes:
         - name: secret-service-configmap-volume
           configMap:
@@ -516,6 +554,20 @@ spec:
         app.kubernetes.io/version: {{ .Values.configurationService.image.tag | default .Chart.AppVersion }}
         helm.sh/chart: {{ include "control-plane.chart" . }}   
     spec:
+      securityContext:
+        fsGroup: 65532
+      initContainers:
+        - name: change-user-init
+          image: "alpine:3.13"
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - mountPath: /data/config
+              name: configuration-volume
+          command:
+            - sh
+            - -c
+            - chown -R 65532 /data/config
       containers:
         - name: configuration-service
           image: {{ .Values.configurationService.image.repository }}:{{ .Values.configurationService.image.tag | default .Chart.AppVersion }}
@@ -542,6 +594,11 @@ spec:
           volumeMounts:
             - mountPath: /data/config
               name: configuration-volume
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
       volumes:
         - name: configuration-volume
           persistentVolumeClaim:
@@ -601,6 +658,8 @@ spec:
         app.kubernetes.io/version: {{ .Values.statisticsService.image.tag | default .Chart.AppVersion }}
         helm.sh/chart: {{ include "control-plane.chart" . }}
     spec:
+      securityContext:
+        fsGroup: 65532
       serviceAccountName: keptn-default
       containers:
         - name: statistics-service
@@ -641,6 +700,11 @@ spec:
             limits:
               memory: "128Mi"
               cpu: "500m"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
         - name: distributor
           image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
           {{- include "control-plane.livenessProbe" . | nindent 10 }}
@@ -663,6 +727,11 @@ spec:
               value: '127.0.0.1'
             - name: PUBSUB_RECIPIENT_PATH
               value: '/v1/event'
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
 ---
 apiVersion: v1
 kind: Service
@@ -714,6 +783,8 @@ spec:
         app.kubernetes.io/version: {{ .Values.approvalService.image.tag | default .Chart.AppVersion }}
         helm.sh/chart: {{ include "control-plane.chart" . }}
     spec:
+      securityContext:
+        fsGroup: 65532
       serviceAccountName: keptn-default
       containers:
         - name: approval-service
@@ -734,6 +805,11 @@ spec:
               value: 'http://configuration-service:8080'
             - name: EVENTBROKER
               value: 'http://localhost:8081/event'
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
         - name: distributor
           image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
           {{- include "control-plane.livenessProbe" . | nindent 10 }}
@@ -748,6 +824,11 @@ spec:
               value: 'sh.keptn.event.approval.>'
             - name: PUBSUB_RECIPIENT
               value: '127.0.0.1'
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
 ---
 apiVersion: v1
 kind: Service

--- a/installer/manifests/keptn/charts/control-plane/templates/core.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/core.yaml
@@ -597,7 +597,7 @@ spec:
           securityContext:
             runAsNonRoot: true
             runAsUser: 65532
-            readOnlyRootFilesystem: true
+            readOnlyRootFilesystem: false # False is necessary because we have to write the git config file
             allowPrivilegeEscalation: false
       volumes:
         - name: configuration-volume

--- a/installer/manifests/keptn/charts/control-plane/templates/mongodb-datastore.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/mongodb-datastore.yaml
@@ -30,6 +30,8 @@ spec:
         app.kubernetes.io/version: {{ .Values.mongodbDatastore.image.tag | default .Chart.AppVersion }}
         helm.sh/chart: {{ include "control-plane.chart" . }}     
     spec:
+      securityContext:
+        fsGroup: 65532
       serviceAccountName: keptn-default
       containers:
       - name: mongodb-datastore
@@ -62,6 +64,11 @@ spec:
             secretKeyRef:
                 name: mongodb-credentials
                 key: password
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 65532
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
       - name: distributor
         image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
         {{- include "control-plane.livenessProbe" . | nindent 8 }}
@@ -80,6 +87,11 @@ spec:
             value: '127.0.0.1'
           - name: PUBSUB_RECIPIENT_PATH
             value: '/event'
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 65532
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
 ---
 apiVersion: v1
 kind: Service

--- a/installer/manifests/keptn/charts/control-plane/templates/quality-gates.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/quality-gates.yaml
@@ -29,6 +29,8 @@ spec:
         app.kubernetes.io/version: {{ .Values.lighthouseService.image.tag | default .Chart.AppVersion }}
         helm.sh/chart: {{ include "control-plane.chart" . }}         
     spec:
+      securityContext:
+        fsGroup: 65532
       containers:
         - name: lighthouse-service
           image: {{ .Values.lighthouseService.image.repository }}:{{ .Values.lighthouseService.image.tag | default .Chart.AppVersion }}
@@ -56,6 +58,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
         - name: distributor
           image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
           {{- include "control-plane.livenessProbe" . | nindent 10 }}
@@ -70,6 +77,11 @@ spec:
               value: 'sh.keptn.event.evaluation.triggered,sh.keptn.event.get-sli.finished,sh.keptn.event.monitoring.configure'
             - name: PUBSUB_RECIPIENT
               value: '127.0.0.1'
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
       serviceAccountName: keptn-lighthouse-service
 ---
 apiVersion: v1

--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -16,6 +16,11 @@ nats:
   natsbox:
     enabled: false
 
+  securityContext:
+    fsGroup: 1000
+    runAsUser: 1000
+    runAsNonRoot: true
+
 apiGatewayNginx:
   type: ClusterIP
   port: 80

--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -16,11 +16,6 @@ nats:
   natsbox:
     enabled: false
 
-  securityContext:
-    fsGroup: 1000
-    runAsUser: 1000
-    runAsNonRoot: true
-
 apiGatewayNginx:
   type: ClusterIP
   port: 80

--- a/lighthouse-service/Dockerfile
+++ b/lighthouse-service/Dockerfile
@@ -32,7 +32,7 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM alpine:3.11
+FROM alpine:3.13
 # we need to install ca-certificates and libc6-compat for go programs to work properly
 RUN apk add --no-cache ca-certificates libc6-compat
 
@@ -48,6 +48,9 @@ ENV GOTRACEBACK=all
 #travis-uncomment ADD MANIFEST /
 #travis-uncomment COPY entrypoint.sh /
 #travis-uncomment ENTRYPOINT ["/entrypoint.sh"]
+
+RUN adduser -D nonroot -u 65532
+USER nonroot
 
 # Run the web service on container startup.
 CMD ["/lighthouse-service"]

--- a/mongodb-datastore/Dockerfile
+++ b/mongodb-datastore/Dockerfile
@@ -61,5 +61,9 @@ ENV GOTRACEBACK=all
 #travis-uncomment COPY entrypoint.sh /
 #travis-uncomment ENTRYPOINT ["/entrypoint.sh"]
 
+
+RUN adduser -D nonroot -u 65532
+USER nonroot
+
 # Run the web service on container startup.
 CMD ["/mongodb-datastore", "--port=8080", "--host=0.0.0.0"]

--- a/remediation-service/Dockerfile
+++ b/remediation-service/Dockerfile
@@ -33,7 +33,7 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o remediat
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM alpine:3.11
+FROM alpine:3.13
 # we need to install ca-certificates and libc6-compat for go programs to work properly
 RUN apk add --no-cache ca-certificates libc6-compat
 
@@ -56,6 +56,9 @@ ENV GOTRACEBACK=all
 #travis-uncomment ADD MANIFEST /
 #travis-uncomment COPY entrypoint.sh /
 #travis-uncomment ENTRYPOINT ["/entrypoint.sh"]
+
+RUN adduser -D nonroot -u 65532
+USER nonroot
 
 # Run the web service on container startup.
 CMD ["/remediation-service"]

--- a/shipyard-controller/Dockerfile
+++ b/shipyard-controller/Dockerfile
@@ -33,7 +33,7 @@ ARG SKAFFOLD_GO_GCFLAGS
 RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v main.go
 
 # Use a Docker multi-stage build to create a lean production image.
-FROM alpine:3.11
+FROM alpine:3.13
 
 ENV env=production
 
@@ -57,6 +57,9 @@ ENV GOTRACEBACK=all
 #travis-uncomment ADD MANIFEST /
 #travis-uncomment COPY entrypoint.sh /
 #travis-uncomment ENTRYPOINT ["/entrypoint.sh"]
+
+RUN adduser -D nonroot -u 65532
+USER nonroot
 
 # Run the web service on container startup.
 ENV GIN_MODE=release

--- a/statistics-service/Dockerfile
+++ b/statistics-service/Dockerfile
@@ -36,7 +36,7 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v main.go
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM alpine:3.11
+FROM alpine:3.13
 ENV ENV=production
 
 # Install extra packages
@@ -69,6 +69,9 @@ ENV GOTRACEBACK=all
 #travis-uncomment ADD MANIFEST /
 #travis-uncomment COPY entrypoint.sh /
 #travis-uncomment ENTRYPOINT ["/entrypoint.sh"]
+
+RUN adduser -D nonroot -u 65532
+USER nonroot
 
 # Run the web service on container startup.
 ENV GIN_MODE=release


### PR DESCRIPTION
This PR adds securityContext properties to all services of the Keptn control-plane.

Out of scope of this PR:
- helm-service
- jmeter-service
- platform-support/openshift-route-service


Signed-off-by: Andreas Grimmer <andreas.grimmer@dynatrace.com>