### PR TITLE
#3801 allow text break for info-group content

### DIFF
--- a/bridge/client/styles.scss
+++ b/bridge/client/styles.scss
@@ -38,6 +38,10 @@ app-root {
   white-space: nowrap;
 }
 
+.dt-info-group-content > *{
+  white-space: normal;
+}
+
 p.small,
 span.small {
   font-family: BerninaSansWeb,OpenSans,sans-serif;


### PR DESCRIPTION
Closes #3801
Service screen:
![image](https://user-images.githubusercontent.com/11599148/121894597-9a386700-cd1f-11eb-990e-ceb7d827d840.png)

Environment screen:
![image](https://user-images.githubusercontent.com/11599148/121894743-c7851500-cd1f-11eb-9b89-9188ba44828d.png)

Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>