### PR TITLE
#4183 Airgapped installation

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -8,6 +8,7 @@ addons
 addrowonbottom
 adduser
 agrabner
+airgapped
 AKS
 alecthomas
 amd
@@ -122,6 +123,7 @@ configurationstore
 configurator
 configuremonitoring
 configutils
+connecteverything
 consumercatalog
 containerregistry
 contenttype
@@ -230,6 +232,7 @@ eventsender
 eventtype
 Evts
 exe
+exechelper
 expr
 expressjs
 externallink
@@ -265,6 +268,7 @@ fwlink
 gcc
 gcflags
 gcloud
+gcr
 gendoc
 genericclioptions
 genid
@@ -697,6 +701,7 @@ rxjs
 scc
 scopesrepository
 screenshot
+scrollbars
 scss
 sdk
 secondstage
@@ -785,6 +790,7 @@ svcs
 svg
 svr
 swaggo
+synadia
 syscall
 tabwidth
 tabwriter
@@ -927,5 +933,3 @@ YAMLTo
 yml
 YOURURL
 zsh
-exechelper
-scrollbars

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -349,7 +349,7 @@ jobs:
           fi
 
           if [[ $RUN_AIRGAPPED_TEST == "true" ]]; then
-            # Install Keptn via Helmer Script
+            # Install Keptn via Helper Script
             installer/airgapped/install_keptn.sh "k3d-container-registry.localhost:12345/" "http://0.0.0.0:8000/$HELM_CHART_NAME" "http://0.0.0.0:8000/$HELM_SERVICE_HELM_CHART_NAME" "http://0.0.0.0:8000/$JMETER_SERVICE_HELM_CHART_NAME"
           else
             # Install Keptn via CLI

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -34,13 +34,13 @@ jobs:
         include:
           - CLOUD_PROVIDER: "minishift-on-GHA"
             PLATFORM: "openshift"
-            VERSION: "3.11"
+            PLATFORM_VERSION: "3.11"
             KEPTN_SERVICE_TYPE: "ClusterIP"
             RUN_QUALITY_GATES_TEST: "false"
             RUN_CONTINUOUS_DELIVERY_TEST: "false"
             COLLECT_RESOURCE_LIMITS: "true"
           - CLOUD_PROVIDER: "k3s-on-GHA"
-            VERSION: "v1.16.15+k3s1" # see https://github.com/rancher/k3s/releases
+            PLATFORM_VERSION: "v1.16.15+k3s1" # see https://github.com/rancher/k3s/releases
             KUBECONFIG: "/etc/rancher/k3s/k3s.yaml"
             PLATFORM: "kubernetes"
             KEPTN_SERVICE_TYPE: "NodePort"
@@ -48,15 +48,24 @@ jobs:
             RUN_CONTINUOUS_DELIVERY_TEST: "false"
             COLLECT_RESOURCE_LIMITS: "false"
           - CLOUD_PROVIDER: "k3s-on-GHA"
-            VERSION: "v1.21.1+k3s1" # see https://github.com/rancher/k3s/releases
+            PLATFORM_VERSION: "v1.21.1+k3s1" # see https://github.com/rancher/k3s/releases
             KUBECONFIG: "/etc/rancher/k3s/k3s.yaml"
             PLATFORM: "kubernetes"
             KEPTN_SERVICE_TYPE: "NodePort"
             RUN_QUALITY_GATES_TEST: "true"
             RUN_CONTINUOUS_DELIVERY_TEST: "false"
             COLLECT_RESOURCE_LIMITS: "false"
+          - CLOUD_PROVIDER: "k3d-on-GHA"
+            PLATFORM_VERSION: "v4.4.4" # see https://github.com/rancher/k3d/releases
+            KUBECONFIG: ""
+            PLATFORM: "kubernetes"
+            KEPTN_SERVICE_TYPE: "NodePort"
+            RUN_AIRGAPPED_TEST: "true"
+            RUN_QUALITY_GATES_TEST: "false"
+            RUN_CONTINUOUS_DELIVERY_TEST: "false"
+            COLLECT_RESOURCE_LIMITS: "false"
           - CLOUD_PROVIDER: "GKE"
-            VERSION: "1.17"
+            PLATFORM_VERSION: "1.17"
             KUBECONFIG: ""
             PLATFORM: "kubernetes"
             KEPTN_SERVICE_TYPE: "LoadBalancer"
@@ -65,7 +74,7 @@ jobs:
             REMOTE_EXECUTION_PLANE: "true"
             COLLECT_RESOURCE_LIMITS: "false"
           - CLOUD_PROVIDER: "GKE"
-            VERSION: "1.19"
+            PLATFORM_VERSION: "1.19"
             KUBECONFIG: ""
             PLATFORM: "kubernetes"
             KEPTN_SERVICE_TYPE: "LoadBalancer"
@@ -76,11 +85,12 @@ jobs:
     env:
       CLOUD_PROVIDER: ${{ matrix.CLOUD_PROVIDER }}
       PLATFORM: ${{ matrix.PLATFORM }}
