### PR TITLE
Added header for get-action event

### DIFF
--- a/cli/internal/cespec/genspec.go
+++ b/cli/internal/cespec/genspec.go
@@ -58,6 +58,7 @@ func Generate(outputDir string) {
 	md.Bullet().Link("Test", "#test")
 	md.Bullet().Link("Evaluation", "#evaluation")
 	md.Bullet().Link("Release", "#release")
+	md.Bullet().Link("Get-Action", "#get-action")
 	md.Bullet().Link("Remediation", "#remediation")
 	md.Bullet().Link("Action", "#action")
 	md.Bullet().Link("Get-SLI", "#get-sli")


### PR DESCRIPTION
The header for the get-action event was missing in the cloudevent spec generation
Signed-off-by: Florian Bacher <florian.bacher@dynatrace.com>