### PR TITLE
Check spelling 0.0.18 updates

### DIFF
--- a/.github/actions/spelling/advice.md
+++ b/.github/actions/spelling/advice.md
@@ -1,0 +1,27 @@
+<!-- See https://github.com/check-spelling/check-spelling/wiki/Configuration-Examples%3A-advice --> <!-- markdownlint-disable MD033 MD041 -->
+<details><summary>If you see a bunch of garbage</summary>
+
+If it relates to a ...
+<details><summary>well-formed pattern</summary>
+
+See if there's a [pattern](https://github.com/check-spelling/check-spelling/wiki/Configuration-Examples:-patterns) that would match it.
+
+If not, try writing one and adding it to the `patterns.txt` file.
+
+Patterns are Perl 5 Regular Expressions - you can [test](
+https://www.regexplanet.com/advanced/perl/) yours before committing to verify it will match your lines.
+
+Note that patterns can't match multiline strings.
+</details>
+<details><summary>binary-ish string</summary>
+
+Please add a file path to the `excludes.txt` file instead of just accepting the garbage.
+
+File paths are Perl 5 Regular Expressions - you can [test](
+https://www.regexplanet.com/advanced/perl/) yours before committing to verify it will match your files.
+
+`^` refers to the file's path from the root of the repository, so `^README\.md$` would exclude [README.md](
+../tree/HEAD/README.md) (on whichever branch you're using).
+</details>
+
+</details>

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -11,11 +11,12 @@ on:
     tags-ignore:
       - "**"
     types: ['opened', 'reopened', 'synchronize']
+  issue_comment:
 
 jobs:
   build:
     name: Spell checking
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: checkout-merge
       if: "contains(github.event_name, 'pull_request')"


### PR DESCRIPTION
Follow-up to #3951

The comment handler needs to be included, otherwise it doesn't work (oops).

The advice file is tunable, this one is from https://github.com/check-spelling/spell-check-this/blob/main/.github/actions/spelling/advice.md