### PR TITLE
Fix unit test in Bridge

### DIFF
--- a/bridge/client/app/_pipes/keptn-url.pipe.ts
+++ b/bridge/client/app/_pipes/keptn-url.pipe.ts
@@ -17,7 +17,7 @@ export class KeptnUrlPipe implements PipeTransform {
       KeptnUrlPipe._version = dataservice.keptnInfo;
       KeptnUrlPipe._version
         .pipe(
-          filter(info => !!info.metadata),
+          filter(info => !!info && !!info.metadata),
           take(1)
         )
         .subscribe(info => {

--- a/bridge/client/app/_views/ktb-settings-view/ktb-settings-view.component.spec.ts
+++ b/bridge/client/app/_views/ktb-settings-view/ktb-settings-view.component.spec.ts
@@ -3,6 +3,8 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { KtbSettingsViewComponent } from './ktb-settings-view.component';
 import {AppModule} from "../../app.module";
 import {HttpClientTestingModule} from "@angular/common/http/testing";
+import {DataService} from "../../_services/data.service";
+import {DataServiceMock} from "../../_services/data.service.mock";
 
 describe('KtbSettingsViewComponent', () => {
   let component: KtbSettingsViewComponent;
@@ -12,6 +14,9 @@ describe('KtbSettingsViewComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ KtbSettingsViewComponent ],
       imports: [ AppModule, HttpClientTestingModule ],
+      providers: [
+        {provide: DataService, useClass: DataServiceMock}
+      ]
     })
     .compileComponents();
   }));


### PR DESCRIPTION
Unit tests are failing randomly, because of "keptnInfo" being null. This PR should fix this.

Signed-off-by: ermin.muratovic <ermin.muratovic@gmail.com>