### PR TITLE
Remove duplicate livenessProbes

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/templates/core.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/core.yaml
@@ -111,12 +111,6 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 10999
-            initialDelaySeconds: 5
-            periodSeconds: 5
           {{- include "keptn.distributor.resources" . | nindent 10 }}
           env:
             - name: PUBSUB_URL
@@ -298,12 +292,6 @@ spec:
               value: {{ .Values.keptnSpecVersion }}
           ports:
             - containerPort: 8080
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 10999
-            initialDelaySeconds: 5
-            periodSeconds: 5
           resources:
             requests:
               memory: "32Mi"
@@ -317,12 +305,6 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 10999
-            initialDelaySeconds: 5
-            periodSeconds: 5
           {{- include "keptn.distributor.resources" . | nindent 10 }}
           env:
             - name: PUBSUB_URL
@@ -420,12 +402,6 @@ spec:
                   fieldPath: metadata.namespace
           ports:
             - containerPort: 8080
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 10999
-            initialDelaySeconds: 5
-            periodSeconds: 5
           resources:
             requests:
               memory: "32Mi"
@@ -628,12 +604,6 @@ spec:
               value: keptn
           ports:
             - containerPort: 8080
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 10999
-            initialDelaySeconds: 5
-            periodSeconds: 5
           resources:
             requests:
               memory: "32Mi"
@@ -647,12 +617,6 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 10999
-            initialDelaySeconds: 5
-            periodSeconds: 5
           {{- include "keptn.distributor.resources" . | nindent 10 }}
           env:
             - name: PUBSUB_URL


### PR DESCRIPTION
Liveness probes are inserted into all containers through the template,
but some resources have duplicate explicit livenessProbes.

The duplicates can cause issues with othering tooling in advanced
install use cases, such as helm templating. Where other tools are less
forgiving of the duplicates.

This change removes the additional explicit livenessProbe definitions
and leaves all containers to be populated only by the template.

closes #3768
