### PR TITLE
Merge changes from release-086 to master

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/templates/_helpers.tpl
+++ b/installer/manifests/keptn/charts/control-plane/templates/_helpers.tpl
@@ -99,7 +99,7 @@ readinessProbe:
      fieldPath: metadata.name
 - name: K8S_NAMESPACE
 {{- if .Values.distributor.metadata.namespace }}
-  value: .Values.distributor.metadata.namespace
+  value: {{ .Values.distributor.metadata.namespace }}
 {{- else }}
   valueFrom:
     fieldRef:
@@ -107,7 +107,7 @@ readinessProbe:
 {{- end }}
 - name: K8S_NODE_NAME
 {{- if .Values.distributor.metadata.hostname }}
-  value: .Values.distributor.metadata.hostname
+  value: {{ .Values.distributor.metadata.hostname }}
 {{- else }}
   valueFrom:
     fieldRef:

--- a/releasenotes/releasenotes_V0.8.6.md
+++ b/releasenotes/releasenotes_V0.8.6.md
@@ -1,0 +1,26 @@
+# Release Notes 0.8.6
+
+This is a hotfix release for Keptn 0.8.5, containing an updated Helm Chart *keptn-0.8.6.tgz* for setting the node/namespace of a distributor.
+
+---
+
+## Fixes
+
+- Allow to set the metadata for the node and namespace [4591](https://github.com/keptn/keptn/issues/4591)
+- Correct syntax [4609](https://github.com/keptn/keptn/issues/4609)
+
+## Installation and upgrade instructions
+
+Installing and/or upgrading to this release should be done using the `helm upgrade` command, e.g.:
+
+**Installation** (using `--install`)
+```console
+helm upgrade keptn keptn --install -n keptn --create-namespace --wait --version=0.8.6 --repo=https://storage.googleapis.com/keptn-installer
+```
+
+**Upgrade** (using `--reuse-values`)
+```console
+helm upgrade keptn keptn -n keptn --wait --version=0.8.6 --repo=https://storage.googleapis.com/keptn-installer --reuse-values
+```
+
+It is not required to upgrade the CLI.


### PR DESCRIPTION
* Changes that were made on the release-0.8.6 branch: (`value: .Values.distributor.metadata.namespace` --> `value: {{ .Values.distributor.metadata.namespace }}` )
are merged into master. 

* Including the release notes for 0.8.6. 

After merging, this PR https://github.com/keptn/keptn/pull/4607 can be closed. 

Signed-off-by: Johannes <johannes.braeuer@dynatrace.com>