### PR TITLE
Add new 'env' Helm chart value to add additional environment variables

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/templates/core.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/core.yaml
@@ -204,6 +204,10 @@ spec:
               value: "{{ .Values.bridge.showApiToken.enabled }}"
             - name: KEPTN_INSTALLATION_TYPE
               value: "{{ .Values.bridge.installationType |default (print "QUALITY_GATES,CONTINUOUS_OPERATIONS") }}"
+            {{- range $key, $value := .Values.bridge.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
           envFrom:
             - secretRef:
                 name: bridge-credentials
@@ -558,6 +562,10 @@ spec:
                   fieldPath: metadata.namespace
             - name: DATASTORE_URI
               value: mongodb-datastore:8080
+            {{- range $key, $value := .Values.configurationService.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
           ports:
             - containerPort: 8080
           resources:


### PR DESCRIPTION
Adds new `env` value for `configurationService` and `bridge` which allows additional environment variables to be added to the `Deployment` manifests. This allows `HTTPS_PROXY` and other environment variables to be passed to the services.

E.g.

```console
$ pwd
xxx/keptn/installer/manifests/keptn

$ helm template . -f values.yaml \
    --set control-plane.configurationService.env.HTTPS_PROXY=https://proxy:3128 \
    --set control-plane.configurationService.env.NO_PROXY=localhost \
    --set control-plane.bridge.env.HTTPS_PROXY=https://proxy:3128 \
    --set control-plane.bridge.env.NO_PROXY=localhost \
    | grep -a3 "HTTPS_PROXY"
              value: "true"
            - name: KEPTN_INSTALLATION_TYPE
              value: "QUALITY_GATES,CONTINUOUS_OPERATIONS"
            - name: HTTPS_PROXY
              value: "https://proxy:3128"
            - name: NO_PROXY
              value: "localhost"
--
--
                  fieldPath: metadata.namespace
            - name: DATASTORE_URI
              value: mongodb-datastore:8080
            - name: HTTPS_PROXY
              value: "https://proxy:3128"
            - name: NO_PROXY
              value: "localhost"

$ # Negative test
$ helm template . -f values.yaml | grep "HTTPS_PROXY"

```

Adding the new value to:

* `configurationService` to solve for use case described in #3806 
* `bridge` for the [version check](https://github.com/keptn/keptn/blob/069dd0f5c7b6f37a3737f4c0c9c7cf07a801b039/bridge/server/api/index.js#L61)

Not sure if any other services would require this but can be added in future.

Resolves #3806