### PR TITLE
Turn off talk-to-bot feature

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -10,7 +10,6 @@ on:
     tags-ignore:
       - "**"
     types: ['opened', 'reopened', 'synchronize']
-  issue_comment:
 
 jobs:
   build:
@@ -26,5 +25,3 @@ jobs:
       if: "!contains(github.event_name, 'pull_request')"
       uses: actions/checkout@v2.0.0
     - uses: check-spelling/check-spelling@v0.0.18
-      with:
-        experimental_apply_changes_via_bot: 1


### PR DESCRIPTION
It's experiential. And this repository identified a logic issue:

There's code to check for:
* Is the commenter allowed to make a request
* Is the comment addressed to the bot
* Does the comment have an action

Unfortunately, right now, it provides feedback for the first thing, but it should only do that if it knows it's being addressed.

I'll fix it (hopefully tonight after work), but it'll need a new release.