### PR TITLE
#3843 Fixing CD integration test

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -450,6 +450,7 @@ len
 libc
 libnpx
 lifecycle
+LINENO
 linkcolor
 linkid
 linkmode

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -159,6 +159,7 @@ dbg
 DDTHH
 Debian
 Debugf
+debuglogs
 ded
 deletecollection
 depd
@@ -202,6 +203,7 @@ ecline
 EKS
 elif
 Emoji
+endgroup
 endpointurl
 entrypoint
 enum

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -185,6 +185,9 @@ jobs:
         run: |
           sleep 30
           kubectl run -i --restart=Never --rm test-${RANDOM} --image=alpine:3.13 -- sh -c "wget https://keptn.sh"
+          if [[ $? -ne 0 ]]; then
+            echo "::error::Could not reach https://keptn.sh - this cluster probably has no working network connection (expected for MiniShift).
+          fi
 
       - name: Install Istio
         if: env.CLOUD_PROVIDER != 'minishift-on-GHA' # no need to install istio on minishift

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch: # run integration tests only when triggered manually
     inputs:
       branch:
-        description: 'Branch for integration tests (e.g., master, release-x.y.z)'
+        description: 'Take CI build artifacts from branch (e.g., master, release-x.y.z)'
         required: true
         default: 'master'
       artifacts_ci_event_type:

--- a/test/test_new_artifact.sh
+++ b/test/test_new_artifact.sh
@@ -18,6 +18,7 @@ verify_test_step $? "Deployment carts-db not available, exiting ..."
 
 # trigger delivery for carts
 test/utils/trigger_delivery_sockshop.sh "$PROJECT" docker.io/keptnexamples/carts 0.10.1 delivery
+verify_test_step $? "Delivery of carts 0.10.1 failed"
 
 # wait before sending the next artifact
 echo "Waiting 30sec before continue ..."
@@ -25,5 +26,6 @@ sleep 30
 
 echo "Trigger delivery now"
 test/utils/trigger_delivery_sockshop.sh "$PROJECT" docker.io/keptnexamples/carts 0.10.3 delivery
+verify_test_step $? "Delivery of carts 0.10.3 failed"
 
 exit 0

--- a/test/test_new_artifact.sh
+++ b/test/test_new_artifact.sh
@@ -3,6 +3,27 @@
 # shellcheck disable=SC1091
 source test/utils.sh
 
+function debuglogs() {
+  echo "::group::Namespaces"
+  kubectl get namespaces
+  echo "::endgroup::"
+  echo "::group::Pods"
+  echo "Show pods in all sockshop-* namespaces"
+  kubectl get pods -n "$PROJECT-dev"
+  kubectl get pods -n "$PROJECT-staging"
+  kubectl get pods -n "$PROJECT-prod-a"
+  kubectl get pods -n "$PROJECT-prod-b"
+  echo "::endgroup::"
+  echo "::group::Deployments"
+  echo "Show deployments in all sockshop-* namespaces"
+  kubectl get deployments -n "$PROJECT-dev" -owide
+  kubectl get deployments -n "$PROJECT-staging" -owide
+  kubectl get deployments -n "$PROJECT-prod-a" -owide
+  kubectl get deployments -n "$PROJECT-prod-b" -owide
+  echo "::endgroup::"
+}
+trap debuglogs EXIT SIGINT
+
 echo "---------------------------------------------"
 echo "- Trigger delivery for mongo            -"
 echo "---------------------------------------------"

