### PR TITLE
#4403 Use image versions in helm charts

### DIFF
--- a/gh-actions-scripts/build_helm_charts.sh
+++ b/gh-actions-scripts/build_helm_charts.sh
@@ -37,7 +37,7 @@ INSTALLER_BASE_PATH=installer/manifests
 helm repo add nats https://nats-io.github.io/k8s/helm/charts/
 helm dependency build ${INSTALLER_BASE_PATH}/keptn/charts/control-plane
 
-helm package ${INSTALLER_BASE_PATH}/keptn --app-version "$VERSION" --version "$VERSION"
+helm package ${INSTALLER_BASE_PATH}/keptn --app-version "$IMAGE_TAG" --version "$VERSION"
 if [ $? -ne 0 ]; then
   echo "Error packing installer, exiting..."
   exit 1
@@ -58,7 +58,7 @@ fi
 # ####################
 HELM_SVC_BASE_PATH=helm-service
 
-helm package ${HELM_SVC_BASE_PATH}/chart --app-version "$VERSION" --version "$VERSION"
+helm package ${HELM_SVC_BASE_PATH}/chart --app-version "$IMAGE_TAG" --version "$VERSION"
 if [ $? -ne 0 ]; then
   echo "Error packaging installer, exiting..."
   exit 1
@@ -79,7 +79,7 @@ fi
 # ####################
 JMETER_SVC_BASE_PATH=jmeter-service
 
-helm package ${JMETER_SVC_BASE_PATH}/chart --app-version "$VERSION" --version "$VERSION"
+helm package ${JMETER_SVC_BASE_PATH}/chart --app-version "$IMAGE_TAG" --version "$VERSION"
 if [ $? -ne 0 ]; then
   echo "Error packaging installer, exiting..."
   exit 1


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

Fixes #4403

```
$ helm ls -n keptn
NAME          	NAMESPACE	REVISION	UPDATED                                 	STATUS  	CHART                           	APP VERSION                   
helm-service  	keptn    	1       	2021-06-23 16:04:47.30580055 +0200 CEST 	deployed	helm-service-0.8.5-dev-PR-4490  	0.8.5-dev-PR-4490.202106231228
jmeter-service	keptn    	1       	2021-06-23 16:04:57.480667732 +0200 CEST	deployed	jmeter-service-0.8.5-dev-PR-4490	0.8.5-dev-PR-4490.202106231228
keptn         	keptn    	4       	2021-06-23 16:05:41.716710766 +0200 CEST	deployed	keptn-0.8.5-dev-PR-4490         	0.8.5-dev-PR-4490.202106231228
```

![image](https://user-images.githubusercontent.com/56065213/123111298-1841ef80-d43d-11eb-9ce0-9b6baf14bec7.png)
