### PR TITLE
Fix e2e test timeout

### DIFF
--- a/bridge/client/app/dashboard/dashboard.component.ts
+++ b/bridge/client/app/dashboard/dashboard.component.ts
@@ -15,7 +15,7 @@ export class DashboardComponent implements OnInit, OnDestroy{
   public logoInvertedUrl = environment?.config?.logoInvertedUrl;
   public isQualityGatesOnly: boolean;
 
-  private readonly _projectTimerInterval = 5 * 1000;
+  private readonly _projectTimerInterval = 30 * 1000;
   private readonly unsubscribe$: Subject<void> = new Subject<void>();
 
   constructor(private _changeDetectorRef: ChangeDetectorRef, private dataService: DataService, private ngZone: NgZone) {

--- a/bridge/client/app/dashboard/dashboard.component.ts
+++ b/bridge/client/app/dashboard/dashboard.component.ts
@@ -15,7 +15,7 @@ export class DashboardComponent implements OnInit, OnDestroy{
   public logoInvertedUrl = environment?.config?.logoInvertedUrl;
   public isQualityGatesOnly: boolean;
 
-  private readonly _projectTimerInterval = 30 * 1000;
+  private readonly _projectTimerInterval = 5 * 1000;
   private readonly unsubscribe$: Subject<void> = new Subject<void>();
 
   constructor(private _changeDetectorRef: ChangeDetectorRef, private dataService: DataService, private ngZone: NgZone) {
@@ -34,7 +34,9 @@ export class DashboardComponent implements OnInit, OnDestroy{
       timer(this._projectTimerInterval, this._projectTimerInterval)
         .pipe(takeUntil(this.unsubscribe$))
         .subscribe(() => {
-          this.loadProjects();
+          this.ngZone.run(() => {
+            this.loadProjects();
+          });
         });
     });
   }

--- a/bridge/client/app/dashboard/dashboard.component.ts
+++ b/bridge/client/app/dashboard/dashboard.component.ts
@@ -1,9 +1,9 @@
-import {ChangeDetectorRef, Component, OnDestroy, OnInit} from '@angular/core';
+import {ChangeDetectorRef, Component, NgZone, OnDestroy, OnInit} from '@angular/core';
 import {Observable, Subject, timer} from 'rxjs';
 import {Project} from '../_models/project';
 import {DataService} from '../_services/data.service';
 import {environment} from '../../environments/environment';
-import {filter, takeUntil} from 'rxjs/operators';
+import {takeUntil} from 'rxjs/operators';
 
 @Component({
   selector: 'app-dashboard',
@@ -18,7 +18,7 @@ export class DashboardComponent implements OnInit, OnDestroy{
   private readonly _projectTimerInterval = 30 * 1000;
   private readonly unsubscribe$: Subject<void> = new Subject<void>();
 
-  constructor(private _changeDetectorRef: ChangeDetectorRef, private dataService: DataService) {
+  constructor(private _changeDetectorRef: ChangeDetectorRef, private dataService: DataService, private ngZone: NgZone) {
     this.projects$ = this.dataService.projects;
   }
 
@@ -27,11 +27,16 @@ export class DashboardComponent implements OnInit, OnDestroy{
       takeUntil(this.unsubscribe$)
     ).subscribe(isQualityGatesOnly => {this.isQualityGatesOnly = isQualityGatesOnly});
 
-    timer(this._projectTimerInterval, this._projectTimerInterval)
-      .pipe(takeUntil(this.unsubscribe$))
-      .subscribe(() => {
-        this.loadProjects();
-      });
+    // If we don't run this outside angular e2e tests will fail
+    // because Protractor waits for async tasks to complete - in case of timer they do not finish so the tests time out
+    // https://github.com/angular/protractor/blob/master/docs/timeouts.md#waiting-for-angular
+    this.ngZone.runOutsideAngular(() => {
+      timer(this._projectTimerInterval, this._projectTimerInterval)
+        .pipe(takeUntil(this.unsubscribe$))
+        .subscribe(() => {
+          this.loadProjects();
+        });
+    });
   }
 
   public loadProjects() {

--- a/bridge/client/app/dashboard/dashboard.component.ts
+++ b/bridge/client/app/dashboard/dashboard.component.ts
@@ -18,7 +18,9 @@ export class DashboardComponent implements OnInit, OnDestroy{
   private readonly _projectTimerInterval = 30 * 1000;
   private readonly unsubscribe$: Subject<void> = new Subject<void>();
 
-  constructor(private _changeDetectorRef: ChangeDetectorRef, private dataService: DataService, private ngZone: NgZone) {
+  constructor(private _changeDetectorRef: ChangeDetectorRef,
+              private dataService: DataService,
+              private ngZone: NgZone) {
     this.projects$ = this.dataService.projects;
   }
 

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -11,7 +11,8 @@
     "test": "ng test",
     "test:ci": "ng test --karma-config karma-headless.conf.js",
     "lint": "ng lint",
-    "e2e": "ng e2e",
+    "e2e": "ng e2e --dev-server-target= --base-url=http://localhost:3000/",
+    "e2e:ci": "ng e2e --dev-server-target= --base-url=http://localhost:3000/ --protractor-config=./e2e/protractor-ci.conf.js",
     "preinstall": "npx npm-force-resolutions"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
Protractor waits for async tasks to complete - in case of rxjs timer they do not finish so the tests time out
To tackle this it is necessary to run this kind of tasks in ngZone.runOutsideAngular in order to not block Angular.
https://github.com/angular/protractor/blob/master/docs/timeouts.md#waiting-for-angular

Signed-off-by: Elisabeth Lang <elisabeth.lang@dynatrace.com>