### PR TITLE
#4041 use go-utils models for uniform structs

### DIFF
--- a/shipyard-controller/db/mongodb_uniformrepo_test.go
+++ b/shipyard-controller/db/mongodb_uniformrepo_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	keptnmodels "github.com/keptn/go-utils/pkg/api/models"
 	"github.com/keptn/keptn/shipyard-controller/models"
 	"github.com/stretchr/testify/require"
 	"testing"
@@ -11,13 +12,13 @@ func TestMongoDBUniformRepo_InsertAndRetrieve(t *testing.T) {
 	integration1 := models.Integration{
 		ID:   "my-integration-id-1",
 		Name: "my-integration",
-		MetaData: models.MetaData{
+		MetaData: keptnmodels.MetaData{
 			DeploymentName: "my-integration",
 		},
-		Subscription: models.Subscription{
+		Subscription: keptnmodels.Subscription{
 			Topics: []string{"sh.keptn.event.test.triggered"},
 			Status: "active",
-			Filter: models.SubscriptionFilter{
+			Filter: keptnmodels.SubscriptionFilter{
 				Project: "my-project",
 			},
 		},
@@ -26,13 +27,13 @@ func TestMongoDBUniformRepo_InsertAndRetrieve(t *testing.T) {
 	integration2 := models.Integration{
 		ID:   "my-integration-id-2",
 		Name: "my-integration2",
-		MetaData: models.MetaData{
+		MetaData: keptnmodels.MetaData{
 			DeploymentName: "my-integration2",
 		},
-		Subscription: models.Subscription{
+		Subscription: keptnmodels.Subscription{
 			Topics: []string{"sh.keptn.event.deployment.triggered"},
 			Status: "active",
-			Filter: models.SubscriptionFilter{
+			Filter: keptnmodels.SubscriptionFilter{
 				Project: "my-project-2",
 			},
 		},

--- a/shipyard-controller/handler/uniformintegrationhandler.go
+++ b/shipyard-controller/handler/uniformintegrationhandler.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	keptnmodels "github.com/keptn/go-utils/pkg/api/models"
 	"github.com/keptn/keptn/shipyard-controller/models"
 	"net/http"
 )
@@ -40,7 +41,7 @@ func (rh *UniformIntegrationHandler) Register(c *gin.Context) {
 		return
 	}
 
-	integrationID := models.IntegrationID{
+	integrationID := keptnmodels.IntegrationID{
 		Name:      integration.Name,
 		Namespace: integration.MetaData.KubernetesMetaData.Namespace,
 		Project:   integration.Subscription.Filter.Project,

--- a/shipyard-controller/handler/uniformintegrationhandler_test.go
+++ b/shipyard-controller/handler/uniformintegrationhandler_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"github.com/gin-gonic/gin"
+	keptnmodels "github.com/keptn/go-utils/pkg/api/models"
 	"github.com/keptn/keptn/shipyard-controller/handler"
 	"github.com/keptn/keptn/shipyard-controller/handler/fake"
 	"github.com/keptn/keptn/shipyard-controller/models"
@@ -78,13 +79,13 @@ func TestUniformIntegrationHandler_Register(t *testing.T) {
 	myValidIntegration := &models.Integration{
 		ID:   "my-id",
 		Name: "my-name",
-		MetaData: models.MetaData{
+		MetaData: keptnmodels.MetaData{
 			DistributorVersion: "0.8.3",
-			KubernetesMetaData: models.KubernetesMetaData{
+			KubernetesMetaData: keptnmodels.KubernetesMetaData{
 				Namespace: "my-namespace",
 			},
 		},
-		Subscription: models.Subscription{
+		Subscription: keptnmodels.Subscription{
 			Topics: []string{
 				"sh.keptn.event.test.triggered",
 			},
@@ -92,13 +93,13 @@ func TestUniformIntegrationHandler_Register(t *testing.T) {
 	}
 	validPayload, _ := json.Marshal(myValidIntegration)
 
-	myInvalidIntegration := &models.Integration{
+	myInvalidIntegration := &keptnmodels.Integration{
 		ID:   "my-id",
 		Name: "my-name",
-		MetaData: models.MetaData{
+		MetaData: keptnmodels.MetaData{
 			DistributorVersion: "0.8.3",
 		},
-		Subscription: models.Subscription{
+		Subscription: keptnmodels.Subscription{
 			Topics: []string{
 				"sh.keptn.event.test.triggered",
 			},

--- a/shipyard-controller/models/uniform.go
+++ b/shipyard-controller/models/uniform.go
@@ -1,9 +1,7 @@
 package models
 
 import (
-	"crypto/sha1"
-	"encoding/hex"
-	"fmt"
+	keptnmodels "github.com/keptn/go-utils/pkg/api/models"
 )
 
 type GetUniformIntegrationParams struct {
@@ -19,61 +17,4 @@ type RegisterResponse struct {
 }
 type UnregisterResponse struct{}
 
-// TODO: delete this and use structs defined in go-utils
-
-type Integration struct {
-	ID           string       `json:"id" bson:"_id"`
-	Name         string       `json:"name" bson:"name"`
-	MetaData     MetaData     `json:"metadata" bson:"metadata"`
-	Subscription Subscription `json:"subscription" bson:"subscription"`
-}
-
-type MetaData struct {
-	Hostname           string             `json:"hostname" bson:"hostname"`
-	DeploymentName     string             `json:"deplyomentname" bson:"deploymentname"`
-	IntegrationVersion string             `json:"integrationversion" bson:"integrationversion"`
-	DistributorVersion string             `json:"distributorversion" bson:"distributorversion"`
-	Status             string             `json:"status" bson:"status"`
-	Location           string             `json:"location" bson:"location"`
-	KubernetesMetaData KubernetesMetaData `json:"kubernetesmetadata" bson:"kubernetesmetadata"`
-}
-
-type Subscription struct {
-	Topics []string           `json:"topics" bson:"topics"`
-	Status string             `json:"status" bson:"status"`
-	Filter SubscriptionFilter `json:"filter" bson:"filter"`
-}
-
-type SubscriptionFilter struct {
-	Project string `json:"project" bson:"project"`
-	Stage   string `json:"stage" bson:"stage"`
-	Service string `json:"service" bson:"service"`
-}
-
-type KubernetesMetaData struct {
-	Namespace      string `json:"namespace" bson:"namespace"`
-	PodName        string `json:"podname" bson:"podname"`
-	DeploymentName string `json:"deploymentname" bson:"deploymentname"`
-}
-
-type IntegrationID struct {
-	Name      string `json:"name" bson:"name"`
-	Namespace string `json:"namespace" bson:"namespace"`
-	Project   string `json:"project" bson:"project"`
-	Stage     string `json:"stage" bson:"stage"`
-	Service   string `json:"service" bson:"service"`
-}
-
-func (i IntegrationID) Hash() (string, error) {
-	if !i.validate() {
-		return "", fmt.Errorf("incomplete integration ID. At least 'name' and 'namespace' must be set.")
-	}
-	raw := fmt.Sprintf("%s-%s-%s-%s-%s", i.Name, i.Namespace, i.Project, i.Stage, i.Service)
-	hasher := sha1.New() //nolint:gosec
-	hasher.Write([]byte(raw))
-	return hex.EncodeToString(hasher.Sum(nil)), nil
-}
-
-func (i IntegrationID) validate() bool {
-	return i.Name != "" && i.Namespace != ""
-}
+type Integration keptnmodels.Integration

--- a/test/go-tests/go.mod
+++ b/test/go-tests/go.mod
@@ -3,10 +3,10 @@ module github.com/keptn/keptn/test/go-tests
 go 1.16
 
 require (
-	github.com/cloudevents/sdk-go/v2 v2.3.1
+	github.com/cloudevents/sdk-go/v2 v2.4.1
 	github.com/google/uuid v1.2.0
 	github.com/imroc/req v0.3.0
-	github.com/keptn/go-utils v0.8.4
+	github.com/keptn/go-utils v0.8.5-0.20210531064227-ecdd3cbbb723
 	github.com/keptn/keptn/shipyard-controller v0.0.0-20210503133401-8c1194432b46
 	github.com/keptn/kubernetes-utils v0.8.1
 	github.com/stretchr/testify v1.7.0

--- a/test/go-tests/go.sum
+++ b/test/go-tests/go.sum
@@ -132,6 +132,8 @@ github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudevents/sdk-go/v2 v2.3.1 h1:QRTu0yRA4FbznjRSds0/4Hy6cVYpWV2wInlNJSHWAtw=
 github.com/cloudevents/sdk-go/v2 v2.3.1/go.mod h1:4fO2UjPMYYR1/7KPJQCwTPb0lFA8zYuitkUpAZFSY1Q=
+github.com/cloudevents/sdk-go/v2 v2.4.1 h1:rZJoz9QVLbWQmnvLPDFEmv17Czu+CfSPwMO6lhJ72xQ=
+github.com/cloudevents/sdk-go/v2 v2.4.1/go.mod h1:MZiMwmAh5tGj+fPFvtHv9hKurKqXtdB9haJYMJ/7GJY=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
@@ -220,6 +222,7 @@ github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2H
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
+github.com/gin-gonic/gin v1.7.2/go.mod h1:jD2toBW3GZUr5UMcdrwQA10I7RuaFOl/SGeDjXkfUtY=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -296,6 +299,7 @@ github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvSc
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
+github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
@@ -489,6 +493,8 @@ github.com/keptn/go-utils v0.8.4-0.20210517102245-5fcad0f27daf h1:PvbMdXvo5lHWWF
 github.com/keptn/go-utils v0.8.4-0.20210517102245-5fcad0f27daf/go.mod h1:8cm/j/fPLl+qpSIDyyw5WVqT7W6W/ZlsAtMv8dLKtPU=
 github.com/keptn/go-utils v0.8.4 h1:v+Wlpw5iD8hauW1nnAt7yKF5+QYEKibljQSozgKouQY=
 github.com/keptn/go-utils v0.8.4/go.mod h1:8cm/j/fPLl+qpSIDyyw5WVqT7W6W/ZlsAtMv8dLKtPU=
+github.com/keptn/go-utils v0.8.5-0.20210531064227-ecdd3cbbb723 h1:YnF0GCEu/24CfMt2OFRnL7GPS2Zfh/H9zpGriB9jQjQ=
+github.com/keptn/go-utils v0.8.5-0.20210531064227-ecdd3cbbb723/go.mod h1://VAg14UZLtAbjvtPOW6qTWiZabWqOXhi5Kib56iN8I=
 github.com/keptn/kubernetes-utils v0.8.1 h1:y02DIIiXeFWU+XfO8Y7y8U8u4HPZx1Lcy3ZVCM27guQ=
 github.com/keptn/kubernetes-utils v0.8.1/go.mod h1:bGCSnzuDVZK1ZwC40HFP5sn+ALB6FY8sw0RYM2M1ARc=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
@@ -1127,6 +1133,8 @@ gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 helm.sh/helm/v3 v3.5.1 h1:XPn6xyH4Lcbx0sdUsVttt2E9jH2oJddpLLZtQH0XNfQ=

--- a/test/go-tests/uniform_test.go
+++ b/test/go-tests/uniform_test.go
@@ -1,6 +1,7 @@
 package go_tests
 
 import (
+	keptnmodels "github.com/keptn/go-utils/pkg/api/models"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 	"github.com/keptn/keptn/shipyard-controller/models"
 	"github.com/stretchr/testify/require"
@@ -10,17 +11,17 @@ import (
 
 func Test_UniformRegistration(t *testing.T) {
 
-	uniformIntegration := &models.Integration{
+	uniformIntegration := &keptnmodels.Integration{
 		Name: "my-uniform-service",
-		MetaData: models.MetaData{
+		MetaData: keptnmodels.MetaData{
 			DeploymentName:     "my-uniform-service",
 			DistributorVersion: "0.8.3",
 			Status:             "active",
-			KubernetesMetaData: models.KubernetesMetaData{
+			KubernetesMetaData: keptnmodels.KubernetesMetaData{
 				Namespace: "my-namespace",
 			},
 		},
-		Subscription: models.Subscription{
+		Subscription: keptnmodels.Subscription{
 			Topics: []string{keptnv2.GetTriggeredEventType(keptnv2.TestTaskName)},
 		},
 	}


### PR DESCRIPTION
Related to #4041 - This PR changes the shipyard controller to use the uniform models of `keptn/go-utils` instead of the ones that were temporarily created within the shipyard controller

Signed-off-by: Florian Bacher <florian.bacher@dynatrace.com>