### PR TITLE
#4000 Fix golangci-lint problem with Go 1.16

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -22,5 +22,6 @@ jobs:
       - name: Run reviewdog
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GO111MODULE: "off" # required for golangci-lint - see https://github.com/keptn/keptn/issues/4000 / https://github.com/golangci/golangci-lint/issues/1833
         run: |
           reviewdog -reporter=github-pr-review


### PR DESCRIPTION
Fixes #4000

The fix is as simple as setting `GO111MODULE=off ` (see https://github.com/golangci/golangci-lint/issues/1833)