### PR TITLE
#4422 Allow host/port for jmeter-service/helm-service repository in helm charts

### DIFF
--- a/helm-service/chart/values.schema.json
+++ b/helm-service/chart/values.schema.json
@@ -57,7 +57,7 @@
         "image": {
           "properties": {
             "repository": {
-              "pattern": "^[a-z0-9][a-z0-9-./]{2,96}$"
+              "pattern": "^([a-z0-9][a-z0-9-.]{2,63})(:[0-9]+)?([a-z0-9-./]{1,128})$"
             },
             "pullPolicy": {
               "enum": [
@@ -85,7 +85,7 @@
         "image": {
           "properties": {
             "repository": {
-              "pattern": "[a-z0-9][a-z0-9-./]{2,96}$"
+              "pattern": "^([a-z0-9][a-z0-9-.]{2,63})(:[0-9]+)?([a-z0-9-./]{1,128})$"
             },
             "pullPolicy": {
               "enum": [

--- a/jmeter-service/chart/values.schema.json
+++ b/jmeter-service/chart/values.schema.json
@@ -57,7 +57,7 @@
         "image": {
           "properties": {
             "repository": {
-              "pattern": "^[a-z0-9][a-z0-9-./]{2,63}$"
+              "pattern": "^([a-z0-9][a-z0-9-.]{2,63})(:[0-9]+)?([a-z0-9-./]{1,128})$"
             },
             "pullPolicy": {
               "enum": [
@@ -85,7 +85,7 @@
         "image": {
           "properties": {
             "repository": {
-              "pattern": "[a-z0-9][a-z0-9-./]{2,63}$"
+              "pattern": "^([a-z0-9][a-z0-9-.]{2,63})(:[0-9]+)?([a-z0-9-./]{1,128})$"
             },
             "pullPolicy": {
               "enum": [


### PR DESCRIPTION
Fixes #4422

This PR modifies helm-charts for helm-service and jmeter-service such that any host/port combination can be used for the repository, e.g.:

* localhost:5000/keptn/helm-service was not valid before, but is valid now
* docker.io/keptn/helm-service is still valid
