### PR TITLE
#3826 Run pull_request CI workflow regardless of type

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,6 @@ on:
     branches:
       - 'master'
       - 'release-*'
-    types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch: # run CI when triggered manually
 
 defaults:


### PR DESCRIPTION
Fixes #3826

As discussed in #3826, I have completely removed `types` in the CI workflow to not have duplicate runs when opening a PR with a label.