### PR TITLE
#3961 Show current time instead of ${currentTime}

### DIFF
--- a/bridge/client/app/_views/ktb-integration-view/ktb-integration-view.component.ts
+++ b/bridge/client/app/_views/ktb-integration-view/ktb-integration-view.component.ts
@@ -54,7 +54,7 @@ export class KtbIntegrationViewComponent implements OnInit, OnDestroy {
   updateIntegrations() {
     if (this.keptnInfo && this.keptnInfo.bridgeInfo.keptnInstallationType && this.keptnInfo.bridgeInfo.keptnInstallationType.includes('QUALITY_GATES')) {
       this.currentTime = moment.utc().startOf('minute').format('YYYY-MM-DDTHH:mm:ss');
-      this.useCaseExamples.cli.find(e => e.label === 'Trigger a quality gate evaluation').code = `keptn trigger evaluation --project=\${PROJECT} --stage=\${STAGE} --service=\${SERVICE} --start=\${this.currentTime} --timeframe=5m`;
+      this.useCaseExamples.cli.find(e => e.label === 'Trigger a quality gate evaluation').code = `keptn trigger evaluation --project=\${PROJECT} --stage=\${STAGE} --service=\${SERVICE} --start=${this.currentTime} --timeframe=5m`;
       this.useCaseExamples.api.find(e => e.label === 'Trigger a quality gate evaluation').code = `curl -X POST "\${KEPTN_API_ENDPOINT}/v1/project/\${PROJECT}/stage/\${STAGE}/service/\${SERVICE}/evaluation" \\
     -H "accept: application/json; charset=utf-8" \\
     -H "x-token: \${KEPTN_API_TOKEN}" \\


### PR DESCRIPTION
Show the current time instead of ${currentTime} in trigger evaluation command in integrations page.
Fixes #3961 

Signed-off-by: ermin.muratovic <ermin.muratovic@gmail.com>