### PR TITLE
#3990 Improve integration test output

### DIFF
--- a/jmeter-service/main.go
+++ b/jmeter-service/main.go
@@ -100,6 +100,7 @@ func runTests(event cloudevents.Event, shkeptncontext string, data keptnv2.TestT
 	var res bool
 	healthCheckWorkload, err = getWorkload(jmeterconf, TestStrategy_HealthCheck)
 	if healthCheckWorkload != nil {
+		// do a basic health check, verifying whether the endpoint is available or not
 		err := checkEndpointAvailable(5*time.Second, serviceUrl)
 		if err != nil {
 			msg := fmt.Sprintf("Jmeter-service cannot reach URL %s: %s", serviceUrl, err.Error())

--- a/test/test_new_artifact.sh
+++ b/test/test_new_artifact.sh
@@ -21,6 +21,14 @@ function debuglogs() {
   kubectl get deployments -n "$PROJECT-prod-a" -owide
   kubectl get deployments -n "$PROJECT-prod-b" -owide
   echo "::endgroup::"
+  echo "::group::CloudEvents Carts DB"
+  echo "Show CloudEvents for service carts-db"
+  keptn get event --project="$PROJECT" --service=carts-db
+  echo "::endgroup::"
+  echo "::group::CloudEvents Carts"
+  echo "Show CloudEvents for service carts"
+  keptn get event --project="$PROJECT" --service=carts
+  echo "::endgroup::"
 }
 trap debuglogs EXIT SIGINT
 


### PR DESCRIPTION
Linked to #3990 

Improve output of continuous-delivery integration tests, by printing cloudevents.