### PR TITLE
#3943 show every nth label starting from the end

### DIFF
--- a/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
+++ b/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
@@ -138,10 +138,11 @@ export class KtbEvaluationDetailsComponent implements OnInit, OnDestroy {
       },
       tickPositioner: function() {
         const positions = [],
+          labelWidth = 70,
           ext = this.getExtremes(),
           xMax = Math.round(ext.max),
           xMin = Math.round(ext.min),
-          maxElements = window.innerWidth / 70,
+          maxElements = (document.querySelector('dt-chart')?.clientWidth || labelWidth) / labelWidth,
           tick = Math.floor(xMax / maxElements) || 1;
 
         for (let i = xMax; i > xMin; i -= tick) {

--- a/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
+++ b/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
@@ -145,14 +145,8 @@ export class KtbEvaluationDetailsComponent implements OnInit, OnDestroy {
           maxElements = (document.querySelector('dt-chart')?.clientWidth || labelWidth) / labelWidth,
           tick = Math.floor(xMax / maxElements) || 1;
 
-        for (let i = xMax; i > xMin; i -= tick) {
+        for (let i = xMax; i >= xMin; i -= tick) {
           positions.push(i);
-        }
-        if(positions[positions.length-1] - tick < xMin){ //if the second item is too near to the first one, remove the second one
-          positions[positions.length-1] = xMin;
-        }
-        else {
-          positions.push(xMin);
         }
         return positions;
       }

--- a/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
+++ b/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.ts
@@ -136,6 +136,25 @@ export class KtbEvaluationDetailsComponent implements OnInit, OnDestroy {
       labels: {
         rotation: -45
       },
+      tickPositioner: function() {
+        const positions = [],
+          ext = this.getExtremes(),
+          xMax = Math.round(ext.max),
+          xMin = Math.round(ext.min),
+          maxElements = window.innerWidth / 70,
+          tick = Math.floor(xMax / maxElements) || 1;
+
+        for (let i = xMax; i > xMin; i -= tick) {
+          positions.push(i);
+        }
+        if(positions[positions.length-1] - tick < xMin){ //if the second item is too near to the first one, remove the second one
+          positions[positions.length-1] = xMin;
+        }
+        else {
+          positions.push(xMin);
+        }
+        return positions;
+      }
     }],
 
     yAxis: [{


### PR DESCRIPTION
Closes #3943 

- Tick interval is now determined by component width.
- Last and first label are always displayed

![image](https://user-images.githubusercontent.com/11599148/121692141-12a4eb00-cac8-11eb-92d6-63f5e7f784c3.png)

Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>