### PR TITLE
#4180 keptn-on-keptn stages with ingress and SSL, use endpoints.yaml files

### DIFF
--- a/.github/actions/spelling/excludes.txt
+++ b/.github/actions/spelling/excludes.txt
@@ -1,6 +1,8 @@
 (?:^|/)(?i)LICENSE
 /package-lock\.json$
 /swagger-ui/
+CODEOWNERS
+CONTRIBUTORS.md
 dynatrace
 ignore$
 reviewdog\.yml$
@@ -16,9 +18,9 @@ reviewdog\.yml$
 \.sum$
 \.xlf$
 ^ADOPTERS\.md$
-CODEOWNERS
 ^bridge/client/app/_models/metadata\.ts$
+^bridge/client/app/_models/uniform-registrations-logs\.mock\.ts$
 ^CODE_OF_CONDUCT\.md$
+^test/assets/keptn-on-keptn/endpoints-keptn\.yaml$
 ^\.github/actions/
 _test\.go$
-CONTRIBUTORS.md

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -189,7 +189,6 @@ dynatrace
 dynatraceheader
 dynatracelabs
 easytravel
-ebd
 ebe
 ECDHE
 ECDSA
@@ -204,6 +203,7 @@ entrypoint
 enum
 envconfig
 envoyproxy
+envsubst
 eofline
 epochconverter
 eql
@@ -453,6 +453,7 @@ Ldate
 ldflags
 leafnode
 len
+letsencrypt
 libc
 libnpx
 lifecycle
@@ -723,7 +724,6 @@ shkeptncontext
 shkeptnspecversion
 shm
 SIGINT
-SIGKILL
 sigs
 SIGTERM
 simplenode

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1056,12 +1056,44 @@ jobs:
         id: deploy_keptn_with_keptn
         run: |
           KEPTN_HELM_CHART_FILENAME=$(ls dist/keptn-installer/keptn*.tgz | head -1)
+          KEPTN_INGRESS_TEMPLATE_FILENAME=test/assets/keptn-on-keptn/ingress.yaml
+          ENDPOINTS_TEMPLATE_BASE_PATH=test/assets/keptn-on-keptn
           HELM_SERVICE_HELM_CHART_FILENAME=$(ls dist/keptn-installer/helm-service*.tgz | head -1)
           JMETER_SERVICE_HELM_CHART_FILENAME=$(ls dist/keptn-installer/jmeter-service*.tgz | head -1)
 
           keptn add-resource --project=${{ env.META_KEPTN_KEPTN_PROJECT }} --service=keptn --all-stages --resource=${KEPTN_HELM_CHART_FILENAME} --resourceUri=helm/keptn.tgz
           keptn add-resource --project=${{ env.META_KEPTN_KEPTN_PROJECT }} --service=helm-service --all-stages --resource=${HELM_SERVICE_HELM_CHART_FILENAME} --resourceUri=helm/helm-service.tgz
           keptn add-resource --project=${{ env.META_KEPTN_KEPTN_PROJECT }} --service=jmeter-service --all-stages --resource=${JMETER_SERVICE_HELM_CHART_FILENAME} --resourceUri=helm/jmeter-service.tgz
+
+          stages=('dev' 'hardening' 'production')
+          services=('keptn' 'helm-service' 'jmeter-service')
+          for SERVICE in "${services[@]}"
+          do
+            for STAGE in "${stages[@]}"
+            do
+              export SERVICE
+              export STAGE
+              envsubst < ${ENDPOINTS_TEMPLATE_BASE_PATH}/endpoints-${SERVICE}.yaml > ${ENDPOINTS_TEMPLATE_BASE_PATH}/endpoints-${SERVICE}-${STAGE}.yaml
+              keptn add-resource \
+                --project=${{ env.META_KEPTN_KEPTN_PROJECT }} \
+                --service=${SERVICE} \
+                --stage=${STAGE} \
+                --resource=${ENDPOINTS_TEMPLATE_BASE_PATH}/endpoints-${SERVICE}-${STAGE}.yaml \
+                --resourceUri=helm/endpoints.yaml
+            done
+          done
+
+          for STAGE in "${stages[@]}"
+          do
+            export STAGE
+            envsubst < ${KEPTN_INGRESS_TEMPLATE_FILENAME} > ${ENDPOINTS_TEMPLATE_BASE_PATH}/ingress-${STAGE}.yaml
+            keptn add-resource \
+              --project=${{ env.META_KEPTN_KEPTN_PROJECT }} \
+              --service=keptn \
+              --stage=${STAGE} \
+              --resource=${ENDPOINTS_TEMPLATE_BASE_PATH}/ingress-${STAGE}.yaml \
+              --resourceUri=helm/keptn/templates/ingress.yaml
+          done
 
       - name: Trigger Keptn Control Plane Delivery
         id: trigger-keptn-control-plane-delivery
