### PR TITLE
#3019 added golang ci lint

### DIFF
--- a/.github/actions/spelling/excludes.txt
+++ b/.github/actions/spelling/excludes.txt
@@ -18,3 +18,4 @@ ignore$
 \.sum$
 \.xlf$
 _test\.go$
+.reviewdog.yml

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -292,6 +292,7 @@ gofmt
 gohugoio
 goland
 golang
+golangci
 golangswaggerpaths
 golint
 gomock

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -12,8 +12,10 @@ jobs:
         id: go
       - name: Check out code.
         uses: actions/checkout@v1
-      - name: Install linters
-        run: '( mkdir linters && cd linters && go get golang.org/x/lint/golint )'
+      - name: Install golangci-lint
+        run: |
+          # binary will be $(go env GOPATH)/bin/golangci-lint
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.39.0
       - uses: reviewdog/action-setup@v1
         with:
           reviewdog_version: latest

--- a/.reviewdog.yml
+++ b/.reviewdog.yml
@@ -1,11 +1,9 @@
 runner:
-  # examples
-  golint:
-    cmd: golint ./...
-    errorformat:
-      - "%f:%l:%c: %m"
-    level: warning
   gofmt:
     cmd: gofmt -l .
+    errorformat:
+      - "%f:%l:%c: %m"
+  golangci-lint:
+    cmd: golangci-lint run -E bodyclose,exportloopref,funlen,gocyclo,gosec,nestif,unparam --out-format=line-number ./...
     errorformat:
       - "%f:%l:%c: %m"


### PR DESCRIPTION
Fixes #3019

I also disabled spellchecks for .reviewdog.yml, as I believe this is a file that does not need to be spell checked but will regularly introduce false positive spelling errors.

Example:
![image](https://user-images.githubusercontent.com/56065213/116852484-ae535980-abf4-11eb-8b59-a9dd53d6df97.png)

