### PR TITLE
disabled annotations from codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -29,6 +29,9 @@ ignore:
 comment:
   show_carryforward_flags: true # see https://docs.codecov.io/docs/carryforward-flags
 
+github_checks:
+  annotations: false
+
 flags:
   microservices:
     carryforward: true # see https://docs.codecov.io/docs/carryforward-flags


### PR DESCRIPTION
This PR disables the codecov PR annotation feature.

Signed-off-by: warber <bernd.warmuth@dynatrace.com>