### PR TITLE
#3772 Only create issue for failing integration tests on master branch

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -2,7 +2,7 @@ name: Integration Tests
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron:  '0 3 * * 1-5' # run integration tests at 3 AM, monday to friday (1-5)
+    - cron: '0 3 * * 1-5' # run integration tests at 3 AM, monday to friday (1-5)
 
   workflow_dispatch: # run integration tests only when triggered manually
     inputs:
@@ -804,7 +804,9 @@ jobs:
           fi
 
       - name: Create issue if tests failed
-        if: github.ref == 'refs/heads/master' && steps.formulate_bug_issue.outputs.INTEGRATION_TESTS_FAILED == 'true'
+        if: always() && \
+            github.ref == 'refs/heads/master' && \
+            steps.formulate_bug_issue.outputs.INTEGRATION_TESTS_FAILED == 'true'
         uses: JasonEtco/create-an-issue@v2.5.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -813,11 +815,17 @@ jobs:
 
       - name: Find PR number for current build
         id: find_pr_for_build
+        if: always()
         uses: jwalton/gh-find-current-pr@v1.1.0
 
       - name: Create PR comment if tests failed
         # Only run if not on master branch and we have a PR number
-        if: github.ref != 'refs/heads/master' && steps.find_pr_for_build.outputs.number && steps.formulate_bug_issue.outputs.INTEGRATION_TESTS_FAILED == 'true'
+        # Also, only run in original repo and not on forks since the github token secret is not accessible in that case
+        if: always() && \
+            github.ref != 'refs/heads/master' && \
+            steps.find_pr_for_build.outputs.number && \
+            steps.formulate_bug_issue.outputs.INTEGRATION_TESTS_FAILED == 'true' && \
+            github.event.pull_request.head.repo.full_name == github.repository
         uses: marocchino/sticky-pull-request-comment@v2.1.0
         with:
           path: integration-tests-failed.md

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -811,6 +811,22 @@ jobs:
         with:
           filename: integration-tests-failed.md
 
+      - name: Find PR number for current build
+        id: find_pr_for_build
+        uses: jwalton/gh-find-current-pr@v1.1.0
+
+      - name: Create PR comment if tests failed
+        # Only run if not on master branch and we have a PR number
+        if: ${{ github.ref != 'refs/heads/master' }} && steps.find_pr_for_build.outputs.number && steps.formulate_bug_issue.outputs.INTEGRATION_TESTS_FAILED == 'true'
+        uses: marocchino/sticky-pull-request-comment@v2.1.0
+        with:
+          path: integration-tests-failed.md
+          recreate: true
+          number: ${{ steps.find_pr_for_build.outputs.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
       # Part of this job is to check if a releasenotes file exists and to use it as the release message
       - name: Try getting release notes
         id: get_releasenotes

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -804,7 +804,7 @@ jobs:
           fi
 
       - name: Create issue if tests failed
-        if: ${{ github.ref == 'refs/heads/master' }} && steps.formulate_bug_issue.outputs.INTEGRATION_TESTS_FAILED == 'true'
+        if: github.ref == 'refs/heads/master' && steps.formulate_bug_issue.outputs.INTEGRATION_TESTS_FAILED == 'true'
         uses: JasonEtco/create-an-issue@v2.5.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -817,7 +817,7 @@ jobs:
 
       - name: Create PR comment if tests failed
         # Only run if not on master branch and we have a PR number
-        if: ${{ github.ref != 'refs/heads/master' }} && steps.find_pr_for_build.outputs.number && steps.formulate_bug_issue.outputs.INTEGRATION_TESTS_FAILED == 'true'
+        if: github.ref != 'refs/heads/master' && steps.find_pr_for_build.outputs.number && steps.formulate_bug_issue.outputs.INTEGRATION_TESTS_FAILED == 'true'
         uses: marocchino/sticky-pull-request-comment@v2.1.0
         with:
           path: integration-tests-failed.md

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -804,7 +804,7 @@ jobs:
           fi
 
       - name: Create issue if tests failed
-        if: always() && steps.formulate_bug_issue.outputs.INTEGRATION_TESTS_FAILED == 'true'
+        if: ${{ github.ref == 'refs/heads/master' }} && steps.formulate_bug_issue.outputs.INTEGRATION_TESTS_FAILED == 'true'
         uses: JasonEtco/create-an-issue@v2.5.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**This PR**

* only creates GH issues for failing integration tests on `master`
* creates a PR comment on PR builds where the integration tests fail
* in both cases the message is the integration test report

Closes #3772