### PR TITLE
Set HTTP_SSL_VERIFY based on remoteControlPlane.api.apiValidateTls

### DIFF
--- a/helm-service/chart/templates/deployment.yaml
+++ b/helm-service/chart/templates/deployment.yaml
@@ -116,7 +116,8 @@ spec:
             - name: KEPTN_API_TOKEN
               value: "{{ .Values.remoteControlPlane.api.token }}"
             - name: HTTP_SSL_VERIFY
-              value: "{{ .Values.remoteControlPlane.api.apiValidateTls | default "true" }}"
+              {{- $apiValidateTls := .Values.remoteControlPlane.api.apiValidateTls | ternary "true" "false" }}
+              value: "{{ $apiValidateTls }}"
             {{- end }}
 
       {{- with .Values.nodeSelector }}

--- a/jmeter-service/chart/templates/deployment.yaml
+++ b/jmeter-service/chart/templates/deployment.yaml
@@ -84,7 +84,8 @@ spec:
             - name: KEPTN_API_TOKEN
               value: "{{ .Values.remoteControlPlane.api.token }}"
             - name: HTTP_SSL_VERIFY
-              value: "{{ .Values.remoteControlPlane.api.apiValidateTls | default "true" }}"
+              {{- $apiValidateTls := .Values.remoteControlPlane.api.apiValidateTls | ternary "true" "false" }}
+              value: "{{ $apiValidateTls }}"
             {{- end }}
 
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
Sets the value of `HTTP_SSL_VERIFY` based on the string representation of the boolean value set with `.Values.remoteControlPlane.api.apiValidateTls`.

E.g. usage:

```console
$ pwd
.../keptn/jmeter-service/chart

$ # Still works with apiValidateTls=true
$ helm template . -f values.yaml \
  --set remoteControlPlane.enabled=true \
  --set remoteControlPlane.api.hostname=keptn.replaceme.com \
  --set remoteControlPlane.api.token=xxx \
  --set remoteControlPlane.api.apiValidateTls=true \
    | grep -a1 "HTTP_SSL_VERIFY"
              value: "xxx"
            - name: HTTP_SSL_VERIFY
              value: "true"

$ # Now works with apiValidateTls=false
$ helm template . -f values.yaml \
  --set remoteControlPlane.enabled=true \
  --set remoteControlPlane.api.hostname=keptn.replaceme.com \
  --set remoteControlPlane.api.token=xxx \
  --set remoteControlPlane.api.apiValidateTls=false \
    | grep -a1 "HTTP_SSL_VERIFY"
              value: "xxx"
            - name: HTTP_SSL_VERIFY
              value: "false"
```

Resolves #3865