### PR TITLE
#3350 Fix release name of service charts when upgrading

### DIFF
--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -266,7 +266,7 @@ func doUpgrade() error {
 		}
 
 		for _, serviceChart := range continuousDeliveryServiceCharts {
-			if err := helmHelper.UpgradeChart(serviceChart, keptnReleaseName+serviceChart.Name(), keptnNamespace, values); err != nil {
+			if err := helmHelper.UpgradeChart(serviceChart, serviceChart.Name(), keptnNamespace, values); err != nil {
 				msg := fmt.Sprintf("Could not complete upgrade of Keptn execution plane services: %s \nFor troubleshooting, please check the status of the keptn deployment by executing the following command: \n\nkubectl get pods -n %s\n", err.Error(), keptnNamespace)
 				return errors.New(msg)
 			}


### PR DESCRIPTION
When calling `keptn upgrade`, I noticed the following output:

```
Start upgrading Helm Chart keptnhelm-service in namespace keptn
Finished upgrading Helm Chart keptnhelm-service in namespace keptn
Start upgrading Helm Chart keptnjmeter-service in namespace keptn
Finished upgrading Helm Chart keptnjmeter-service in namespace keptn
```

When looking at the code, it became clear that we were calling the helm release `"keptn" + serviceName`, which is suboptimal. 

As we recommend our users to just use serviceName (e.g., `helm-service`, `jmeter-service` - see https://keptn.sh/docs/0.8.x/operate/multi_cluster/ ), I have change the code accordingly.

In addition, in `install.go` we already use just the service name: 
https://github.com/keptn/keptn/blob/e48cf151297622ad790cdd98f84df78333978dd9/cli/cmd/install.go#L269-L276