### PR TITLE
Re-enable macos builds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -504,10 +504,9 @@ jobs:
           - platform: "ubuntu-20.04"
             GOOS: "linux"
             GOARCH: "arm64"
-# temporarily disable macOS builds due to an issue on GH actions
-#          - platform: "macOS-11.0" # cross-compiling the CLI for macOS does not work - see https://github.com/keptn/keptn/issues/2738
-#            GOOS: "darwin"
-#            GOARCH: "amd64"
+          - platform: "macOS-11.0" # cross-compiling the CLI for macOS does not work - see https://github.com/keptn/keptn/issues/2738
+            GOOS: "darwin"
+            GOARCH: "amd64"
           # support for apple silicon (arm64 on macOS) is pending Go 1.16 release
 #          - platform: "macOS-11.0" # cross-compiling the CLI for macOS does not work - see https://github.com/keptn/keptn/issues/2738
 #            GOOS: "darwin"


### PR DESCRIPTION
We disabled macos builds for the 0.8.2 release as the respective VMs on GitHub were no longer working.

With this PR we are re-enabling macos builds.