### PR TITLE
#4366 Auto update spec when a new version is released

### DIFF
--- a/.github/workflows/auto-update-keptn-spec.yml
+++ b/.github/workflows/auto-update-keptn-spec.yml
@@ -1,0 +1,43 @@
+name: Spec Auto Update
+on:
+  repository_dispatch:
+    types: [spec-update]
+defaults:
+  run:
+    shell: bash
+jobs:
+  update-spec:
+    env:
+      SPEC_VERSION: ${{ github.event.client_payload.ref }}
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: true
+
+      - name: Update keptn/spec
+        run: |
+          cd specification
+          git fetch
+          git checkout ${{ env.SPEC_VERSION }}
+          cd ..
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.KEPTN_BOT_TOKEN }}
+          commit-message: "Update keptn/spec to release ${{ env.SPEC_VERSION }}"
+          committer: "keptn-bot <86361500+keptn-bot@users.noreply.github.com>"
+          author: "keptn-bot <86361500+keptn-bot@users.noreply.github.com>"
+          signoff: true
+          branch: patch/update-keptn-spec-${{ env.SPEC_VERSION }}
+          delete-branch: true
+          base: master
+          labels: "area:spec,automated pr,dependencies"
+          title: "Update keptn/spec to release ${{ env.SPEC_VERSION }}"
+          body: |
+            **This is an automated PR!**
+
+            Update to the keptn/spec
+            New version: ${{ env.SPEC_VERSION }}

--- a/.github/workflows/auto-update-keptn-spec.yml
+++ b/.github/workflows/auto-update-keptn-spec.yml
@@ -1,4 +1,4 @@
-name: Spec Auto Update
+name: Auto Update - Spec
 on:
   repository_dispatch:
     types: [spec-update]

--- a/.github/workflows/auto-update-keptn-spec.yml
+++ b/.github/workflows/auto-update-keptn-spec.yml
@@ -26,19 +26,21 @@ jobs:
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
+        env:
+          SPEC_VERSION: ${{ env.SPEC_VERSION }}
         with:
           token: ${{ secrets.KEPTN_BOT_TOKEN }}
-          commit-message: "Update keptn/spec to release ${{ env.SPEC_VERSION }}"
+          commit-message: "Update keptn/spec to release ${SPEC_VERSION#refs/tags/}"
           committer: "keptn-bot <86361500+keptn-bot@users.noreply.github.com>"
           author: "keptn-bot <86361500+keptn-bot@users.noreply.github.com>"
           signoff: true
-          branch: patch/update-keptn-spec-${{ env.SPEC_VERSION }}
+          branch: patch/update-keptn-spec-${SPEC_VERSION#refs/tags/}
           delete-branch: true
           base: master
           labels: "area:spec,automated pr,dependencies"
-          title: "Update keptn/spec to release ${{ env.SPEC_VERSION }}"
+          title: "Update keptn/spec to release ${SPEC_VERSION#refs/tags/}"
           body: |
             **This is an automated PR!**
 
             Update to the keptn/spec
-            New version: ${{ env.SPEC_VERSION }}
+            New version: ${SPEC_VERSION#refs/tags/}

--- a/.github/workflows/auto-update-keptn-spec.yml
+++ b/.github/workflows/auto-update-keptn-spec.yml
@@ -11,7 +11,8 @@ jobs:
       SPEC_VERSION: ${{ github.event.client_payload.ref }}
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
         with:
           fetch-depth: 0
           submodules: true


### PR DESCRIPTION
**This PR**
* adds a new workflow to update the spec submodule to the latest release
* the workflow is triggered by a `repository_dispatch` event coming from the keptn/spec repo
* creates a PR with the updated submodule

Fixes #4366

Signed-off-by: Moritz Wiesinger <moritz.wiesinger@dynatrace.com>