### PR TITLE
Use retry function for fetching .finished event

### DIFF
--- a/test/test_self_healing.sh
+++ b/test/test_self_healing.sh
@@ -180,7 +180,7 @@ keptn_context_id=$(send_event_json ./test/assets/self_healing_remediation_trigge
 
 sleep 10
 
-response=$(get_keptn_event "$PROJECT" "$keptn_context_id" sh.keptn.event.production.remediation.finished "$KEPTN_ENDPOINT" "$KEPTN_API_TOKEN")
+response=$(get_event_with_retry sh.keptn.event.production.remediation.finished "$keptn_context_id" "$PROJECT")
 # print the response
 echo "$response" | jq .
 


### PR DESCRIPTION
Closes #4100
On minishift, we had a timing issue because we were not waiting long enough for the `remediation.finished` event to be available. This PR makes the self healing test more robust by using the `get_event_with_retry` function to fetch the `remediation.finished` event.

Integration test run: https://github.com/keptn/keptn/actions/runs/853587298

Signed-off-by: Florian Bacher <florian.bacher@dynatrace.com>