### PR TITLE
#3876 do not cache index.html

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -217,6 +217,7 @@ errstr
 eslint
 esnext
 esource
+etag
 Eter
 euo
 evaluationdetails

--- a/bridge/server/app.js
+++ b/bridge/server/app.js
@@ -34,7 +34,18 @@ module.exports = (async function (){
   app.use('/static', express.static(path.join(__dirname, 'views/static'), {maxAge: oneWeek}));
 
   // UI static files - Angular application
-  app.use(express.static(path.join(__dirname, '../dist'), {maxAge: oneWeek}));
+  app.use(express.static(path.join(__dirname, '../dist'), {
+    maxAge: oneWeek, // cache files for one week
+    etag: true, // Just being explicit about the default.
+    lastModified: true,  // Just being explicit about the default.
+    setHeaders: (res, path) => {
+      // however, do not cache .html files (e.g., index.html)
+      if (path.endsWith('.html')) {
+        res.setHeader('Cache-Control', 'no-cache');
+      }
+    },
+  })
+  );
 
   // Server views based on Pug
   app.set('views', path.join(__dirname, 'views'));
@@ -102,7 +113,7 @@ module.exports = (async function (){
 // fallback: go to index.html
   app.use((req, res, next) => {
     console.error("Not found: " + req.url);
-    res.sendFile(path.join(`${__dirname}/../dist/index.html`));
+    res.sendFile(path.join(`${__dirname}/../dist/index.html`), {maxAge: 0});
   });
 
 // error handler


### PR DESCRIPTION
Fixes #3876 by introducing a function that prevents .HTML files from being cached.

Installed it on my Kubernetes cluster and verified it works.