### PR TITLE
Remediation-Service: removed outdated environment variables

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/templates/continuous-operations.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/continuous-operations.yaml
@@ -51,26 +51,8 @@ spec:
             value: 'http://localhost:8081/event'
           - name: CONFIGURATION_SERVICE
             value: 'http://configuration-service:8080'
-          - name: MONGODB_DATASTORE
-            value: 'http://mongodb-datastore:8080'
           - name: ENVIRONMENT
             value: 'production'
-          - name: WAIT_TIME_MINUTES
-            value: '10m'
-          - name: MONGODB_HOST
-            value: 'mongodb:27017'
-          - name: MONGODB_USER
-            valueFrom:
-              secretKeyRef:
-                name: mongodb-credentials
-                key: user
-          - name: MONGODB_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: mongodb-credentials
-                key: password
-          - name: MONGO_DB_NAME
-            value: 'keptn'
         securityContext:
           runAsNonRoot: true
           runAsUser: 65532

--- a/remediation-service/deploy/service.yaml
+++ b/remediation-service/deploy/service.yaml
@@ -44,26 +44,8 @@ spec:
             value: 'http://event-broker/keptn'
           - name: CONFIGURATION_SERVICE
             value: 'http://configuration-service:8080'
-          - name: MONGODB_DATASTORE
-            value: 'http://mongodb-datastore:8080'
           - name: ENVIRONMENT
             value: 'production'
-          - name: WAIT_TIME_MINUTES
-            value: '10m'
-          - name: MONGODB_HOST
-            value: 'mongodb:27017'
-          - name: MONGODB_USER
-            valueFrom:
-              secretKeyRef:
-                name: mongodb-credentials
-                key: user
-          - name: MONGODB_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: mongodb-credentials
-                key: password
-          - name: MONGO_DB_NAME
-            value: 'keptn'
       - name: distributor
         image: keptn/distributor:latest
         imagePullPolicy: Always


### PR DESCRIPTION
Cleanup: Just removing some outdated environment variables from the `remediation-service` deployment resource.

Signed-off-by: warber <bernd.warmuth@dynatrace.com>