### PR TITLE
Revert "#2479 Switch to nats 0.8.0"

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/Chart.yaml
+++ b/installer/manifests/keptn/charts/control-plane/Chart.yaml
@@ -27,5 +27,5 @@ dependencies:
     version: 0.1.0
     condition: mongodb.enabled
   - name: nats
-    version: 0.8.0
+    version: 0.7.4
     repository: https://nats-io.github.io/k8s/helm/charts/

--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -11,7 +11,6 @@ keptnSpecVersion: latest
 
 nats:
   nameOverride: keptn-nats-cluster
-  fullnameOverride: keptn-nats-cluster
   nats.cluster.replicas: 3
 
   natsbox:


### PR DESCRIPTION
Reverts keptn/keptn#4316 as we ran into an issue when upgrading from an older Keptn version:

Error: Could not complete Keptn installation: Error when installing/upgrading Helm Chart keptn in namespace keptn: cannot patch "keptn-nats-cluster" with kind StatefulSet: StatefulSet.apps "keptn-nats-cluster" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden 

