### PR TITLE
#3927 Broken UI in quality gates only

### DIFF
--- a/bridge/client/app/_models/root.ts
+++ b/bridge/client/app/_models/root.ts
@@ -98,7 +98,7 @@ export class Root extends Trace {
   }
 
   getEvaluation(stageName: String): Trace {
-    return this.findTrace(t => t.type == EventTypes.EVALUATION_TRIGGERED && t.data.stage == stageName);
+    return this.findTrace(trace => trace.type == EventTypes.EVALUATION_TRIGGERED && trace.data.stage == stageName && trace.traces.some(t => t.type == EventTypes.EVALUATION_STARTED));
   }
 
   getDeploymentDetails(stage: string): Trace {


### PR DESCRIPTION
Retrieve correct evaluation event in case that the sequence and the evaluation event have the same name.

Fixes #3927 
