### PR TITLE
#3948 highlight stages in timelines with color

### DIFF
--- a/bridge/client/_variables.scss
+++ b/bridge/client/_variables.scss
@@ -2,7 +2,7 @@ $base-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Ne
 
 $primary-color: #006bb8;
 $secondary-color: #002c66;
-$transition-time: 500ms;
+$focused-stage-color: #00848e;
 $link-icon-color: #00a1b2;
 
 $gap-normal: 8px;

--- a/bridge/client/_variables.scss
+++ b/bridge/client/_variables.scss
@@ -2,7 +2,6 @@ $base-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Ne
 
 $primary-color: #006bb8;
 $secondary-color: #002c66;
-$focused-stage-color: #00848e;
 $link-icon-color: #00a1b2;
 
 $gap-normal: 8px;

--- a/bridge/client/app/_components/ktb-sequence-timeline/ktb-sequence-timeline.component.html
+++ b/bridge/client/app/_components/ktb-sequence-timeline/ktb-sequence-timeline.component.html
@@ -2,7 +2,7 @@
   <div class="ktb-sequence-timeline-container">
     <div class="timeline"></div>
     <div fxLayout="row" fxLayoutAlign="space-between">
-      <div class="text-center pointer stage-item" [class.focused]="stage === selectedStage" *ngFor="let stage of currentSequence.getStages(); last as isLast" (click)="selectStage(stage)">
+      <div class="text-center pointer stage-item" *ngFor="let stage of currentSequence.getStages(); last as isLast" (click)="selectStage(stage)">
         <div class="stage-info">
           <dt-icon *ngIf="!currentSequence.getLastSequenceOfStage(stage).isLoading(); else showLoading" class="event-icon"
                    [name]="currentSequence.getFirstTraceOfStage(stage).isFinished() ? currentSequence.getIcon() : currentSequence.getLastTrace().getIcon()"
@@ -14,7 +14,12 @@
               <dt-loading-spinner aria-label="Task is running..."></dt-loading-spinner>
             </button>
           </ng-template>
-          <span [textContent]="stage"></span>
+          <span class="stage-text"
+                [class.error]="stage === currentSequence.isFaulty()"
+                [class.success]="currentSequence.getFirstTraceOfStage(stage).isFinished() && stage !== currentSequence.isFaulty()"
+                [class.highlight]="currentSequence.hasPendingApproval(stage)"
+                [class.focused]="stage === selectedStage"
+                [textContent]="stage"></span>
         </div>
         <p class="m-0">|</p>
         <p class="m-0" [textContent]="currentSequence.getFirstTraceOfStage(stage)?.time | date:'HH:mm'"></p>

--- a/bridge/client/app/_components/ktb-sequence-timeline/ktb-sequence-timeline.component.html
+++ b/bridge/client/app/_components/ktb-sequence-timeline/ktb-sequence-timeline.component.html
@@ -2,7 +2,7 @@
   <div class="ktb-sequence-timeline-container">
     <div class="timeline"></div>
     <div fxLayout="row" fxLayoutAlign="space-between">
-      <div class="text-center pointer stage-transition" [class.focused]="stage === selectedStage" *ngFor="let stage of currentSequence.getStages(); last as isLast" (click)="selectStage(stage)">
+      <div class="text-center pointer stage-item" [class.focused]="stage === selectedStage" *ngFor="let stage of currentSequence.getStages(); last as isLast" (click)="selectStage(stage)">
         <div class="stage-info">
           <dt-icon *ngIf="!currentSequence.getLastSequenceOfStage(stage).isLoading(); else showLoading" class="event-icon"
                    [name]="currentSequence.getFirstTraceOfStage(stage).isFinished() ? currentSequence.getIcon() : currentSequence.getLastTrace().getIcon()"

--- a/bridge/client/app/_components/ktb-sequence-timeline/ktb-sequence-timeline.component.scss
+++ b/bridge/client/app/_components/ktb-sequence-timeline/ktb-sequence-timeline.component.scss
@@ -27,12 +27,8 @@
     }
   }
 