-      VERSION: ${{ matrix.VERSION }}
+      PLATFORM_VERSION: ${{ matrix.PLATFORM_VERSION }}
       KUBECONFIG: ${{ matrix.KUBECONFIG }}
       KEPTN_NAMESPACE: "keptn-test"
       KEPTN_SERVICE_TYPE: ${{ matrix.KEPTN_SERVICE_TYPE }}
       RUN_CONTINUOUS_DELIVERY_TEST: ${{ matrix.RUN_CONTINUOUS_DELIVERY_TEST }}
+      RUN_AIRGAPPED_TEST: ${{ matrix.RUN_AIRGAPPED_TEST }}
       REMOTE_EXECUTION_PLANE: ${{ matrix.REMOTE_EXECUTION_PLANE }}
       RUN_QUALITY_GATES_TEST: ${{ matrix.RUN_QUALITY_GATES_TEST }}
       KEPTN_EXAMPLES_BRANCH: ${{ github.event.inputs.examples_branch }}
@@ -89,6 +99,7 @@ jobs:
       BRANCH: ${{ steps.determine_branch.outputs.BRANCH }}
       ARTIFACTS_CI_EVENT_TYPE: ${{ github.event.inputs.artifacts_ci_event_type }}
     steps:
+
       - name: Check out code.
         uses: actions/checkout@v2.3.4
 
@@ -131,6 +142,63 @@ jobs:
 
           echo "##[set-output name=BRANCH;]$(echo ${BRANCH})"
 
