### PR TITLE
Also forward messages of .finished events with result=fail

### DIFF
--- a/distributor/pkg/lib/uniformlog.go
+++ b/distributor/pkg/lib/uniformlog.go
@@ -59,7 +59,7 @@ func (l *EventUniformLog) OnEvent(event cloudevents.Event) error {
 
 		taskName, _, _ := keptnv2.ParseTaskEventType(*keptnEvent.Type)
 
-		if eventData.Status == keptnv2.StatusErrored {
+		if eventData.Status == keptnv2.StatusErrored || eventData.Result == keptnv2.ResultFailed {
 			logger.Info("UniformLogger: received .finished event with status errored. forwarding log message to log ingestion API")
 			l.Log(keptnapimodels.LogEntry{
 				IntegrationID: l.IntegrationID,


### PR DESCRIPTION
addition for #4030: With this PR, the distributor also considers .finished events with `result=fail`, in addition to `status=errored`
Signed-off-by: Florian Bacher <florian.bacher@dynatrace.com>