### PR TITLE
#3688 Show bridge URL when executing keptn configure bridge --output

### DIFF
--- a/cli/cmd/configure_bridge.go
+++ b/cli/cmd/configure_bridge.go
@@ -60,6 +60,8 @@ func configureBridge(endpoint string, apiToken string, configureBridgeParams *co
 			fmt.Println("Could not retrieve bridge credentials: " + err.Error())
 			return err
 		}
+		fmt.Println("Your Keptn Bridge is available under: " + endpoint)
+		fmt.Println("\nThese are your credentials")
 		fmt.Println("user: " + creds.User)
 		fmt.Println("password: " + creds.Password)
 		return nil


### PR DESCRIPTION
Tries to address #3688.

The output of
```shell
keptn configure bridge -o
```
now looks like this
```shell
Your Keptn Bridge is available under: https://yourkeptn.com/bridge

These are your credentials
user: keptn
password: Axxxxxxxx
```