### PR TITLE
Added keptnContext query parameter to sequence state GET endpoint

### DIFF
--- a/shipyard-controller/db/mongodb_staterepo.go
+++ b/shipyard-controller/db/mongodb_staterepo.go
@@ -113,8 +113,8 @@ func (mdbrepo *MongoDBStateRepo) getSearchOptions(filter models.StateFilter) bso
 		"project": filter.Project,
 	}
 
-	if filter.Shkeptncontext != "" {
-		searchOptions["shkeptncontext"] = filter.Shkeptncontext
+	if filter.KeptnContext != "" {
+		searchOptions["shkeptncontext"] = filter.KeptnContext
 	}
 
 	if filter.Name != "" {
@@ -176,8 +176,8 @@ func (mdbrepo *MongoDBStateRepo) DeleteSequenceStates(filter models.StateFilter)
 	if filter.Project == "" {
 		return errors.New("project must be set")
 	}
-	if filter.Shkeptncontext == "" {
-		return errors.New("shkeptncontext must be set")
+	if filter.KeptnContext == "" {
+		return errors.New("keptnContext must be set")
 	}
 	err := mdbrepo.DBConnection.EnsureDBConnection()
 	if err != nil {

--- a/shipyard-controller/db/mongodb_staterepo_test.go
+++ b/shipyard-controller/db/mongodb_staterepo_test.go
@@ -123,8 +123,21 @@ func TestMongoDBStateRepo_FindSequenceStates(t *testing.T) {
 	err = mdbrepo.CreateSequenceState(state3)
 	require.Nil(t, err)
 
-	// Find by project name
+	// Find by keptn context
 	states, err := mdbrepo.FindSequenceStates(models.StateFilter{
+		GetSequenceStateParams: models.GetSequenceStateParams{
+			Project:      "my-project",
+			KeptnContext: "my-context",
+		},
+	})
+
+	require.Nil(t, err)
+	require.Equal(t, int64(1), states.TotalCount)
+	require.Equal(t, 1, len(states.States))
+	require.Equal(t, state, states.States[0])
+
+	// Find by project name
+	states, err = mdbrepo.FindSequenceStates(models.StateFilter{
 		GetSequenceStateParams: models.GetSequenceStateParams{
 			Project: "my-project",
 		},
@@ -222,9 +235,9 @@ func TestMongoDBStateRepo_StateRepoInsertAndRetrieve(t *testing.T) {
 	// first, delete any entries that might have been inserted previously
 	err := mdbrepo.DeleteSequenceStates(models.StateFilter{
 		GetSequenceStateParams: models.GetSequenceStateParams{
-			Project: "my-project",
+			Project:      "my-project",
+			KeptnContext: "my-context",
 		},
-		Shkeptncontext: "my-context",
 	})
 	require.Nil(t, err)
 
@@ -233,9 +246,9 @@ func TestMongoDBStateRepo_StateRepoInsertAndRetrieve(t *testing.T) {
 
 	states, err := mdbrepo.FindSequenceStates(models.StateFilter{
 		GetSequenceStateParams: models.GetSequenceStateParams{
-			Project: "my-project",
+			Project:      "my-project",
+			KeptnContext: "my-context",
 		},
-		Shkeptncontext: "my-context",
 	})
 
 	require.Nil(t, err)
@@ -255,9 +268,9 @@ func TestMongoDBStateRepo_StateRepoInsertAndRetrieve(t *testing.T) {
 	// fetch the state again
 	states, err = mdbrepo.FindSequenceStates(models.StateFilter{
 		GetSequenceStateParams: models.GetSequenceStateParams{
-			Project: "my-project",
+			Project:      "my-project",
+			KeptnContext: "my-context",
 		},
-		Shkeptncontext: "my-context",
 	})
 
 	require.Nil(t, err)
@@ -269,17 +282,17 @@ func TestMongoDBStateRepo_StateRepoInsertAndRetrieve(t *testing.T) {
 	// delete the state
 	err = mdbrepo.DeleteSequenceStates(models.StateFilter{
 		GetSequenceStateParams: models.GetSequenceStateParams{
-			Project: state.Project,
+			Project:      state.Project,
+			KeptnContext: "my-context",
 		},
-		Shkeptncontext: state.Shkeptncontext,
 	})
 	require.Nil(t, err)
 
 	states, err = mdbrepo.FindSequenceStates(models.StateFilter{
 		GetSequenceStateParams: models.GetSequenceStateParams{
-			Project: "my-project",
+			Project:      "my-project",
+			KeptnContext: "my-context",
 		},
-		Shkeptncontext: "my-context",
 	})
 	require.Nil(t, err)
 	require.Equal(t, int64(0), states.TotalCount)

--- a/shipyard-controller/docs/docs.go
+++ b/shipyard-controller/docs/docs.go
@@ -1075,6 +1075,12 @@ var doc = `{
                         "description": "Pointer to the next set of items",
                         "name": "nextPageKey",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "The keptn context",
+                        "name": "keptnContext",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1268,31 +1274,6 @@ var doc = `{
         }
     },
     "definitions": {
-        "models.Approval": {
-            "type": "object",
-            "properties": {
-                "eventId": {
-                    "description": "ID of the event",
-                    "type": "string"
-                },
-                "image": {
-                    "description": "image",
-                    "type": "string"
-                },
-                "keptnContext": {
-                    "description": "Keptn Context ID of the event",
-                    "type": "string"
-                },
-                "tag": {
-                    "description": "tag",
-                    "type": "string"
-                },
-                "time": {
-                    "description": "Time of the event",
-                    "type": "string"
-                }
-            }
-        },
         "models.CreateLogsRequest": {
             "type": "object",
             "properties": {
@@ -1383,23 +1364,6 @@ var doc = `{
                 }
             }
         },
-        "models.EventContextInfo": {
-            "type": "object",
-            "properties": {
-                "eventId": {
-                    "description": "ID of the event",
-                    "type": "string"
-                },
-                "keptnContext": {
-                    "description": "Keptn Context ID of the event",
-                    "type": "string"
-                },
-                "time": {
-                    "description": "Time of the event",
-                    "type": "string"
-                }
-            }
-        },
         "models.Events": {
             "type": "object",
             "properties": {
@@ -1407,7 +1371,7 @@ var doc = `{
                     "description": "events",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/models.Event"
+                        "$ref": "#/definitions/models.KeptnContextExtendedCE"
                     }
                 },
                 "nextPageKey": {
@@ -1419,7 +1383,7 @@ var doc = `{
                     "type": "number"
                 },
                 "totalCount": {
-                    "description": "Total number of events",
+                    "description": "Total number of resources",
                     "type": "number"
                 }
             }
@@ -1611,6 +1575,55 @@ var doc = `{
                 }
             }
         },
+        "models.KeptnContextExtendedCE": {
+            "type": "object",
+            "properties": {
+                "contenttype": {
+                    "description": "contenttype",
+                    "type": "string"
+                },
+                "data": {
+                    "description": "data\nRequired: true",
+                    "type": "object"
+                },
+                "extensions": {
+                    "description": "extensions",
+                    "type": "object"
+                },
+                "id": {
+                    "description": "id",
+                    "type": "string"
+                },
+                "shkeptncontext": {
+                    "description": "shkeptncontext",
+                    "type": "string"
+                },
+                "shkeptnspecversion": {
+                    "description": "shkeptnspecversion",
+                    "type": "string"
+                },
+                "source": {
+                    "description": "source\nRequired: true",
+                    "type": "string"
+                },
+                "specversion": {
+                    "description": "specversion",
+                    "type": "string"
+                },
+                "time": {
+                    "description": "time\nFormat: date-time",
+                    "type": "string"
+                },
+                "triggeredid": {
+                    "description": "triggeredid",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "type\nRequired: true",
+                    "type": "string"
+                }
+            }
+        },
         "models.KubernetesMetaData": {
             "type": "object",
             "properties": {
@@ -1790,53 +1803,6 @@ var doc = `{
                 }
             }
         },
-        "models.Service": {
-            "type": "object",
-            "properties": {
-                "creationDate": {
-                    "description": "Creation date of the service",
-                    "type": "string"
-                },
-                "deployedImage": {
-                    "description": "Currently deployed image",
-                    "type": "string"
-                },
-                "lastEventTypes": {
-                    "description": "last event types",
-                    "type": "object",
-                    "additionalProperties": {
-                        "$ref": "#/definitions/models.EventContextInfo"
-                    }
-                },
-                "openApprovals": {
-                    "description": "open approvals",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.Approval"
-                    }
-                },
-                "serviceName": {
-                    "description": "Service name",
-                    "type": "string"
-                }
-            }
-        },
-        "models.Stage": {
-            "type": "object",
-            "properties": {
-                "services": {
-                    "description": "services",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.Service"
-                    }
-                },
-                "stageName": {
-                    "description": "Stage name",
-                    "type": "string"
-                }
-            }
-        },
         "models.Stages": {
             "type": "object",
             "properties": {
@@ -1852,7 +1818,7 @@ var doc = `{
                     "description": "stages",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/models.Stage"
+                        "$ref": "#/definitions/models.ExpandedStage"
                     }
                 },
                 "totalCount": {
@@ -2033,7 +1999,7 @@ type swaggerInfo struct {
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = swaggerInfo{
-	Version:     "1.0",
+	Version:     "develop",
 	Host:        "",
 	BasePath:    "/v1",
 	Schemes:     []string{},

--- a/shipyard-controller/docs/swagger.json
+++ b/shipyard-controller/docs/swagger.json
@@ -11,7 +11,7 @@
             "name": "Apache 2.0",
             "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
         },
-        "version": "1.0"
+        "version": "develop"
     },
     "basePath": "/v1",
     "paths": {
@@ -1060,6 +1060,12 @@
                         "description": "Pointer to the next set of items",
                         "name": "nextPageKey",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "The keptn context",
+                        "name": "keptnContext",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1253,31 +1259,6 @@
         }
     },
     "definitions": {
-        "models.Approval": {
-            "type": "object",
-            "properties": {
-                "eventId": {
-                    "description": "ID of the event",
-                    "type": "string"
-                },
-                "image": {
-                    "description": "image",
-                    "type": "string"
-                },
-                "keptnContext": {
-                    "description": "Keptn Context ID of the event",
-                    "type": "string"
-                },
-                "tag": {
-                    "description": "tag",
-                    "type": "string"
-                },
-                "time": {
-                    "description": "Time of the event",
-                    "type": "string"
-                }
-            }
-        },
         "models.CreateLogsRequest": {
             "type": "object",
             "properties": {
@@ -1368,23 +1349,6 @@
                 }
             }
         },
-        "models.EventContextInfo": {
-            "type": "object",
-            "properties": {
-                "eventId": {
-                    "description": "ID of the event",
-                    "type": "string"
-                },
-                "keptnContext": {
-                    "description": "Keptn Context ID of the event",
-                    "type": "string"
-                },
-                "time": {
-                    "description": "Time of the event",
-                    "type": "string"
-                }
-            }
-        },
         "models.Events": {
             "type": "object",
             "properties": {
@@ -1392,7 +1356,7 @@
                     "description": "events",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/models.Event"
+                        "$ref": "#/definitions/models.KeptnContextExtendedCE"
                     }
                 },
                 "nextPageKey": {
@@ -1404,7 +1368,7 @@
                     "type": "number"
                 },
                 "totalCount": {
-                    "description": "Total number of events",
+                    "description": "Total number of resources",
                     "type": "number"
                 }
             }
@@ -1596,6 +1560,55 @@
                 }
             }
         },
+        "models.KeptnContextExtendedCE": {
+            "type": "object",
+            "properties": {
+                "contenttype": {
+                    "description": "contenttype",
+                    "type": "string"
+                },
+                "data": {
+                    "description": "data\nRequired: true",
+                    "type": "object"
+                },
+                "extensions": {
+                    "description": "extensions",
+                    "type": "object"
+                },
+                "id": {
+                    "description": "id",
+                    "type": "string"
+                },
+                "shkeptncontext": {
+                    "description": "shkeptncontext",
+                    "type": "string"
+                },
+                "shkeptnspecversion": {
+                    "description": "shkeptnspecversion",
+                    "type": "string"
+                },
+                "source": {
+                    "description": "source\nRequired: true",
+                    "type": "string"
+                },
+                "specversion": {
+                    "description": "specversion",
+                    "type": "string"
+                },
+                "time": {
+                    "description": "time\nFormat: date-time",
+                    "type": "string"
+                },
+                "triggeredid": {
+                    "description": "triggeredid",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "type\nRequired: true",
+                    "type": "string"
+                }
+            }
+        },
         "models.KubernetesMetaData": {
             "type": "object",
             "properties": {
@@ -1775,53 +1788,6 @@
                 }
             }
         },
-        "models.Service": {
-            "type": "object",
-            "properties": {
-                "creationDate": {
-                    "description": "Creation date of the service",
-                    "type": "string"
-                },
-                "deployedImage": {
-                    "description": "Currently deployed image",
-                    "type": "string"
-                },
-                "lastEventTypes": {
-                    "description": "last event types",
-                    "type": "object",
-                    "additionalProperties": {
-                        "$ref": "#/definitions/models.EventContextInfo"
-                    }
-                },
-                "openApprovals": {
-                    "description": "open approvals",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.Approval"
-                    }
-                },
-                "serviceName": {
-                    "description": "Service name",
-                    "type": "string"
-                }
-            }
-        },
-        "models.Stage": {
-            "type": "object",
-            "properties": {
-                "services": {
-                    "description": "services",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.Service"
-                    }
-                },
-                "stageName": {
-                    "description": "Stage name",
-                    "type": "string"
-                }
-            }
-        },
         "models.Stages": {
             "type": "object",
             "properties": {
@@ -1837,7 +1803,7 @@
                     "description": "stages",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/models.Stage"
+                        "$ref": "#/definitions/models.ExpandedStage"
                     }
                 },
                 "totalCount": {

--- a/shipyard-controller/docs/swagger.yaml
+++ b/shipyard-controller/docs/swagger.yaml
@@ -1,23 +1,5 @@
 basePath: /v1
 definitions:
-  models.Approval:
-    properties:
-      eventId:
-        description: ID of the event
-        type: string
-      image:
-        description: image
-        type: string
-      keptnContext:
-        description: Keptn Context ID of the event
-        type: string
-      tag:
-        description: tag
-        type: string
-      time:
-        description: Time of the event
-        type: string
-    type: object
   models.CreateLogsRequest:
     properties:
       logs:
@@ -90,24 +72,12 @@ definitions:
         description: Time of the event
         type: string
     type: object
-  models.EventContextInfo:
-    properties:
-      eventId:
-        description: ID of the event
-        type: string
-      keptnContext:
-        description: Keptn Context ID of the event
-        type: string
-      time:
-        description: Time of the event
-        type: string
-    type: object
   models.Events:
     properties:
       events:
         description: events
         items:
-          $ref: '#/definitions/models.Event'
+          $ref: '#/definitions/models.KeptnContextExtendedCE'
         type: array
       nextPageKey:
         description: Pointer to next page, base64 encoded
@@ -116,7 +86,7 @@ definitions:
         description: Size of returned page
         type: number
       totalCount:
-        description: Total number of events
+        description: Total number of resources
         type: number
     type: object
   models.ExpandedProject:
@@ -251,6 +221,50 @@ definitions:
       subscription:
         $ref: '#/definitions/models.Subscription'
     type: object
+  models.KeptnContextExtendedCE:
+    properties:
+      contenttype:
+        description: contenttype
+        type: string
+      data:
+        description: |-
+          data
+          Required: true
+        type: object
+      extensions:
+        description: extensions
+        type: object
+      id:
+        description: id
+        type: string
+      shkeptncontext:
+        description: shkeptncontext
+        type: string
+      shkeptnspecversion:
+        description: shkeptnspecversion
+        type: string
+      source:
+        description: |-
+          source
+          Required: true
+        type: string
+      specversion:
+        description: specversion
+        type: string
+      time:
+        description: |-
+          time
+          Format: date-time
+        type: string
+      triggeredid:
+        description: triggeredid
+        type: string
+      type:
+        description: |-
+          type
+          Required: true
+        type: string
+    type: object
   models.KubernetesMetaData:
     properties:
       deploymentname:
@@ -370,39 +384,6 @@ definitions:
         description: Total number of events
         type: integer
     type: object
-  models.Service:
-    properties:
-      creationDate:
-        description: Creation date of the service
-        type: string
-      deployedImage:
-        description: Currently deployed image
-        type: string
-      lastEventTypes:
-        additionalProperties:
-          $ref: '#/definitions/models.EventContextInfo'
-        description: last event types
-        type: object
-      openApprovals:
-        description: open approvals
-        items:
-          $ref: '#/definitions/models.Approval'
-        type: array
-      serviceName:
-        description: Service name
-        type: string
-    type: object
-  models.Stage:
-    properties:
-      services:
-        description: services
-        items:
-          $ref: '#/definitions/models.Service'
-        type: array
-      stageName:
-        description: Stage name
-        type: string
-    type: object
   models.Stages:
     properties:
       nextPageKey:
@@ -414,7 +395,7 @@ definitions:
       stages:
         description: stages
         items:
-          $ref: '#/definitions/models.Stage'
+          $ref: '#/definitions/models.ExpandedStage'
         type: array
       totalCount:
         description: Total number of stages
@@ -533,7 +514,7 @@ info:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
   title: Control Plane API
-  version: "1.0"
+  version: develop
 paths:
   /event:
     post:
@@ -1200,6 +1181,10 @@ paths:
       - description: Pointer to the next set of items
         in: query
         name: nextPageKey
+        type: string
+      - description: The keptn context
+        in: query
+        name: keptnContext
         type: string
       produces:
       - application/json

--- a/shipyard-controller/handler/sequence_migrator.go
+++ b/shipyard-controller/handler/sequence_migrator.go
@@ -82,9 +82,9 @@ func (sm *SequenceMigrator) migrateSequence(projectName string, rootEvent models
 	log.Infof("checking if root event for shkeptncontext %s already has a task sequence state in the collection", rootEvent.Shkeptncontext)
 	sequence, err := sm.taskSequenceRepo.FindSequenceStates(models.StateFilter{
 		GetSequenceStateParams: models.GetSequenceStateParams{
-			Project: projectName,
+			Project:        projectName,
+			KeptnContext: rootEvent.Shkeptncontext,
 		},
-		Shkeptncontext: rootEvent.Shkeptncontext,
 	})
 	if err != nil {
 		return err

--- a/shipyard-controller/handler/sequence_migrator.go
+++ b/shipyard-controller/handler/sequence_migrator.go
@@ -82,7 +82,7 @@ func (sm *SequenceMigrator) migrateSequence(projectName string, rootEvent models
 	log.Infof("checking if root event for shkeptncontext %s already has a task sequence state in the collection", rootEvent.Shkeptncontext)
 	sequence, err := sm.taskSequenceRepo.FindSequenceStates(models.StateFilter{
 		GetSequenceStateParams: models.GetSequenceStateParams{
-			Project:        projectName,
+			Project:      projectName,
 			KeptnContext: rootEvent.Shkeptncontext,
 		},
 	})

--- a/shipyard-controller/handler/sequencehooks/sequencestate.go
+++ b/shipyard-controller/handler/sequencehooks/sequencestate.go
@@ -123,9 +123,9 @@ func (smv *SequenceStateMaterializedView) findSequenceStateForEvent(event models
 
 	return smv.SequenceStateRepo.FindSequenceStates(models.StateFilter{
 		GetSequenceStateParams: models.GetSequenceStateParams{
-			Project: eventScope.Project,
+			Project:        eventScope.Project,
+			KeptnContext: eventScope.KeptnContext,
 		},
-		Shkeptncontext: eventScope.KeptnContext,
 	})
 }
 
@@ -199,9 +199,9 @@ func (smv *SequenceStateMaterializedView) updateLastEventOfSequence(event models
 
 	states, err := smv.SequenceStateRepo.FindSequenceStates(models.StateFilter{
 		GetSequenceStateParams: models.GetSequenceStateParams{
-			Project: eventScope.Project,
+			Project:        eventScope.Project,
+			KeptnContext: eventScope.KeptnContext,
 		},
-		Shkeptncontext: eventScope.KeptnContext,
 	})
 	if err != nil {
 		return models.SequenceState{}, fmt.Errorf("could not fetch sequence state for keptnContext %s: %s", eventScope.KeptnContext, err.Error())

--- a/shipyard-controller/handler/statehandler.go
+++ b/shipyard-controller/handler/statehandler.go
@@ -33,6 +33,7 @@ func NewStateHandler(stateRepo db.SequenceStateRepo) *StateHandler {
 // @Param 	beforeTime			query	string	false	"The before time stamp for fetching sequence states (in ISO8601 time format, e.g.: 2021-05-10T09:51:00.000Z)"
 // @Param	pageSize			query	int		false	"The number of items to return"
 // @Param   nextPageKey     	query   string  false	"Pointer to the next set of items"
+// @Param   keptnContext		query	string	false	"The keptn context"
 // @Success 200 {object} models.SequenceStates	"ok"
 // @Failure 400 {object} models.Error "Invalid payload"
 // @Failure 500 {object} models.Error "Internal error"

--- a/shipyard-controller/handler/statehandler_test.go
+++ b/shipyard-controller/handler/statehandler_test.go
@@ -33,6 +33,7 @@ func TestStateHandler_GetState(t *testing.T) {
 						require.Equal(t, "sequenceState", filter.State)
 						require.Equal(t, "2021-05-10T09:51:00.000Z", filter.FromTime)
 						require.Equal(t, "2021-05-10T09:50:00.000Z", filter.BeforeTime)
+						require.Equal(t, "my-context", filter.KeptnContext)
 						return &models.SequenceStates{
 							States: []models.SequenceState{
 								{
@@ -52,7 +53,7 @@ func TestStateHandler_GetState(t *testing.T) {
 					},
 				},
 			},
-			request:    httptest.NewRequest("GET", "/state/my-project?name=sequenceName&state=sequenceState&fromTime=2021-05-10T09:51:00.000Z&beforeTime=2021-05-10T09:50:00.000Z", nil),
+			request:    httptest.NewRequest("GET", "/state/my-project?name=sequenceName&state=sequenceState&fromTime=2021-05-10T09:51:00.000Z&beforeTime=2021-05-10T09:50:00.000Z&keptnContext=my-context", nil),
 			wantStatus: http.StatusOK,
 		},
 		{

--- a/shipyard-controller/models/state.go
+++ b/shipyard-controller/models/state.go
@@ -42,11 +42,15 @@ type GetSequenceStateParams struct {
 	  In: query
 	*/
 	BeforeTime string `form:"beforeTime" json:"beforeTime"`
+
+	/** Keptn context
+	  In: query
+	*/
+	KeptnContext string `form:"keptnContext" json:"keptnContext"`
 }
 
 type StateFilter struct {
 	GetSequenceStateParams
-	Shkeptncontext string
 }
 
 type SequenceStateEvaluation struct {


### PR DESCRIPTION
closes #4433 

I've introduced an additional query parameter go fetch sequence enpoints by keptn context.
Note, that I've named the paramter `keptnContext` instead of `shkeptncontext`.

I would also propose to switch to just `keptnContext` in other places as well.
This needs to be backwards compatible, though.

Please comment your opinion on that.

Signed-off-by: warber <bernd.warmuth@dynatrace.com>