### PR TITLE
Load traces in the sequence screen for not selected sequences

### DIFF
--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.html
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.html
@@ -1,8 +1,8 @@
-<div class="container p-0" fxFlex="40" fxLayout="column" fxLayoutGap="15px" *ngIf="project$ | async as project">
+<div class="container p-0" fxFlex="40" fxLayout="column" fxLayoutGap="15px" *ngIf="roots$ | async as roots">
   <div fxFlex fxLayout="column" fxLayoutGap="15px">
     <dt-quick-filter [dataSource]="_filterDataSource" [filters]="_seqFilters" (filterChanges)="filtersChanged($event)" aria-label="Filter By Input value" label="Filter by" clearAllLabel="Clear all" fxFlex>
       <div class="container" fxFlex fxLayout="column">
-        <ktb-root-events-list [events]="getFilteredSequences(project.sequences)" [selectedEvent]="currentSequence" (selectedEventChange)="selectSequence($event)" fxFlex></ktb-root-events-list>
+        <ktb-root-events-list [events]="getFilteredSequences(roots)" [selectedEvent]="currentSequence" (selectedEventChange)="selectSequence($event)" fxFlex></ktb-root-events-list>
         <div class="mb-3"></div>
       </div>
     </dt-quick-filter>

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
@@ -143,7 +143,7 @@ export class KtbSequenceViewComponent implements OnInit, OnDestroy {
                 this._filterDataSource.data = this.filterFieldData;
                 // Set unfinished roots so that the traces for updates can be loaded
                 // Also ignore currently selected root, as this is getting already polled
-                this.unfinishedRoots = roots.filter(root => !!root && root.traces.some(r => r.finished !== undefined && !r.finished)).filter(root => this.currentSequence !== root);
+                this.unfinishedRoots = roots.filter(root => root && !root.isFinished() && root !== this.currentSequence);
               }
               this._changeDetectorRef.markForCheck();
             })

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
@@ -116,7 +116,7 @@ export class KtbSequenceViewComponent implements OnInit, OnDestroy {
               .subscribe(() => {
                 // This triggers the subscription for roots$
                 this.unfinishedRoots?.forEach(root => {
-                  this.loadTraces(root);
+                  this.dataService.loadTraces(root);
                 })
               });
 


### PR DESCRIPTION
Fixes #4051

The traces of the sequences were only loaded when a detail was opened.
Now it checks regularly, if there are any running sequences and loads traces for them.
Also the currently selected sequence is also excluded by this mechanism, because it gets already loaded.

Signed-off-by: Elisabeth Lang <elisabeth.lang@dynatrace.com>