@@ -1072,10 +1104,6 @@ jobs:
           event: |
             {
               "data": {
-                "deployment": {
-                  "deploymentURIsLocal": ["http://api-gateway-nginx.keptn-dev"],
-                  "deploymentstrategy": "user_managed"
-                },
                 "message": "",
                 "project": "${{ env.META_KEPTN_KEPTN_PROJECT }}",
                 "result": "",
@@ -1101,10 +1129,6 @@ jobs:
           event: |
             {
               "data": {
-                "deployment": {
-                  "deploymentURIsLocal": ["http://keptn-dev-helm-service.keptn-dev:8080"],
-                  "deploymentstrategy": "user_managed"
-                },
                 "message": "",
                 "project": "${{ env.META_KEPTN_KEPTN_PROJECT }}",
                 "result": "",
@@ -1130,10 +1154,6 @@ jobs:
           event: |
             {
               "data": {
-                "deployment": {
-                  "deploymentURIsLocal": ["http://keptn-dev-jmeter-service.keptn-dev:8080"],
-                  "deploymentstrategy": "user_managed"
-                },
                 "message": "",
                 "project": "${{ env.META_KEPTN_KEPTN_PROJECT }}",
                 "result": "",

--- a/test/assets/creds.sav
+++ b/test/assets/creds.sav
@@ -1,5 +1,0 @@
-{
-    "clusterName": "CLUSTER_NAME_PLACEHOLDER",
-    "clusterZone": "CLUSTER_ZONE_PLACEHOLDER",
-    "gkeProject": "GKE_PROJECT_PLACEHOLDER"
-}

--- a/test/assets/keptn-on-keptn/endpoints-helm-service.yaml
+++ b/test/assets/keptn-on-keptn/endpoints-helm-service.yaml
@@ -1,0 +1,2 @@
+deploymentURIsLocal:
+  - "http://keptn-$STAGE-helm-service.keptn-$STAGE:8080"

--- a/test/assets/keptn-on-keptn/endpoints-jmeter-service.yaml
+++ b/test/assets/keptn-on-keptn/endpoints-jmeter-service.yaml
@@ -1,0 +1,2 @@
+deploymentURIsLocal:
+  - "http://keptn-$STAGE-jmeter-service.keptn-$STAGE:8080"

--- a/test/assets/keptn-on-keptn/endpoints-keptn.yaml
+++ b/test/assets/keptn-on-keptn/endpoints-keptn.yaml
@@ -1,0 +1,4 @@
+deploymentURIsLocal:
+  - "http://api-gateway-nginx.keptn-$STAGE"
+deploymentURIsPublic:
+  - "https://$STAGE.keptn-on.keptn.sh"

--- a/test/assets/keptn-on-keptn/ingress.yaml
+++ b/test/assets/keptn-on-keptn/ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  name: api-keptn-ingress
+spec:
+  rules:
+    - host: &host $STAGE.keptn-on.keptn.sh
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: api-gateway-nginx
+                port:
+                  name: http
+  tls:
+    - hosts:
+        - *host
+      secretName: api-keptn-ingress-cert


### PR DESCRIPTION
**This PR**
* adds ingress k8s manifests to all keptn-on-keptn stages
* adds SSL certificates automatically through LE and cert-manager
* makes use of the `endpoints.yaml` file instead of sending the deployment URIs with the cloud events to trigger deliveries
* removes unused `creds.sav` file

Fixes #4180 

Signed-off-by: Moritz Wiesinger <moritz.wiesinger@dynatrace.com>