--- a/test/utils.sh
+++ b/test/utils.sh
@@ -5,7 +5,7 @@ function timestamp() {
 }
 
 function print_error() {
-  echo "::error::$(timestamp) $1"
+  echo "::error file=${BASH_SOURCE[1]##*/},line=${BASH_LINENO[0]}::$(timestamp) ${*}"
 }
 
 function auth_at_keptn() {

--- a/test/utils.sh
+++ b/test/utils.sh
@@ -507,8 +507,10 @@ function verify_sockshop_deployment() {
   KEPTN_NAMESPACE=$5
   BLUE_GREEN_DEPLOYMENT=$6
 
-  echo "-------------------------------------------------------------"
-  echo "Checking ${STAGE} deployment (namespace: ${PROJECT}-${STAGE})"
+  echo ""
+  echo "---------------------------------------------------------------------------------------------------------"
+  echo "Checking ${STAGE} deployment (namespace: ${PROJECT}-${STAGE}) for ${ARTIFACT_IMAGE}:${ARTIFACT_IMAGE_TAG}"
+  echo "---------------------------------------------------------------------------------------------------------"
   echo ""
 
   echo "Pre-req: Checking if carts-db is already running..."
@@ -526,7 +528,7 @@ function verify_sockshop_deployment() {
 
   # verify that a carts deployment is up and running
   wait_for_deployment_with_image_in_namespace "carts" "${PROJECT}-${STAGE}" "${ARTIFACT_IMAGE}:${ARTIFACT_IMAGE_TAG}"
-  verify_test_step $? "Deployment carts not up in ${PROJECT}-${STAGE}, exiting ..."
+  verify_test_step $? "Deployment ${ARTIFACT_IMAGE}:${ARTIFACT_IMAGE_TAG} carts not up in ${PROJECT}-${STAGE}, exiting ..."
 
   # verify that a carts pod is up and running
   verify_pod_in_namespace "carts" "${PROJECT}-${STAGE}"
@@ -535,7 +537,7 @@ function verify_sockshop_deployment() {
   if [[ "${BLUE_GREEN_DEPLOYMENT}" == "true" ]]; then
     # verify that a blue-green carts deployment is up and running
     wait_for_deployment_with_image_in_namespace "carts-primary" "${PROJECT}-${STAGE}" "${ARTIFACT_IMAGE}:${ARTIFACT_IMAGE_TAG}"
-    verify_test_step $? "Deployment carts not up in ${PROJECT}-${STAGE}, exiting ..."
+    verify_test_step $? "Deployment carts ${ARTIFACT_IMAGE}:${ARTIFACT_IMAGE_TAG} not up in ${PROJECT}-${STAGE}, exiting ..."
 
     # verify that a blue-green carts pod is up and running
     verify_pod_in_namespace "carts-primary" "${PROJECT}-${STAGE}"
@@ -546,7 +548,7 @@ function verify_sockshop_deployment() {
   echo "Verifying that the correct image has been deployed..."
   # verify image name of carts deployment
   verify_image_of_deployment "carts" "${PROJECT}-${STAGE}" "${ARTIFACT_IMAGE}:$ARTIFACT_IMAGE_TAG"
-  verify_test_step $? "Wrong image for deployment carts in ${PROJECT}-${STAGE}"
+  verify_test_step $? "Wrong image for deployment carts in ${PROJECT}-${STAGE} - expected ${ARTIFACT_IMAGE}:${ARTIFACT_IMAGE_TAG}"
 
   echo ""
   echo "Trying to access public URI for carts..."

--- a/test/utils.sh
+++ b/test/utils.sh
@@ -557,27 +557,19 @@ function verify_sockshop_deployment() {
 
     # verify that a blue-green carts deployment is up and running
     wait_for_deployment_with_image_in_namespace "carts-primary" "${PROJECT}-${STAGE}" "${ARTIFACT_IMAGE}:${ARTIFACT_IMAGE_TAG}"
-    verify_test_step $? "Deployment carts ${ARTIFACT_IMAGE}:${ARTIFACT_IMAGE_TAG} not up in ${PROJECT}-${STAGE}, exiting ..."
+    verify_test_step $? "Deployment carts-primary with image ${ARTIFACT_IMAGE}:${ARTIFACT_IMAGE_TAG} not up in ${PROJECT}-${STAGE}, exiting ..."
 
     # verify that a blue-green carts pod is up and running
     verify_pod_in_namespace "carts-primary" "${PROJECT}-${STAGE}"
     verify_test_step $? "Pod carts-primary not found, exiting ..."
-
-    # verify image name of carts-primary deployment
-    verify_image_of_deployment "carts-primary" "${PROJECT}-${STAGE}" "${ARTIFACT_IMAGE}:$ARTIFACT_IMAGE_TAG"
-    verify_test_step $? "Wrong image for deployment carts-primary in ${PROJECT}-${STAGE} - expected ${ARTIFACT_IMAGE}:${ARTIFACT_IMAGE_TAG}"
   else # direct deployment
     # verify that a carts deployment is up and running
     wait_for_deployment_with_image_in_namespace "carts" "${PROJECT}-${STAGE}" "${ARTIFACT_IMAGE}:${ARTIFACT_IMAGE_TAG}"
-    verify_test_step $? "Deployment ${ARTIFACT_IMAGE}:${ARTIFACT_IMAGE_TAG} carts not up in ${PROJECT}-${STAGE}, exiting ..."
+    verify_test_step $? "Deployment carts with image ${ARTIFACT_IMAGE}:${ARTIFACT_IMAGE_TAG} carts not up in ${PROJECT}-${STAGE}, exiting ..."
 
     # verify that a carts pod is up and running
     verify_pod_in_namespace "carts" "${PROJECT}-${STAGE}"
     verify_test_step $? "Pod carts not found, exiting ..."
-
-    # verify image name of carts deployment
-    verify_image_of_deployment "carts" "${PROJECT}-${STAGE}" "${ARTIFACT_IMAGE}:$ARTIFACT_IMAGE_TAG"
-    verify_test_step $? "Wrong image for deployment carts in ${PROJECT}-${STAGE} - expected ${ARTIFACT_IMAGE}:${ARTIFACT_IMAGE_TAG}"
   fi
 
   echo ""


### PR DESCRIPTION
Fixes #3843

* made sure that errors are logged using `print_error` rather than just `echo` (`print_error`does an `echo "::error::...."` in the background)
* added verify steps that were missing in several places
* added echo statements that help troubleshooting in the future
* added filename and line number for integration test errors (print_error function)

**Example (from current master branch):**
![image](https://user-images.githubusercontent.com/56065213/116090162-dd714480-a6a3-11eb-97ec-7b7085ee12d7.png)

![image](https://user-images.githubusercontent.com/56065213/116090052-c29ed000-a6a3-11eb-909b-b46ffd070a42.png)


**Example with release-0.8.2 branch**
https://github.com/keptn/keptn/actions/runs/785731421
