### PR TITLE
Helm Schema: Repository might contain a digit on the start

### DIFF
--- a/helm-service/chart/values.schema.json
+++ b/helm-service/chart/values.schema.json
@@ -57,7 +57,7 @@
         "image": {
           "properties": {
             "repository": {
-              "pattern": "^[a-z][a-z0-9-./]{2,63}$"
+              "pattern": "^[a-z0-9][a-z0-9-./]{2,63}$"
             },
             "pullPolicy": {
               "enum": [
@@ -85,7 +85,7 @@
         "image": {
           "properties": {
             "repository": {
-              "pattern": "[a-z][a-z0-9-./]{2,63}$"
+              "pattern": "[a-z0-9][a-z0-9-./]{2,63}$"
             },
             "pullPolicy": {
               "enum": [

--- a/jmeter-service/chart/values.schema.json
+++ b/jmeter-service/chart/values.schema.json
@@ -57,7 +57,7 @@
         "image": {
           "properties": {
             "repository": {
-              "pattern": "^[a-z][a-z0-9-./]{2,63}$"
+              "pattern": "^[a-z0-9][a-z0-9-./]{2,63}$"
             },
             "pullPolicy": {
               "enum": [
@@ -85,7 +85,7 @@
         "image": {
           "properties": {
             "repository": {
-              "pattern": "[a-z][a-z0-9-./]{2,63}$"
+              "pattern": "[a-z0-9][a-z0-9-./]{2,63}$"
             },
             "pullPolicy": {
               "enum": [


### PR DESCRIPTION
As AWS repositories often start with digits and the current JSON schema does not allow this at the moment, this has been added.