### PR TITLE
Update Readme.md outdated community link

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,4 +74,4 @@ For a list of users, please refer to [ADOPTERS.md](ADOPTERS.md).
 ## Further information
 
 * The [Keptn`s website](https://keptn.sh) has the documentation of Keptn and its use cases.
-* Please join the [Keptn community](https://github.com/keptn/community).
+* Please join the [Keptn community](https://keptn.sh/community/).


### PR DESCRIPTION
Kept community link was moved, so I updated it.
Because right now the community link redirecting to this repo https://github.com/keptn/community, where its written:
Please note that we have migrated the community page to keptn.sh/community! ⚠️

So I think it should be better to get direct link to community page.