### PR TITLE
#4143 Determine remediation sequence correctly as faulty

### DIFF
--- a/bridge/client/app/_components/ktb-root-events-list/ktb-root-events-list.component.html
+++ b/bridge/client/app/_components/ktb-root-events-list/ktb-root-events-list.component.html
@@ -1,8 +1,8 @@
 <div fxLayout="column" fxLayoutGap="5px">
   <div *ngFor="let event of _events;trackBy: identifyEvent">
     <ktb-selectable-tile (click)="selectEvent(event)"
-                         [error]="event.isFaulty() && (!event.isProblem() || event.isFaulty() != event.isSuccessful())"
-                         [success]="!event.isFaulty() && event.isFinished()"
+                         [error]="event.isFinished() && event.isFaulty()"
+                         [success]="event.isFinished() && !event.isFaulty()"
                          [highlight]="!!event.getPendingApproval()" [selected]="_selectedEvent == event"
                          *ngIf="event">
       <ktb-selectable-tile-header>

--- a/bridge/client/app/_models/event-types.ts
+++ b/bridge/client/app/_models/event-types.ts
@@ -24,6 +24,7 @@ export enum EventTypes {
   REMEDIATION_TRIGGERED_SUFFIX = 'remediation.triggered',
   REMEDIATION_TRIGGERED = 'sh.keptn.event.remediation.triggered',
   REMEDIATION_STATUS_CHANGED = 'sh.keptn.event.remediation.status.changed',
+  REMEDIATION_FINISHED_SUFFIX = 'remediation.finished',
   REMEDIATION_FINISHED = 'sh.keptn.event.remediation.finished',
   ACTION_TRIGGERED = 'sh.keptn.event.action.triggered',
   ACTION_STARTED = 'sh.keptn.event.action.started',

--- a/bridge/client/app/_models/root.ts
+++ b/bridge/client/app/_models/root.ts
@@ -1,12 +1,18 @@
 import {Trace} from "./trace";
 import {EventTypes} from "./event-types";
-import {Stage} from "./stage";
 
 export class Root extends Trace {
   traces: Trace[] = [];
 
   isFaulty(): string {
-    return this.findLastTrace(t => t.isSequence() && t.getEvaluation() != null)?.isFaulty() || null;
+    // a Sequence is faulty, if there is a sequence that is faulty, but no other sequence that is successful on the same stage
+    let result: string = null;
+    this.getStages().forEach(stage => {
+      let stageTraces = this.traces.filter(t => t.getStage() == stage);
+      if(stageTraces.some(t => t.isFaulty() != null) && !stageTraces.some(t => t.isSuccessful() != null))
+        result = stage;
+    });
+    return result;
   }
 
   isStarted(): boolean {

--- a/bridge/client/app/_models/service.ts
+++ b/bridge/client/app/_models/service.ts
@@ -35,7 +35,8 @@ export class Service {
   }
 
   getOpenProblems(): Trace[] {
-    return this.roots?.filter(root => root.isProblem() && !root.isProblemResolvedOrClosed() || root.isRemediation() && !root.isFinished()) || [];
+    // show running remediation or last faulty remediation
+    return this.roots?.filter((root, index) => root.isRemediation() && (!root.isFinished() || root.isFaulty() && index == 0)) || [];
   }
 
   getRecentSequence(): Root {

--- a/bridge/client/app/_models/trace.ts
+++ b/bridge/client/app/_models/trace.ts
@@ -119,7 +119,8 @@ class Trace {
     if(this.data) {
       if(this.isFailed() ||
         (this.isProblem() && !this.isProblemResolvedOrClosed()) ||
-        this.traces.some(t => t.isFailed() || (t.isProblem() && !t.isProblemResolvedOrClosed()))) {
+        (this.isRemediation() && !this.isSuccessfulRemediation()) ||
+        this.traces.some(t => t.isFaulty() != null)) {
         result = this.data.stage;
       }
     }
@@ -180,7 +181,10 @@ class Trace {
   }
 
   public isSuccessfulRemediation(): boolean {
-    return this.type === EventTypes.REMEDIATION_FINISHED && this.data.result == ResultTypes.PASSED;
+    if (!this.traces || this.traces.length === 0)
+      return this.type.endsWith(EventTypes.REMEDIATION_FINISHED_SUFFIX) && this.data.result !== ResultTypes.FAILED;
+    else
+      return this.traces.some(t => t.isSuccessfulRemediation());
   }
 
   public isApproval(): string {


### PR DESCRIPTION
Determine remediation sequence correctly as faulty, if all actions are faulty and show running remediation or last faulty remediation in environments screen.

All actions failed:
![image](https://user-images.githubusercontent.com/6098219/119103264-3f129d80-ba1b-11eb-96ee-bfe78920798c.png)

Last action succeeded:
![image](https://user-images.githubusercontent.com/6098219/119103450-7a14d100-ba1b-11eb-9304-dc29c32edaf8.png)

But, Delivery failed, although Rollback sequence is last and "succeeded":
![image](https://user-images.githubusercontent.com/6098219/119103326-52be0400-ba1b-11eb-9c0e-edfc04b372a1.png)


Signed-off-by: ermin.muratovic <ermin.muratovic@gmail.com>