+      # download artifacts from the specified branch with event type push (e.g., push to master/release branch)
+      - name: Download build artifacts from specified branch
+        uses: dawidd6/action-download-artifact@v2.14.0
+        id: download_artifacts_push
+        with:
+          # Download last successful artifact from a CI build
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          workflow: CI.yml
+          event: ${{ github.event.inputs.artifacts_ci_event_type }} # e.g., push, pull_request
+          workflow_conclusion: success
+          # use the following branch
+          branch: ${{ steps.determine_branch.outputs.BRANCH}}
+          # directory where to extract artifacts to
+          path: ./dist
+
+      # load build-config
+      - name: Load Build-Config Environment from ./dist/build-config/build-config.env
+        id: load_build_env
+        uses: c-py/action-dotenv-to-setenv@v3
+        with:
+          env-file: ./dist/build-config/build-config.env
+
+      - name: Overwrite VERSION String for nightly builds
+        run: |
+          if [[ "$BRANCH" == "master" ]]; then
+            # use VERSION.DATETIME for the cli version (e.g., nightly build)
+            VERSION=${VERSION}.${DATETIME}
+            # overwrite VERSION
+            echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          fi
+
+      - name: DEBUG Build-Config
+        run: |
+          echo VERSION=${VERSION}
+          echo BRANCH=${BRANCH}
+
+      - name: Extract Keptn CLI artifact
+        run: |
+          tar -zxvf dist/keptn-cli/keptn-*-linux-amd64.tar.gz
+          sudo mv keptn-*-linux-amd64 /usr/local/bin/keptn
+
+      - name: Verify Keptn CLI works
+        timeout-minutes: 1
+        run: keptn version
+
+      - name: Extract name of helm chart
+        id: extract_helm_chart_name
+        run: |
+          ls dist/keptn-installer/*.tgz # debug output
+          HELM_CHART_NAME=$(ls dist/keptn-installer/keptn*.tgz | grep -o keptn-[A-Za-z0-9.-]*.tgz)
+          HELM_SERVICE_HELM_CHART_NAME=$(ls dist/keptn-installer/helm*.tgz | grep -o helm-[A-Za-z0-9.-]*.tgz)
+          JMETER_SERVICE_HELM_CHART_NAME=$(ls dist/keptn-installer/jmeter*.tgz | grep -o jmeter-[A-Za-z0-9.-]*.tgz)
+
+          echo "##[set-output name=HELM_CHART_NAME;]$(echo ${HELM_CHART_NAME})"
+          echo "##[set-output name=HELM_SERVICE_HELM_CHART_NAME;]$(echo ${HELM_SERVICE_HELM_CHART_NAME})"
+          echo "##[set-output name=JMETER_SERVICE_HELM_CHART_NAME;]$(echo ${JMETER_SERVICE_HELM_CHART_NAME})"
+
       # setup cloud provider kubernetes instance
       - name: Install and start Minishift
         timeout-minutes: 15
@@ -147,14 +215,26 @@ jobs:
       - name: Install and start K3s
         if: env.CLOUD_PROVIDER == 'k3s-on-GHA'
         env:
-          K3S_VERSION: ${{ matrix.VERSION }}
+          K3S_VERSION: ${{ matrix.PLATFORM_VERSION }}
         run: |
           test/utils/download_and_install_k3s.sh
           test/utils/k3s_create_cluster.sh
+
+      - name: Install and start K3d
+        if: env.CLOUD_PROVIDER == 'k3d-on-GHA'
+        env:
+          K3D_VERSION: ${{ matrix.PLATFORM_VERSION }}
+        run: |
+          test/utils/download_and_install_k3d.sh
+
+          # create registry and cluster
+          k3d registry create container-registry.localhost --port 12345
+          k3d cluster create mykeptn --k3s-server-arg '--no-deploy=traefik' --agents 1 --registry-use k3d-container-registry.localhost:12345
+
       - name: Install and start GKE cluster
         if: env.CLOUD_PROVIDER == 'GKE'
         env:
-          GKE_VERSION: ${{ matrix.VERSION }}
+          GKE_VERSION: ${{ matrix.PLATFORM_VERSION }}
           GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
           GCLOUD_PROJECT_NAME: ${{ secrets.GCLOUD_PROJECT_NAME }}
           CLOUDSDK_COMPUTE_ZONE: "us-east1-b"
@@ -209,53 +289,50 @@ jobs:
         run: kubectl get services --all-namespaces
       - name: Debug - Get Kubernetes Deployments
         run: kubectl get deployments --all-namespaces -owide
-      # try to download artifacts from the specified branch with event type push (e.g., push to master/release branch)
-      - name: Download CLI artifact from specified branch
-        uses: dawidd6/action-download-artifact@v2.14.0
-        id: download_artifacts_push
-        with:
-          # Download last successful artifact from a CI build
-          github_token: ${{secrets.GITHUB_TOKEN}}
-          workflow: CI.yml
-          event: ${{ github.event.inputs.artifacts_ci_event_type }} # e.g., push, pull_request
-          workflow_conclusion: success
-          # use the following branch
-          branch: ${{ steps.determine_branch.outputs.BRANCH}}
-          # directory where to extract artifacts to
-          path: ./dist
-      - name: Extract Keptn CLI artifact
-        run: |
-          tar -zxvf dist/keptn-cli/keptn-*-linux-amd64.tar.gz
-          sudo mv keptn-*-linux-amd64 /usr/local/bin/keptn
-
-      - name: Verify Keptn CLI works
-        timeout-minutes: 1
-        run: keptn version
-
-      - name: Extract name of helm chart
-        id: extract_helm_chart_name
-        run: |
-          ls dist/keptn-installer/*.tgz # debug output
-          HELM_CHART_NAME=$(ls dist/keptn-installer/keptn*.tgz | grep -o keptn-[A-Za-z0-9.-]*.tgz)
-          HELM_SERVICE_HELM_CHART_NAME=$(ls dist/keptn-installer/helm*.tgz | grep -o helm-[A-Za-z0-9.-]*.tgz)
-          JMETER_SERVICE_HELM_CHART_NAME=$(ls dist/keptn-installer/jmeter*.tgz | grep -o jmeter-[A-Za-z0-9.-]*.tgz)
-
-          echo "##[set-output name=HELM_CHART_NAME;]$(echo ${HELM_CHART_NAME})"
-          echo "##[set-output name=HELM_SERVICE_HELM_CHART_NAME;]$(echo ${HELM_SERVICE_HELM_CHART_NAME})"
-          echo "##[set-output name=JMETER_SERVICE_HELM_CHART_NAME;]$(echo ${JMETER_SERVICE_HELM_CHART_NAME})"
-
 
       - name: Host helm chart via python http server
         run: cd dist/keptn-installer/ && python3 -m http.server &
+
+      - name: Push images to airgapped registry
+        if: env.RUN_AIRGAPPED_TEST == 'true'
+        timeout-minutes: 15
+        env:
+          KEPTN_TAG: ${{ env.VERSION }}
+        run: |
+          # pull images and push it to the local k3d registry
+          installer/airgapped/pull_and_retag_images.sh "k3d-container-registry.localhost:12345/"
+
+      - name: Prevent egress traffic for airgapped system
+        # this only prevents pods / containers from accessing services outside of the Kubernetes cluster, it does not
+        # prevent containers/images to be pulled from DockerHub
+        if: env.RUN_AIRGAPPED_TEST == 'true'
+        run: |
+          # Deny egress traffic: https://kubernetes.io/docs/concepts/services-networking/network-policies/#default-deny-all-ingress-and-all-egress-traffic
+          kubectl apply -f - <<EOF
+          ---
+          apiVersion: networking.k8s.io/v1
+          kind: NetworkPolicy
+          metadata:
+            name: default-deny-all
+          spec:
+            podSelector: {}
+            policyTypes:
+              - Egress
+          EOF
+
+          # wait a bit
+          sleep 30
 
       - name: Install Keptn
         id: keptn_install
         timeout-minutes: 10
         env:
           HELM_CHART_NAME: ${{ steps.extract_helm_chart_name.outputs.HELM_CHART_NAME }}
+          HELM_SERVICE_HELM_CHART_NAME: ${{ steps.extract_helm_chart_name.outputs.HELM_SERVICE_HELM_CHART_NAME }}
+          JMETER_SERVICE_HELM_CHART_NAME: ${{ steps.extract_helm_chart_name.outputs.JMETER_SERVICE_HELM_CHART_NAME }}
+          RUN_AIRGAPPED_TEST: ${{ env.RUN_AIRGAPPED_TEST }}
         run: |
           echo "Installing Keptn on cluster"
-
           if [[ $PLATFORM == "openshift" ]]; then
             echo "{
               \"openshiftUrl\": \"https://127.0.0.1:8443\",
@@ -265,22 +342,27 @@ jobs:
           else
             echo "{}" > creds.json # empty credentials file
           fi
-
           # Determine use case
           USE_CASE=""
           if [[ $RUN_CONTINUOUS_DELIVERY_TEST == "true" ]]; then
             USE_CASE="--use-case=continuous-delivery"
           fi
 
-          # Install Keptn
-          keptn install --platform=${PLATFORM} --namespace=${KEPTN_NAMESPACE} --endpoint-service-type=${KEPTN_SERVICE_TYPE} \
-             --chart-repo=http://0.0.0.0:8000/${HELM_CHART_NAME} --creds=creds.json --verbose $USE_CASE
+          if [[ $RUN_AIRGAPPED_TEST == "true" ]]; then
+            # Install Keptn via Helmer Script
+            installer/airgapped/install_keptn.sh "k3d-container-registry.localhost:12345/" "http://0.0.0.0:8000/$HELM_CHART_NAME" "http://0.0.0.0:8000/$HELM_SERVICE_HELM_CHART_NAME" "http://0.0.0.0:8000/$JMETER_SERVICE_HELM_CHART_NAME"
+          else
+            # Install Keptn via CLI
+            keptn install --platform=${PLATFORM} --namespace=${KEPTN_NAMESPACE} --endpoint-service-type=${KEPTN_SERVICE_TYPE} \
+               --chart-repo=http://0.0.0.0:8000/${HELM_CHART_NAME} --creds=creds.json --verbose $USE_CASE
+          fi
+
 
       # Gather resource limits directly after installation of Keptn
       - name: Gather resource limits
         if: env.COLLECT_RESOURCE_LIMITS == 'true'
         env:
-          TEST_REPORT_FILENAME: test-resource-limits-${{ github.run_id }}-${{ matrix.PLATFORM }}-${{ matrix.CLOUD_PROVIDER}}-${{ matrix.VERSION }}.txt
+          TEST_REPORT_FILENAME: test-resource-limits-${{ github.run_id }}-${{ matrix.PLATFORM }}-${{ matrix.CLOUD_PROVIDER}}-${{ matrix.PLATFORM_VERSION }}.txt
         run: |
           echo "**Resource Limits for ${{ matrix.PLATFORM }}-${{ matrix.CLOUD_PROVIDER}}**" > $TEST_REPORT_FILENAME
           test/utils/k8s_collect_resources.sh ${KEPTN_NAMESPACE} >> $TEST_REPORT_FILENAME
@@ -391,7 +473,16 @@ jobs:
         timeout-minutes: 1
         run: keptn status
 
+      - name: Test Airgapped Images
+        id: test_airgapped_images
+        if: env.RUN_AIRGAPPED_TEST == 'true'
+        timeout-minutes: 2
+        continue-on-error: true
+        run: test/test_airgapped_images.sh "k3d-container-registry.localhost:12345"
+
       - name: Test Linking Stages
+        # do not run this test for the airgapped scenario
+        if: env.RUN_AIRGAPPED_TEST != 'true'
         id: test_linking_stages
         timeout-minutes: 5
         continue-on-error: true
@@ -400,6 +491,8 @@ jobs:
         run: test/test_linking_stages.sh
 
       - name: Test Uniform Registration
+        # do not run this test for the airgapped scenario
+        if: env.RUN_AIRGAPPED_TEST != 'true'
         id: test_uniform_registration
         timeout-minutes: 5
         continue-on-error: true
@@ -408,6 +501,8 @@ jobs:
         run: cd test/go-tests && go test -run UniformRegistration -v
 
       - name: Test Log Ingestion
+        # do not run this test for the airgapped scenario
+        if: env.RUN_AIRGAPPED_TEST != 'true'
         id: test_log_ingestion
         timeout-minutes: 5
         continue-on-error: true
@@ -416,6 +511,8 @@ jobs:
         run: cd test/go-tests && go test -run LogIngestion -v
 
       - name: Test Log Forwarding
+        # do not run this test for the airgapped scenario
+        if: env.RUN_AIRGAPPED_TEST != 'true'
         id: test_log_forwarding
         timeout-minutes: 5
         continue-on-error: true
@@ -424,6 +521,8 @@ jobs:
         run: cd test/go-tests && go test -run LogForwarding -v
 
       - name: Test Sequence States
+        # do not run this test for the airgapped scenario
+        if: env.RUN_AIRGAPPED_TEST != 'true'
         id: test_sequence_states
         timeout-minutes: 5
         continue-on-error: true
@@ -432,6 +531,8 @@ jobs:
         run: cd test/go-tests && go test -run SequenceStateIntegrationTest -v
 
       - name: Test Sequence Loop
+        # do not run this test for the airgapped scenario
+        if: env.RUN_AIRGAPPED_TEST != 'true'
         id: test_sequence_loop
         timeout-minutes: 5
         continue-on-error: true
@@ -440,6 +541,8 @@ jobs:
         run: cd test/go-tests && go test -run SequenceLoopIntegrationTest -v
 
       - name: Test Delayed Tasks
+        # do not run this test for the airgapped scenario
+        if: env.RUN_AIRGAPPED_TEST != 'true'
         id: test_delayed_tasks
         timeout-minutes: 5
         continue-on-error: true
@@ -449,8 +552,8 @@ jobs:
 
       - name: Test Quality Gates Standalone
         id: test_quality_gates
-        # Note: quality gates test requires network access, which doesn't work on some platforms
-        if: env.RUN_QUALITY_GATES_TEST == 'true' # run test only if set to true
+        # Note: quality gates test requires network access, which doesn't work on some platforms (also not on airgapped)
+        if: env.RUN_AIRGAPPED_TEST != 'true' && env.RUN_QUALITY_GATES_TEST == 'true'
         timeout-minutes: 10
         continue-on-error: true
         env:
@@ -463,8 +566,8 @@ jobs:
 
       - name: Test Quality Gates Backwards compatibility
         id: test_quality_gates_backwards_compatibility
-        # Note: quality gates test requires network access, which doesn't work on some platforms
-        if: env.RUN_QUALITY_GATES_TEST == 'true' # run test only if set to true
+        # Note: quality gates test requires network access, which doesn't work on some platforms (also not on airgapped)
+        if: env.RUN_AIRGAPPED_TEST != 'true' && env.RUN_QUALITY_GATES_TEST == 'true'
         timeout-minutes: 10
         continue-on-error: true
         env:
@@ -472,6 +575,8 @@ jobs:
         run: test/test_quality_gates_backwards_compatibility.sh
 
       - name: Test Self Healing
+        # do not run this test for the airgapped scenario
+        if: env.RUN_AIRGAPPED_TEST != 'true'
         id: test_self_healing
         timeout-minutes: 10
         continue-on-error: true
@@ -481,6 +586,8 @@ jobs:
         run: test/test_self_healing.sh
 
       - name: Bridge E2E Tests (Protractor, Selenium)
+        # do not run this test for the airgapped scenario
+        if: env.RUN_AIRGAPPED_TEST != 'true'
         id: test_bridge_e2e
         timeout-minutes: 15
         continue-on-error: true
@@ -513,7 +620,7 @@ jobs:
       - name: Test Delivery Assistant
         id: test_delivery_assistant
         # Delivery Assistant only works when we install keptn with continuous delivery use-case
-        if: env.RUN_CONTINUOUS_DELIVERY_TEST == 'true' # run test only if set to true
+        if: env.RUN_AIRGAPPED_TEST != 'true' && env.RUN_CONTINUOUS_DELIVERY_TEST == 'true'
         timeout-minutes: 5
         continue-on-error: true
         env:
@@ -524,7 +631,7 @@ jobs:
 
       - name: Test User Managed Delivery
         id: test_user_managed_delivery
-        if: env.RUN_CONTINUOUS_DELIVERY_TEST == 'true'
+        if: env.RUN_AIRGAPPED_TEST != 'true' && env.RUN_CONTINUOUS_DELIVERY_TEST == 'true'
         timeout-minutes: 5
         continue-on-error: true
         env:
@@ -554,7 +661,7 @@ jobs:
 
       - name: Test Continuous Delivery with parallel stages (with sockshop)
         id: test_continuous_delivery
-        if: (env.RUN_CONTINUOUS_DELIVERY_TEST == 'true') && (env.REMOTE_EXECUTION_PLANE != 'true')
+        if: env.RUN_AIRGAPPED_TEST != 'true' && (env.RUN_CONTINUOUS_DELIVERY_TEST == 'true') && (env.REMOTE_EXECUTION_PLANE != 'true')
         timeout-minutes: 45
         continue-on-error: true
         env:
@@ -568,7 +675,7 @@ jobs:
 
       - name: Test Continuous Delivery with parallel stages on Remote Exec Plane (with sockshop)
         id: test_continuous_delivery_remote_exec
-        if: (env.RUN_CONTINUOUS_DELIVERY_TEST == 'true') && (env.REMOTE_EXECUTION_PLANE == 'true')
+        if: env.RUN_AIRGAPPED_TEST != 'true' && (env.RUN_CONTINUOUS_DELIVERY_TEST == 'true') && (env.REMOTE_EXECUTION_PLANE == 'true')
         timeout-minutes: 45
         continue-on-error: true
         env:
@@ -582,6 +689,8 @@ jobs:
 
       - name: Test Manage Secrets
         id: test_manage_secrets
+        # do not run this test for the airgapped scenario
+        if: env.RUN_AIRGAPPED_TEST != 'true'
         timeout-minutes: 5
         continue-on-error: true
         env:
@@ -618,7 +727,7 @@ jobs:
       - name: keptn generate support-archive
         if: always()
         env:
-          SUPPORT_ARCHIVE_FILENAME: keptn-support-archive-${{ github.run_id }}-${{ matrix.PLATFORM }}-${{ matrix.CLOUD_PROVIDER}}-${{ matrix.VERSION }}
+          SUPPORT_ARCHIVE_FILENAME: keptn-support-archive-${{ github.run_id }}-${{ matrix.PLATFORM }}-${{ matrix.CLOUD_PROVIDER}}-${{ matrix.PLATFORM_VERSION }}
         timeout-minutes: 5
         run: |
           mkdir support-archive/
@@ -659,7 +768,7 @@ jobs:
         if: always() && env.CLOUD_PROVIDER == 'GKE' # we always need to cleanup GKE clusters
         timeout-minutes: 5
         env:
-          GKE_VERSION: ${{ matrix.VERSION }}
+          GKE_VERSION: ${{ matrix.PLATFORM_VERSION }}
           GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
           GCLOUD_PROJECT_NAME: ${{ secrets.GCLOUD_PROJECT_NAME }}
           CLOUDSDK_COMPUTE_ZONE: "us-east1-b"
@@ -678,11 +787,11 @@ jobs:
         id: write_test_report
         if: always()
         env:
-          TEST_REPORT_FILENAME: test-report-${{ github.run_id }}-${{ matrix.PLATFORM }}-${{ matrix.CLOUD_PROVIDER}}-${{ matrix.VERSION }}.txt
+          TEST_REPORT_FILENAME: test-report-${{ github.run_id }}-${{ matrix.PLATFORM }}-${{ matrix.CLOUD_PROVIDER}}-${{ matrix.PLATFORM_VERSION }}.txt
         run: |
           echo "write test report to $TEST_REPORT_FILENAME"
           # please check with headings in print_test_report task roughly 50 lines below
-          echo "| ${{ matrix.PLATFORM }}/${{ matrix.CLOUD_PROVIDER}} ${{ matrix.VERSION }} | ${{ steps.keptn_install.outcome }} | ${{ steps.authenticate_keptn_cli.outcome }} | ${{ steps.test_linking_stages.outcome }} | ${{ steps.test_uniform_registration.outcome }} | ${{ steps.test_log_ingestion.outcome }} | ${{ steps.test_log_forwarding.outcome }} | ${{ steps.test_sequence_states.outcome }} | ${{ steps.test_sequence_loop.outcome }} | ${{ steps.test_quality_gates.outcome }} | ${{ steps.test_quality_gates_backwards_compatibility.outcome }} | ${{ steps.test_self_healing.outcome }} | ${{ steps.test_delivery_assistant.outcome }} | ${{ steps.test_user_managed_delivery.outcome }} | ${{ steps.test_continuous_delivery.outcome }} | ${{ steps.test_continuous_delivery_remote_exec.outcome }} | ${{ steps.test_manage_secrets.outcome }} | ${{ steps.test_bridge_e2e.outcome }} |" > $TEST_REPORT_FILENAME
+          echo "| ${{ matrix.PLATFORM }}/${{ matrix.CLOUD_PROVIDER}} ${{ matrix.PLATFORM_VERSION }} | ${{ steps.keptn_install.outcome }} | ${{ steps.authenticate_keptn_cli.outcome }} | ${{ steps.test_airgapped_images.outcome }} | ${{ steps.test_linking_stages.outcome }} | ${{ steps.test_uniform_registration.outcome }} | ${{ steps.test_log_ingestion.outcome }} | ${{ steps.test_log_forwarding.outcome }} | ${{ steps.test_sequence_states.outcome }} | ${{ steps.test_sequence_loop.outcome }} | ${{ steps.test_quality_gates.outcome }} | ${{ steps.test_quality_gates_backwards_compatibility.outcome }} | ${{ steps.test_self_healing.outcome }} | ${{ steps.test_delivery_assistant.outcome }} | ${{ steps.test_user_managed_delivery.outcome }} | ${{ steps.test_continuous_delivery.outcome }} | ${{ steps.test_continuous_delivery_remote_exec.outcome }} | ${{ steps.test_manage_secrets.outcome }} | ${{ steps.test_bridge_e2e.outcome }} |" > $TEST_REPORT_FILENAME
           cat $TEST_REPORT_FILENAME
 
       - name: Upload Bridge E2E Screenshots
@@ -741,8 +850,8 @@ jobs:
           echo "Integration Tests have finished." > final-test-report.txt
           echo "" >> final-test-report.txt
           # please check with output in write_test_report task roughly 50 lines above
-          echo "| Target Platform        |  Keptn Install    |  Keptn Auth  | Linking Stages   | Uniform Registration   | Log Ingestion   | Log Forwarding   | Sequence States   | Sequence Loop |  QG Standalone  |  QG Backwards Compat. | Self Healing  |  Del-Assist  |  User-Man. Depl.  | Cont Deliv | Cont Deliv (Remote Exec) | Manage secrets | Bridge E2E |" >> final-test-report.txt
-          echo "| ---------------------- | ----------------- | ------------ | ---------------- | ---------------------- | --------------- | ---------------- | ----------------- | ------------- | --------------- | ----------------------|-------------- | ------------ | ----------------- |----------- | ------------------------ | -------------- | ---------- |" >> final-test-report.txt
+          echo "| Target Platform        |  Keptn Install    |  Keptn Auth  | Airgapped Images | Linking Stages   | Uniform Registration   | Log Ingestion   | Log Forwarding   | Sequence States   | Sequence Loop |  QG Standalone  |  QG Backwards Compat. | Self Healing  |  Del-Assist  |  User-Man. Depl.  | Cont Deliv | Cont Deliv (Remote Exec) | Manage secrets | Bridge E2E |" >> final-test-report.txt
+          echo "| ---------------------- | ----------------- | ------------ | ---------------- | ---------------- | ---------------------- | --------------- | ---------------- | ----------------- | ------------- | --------------- | ----------------------|-------------- | ------------ | ----------------- |----------- | ------------------------ | -------------- | ---------- |" >> final-test-report.txt
           cat test-report*.txt >> final-test-report.txt
 
           # print test report

--- a/installer/airgapped/install_keptn.sh
+++ b/installer/airgapped/install_keptn.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+if [[ $# -ne 4 ]]; then
+    echo "Please provide the target registry and helm charts as parameters, e.g., "
+    echo "$1 \"docker.io/your-username/\" \"keptn-0.8.4.tgz\" \"helm-service-0.8.4.tgz\" \"jmeter-service-0.8.4.tgz\""
+    exit 1
+fi
+
+TARGET_INTERNAL_DOCKER_REGISTRY=${1}
+KEPTN_HELM_CHART=${2}
+KEPTN_HELM_SERVICE_HELM_CHART=${3}
+KEPTN_JMETER_SERVICE_HELM_CHART=${4}
+
+KEPTN_NAMESPACE=${KEPTN_NAMESPACE:-"keptn"}
+KEPTN_SERVICE_TYPE=${KEPTN_SERVICE_TYPE:-"ClusterIP"}
+
+echo "-----------------------------------------------------------------------"
+echo "Installing Keptn Core Helm Chart in Namespace ${KEPTN_NAMESPACE}"
+echo "-----------------------------------------------------------------------"
+
+
+helm upgrade keptn "${KEPTN_HELM_CHART}" --install -n "${KEPTN_NAMESPACE}" --create-namespace --wait --set="control-plane.apiGatewayNginx.type=${KEPTN_SERVICE_TYPE},continuous-delivery.enabled=true,\
+control-plane.mongodb.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}centos/mongodb-36-centos7,\
+control-plane.nats.nats.image=${TARGET_INTERNAL_DOCKER_REGISTRY}nats:2.1.9-alpine3.12,\
+control-plane.nats.reloader.image=${TARGET_INTERNAL_DOCKER_REGISTRY}connecteverything/nats-server-config-reloader:0.6.0,\
+control-plane.nats.exporter.image=${TARGET_INTERNAL_DOCKER_REGISTRY}synadia/prometheus-nats-exporter:0.5.0,\
+control-plane.apiGatewayNginx.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}nginxinc/nginx-unprivileged,\
+control-plane.apiGatewayNginx.image.tag=1.19.4-alpine,\
+control-plane.remediationService.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/remediation-service,\
+control-plane.apiService.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/api,\
+control-plane.bridge.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/bridge2,\
+control-plane.distributor.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/distributor,\
+control-plane.shipyardController.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/shipyard-controller,\
+control-plane.configurationService.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/configuration-service,\
+control-plane.mongodbDatastore.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/mongodb-datastore,\
+control-plane.statisticsService.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/statistics-service,\
+control-plane.lighthouseService.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/lighthouse-service,\
+control-plane.secretService.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/secret-service,\
+control-plane.approvalService.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/approval-service,\
+continuous-delivery.distributor.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/distributor"
+
+echo ""
+
+echo "-----------------------------------------------------------------------"
+echo "Installing Keptn Helm-Service Helm Chart in Namespace ${KEPTN_NAMESPACE}"
+echo "-----------------------------------------------------------------------"
+
+helm upgrade helm-service "${KEPTN_HELM_SERVICE_HELM_CHART}" --install -n "${KEPTN_NAMESPACE}" --set="helmservice.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/helm-service,\
+distributor.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/distributor"
+
+echo ""
+
+echo "-----------------------------------------------------------------------"
+echo "Installing Keptn JMeter-Service Helm Chart in Namespace ${KEPTN_NAMESPACE}"
+echo "-----------------------------------------------------------------------"
+
+helm upgrade jmeter-service "${KEPTN_JMETER_SERVICE_HELM_CHART}" --install -n "${KEPTN_NAMESPACE}" --set="jmeterservice.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/jmeter-service,\
+distributor.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/distributor"
+
+
+# add keptn.sh/managed-by annotation to the namespace
+kubectl patch namespace "${KEPTN_NAMESPACE}" -p "{\"metadata\": {\"annotations\": {\"keptn.sh/managed-by\": \"keptn\"}, \"labels\": {\"keptn.sh/managed-by\": \"keptn\"}}}"

--- a/installer/airgapped/pull_and_retag_images.sh
+++ b/installer/airgapped/pull_and_retag_images.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+KEPTN_TAG=${KEPTN_TAG:-"0.8.4"}
+
+if [[ $# -ne 1 ]]; then
+    echo "Please provide the target registry as a param, e.g., $1 gcr.io/your-registry/"
+    exit 1
+fi
+
+TARGET_INTERNAL_DOCKER_REGISTRY=${1}
+
+IMAGES_CONTROL_PLANE_THIRD_PARTY="centos/mongodb-36-centos7:1 nats:2.1.9-alpine3.12 connecteverything/nats-server-config-reloader:0.6.0 synadia/prometheus-nats-exporter:0.5.0 nginxinc/nginx-unprivileged:1.19.4-alpine"
+IMAGES_CONTROL_PLANE="keptn/api:${KEPTN_TAG} keptn/bridge2:${KEPTN_TAG} keptn/configuration-service:${KEPTN_TAG} keptn/distributor:${KEPTN_TAG} keptn/secret-service:${KEPTN_TAG} keptn/shipyard-controller:${KEPTN_TAG} keptn/remediation-service:${KEPTN_TAG} keptn/mongodb-datastore:${KEPTN_TAG} keptn/statistics-service:${KEPTN_TAG} keptn/lighthouse-service:${KEPTN_TAG} keptn/approval-service:${KEPTN_TAG}"
+IMAGES_CONTINUOUS_DELIVERY="keptn/helm-service:${KEPTN_TAG} keptn/jmeter-service:${KEPTN_TAG}"
+
+IMAGES="$IMAGES_CONTROL_PLANE_THIRD_PARTY $IMAGES_CONTROL_PLANE $IMAGES_CONTINUOUS_DELIVERY"
+
+
+for img in $IMAGES
+do
+    echo "Processing $img..."
+    docker pull "$img"
+    docker tag "$img" "${TARGET_INTERNAL_DOCKER_REGISTRY}${img}"
+    docker push "${TARGET_INTERNAL_DOCKER_REGISTRY}${img}"
+    echo "$img -> ${TARGET_INTERNAL_DOCKER_REGISTRY}${img}"
+done

--- a/installer/manifests/keptn/charts/continuous-delivery/values.yaml
+++ b/installer/manifests/keptn/charts/continuous-delivery/values.yaml
@@ -11,13 +11,3 @@ distributor:
   image:
     repository: docker.io/keptn/distributor
     tag: ""
-
-jmeterService:
-  image:
-    repository: docker.io/keptn/jmeter-service
-    tag: ""
-
-helmService:
-  image:
-    repository: docker.io/keptn/helm-service
-    tag: ""

--- a/installer/manifests/keptn/charts/control-plane/templates/core.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/core.yaml
@@ -563,18 +563,6 @@ spec:
     spec:
       securityContext:
         fsGroup: 65532
-      initContainers:
-        - name: change-user-init
-          image: "alpine:3.13"
-          securityContext:
-            runAsUser: 0
-          volumeMounts:
-            - mountPath: /data/config
-              name: configuration-volume
-          command:
-            - sh
-            - -c
-            - chown -R 65532 /data/config
       containers:
         - name: configuration-service
           image: {{ .Values.configurationService.image.repository }}:{{ .Values.configurationService.image.tag | default .Chart.AppVersion }}

--- a/test/test_airgapped_images.sh
+++ b/test/test_airgapped_images.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# shellcheck disable=SC1091
+source test/utils.sh
+
+EXPECTED_REGISTRY=${1}
+
+KEPTN_NAMESPACE=${KEPTN_NAMESPACE:-keptn}
+
+PULLED_IMAGES=$(kubectl get events -n "${KEPTN_NAMESPACE}" | awk -F'Pulling image ' '{ print $2 }' | xargs)
+
+
+for IMAGE in ${PULLED_IMAGES}; do
+
+  if [[ "$IMAGE" == "rancher/"* ]]; then
+    # ignore rancher / k3s base images
+    continue
+  fi
+
+  if [[ "$IMAGE" == "$EXPECTED_REGISTRY"* ]]; then
+    # okay, as expected
+    continue
+  fi
+
+  print_error "ERROR: Expected $EXPECTED_REGISTRY in image name, but found '$IMAGE'"
+  print_error "Airgapped scenario failed! Please check which images Keptn helm charts are consuming."
+  exit 1
+done
+
+exit 0

--- a/test/test_airgapped_images.sh
+++ b/test/test_airgapped_images.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# This integration test checks that all images that are pulled (can be retrieved by kubectl get events -n keptn)
+# are coming from the local registry from K3d (passed as a parameter to this script), rather than anywhere else.
+# Exception: k3s/rancher based images, as they are needed internally by K3d.
+
 # shellcheck disable=SC1091
 source test/utils.sh
 

--- a/test/utils/download_and_install_k3d.sh
+++ b/test/utils/download_and_install_k3d.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# install k3d version from github (see https://github.com/rancher/k3s/releases)
+K3D_VERSION=${K3D_VERSION:-"v4.4.4"}
+# install K3d
+curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=${K3D_VERSION} bash


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

Fixes #4183

Note: it's not possible to have a cluster that's completely locked down, but it is possible to use a local registry with K3d (hence I also used K3d for the integration test).

The integration test now checks that all images that are pulled are coming from the local registry from K3d, rather than anywhere else (with the exception of k3s/rancher based images, as they are needed internally by K3d).

Example:
![image](https://user-images.githubusercontent.com/56065213/122924594-3be63680-d366-11eb-9917-5e17b2513cd3.png)

