### PR TITLE
CLI: Disable Kubernetes Context Check

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -210,7 +210,6 @@ errored
 Errorf
 errstr
 eslint
-esnext
 esource
 etag
 Eter
@@ -307,7 +306,6 @@ guiclass
 gunzip
 gws
 halem
-hammerjs
 hardcoded
 hardenings
 hashicorp
@@ -356,7 +354,6 @@ ioutil
 ipaddress
 IProject
 iptables
-IRemediation
 IResource
 ISecret
 ISequence
@@ -433,6 +430,7 @@ KTSESSION
 kube
 kubeclient
 kubeconfig
+kubecontextcheck
 kubectl
 kubernetes
 kvm
@@ -566,7 +564,6 @@ ojsonpath
 okm
 OLDVAL
 omitempty
-OOM
 onboarded
 onboarder
 onboarding
@@ -574,6 +571,7 @@ onboards
 onclick
 oneof
 onespace
+OOM
 openapi
 openapierrors
 openjdk
@@ -604,7 +602,6 @@ png
 poddescriptions
 podlogs
 polyfills
-postcss
 powershell
 pprove
 prebuilt
@@ -614,7 +611,6 @@ printf
 Println
 prj
 problemdetails
-problemtype
 productpage
 PROJ
 projectes

--- a/cli/cmd/set_config.go
+++ b/cli/cmd/set_config.go
@@ -45,16 +45,23 @@ var setConfigCmd = &cobra.Command{
 		case "automaticversioncheck":
 			val, err := strconv.ParseBool(args[1])
 			if err != nil {
-				return fmt.Errorf("error when parsing value %v", err)
+				return fmt.Errorf("error when parsing value %w", err)
 			}
 			cliConfig.AutomaticVersionCheck = val
 			newConfig = true
 		case "lastversioncheck":
 			val, err := time.Parse("RFC3339", args[1])
 			if err != nil {
-				return fmt.Errorf("error when parsing value %v", err)
+				return fmt.Errorf("error when parsing value %w", err)
 			}
 			cliConfig.LastVersionCheck = &val
+			newConfig = true
+		case "kubecontextcheck":
+			val, err := strconv.ParseBool(args[1])
+			if err != nil {
+				return fmt.Errorf("error when parsing value %w", err)
+			}
+			cliConfig.KubeContextCheck = val
 			newConfig = true
 		default:
 			return fmt.Errorf("Unsupported key %s", args[0])

--- a/cli/pkg/config/cli_config.go
+++ b/cli/pkg/config/cli_config.go
@@ -14,6 +14,7 @@ import (
 // CLIConfig holds infos of the CLI config
 type CLIConfig struct {
 	AutomaticVersionCheck bool       `json:"automatic_version_check"`
+	KubeContextCheck      bool       `json:"kube_context_check"`
 	LastVersionCheck      *time.Time `json:"last_version_check"`
 	CurrentContext        string     `json:"current-context"`
 }
@@ -37,18 +38,17 @@ func NewCLIConfigManager() *CLIConfigManager {
 
 // LoadCLIConfig loads the configuration from file
 func (c *CLIConfigManager) LoadCLIConfig() (CLIConfig, error) {
-
-	cliConfig := CLIConfig{AutomaticVersionCheck: true}
+	cliConfig := CLIConfig{AutomaticVersionCheck: true, KubeContextCheck: true}
 	if !fileutils.FileExists(c.CLIConfigPath) {
 		return cliConfig, nil
 	}
 
 	data, err := fileutils.ReadFile(c.CLIConfigPath)
 	if err != nil {
-		return cliConfig, fmt.Errorf("error when reading config file: %v", err)
+		return cliConfig, fmt.Errorf("error when reading config file: %w", err)
 	}
 	if err := json.Unmarshal(data, &cliConfig); err != nil {
-		return cliConfig, fmt.Errorf("error when unmarshalling config file: %v", err)
+		return cliConfig, fmt.Errorf("error when unmarshalling config file: %w", err)
 	}
 
 	return cliConfig, nil
@@ -58,10 +58,10 @@ func (c *CLIConfigManager) LoadCLIConfig() (CLIConfig, error) {
 func (c *CLIConfigManager) StoreCLIConfig(config CLIConfig) error {
 	data, err := json.Marshal(config)
 	if err != nil {
-		return fmt.Errorf("error when marshalling config file: %v", err)
+		return fmt.Errorf("error when marshalling config file: %w", err)
 	}
 	if err := ioutil.WriteFile(c.CLIConfigPath, []byte(data), 0644); err != nil {
-		return fmt.Errorf("error when writing config file: %v", err)
+		return fmt.Errorf("error when writing config file: %w", err)
 	}
 	return nil
 }

--- a/cli/pkg/config/cli_config_test.go
+++ b/cli/pkg/config/cli_config_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-const testConfig = `{"automatic_version_check":true,"last_version_check":"2020-02-20T00:00:00Z","current-context":""}`
+const testConfig = `{"automatic_version_check":true,"kube_context_check":true,"last_version_check":"2020-02-20T00:00:00Z","current-context":""}`
 
 var testTime time.Time
 
@@ -19,7 +19,6 @@ func init() {
 }
 
 func TestLoadNonExistingCLIConfig(t *testing.T) {
-
 	mng := NewCLIConfigManager()
 	tmpDir, err := ioutil.TempDir("", "")
 	if err != nil {
@@ -43,7 +42,6 @@ func TestLoadNonExistingCLIConfig(t *testing.T) {
 }
 
 func TestStoreCLIConfig(t *testing.T) {
-
 	mng := NewCLIConfigManager()
 	tmpDir, err := ioutil.TempDir("", "")
 	if err != nil {
@@ -54,7 +52,7 @@ func TestStoreCLIConfig(t *testing.T) {
 
 	mng.CLIConfigPath = filepath.Join(tmpDir, "config")
 
-	cliConfig := CLIConfig{AutomaticVersionCheck: true, LastVersionCheck: &testTime}
+	cliConfig := CLIConfig{AutomaticVersionCheck: true, KubeContextCheck: true, LastVersionCheck: &testTime}
 
 	err = mng.StoreCLIConfig(cliConfig)
 	if err != nil {
@@ -71,7 +69,6 @@ func TestStoreCLIConfig(t *testing.T) {
 }
 
 func TestLoadCLIConfig(t *testing.T) {
-
 	mng := NewCLIConfigManager()
 	tmpDir, err := ioutil.TempDir("", "")
 	if err != nil {

--- a/cli/pkg/credentialmanager/handler.go
+++ b/cli/pkg/credentialmanager/handler.go
@@ -189,7 +189,6 @@ func getCurrentContextFromKubeConfig() error {
 }
 
 func checkForContextChange(cliConfigManager *config.CLIConfigManager, autoApplyNewContext bool) error {
-
 	if MockAuthCreds || MockKubeConfigCheck {
 		// Do nothing
 		return nil
@@ -198,21 +197,25 @@ func checkForContextChange(cliConfigManager *config.CLIConfigManager, autoApplyN
 	if err != nil {
 		log.Fatal(err)
 	}
-	// Setting keptnContext from ~/.keptn/config file
-	keptnContext = cliConfig.CurrentContext
-	if kubeConfigFile.CurrentContext != "" && keptnContext != kubeConfigFile.CurrentContext {
-		fmt.Printf("Kube context has been changed to %s\n", kubeConfigFile.CurrentContext)
-		if keptnContext != "" {
-			userConfirmation := common.NewUserInput().AskBool("Do you want to switch to the new Kube context with the Keptn running there?", &common.UserInputOptions{AssumeYes: autoApplyNewContext})
-			if !userConfirmation {
-				return nil
+
+	if cliConfig.KubeContextCheck {
+		// Setting keptnContext from ~/.keptn/config file
+		keptnContext = cliConfig.CurrentContext
+		if kubeConfigFile.CurrentContext != "" && keptnContext != kubeConfigFile.CurrentContext {
+			fmt.Printf("Kube context has been changed to %s\n", kubeConfigFile.CurrentContext)
+			if keptnContext != "" {
+				userConfirmation := common.NewUserInput().AskBool("Do you want to switch to the new Kube context with the Keptn running there?", &common.UserInputOptions{AssumeYes: autoApplyNewContext})
+				fmt.Println("Info: You can turn off the Kube context check by executing: keptn set config KubeContextCheck false")
+				if !userConfirmation {
+					return nil
+				}
 			}
-		}
-		cliConfig.CurrentContext = kubeConfigFile.CurrentContext
-		keptnContext = kubeConfigFile.CurrentContext
-		err = cliConfigManager.StoreCLIConfig(cliConfig)
-		if err != nil {
-			return err
+			cliConfig.CurrentContext = kubeConfigFile.CurrentContext
+			keptnContext = kubeConfigFile.CurrentContext
+			err = cliConfigManager.StoreCLIConfig(cliConfig)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
fixes #3666 

The user is now able to permanently disable the kube context check via `keptn set config KubeContextCheck false`

Signed-off-by: warber <bernd.warmuth@dynatrace.com>