### PR TITLE
#4155 Bridge breaks on "sh.keptn.event.evaluation.triggered" root event

### DIFF
--- a/bridge/client/app/_models/project.ts
+++ b/bridge/client/app/_models/project.ts
@@ -60,7 +60,7 @@ export class Project {
   }
 
   getLatestFailedRootEvents(stage: Stage): Root[] {
-    return this.getServices(stage).map(service => service.getRecentSequence()).filter(seq => seq?.isFailedEvaluation() === stage.stageName);
+    return this.getServices(stage).map(service => service.getRecentSequence()).filter(seq => seq?.hasFailedEvaluation() === stage.stageName);
   }
 
   getLatestProblemEvents(stage: Stage): Root[] {

--- a/bridge/client/app/_models/root.ts
+++ b/bridge/client/app/_models/root.ts
@@ -19,7 +19,7 @@ export class Root extends Trace {
     return this.traces.length === 0 ? false : this.traces[this.traces.length-1].isStarted();
   }
 
-  isFailedEvaluation(): string {
+  hasFailedEvaluation(): string {
     let result: string = null;
     if(this.traces) {
       let failedEvaluation = this.findTrace(t => t.isEvaluation() && t.isFailedEvaluation());


### PR DESCRIPTION
Call hasFailedEvaluation() on root event to prevent endless loop of calling "isFailedEvaluation()"

Signed-off-by: ermin.muratovic <ermin.muratovic@gmail.com>