### PR TITLE
Report failing unit tests

### DIFF
--- a/bridge/angular.json
+++ b/bridge/angular.json
@@ -99,7 +99,7 @@
             "polyfills": "client/polyfills.ts",
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
-            "sourceMap": false,
+            "sourceMap": true,
             "codeCoverage": true,
             "watch": false,
             "assets": [

--- a/bridge/karma-headless.conf.js
+++ b/bridge/karma-headless.conf.js
@@ -11,6 +11,7 @@ module.exports = function (config) {
       require('karma-chrome-launcher'),
       require('karma-jasmine-html-reporter'),
       require('karma-coverage-istanbul-reporter'),
+      require('karma-spec-reporter'),
       require('@angular-devkit/build-angular/plugins/karma')
     ],
     client: {
@@ -21,11 +22,12 @@ module.exports = function (config) {
       reports: ['html', 'lcovonly', 'text-summary'],
       fixWebpackSourcePaths: true
     },
-    reporters: ['progress', 'kjhtml'],
+    reporters: ['progress', 'kjhtml', 'spec'],
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: false,
+    sourceMap: true,
     singleRun: true,
     browsers: ['ChromeHeadlessCI'],
     customLaunchers: {

--- a/bridge/karma.conf.js
+++ b/bridge/karma.conf.js
@@ -13,6 +13,7 @@ module.exports = function (config) {
       require('karma-chrome-launcher'),
       require('karma-jasmine-html-reporter'),
       require('karma-coverage-istanbul-reporter'),
+      require('karma-spec-reporter'),
       require('@angular-devkit/build-angular/plugins/karma')
     ],
     client: {
@@ -23,13 +24,13 @@ module.exports = function (config) {
       reports: ['html', 'lcovonly', 'text-summary'],
       fixWebpackSourcePaths: true
     },
-    reporters: ['progress', 'kjhtml'],
+    reporters: ['progress', 'kjhtml', 'spec'],
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
     singleRun: false,
-    sourceMap: false,
+    sourceMap: true,
     codeCoverage: true,
     browsers: ['Chrome'],
     restartOnFileChange: true

--- a/bridge/package-lock.json
+++ b/bridge/package-lock.json
@@ -9490,6 +9490,15 @@
         "source-map-support": "^0.5.5"
       }
     },
+    "karma-spec-reporter": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/karma-spec-reporter/-/karma-spec-reporter-0.0.32.tgz",
+      "integrity": "sha1-LpxyB+pyZ3EmAln4K+y1QyCeRAo=",
+      "dev": true,
+      "requires": {
+        "colors": "^1.1.2"
+      }
+    },
     "keyv": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -83,6 +83,7 @@
     "karma-coverage-istanbul-reporter": "~2.0.1",
     "karma-jasmine": "~2.0.1",
     "karma-jasmine-html-reporter": "^1.5.4",
+    "karma-spec-reporter": "0.0.32",
     "minimist": "^1.2.5",
     "nodemon": "^2.0.4",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
This PR enhances our karma configuration for Bridge such that it reports failing unit tests by name (generated out of the spec file).

For this I had to add the karma-spec-reporter.
In addition, I enabled `sourceMap` such that we get stacktraces with typescript files, not the generated js files.