### PR TITLE
#3987 Enable Apple Silicon Build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -507,10 +507,9 @@ jobs:
           - platform: "macOS-11.0" # cross-compiling the CLI for macOS does not work - see https://github.com/keptn/keptn/issues/2738
             GOOS: "darwin"
             GOARCH: "amd64"
-# builds for apple silicon still dont work https://github.com/keptn/keptn/issues/3987
-#          - platform: "macOS-11.0" # cross-compiling the CLI for macOS does not work - see https://github.com/keptn/keptn/issues/2738
-#            GOOS: "darwin"
-#            GOARCH: "arm64"
+          - platform: "macOS-11.0" # cross-compiling the CLI for macOS does not work - see https://github.com/keptn/keptn/issues/2738
+            GOOS: "darwin"
+            GOARCH: "arm64"
           - platform: "ubuntu-20.04"
             GOOS: "windows"
             GOARCH: "amd64"
@@ -560,6 +559,11 @@ jobs:
           if [[ "$GOOS" == "linux" ]]; then
             # enable static build for linux
             export CGO_ENABLED=0
+          fi
+
+          if [[ "$GOOS" == "darwin" ]]; then
+            # enable CGO for compiling docker credential helper natively
+            export CGO_ENABLED=1
           fi
 
           # build the binary using makefile


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

Fixes #3987

![image](https://user-images.githubusercontent.com/56065213/122947796-b9b43d00-d37a-11eb-9f69-b1edcaca375e.png)

**Note**: Apparently we need to enable CGO when cross compiling from amd64 to a**r**m64. I've enabled it for both MacOS builds.

This might change the resulting CLI binary size.