### PR TITLE
Improve tile width for environment screen

### DIFF
--- a/bridge/client/app/_components/ktb-stage-overview/ktb-stage-overview.component.html
+++ b/bridge/client/app/_components/ktb-stage-overview/ktb-stage-overview.component.html
@@ -12,7 +12,7 @@
     ></dt-filter-field>
   </div>
   <div class="container p-0" fxFlex fxLayout="column">
-    <div class="stage-list" fxLayout="row" fxLayout.lt-sm="column" fxLayoutGap="15px" fxLayoutAlign="start">
+    <div [ngClass]="{'stage-list': true, 'scrollable': project.getParentStages().length > 3}" fxLayout="row" fxLayout.lt-sm="column" fxLayoutGap="15px" fxLayoutAlign="start">
       <div class="stage-group" fxLayout="column" fxLayoutGap="15px" *ngFor="let parentStage of project.getParentStages(); let i = index; trackBy:trackStage">
         <ktb-selectable-tile *ngFor="let stage of project.getStages(parentStage)"
                              (click)="selectStage($event, stage);" [selected]="selectedStage == stage">

--- a/bridge/client/app/_components/ktb-stage-overview/ktb-stage-overview.component.scss
+++ b/bridge/client/app/_components/ktb-stage-overview/ktb-stage-overview.component.scss
@@ -25,6 +25,9 @@
   &.scrollable {
     .stage-group {
       min-width: 30%;
+      @media screen and (max-width: 1560px) {
+        min-width: 335px;
+      }
     }
   }
 
@@ -34,6 +37,10 @@
     // prevent jumping horizontal scrollbar
     @media screen and (max-width: 2073px){
       min-width: 32.6%;
+    }
+
+    @media screen and (max-width: 1560px) {
+      min-width: 335px;
     }
   }
 

--- a/bridge/client/app/_components/ktb-stage-overview/ktb-stage-overview.component.scss
+++ b/bridge/client/app/_components/ktb-stage-overview/ktb-stage-overview.component.scss
@@ -22,8 +22,19 @@
 .stage-list {
   padding: 1rem;
 
+  &.scrollable {
+    .stage-group {
+      min-width: 30%;
+    }
+  }
+
   .stage-group {
-    min-width: 25vw;
+    min-width: 33%;
+
+    // prevent jumping horizontal scrollbar
+    @media screen and (max-width: 2073px){
+      min-width: 32.6%;
+    }
   }
 
   .stage-group:last-child {


### PR DESCRIPTION
Closes #4146 
Signed-off-by: Elisabeth Lang <elisabeth.lang@dynatrace.com>

When only 3 tiles are available the size of the tiles is adapted so that all of them fit on the screen:
![image](https://user-images.githubusercontent.com/2674029/124135212-e4da1300-da83-11eb-8a88-cfe036c05a5b.png)

When more than 3 tiles are available in the row, the panel size is reduced to show that it can be scrolled:
![image](https://user-images.githubusercontent.com/2674029/124135064-c247fa00-da83-11eb-8506-4e0e5c647cc8.png)
