### PR TITLE
#4262 fix color for loading stages in timeline

### DIFF
--- a/bridge/client/app/_components/ktb-deployment-stage-timeline/ktb-deployment-stage-timeline.component.html
+++ b/bridge/client/app/_components/ktb-deployment-stage-timeline/ktb-deployment-stage-timeline.component.html
@@ -6,7 +6,7 @@
         [stage]="stage"
         [evaluation]="deployment.getEvaluation(stage)"
         [isSelected]="selectedStage === stage"
-        [success]="deployment.sequence.getFirstTraceOfStage(stage).isFinished() && stage !== deployment.sequence.isFaulty()"
+        [success]="!deployment.sequence.hasPendingApproval(stage) && stage !== deployment.sequence.isFaulty()"
         [error]="stage === deployment.sequence.isFaulty()"
         [class.warning]="stage === deployment.sequence.isWarning()"
         [highlight]="deployment.sequence.hasPendingApproval(stage)"

--- a/bridge/client/app/_components/ktb-sequence-timeline/ktb-sequence-timeline.component.html
+++ b/bridge/client/app/_components/ktb-sequence-timeline/ktb-sequence-timeline.component.html
@@ -16,8 +16,9 @@
           </ng-template>
           <span class="stage-text"
                 [class.error]="stage === currentSequence.isFaulty()"
-                [class.success]="currentSequence.getFirstTraceOfStage(stage).isFinished() && stage !== currentSequence.isFaulty()"
+                [class.success]="!currentSequence.hasPendingApproval(stage) && stage !== currentSequence.isFaulty()"
                 [class.highlight]="currentSequence.hasPendingApproval(stage)"
+                [class.warning]="stage === currentSequence.isWarning()"
                 [class.focused]="stage === selectedStage"
                 [textContent]="stage"></span>
         </div>

--- a/bridge/client/app/_components/ktb-sequence-timeline/ktb-sequence-timeline.component.scss
+++ b/bridge/client/app/_components/ktb-sequence-timeline/ktb-sequence-timeline.component.scss
@@ -48,6 +48,9 @@
     &.highlight {
       background-color: $blue-400;
     }
+    &.warning {
+      background-color: $warning-color;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #4262 

Timeline in sequence screen:
![image](https://user-images.githubusercontent.com/11599148/121206085-78029d00-c878-11eb-8cc7-3485293b4a1a.png)

Timeline in services screen:
![image](https://user-images.githubusercontent.com/11599148/121206277-9ff20080-c878-11eb-90cc-720d58583143.png)


Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>