### PR TITLE
#4540 Helm-Service Adjust primary service labels for more consistency

### DIFF
--- a/helm-service/pkg/helm/generated_chart_handler.go
+++ b/helm-service/pkg/helm/generated_chart_handler.go
@@ -138,6 +138,12 @@ func (c *GeneratedChartGenerator) generateServices(svc *corev1.Service, project 
 	if _, ok := servicePrimary.Spec.Selector["app.kubernetes.io/name"]; ok {
 		servicePrimary.Spec.Selector["app.kubernetes.io/name"] = servicePrimary.Spec.Selector["app.kubernetes.io/name"] + "-primary"
 	}
+	if _, ok := servicePrimary.ObjectMeta.Labels["app"]; ok {
+		servicePrimary.ObjectMeta.Labels["app"] = servicePrimary.ObjectMeta.Labels["app"] + "-primary"
+	}
+	if _, ok := servicePrimary.ObjectMeta.Labels["app.kubernetes.io/name"]; ok {
+		servicePrimary.ObjectMeta.Labels["app.kubernetes.io/name"] = servicePrimary.ObjectMeta.Labels["app.kubernetes.io/name"] + "-primary"
+	}
 	resetService(servicePrimary)
 	data, err = yaml.Marshal(servicePrimary)
 	if err != nil {

--- a/helm-service/pkg/helm/helm_mock_executor.go
+++ b/helm-service/pkg/helm/helm_mock_executor.go
@@ -20,6 +20,9 @@ apiVersion: v1
 kind: Service
 metadata: 
   name: carts
+  labels:
+    app: carts
+    app.kubernetes.io/name: carts
 spec: 
   type: LoadBalancer
   ports: 
@@ -29,6 +32,7 @@ spec:
     targetPort: 8080
   selector: 
     app: carts
+    app.kubernetes.io/name: carts
 `
 
 const userDeployment = `--- 
@@ -110,6 +114,9 @@ kind: Service
 metadata:
   creationTimestamp: null
   name: carts-canary
+  labels:
+    app: carts
+    app.kubernetes.io/name: carts
 spec:
   ports:
   - name: http
@@ -118,6 +125,7 @@ spec:
     targetPort: 8080
   selector:
     app: carts
+    app.kubernetes.io/name: carts
   type: LoadBalancer
 status:
   loadBalancer: {}
@@ -130,6 +138,9 @@ kind: Service
 metadata:
   creationTimestamp: null
   name: carts-primary
+  labels:
+    app: carts-primary
+    app.kubernetes.io/name: carts-primary
 spec:
   ports:
   - name: http
@@ -138,6 +149,7 @@ spec:
     targetPort: 8080
   selector:
     app: carts-primary
+    app.kubernetes.io/name: carts-primary
   type: LoadBalancer
 status:
   loadBalancer: {}


### PR DESCRIPTION
See related issue #4540 - this adds the `-primary` suffix for the labeled service to be consistent with the modifications of the pod labels. This won't change any behavior within the Kubernetes cluster, the labels are usually not referenced in ServiceMesh components.

Signed-off-by: Tolleiv Nietsch <github@tolleiv.de>