### PR TITLE
#3841 fix keptn ugprade using wrong keptn helm version

### DIFF
--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -207,7 +207,15 @@ func getLatestKeptnRelease() (*release.Release, error) {
 		return nil, fmt.Errorf("No Keptn release found in namespace %s: %v", keptnNamespace, err)
 	}
 
-	return releases[len(releases)-1], nil
+	// iterate over releases and find the one with status = deployed
+	for _, release := range releases {
+		if release.Info.Status == "deployed" {
+			return release, nil
+		}
+	}
+
+	return nil, fmt.Errorf("Found %d releases, but none of them is currently deployed", len(releases))
+
 }
 
 func init() {

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -208,9 +208,9 @@ func getLatestKeptnRelease() (*release.Release, error) {
 	}
 
 	// iterate over releases and find the one with status = deployed
-	for _, release := range releases {
-		if release.Info.Status == "deployed" {
-			return release, nil
+	for _, r := range releases {
+		if r.Info.Status == release.StatusDeployed {
+			return r, nil
 		}
 	}
 


### PR DESCRIPTION
Fixes #3841

Basically I added a for loop that iterates over all helm releases from the history, and choose the one that has status deployed.