### PR TITLE
#3781 Rename rolebinding to get-secrets

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/templates/rbac.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/rbac.yaml
@@ -315,9 +315,9 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: keptn-configuration-service-manage-secrets
+  name: keptn-configuration-service-get-secrets
   labels:
-    app.kubernetes.io/name: keptn-configuration-service-manage-secrets
+    app.kubernetes.io/name: keptn-configuration-service-get-secrets
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}


### PR DESCRIPTION
An error was introduced in https://github.com/keptn/keptn/pull/3782 whereas the roleRef of a rolebinding was changed.

This leads to a problem when upgrading from an older version, e.g.:
```
Start upgrading Helm Chart keptn in namespace keptn
Error: Could not complete Keptn upgrade: Error when installing/upgrading Helm Chart keptn in namespace keptn: cannot patch "keptn-configuration-service-manage-secrets" with kind RoleBinding: RoleBinding.rbac.authorization.k8s.io "keptn-configuration-service-manage-secrets" is invalid: roleRef: Invalid value: rbac.RoleRef{APIGroup:"rbac.authorization.k8s.io", Kind:"Role", Name:"keptn-get-secrets"}: cannot change roleRef 
```

Together with @bacherfl we decided that renaming the rolebinding should fix this problem (and this also ensures that the rolebinding is properly named, in this case).