### PR TITLE
#3423 Switch authentication param to key

### DIFF
--- a/secret-service/docs/docs.go
+++ b/secret-service/docs/docs.go
@@ -8,8 +8,9 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/alecthomas/template"
 	"github.com/swaggo/swag"
+
+	"text/template"
 )
 
 var doc = `{

--- a/secret-service/docs/docs.go
+++ b/secret-service/docs/docs.go
@@ -8,8 +8,8 @@ import (
 	"encoding/json"
 	"strings"
 
+	"github.com/alecthomas/template"
 	"github.com/swaggo/swag"
-	"text/template"
 )
 
 var doc = `{
@@ -267,7 +267,7 @@ var doc = `{
         }
     },
     "securityDefinitions": {
-        "ApiKeyAuth": {
+        "key": {
             "type": "apiKey",
             "name": "x-token",
             "in": "header"

--- a/secret-service/docs/swagger.json
+++ b/secret-service/docs/swagger.json
@@ -251,7 +251,7 @@
         }
     },
     "securityDefinitions": {
-        "ApiKeyAuth": {
+        "key": {
             "type": "apiKey",
             "name": "x-token",
             "in": "header"

--- a/secret-service/docs/swagger.yaml
+++ b/secret-service/docs/swagger.yaml
@@ -160,7 +160,7 @@ paths:
       tags:
       - Secrets
 securityDefinitions:
-  ApiKeyAuth:
+  key:
     in: header
     name: x-token
     type: apiKey

--- a/secret-service/main.go
+++ b/secret-service/main.go
@@ -16,7 +16,7 @@ import (
 // @version 1.0
 // @description This is the API documentation of the Secret Service.
 
-// @securityDefinitions.apiKey ApiKeyAuth
+// @securityDefinitions.apiKey key
 // @in header
 // @name x-token
 

--- a/shipyard-controller/docs/docs.go
+++ b/shipyard-controller/docs/docs.go
@@ -8,8 +8,8 @@ import (
 	"encoding/json"
 	"strings"
 
+	"github.com/alecthomas/template"
 	"github.com/swaggo/swag"
-	"text/template"
 )
 
 var doc = `{
@@ -1284,31 +1284,6 @@ var doc = `{
         "models.DeleteLogResponse": {
             "type": "object"
         },
-        "models.Approval": {
-            "type": "object",
-            "properties": {
-                "eventId": {
-                    "description": "ID of the event",
-                    "type": "string"
-                },
-                "image": {
-                    "description": "image",
-                    "type": "string"
-                },
-                "keptnContext": {
-                    "description": "Keptn Context ID of the event",
-                    "type": "string"
-                },
-                "tag": {
-                    "description": "tag",
-                    "type": "string"
-                },
-                "time": {
-                    "description": "Time of the event",
-                    "type": "string"
-                }
-            }
-        },
         "models.Error": {
             "type": "object",
             "properties": {
@@ -1370,33 +1345,8 @@ var doc = `{
         "models.EventContext": {
             "type": "object",
             "properties": {
-                "eventId": {
-                    "description": "ID of the event",
-                    "type": "string"
-                },
                 "keptnContext": {
-                    "description": "Keptn Context ID of the event",
-                    "type": "string"
-                },
-                "time": {
-                    "description": "Time of the event",
-                    "type": "string"
-                }
-            }
-        },
-        "models.EventContextInfo": {
-            "type": "object",
-            "properties": {
-                "eventId": {
-                    "description": "ID of the event",
-                    "type": "string"
-                },
-                "keptnContext": {
-                    "description": "Keptn Context ID of the event",
-                    "type": "string"
-                },
-                "time": {
-                    "description": "Time of the event",
+                    "description": "keptn context\nRequired: true",
                     "type": "string"
                 }
             }
@@ -1575,18 +1525,22 @@ var doc = `{
             "type": "object",
             "properties": {
                 "logs": {
+                    "description": "logs",
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/models.LogEntry"
                     }
                 },
                 "nextPageKey": {
+                    "description": "Pointer to next page",
                     "type": "integer"
                 },
                 "pageSize": {
+                    "description": "Size of returned page",
                     "type": "integer"
                 },
                 "totalCount": {
+                    "description": "Total number of logs",
                     "type": "integer"
                 }
             }
@@ -1697,9 +1651,6 @@ var doc = `{
         "models.MetaData": {
             "type": "object",
             "properties": {
-                "deplyomentname": {
-                    "type": "string"
-                },
                 "distributorversion": {
                     "type": "string"
                 },
@@ -1713,9 +1664,6 @@ var doc = `{
                     "$ref": "#/definitions/models.KubernetesMetaData"
                 },
                 "location": {
-                    "type": "string"
-                },
-                "status": {
                     "type": "string"
                 }
             }
@@ -1842,53 +1790,6 @@ var doc = `{
                 }
             }
         },
-        "models.Service": {
-            "type": "object",
-            "properties": {
-                "creationDate": {
-                    "description": "Creation date of the service",
-                    "type": "string"
-                },
-                "deployedImage": {
-                    "description": "Currently deployed image",
-                    "type": "string"
-                },
-                "lastEventTypes": {
-                    "description": "last event types",
-                    "type": "object",
-                    "additionalProperties": {
-                        "$ref": "#/definitions/models.EventContextInfo"
-                    }
-                },
-                "openApprovals": {
-                    "description": "open approvals",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.Approval"
-                    }
-                },
-                "serviceName": {
-                    "description": "Service name",
-                    "type": "string"
-                }
-            }
-        },
-        "models.Stage": {
-            "type": "object",
-            "properties": {
-                "services": {
-                    "description": "services",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.Service"
-                    }
-                },
-                "stageName": {
-                    "description": "Stage name",
-                    "type": "string"
-                }
-            }
-        },
         "models.Stages": {
             "type": "object",
             "properties": {
@@ -1904,7 +1805,7 @@ var doc = `{
                     "description": "stages",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/models.Stage"
+                        "$ref": "#/definitions/models.ExpandedStage"
                     }
                 },
                 "totalCount": {
@@ -2066,7 +1967,7 @@ var doc = `{
         }
     },
     "securityDefinitions": {
-        "ApiKeyAuth": {
+        "key": {
             "type": "apiKey",
             "name": "x-token",
             "in": "header"

--- a/shipyard-controller/docs/docs.go
+++ b/shipyard-controller/docs/docs.go
@@ -8,8 +8,9 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/alecthomas/template"
 	"github.com/swaggo/swag"
+
+	"text/template"
 )
 
 var doc = `{

--- a/shipyard-controller/docs/swagger.json
+++ b/shipyard-controller/docs/swagger.json
@@ -1253,31 +1253,6 @@
         }
     },
     "definitions": {
-        "models.Approval": {
-            "type": "object",
-            "properties": {
-                "eventId": {
-                    "description": "ID of the event",
-                    "type": "string"
-                },
-                "image": {
-                    "description": "image",
-                    "type": "string"
-                },
-                "keptnContext": {
-                    "description": "Keptn Context ID of the event",
-                    "type": "string"
-                },
-                "tag": {
-                    "description": "tag",
-                    "type": "string"
-                },
-                "time": {
-                    "description": "Time of the event",
-                    "type": "string"
-                }
-            }
-        },
         "models.CreateLogsRequest": {
             "type": "object",
             "properties": {
@@ -1354,33 +1329,8 @@
         "models.EventContext": {
             "type": "object",
             "properties": {
-                "eventId": {
-                    "description": "ID of the event",
-                    "type": "string"
-                },
                 "keptnContext": {
-                    "description": "Keptn Context ID of the event",
-                    "type": "string"
-                },
-                "time": {
-                    "description": "Time of the event",
-                    "type": "string"
-                }
-            }
-        },
-        "models.EventContextInfo": {
-            "type": "object",
-            "properties": {
-                "eventId": {
-                    "description": "ID of the event",
-                    "type": "string"
-                },
-                "keptnContext": {
-                    "description": "Keptn Context ID of the event",
-                    "type": "string"
-                },
-                "time": {
-                    "description": "Time of the event",
+                    "description": "keptn context\nRequired: true",
                     "type": "string"
                 }
             }
@@ -1559,18 +1509,22 @@
             "type": "object",
             "properties": {
                 "logs": {
+                    "description": "logs",
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/models.LogEntry"
                     }
                 },
                 "nextPageKey": {
+                    "description": "Pointer to next page",
                     "type": "integer"
                 },
                 "pageSize": {
+                    "description": "Size of returned page",
                     "type": "integer"
                 },
                 "totalCount": {
+                    "description": "Total number of logs",
                     "type": "integer"
                 }
             }
@@ -1681,9 +1635,6 @@
         "models.MetaData": {
             "type": "object",
             "properties": {
-                "deplyomentname": {
-                    "type": "string"
-                },
                 "distributorversion": {
                     "type": "string"
                 },
@@ -1697,9 +1648,6 @@
                     "$ref": "#/definitions/models.KubernetesMetaData"
                 },
                 "location": {
-                    "type": "string"
-                },
-                "status": {
                     "type": "string"
                 }
             }
@@ -1826,53 +1774,6 @@
                 }
             }
         },
-        "models.Service": {
-            "type": "object",
-            "properties": {
-                "creationDate": {
-                    "description": "Creation date of the service",
-                    "type": "string"
-                },
-                "deployedImage": {
-                    "description": "Currently deployed image",
-                    "type": "string"
-                },
-                "lastEventTypes": {
-                    "description": "last event types",
-                    "type": "object",
-                    "additionalProperties": {
-                        "$ref": "#/definitions/models.EventContextInfo"
-                    }
-                },
-                "openApprovals": {
-                    "description": "open approvals",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.Approval"
-                    }
-                },
-                "serviceName": {
-                    "description": "Service name",
-                    "type": "string"
-                }
-            }
-        },
-        "models.Stage": {
-            "type": "object",
-            "properties": {
-                "services": {
-                    "description": "services",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.Service"
-                    }
-                },
-                "stageName": {
-                    "description": "Stage name",
-                    "type": "string"
-                }
-            }
-        },
         "models.Stages": {
             "type": "object",
             "properties": {
@@ -1888,7 +1789,7 @@
                     "description": "stages",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/models.Stage"
+                        "$ref": "#/definitions/models.ExpandedStage"
                     }
                 },
                 "totalCount": {
@@ -2050,7 +1951,7 @@
         }
     },
     "securityDefinitions": {
-        "ApiKeyAuth": {
+        "key": {
             "type": "apiKey",
             "name": "x-token",
             "in": "header"

--- a/shipyard-controller/docs/swagger.yaml
+++ b/shipyard-controller/docs/swagger.yaml
@@ -1,23 +1,5 @@
 basePath: /v1
 definitions:
-  models.Approval:
-    properties:
-      eventId:
-        description: ID of the event
-        type: string
-      image:
-        description: image
-        type: string
-      keptnContext:
-        description: Keptn Context ID of the event
-        type: string
-      tag:
-        description: tag
-        type: string
-      time:
-        description: Time of the event
-        type: string
-    type: object
   models.CreateLogsRequest:
     properties:
       logs:
@@ -80,26 +62,10 @@ definitions:
     type: object
   models.EventContext:
     properties:
-      eventId:
-        description: ID of the event
-        type: string
       keptnContext:
-        description: Keptn Context ID of the event
-        type: string
-      time:
-        description: Time of the event
-        type: string
-    type: object
-  models.EventContextInfo:
-    properties:
-      eventId:
-        description: ID of the event
-        type: string
-      keptnContext:
-        description: Keptn Context ID of the event
-        type: string
-      time:
-        description: Time of the event
+        description: |-
+          keptn context
+          Required: true
         type: string
     type: object
   models.Events:
@@ -226,14 +192,18 @@ definitions:
   models.GetLogsResponse:
     properties:
       logs:
+        description: logs
         items:
           $ref: '#/definitions/models.LogEntry'
         type: array
       nextPageKey:
+        description: Pointer to next page
         type: integer
       pageSize:
+        description: Size of returned page
         type: integer
       totalCount:
+        description: Total number of logs
         type: integer
     type: object
   models.Integration:
@@ -317,8 +287,6 @@ definitions:
     type: object
   models.MetaData:
     properties:
-      deplyomentname:
-        type: string
       distributorversion:
         type: string
       hostname:
@@ -328,8 +296,6 @@ definitions:
       kubernetesmetadata:
         $ref: '#/definitions/models.KubernetesMetaData'
       location:
-        type: string
-      status:
         type: string
     type: object
   models.Remediation:
@@ -414,39 +380,6 @@ definitions:
         description: Total number of events
         type: integer
     type: object
-  models.Service:
-    properties:
-      creationDate:
-        description: Creation date of the service
-        type: string
-      deployedImage:
-        description: Currently deployed image
-        type: string
-      lastEventTypes:
-        additionalProperties:
-          $ref: '#/definitions/models.EventContextInfo'
-        description: last event types
-        type: object
-      openApprovals:
-        description: open approvals
-        items:
-          $ref: '#/definitions/models.Approval'
-        type: array
-      serviceName:
-        description: Service name
-        type: string
-    type: object
-  models.Stage:
-    properties:
-      services:
-        description: services
-        items:
-          $ref: '#/definitions/models.Service'
-        type: array
-      stageName:
-        description: Stage name
-        type: string
-    type: object
   models.Stages:
     properties:
       nextPageKey:
@@ -458,7 +391,7 @@ definitions:
       stages:
         description: stages
         items:
-          $ref: '#/definitions/models.Stage'
+          $ref: '#/definitions/models.ExpandedStage'
         type: array
       totalCount:
         description: Total number of stages
@@ -1372,7 +1305,7 @@ paths:
       tags:
       - Uniform
 securityDefinitions:
-  ApiKeyAuth:
+  key:
     in: header
     name: x-token
     type: apiKey

--- a/shipyard-controller/main.go
+++ b/shipyard-controller/main.go
@@ -25,7 +25,7 @@ import (
 // @version 1.0
 // @description This is the API documentation of the Shipyard Controller.
 
-// @securityDefinitions.apiKey ApiKeyAuth
+// @securityDefinitions.apiKey key
 // @in header
 // @name x-token
 

--- a/statistics-service/docs/docs.go
+++ b/statistics-service/docs/docs.go
@@ -8,8 +8,8 @@ import (
 	"encoding/json"
 	"strings"
 
+	"github.com/alecthomas/template"
 	"github.com/swaggo/swag"
-	"text/template"
 )
 
 var doc = `{
@@ -280,7 +280,7 @@ var doc = `{
         }
     },
     "securityDefinitions": {
-        "ApiKeyAuth": {
+        "key": {
             "type": "apiKey",
             "name": "x-token",
             "in": "header"

--- a/statistics-service/docs/docs.go
+++ b/statistics-service/docs/docs.go
@@ -8,8 +8,9 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/alecthomas/template"
 	"github.com/swaggo/swag"
+
+	"text/template"
 )
 
 var doc = `{

--- a/statistics-service/docs/swagger.json
+++ b/statistics-service/docs/swagger.json
@@ -264,7 +264,7 @@
         }
     },
     "securityDefinitions": {
-        "ApiKeyAuth": {
+        "key": {
             "type": "apiKey",
             "name": "x-token",
             "in": "header"

--- a/statistics-service/docs/swagger.yaml
+++ b/statistics-service/docs/swagger.yaml
@@ -173,7 +173,7 @@ paths:
       tags:
       - Statistics
 securityDefinitions:
-  ApiKeyAuth:
+  key:
     in: header
     name: x-token
     type: apiKey

--- a/statistics-service/main.go
+++ b/statistics-service/main.go
@@ -16,7 +16,7 @@ import (
 // @version 1.0
 // @description This is the API documentation of the Statistics Service.
 
-// @securityDefinitions.apiKey ApiKeyAuth
+// @securityDefinitions.apiKey key
 // @in header
 // @name x-token
 


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

Fixes #3423 

This is what I did:

Edit statistics-service/main.go, secret-service/main.go, shipyard-controller/main.go and switch the authentication parameter to `key`.
Then I executed `swag init --parseDependency` in all of these three directories, which resulted in the changes shown in the PR.
Last but not least, I manually switched the dependency of `github.com/alecthomas/template` back to `text/template`.

Please note that I am only responsible for the changes regarding authentication. All other changes are not made by me, but they must have been forgotten by the contributors before.