### PR TITLE
#2479 Switch to nats 0.8.0

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/Chart.yaml
+++ b/installer/manifests/keptn/charts/control-plane/Chart.yaml
@@ -27,5 +27,5 @@ dependencies:
     version: 0.1.0
     condition: mongodb.enabled
   - name: nats
-    version: 0.7.4
+    version: 0.8.0
     repository: https://nats-io.github.io/k8s/helm/charts/

--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -11,6 +11,7 @@ keptnSpecVersion: latest
 
 nats:
   nameOverride: keptn-nats-cluster
+  fullnameOverride: keptn-nats-cluster
   nats.cluster.replicas: 3
 
   natsbox:


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

Finally fix #2479 by switching to nats 0.8.0.
Apparently something has changed with the service-naming, hence I needed to add `fullnameOverride`.

Integration Tests: https://github.com/keptn/keptn/actions/runs/938419801
