### PR TITLE
#4185 fix jmeter and helm service urls

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1102,7 +1102,7 @@ jobs:
             {
               "data": {
                 "deployment": {
-                  "deploymentURIsLocal": ["http://helm-service.keptn-dev:8080"],
+                  "deploymentURIsLocal": ["http://keptn-dev-helm-service.keptn-dev:8080"],
                   "deploymentstrategy": "user_managed"
                 },
                 "message": "",
@@ -1131,7 +1131,7 @@ jobs:
             {
               "data": {
                 "deployment": {
-                  "deploymentURIsLocal": ["http://jmeter-service.keptn-dev:8080"],
+                  "deploymentURIsLocal": ["http://keptn-dev-jmeter-service.keptn-dev:8080"],
                   "deploymentstrategy": "user_managed"
                 },
                 "message": "",


### PR DESCRIPTION
**This PR**
* adjusts the URLs for the helm and jmeter services in keptn on keptn

Fixes #4185 

Signed-off-by: Moritz Wiesinger <moritz.wiesinger@dynatrace.com>