### PR TITLE
#4185 bump meta keptn version to 0.8.3

### DIFF
--- a/.ci_env
+++ b/.ci_env
@@ -34,5 +34,5 @@ MONGODB_DS_FOLDER="mongodb-datastore/"
 STATISTICS_SVC_IMAGE="statistics-service"
 STATISTICS_SVC_FOLDER="statistics-service/"
 
-META_KEPTN_VERSION="0.8.1"
+META_KEPTN_VERSION="0.8.3"
 META_KEPTN_KEPTN_PROJECT="keptn"


### PR DESCRIPTION
**This PR**

* bumps the keptn version for meta keptn to 0.8.3
* other things that were done on the meta keptn instance
  * replaced istio with nginx ingress controller 0.47.0 (using helm)
  * added cert-manager 1.3.1 plus Let's Encrypt ClusterIssuer for SSL certificate handling (using helm)

Closes #4185 

Signed-off-by: Moritz Wiesinger <moritz.wiesinger@dynatrace.com>