-  .stage-transition {
-    transition: font-size $transition-time, font-weight $transition-time;
-    &.focused {
-      font-size: $default-font-size + 2px;
-      font-weight: bold;
-    }
+  .focused, .stage-item:hover {
+    color: $focused-stage-color;
   }
 }
 

--- a/bridge/client/app/_components/ktb-sequence-timeline/ktb-sequence-timeline.component.scss
+++ b/bridge/client/app/_components/ktb-sequence-timeline/ktb-sequence-timeline.component.scss
@@ -27,8 +27,27 @@
     }
   }
 
-  .focused, .stage-item:hover {
-    color: $focused-stage-color;
+  .stage-text {
+    color: black;
+    padding: 3px 10px;
+    margin-left: 2px;
+    text-decoration: black underline;
+  }
+
+  .focused, .stage-item:hover .stage-text {
+    color: white;
+    text-decoration: white underline;
+    border-radius: 15px;
+
+    &.error {
+      background-color: $error-color;
+    }
+    &.success {
+      background-color: $cta-color-active;
+    }
+    &.highlight {
+      background-color: $blue-400;
+    }
   }
 }
 

--- a/bridge/client/app/_components/ktb-stage-badge/ktb-stage-badge.component.html
+++ b/bridge/client/app/_components/ktb-stage-badge/ktb-stage-badge.component.html
@@ -6,7 +6,7 @@
      fxLayout="row" fxLayoutAlign="start center">
   <dt-tag-list>
     <dt-tag class="m-0 justify-content-center"
-            [class.stage-transition]="isSelected !== undefined"
+            [class.timeline-item]="isSelected !== undefined"
             [class.focused]="isSelected"
             [textContent]="stage"></dt-tag>
   </dt-tag-list>

--- a/bridge/client/app/_components/ktb-stage-badge/ktb-stage-badge.component.scss
+++ b/bridge/client/app/_components/ktb-stage-badge/ktb-stage-badge.component.scss
@@ -48,11 +48,10 @@
   }
 }
 
-.stage-transition {
+.timeline-item {
   font-size: $default-font-size;
-  transition: font-size $transition-time, font-weight $transition-time;
-  &.focused {
-    font-size: $default-font-size + 2px;
-    font-weight: bold;
-  }
+}
+
+.timeline-item:hover, .focused {
+  color: $focused-stage-color;
 }

--- a/bridge/client/app/_components/ktb-stage-badge/ktb-stage-badge.component.scss
+++ b/bridge/client/app/_components/ktb-stage-badge/ktb-stage-badge.component.scss
@@ -27,11 +27,17 @@
     .dt-tag {
       border-color: $error-color;
     }
+    .timeline-item:hover, .focused {
+      background-color: $error-color;
+    }
   }
 
   &.ktb-stage-badge-warning {
     .dt-tag {
       border-color: $warning-color;
+    }
+    .timeline-item:hover, .focused {
+      background-color: $warning-color;
     }
   }
 
@@ -39,19 +45,27 @@
     .dt-tag {
       border-color: $cta-color;
     }
+    .timeline-item:hover, .focused {
+      background-color: $cta-color-active;
+    }
   }
 
   &.ktb-stage-badge-highlight {
     .dt-tag {
       border-color: $blue-400;
     }
+    .timeline-item:hover, .focused {
+      background-color: $blue-400;
+    }
   }
 }
 
 .timeline-item {
   font-size: $default-font-size;
+  text-decoration: black underline;
 }
 
 .timeline-item:hover, .focused {
-  color: $focused-stage-color;
+  color: white;
+  text-decoration: white underline;
 }


### PR DESCRIPTION
Closes #3948

Timeline in service screen:
![image](https://user-images.githubusercontent.com/11599148/120203320-e10a6500-c227-11eb-8fc2-108b38d4b878.png)

Timeline in sequence screen:
![image](https://user-images.githubusercontent.com/11599148/120203208-c0420f80-c227-11eb-9a23-3bde73934881.png)

Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>