### PR TITLE
#3944 Allow switching the project while keeping the context

### DIFF
--- a/bridge/client/app/app-header/app-header.component.html
+++ b/bridge/client/app/app-header/app-header.component.html
@@ -6,8 +6,11 @@
     </a>
     <p class="m-2">/</p>
     <p class="m-0">
+      <!-- Show projects picker -->
       <dt-select id="projectSelect" placeholder="Choose project" aria-label="Choose project" [value]="(project | async)?.projectName">
-        <dt-option *ngFor="let project of projects | async" [routerLink]="['/project', project.projectName]" [value]="project.projectName" [textContent]="project.projectName"></dt-option>
+        <dt-option *ngFor="let project of projects | async"
+                   [routerLink]="getRouterLink(project.projectName)"
+                   [value]="project.projectName" [textContent]="project.projectName"></dt-option>
       </dt-select>
     </p>
   </dt-top-bar-navigation-item>


### PR DESCRIPTION
Fixes #3944

I noticed that routing for this case is not implemented using angular router, but using a switch/case statement in project board:

https://github.com/keptn/keptn/blob/da5859fb8291894c6b019d60781834db4192eb09/bridge/client/app/project-board/project-board.component.html#L64-L71

This leads to call kind of strange effects, like the fact that the route itself is not really changing. Hence I needed to 

a) implement the hacky `getRouterLink` to handle the case of the environment screen (you can't route to `/projects/${PROJECTNAME}/environment` nor `/projects/${PROJECTNAME}/environment`, as it redirects you to `service/environment` or `/service/` respectively,
b) add implementation to the router events (for the case of `NavigationEnd`) to parse the URL and extract a certain part of the URL.

I believe this part is in desperate need of refactoring, though as the issue was rated with 1 SP, I will create an issue that proposes refactoring (-> https://github.com/keptn/keptn/issues/4022 )