### PR TITLE
Distributor: using scheme from `KEPTN_API_ENDPOINT` environment variable for uniform api

### DIFF
--- a/distributor/pkg/config/envconfig.go
+++ b/distributor/pkg/config/envconfig.go
@@ -52,6 +52,15 @@ func GetPubSubConnectionType(env EnvConfig) ConnectionType {
 	return ConnectionTypeHTTP
 }
 
+func (env *EnvConfig) ValidateKeptnAPIEndpointURL() error {
+	if env.KeptnAPIEndpoint != "" {
+		_, err := url.ParseRequestURI(env.KeptnAPIEndpoint)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
 func (env *EnvConfig) GetProxyHost(path string) (string, string, string) {
 	// if the endpoint is empty, redirect to the internal services
 	if env.KeptnAPIEndpoint == "" {

--- a/distributor/pkg/config/envconfig_test.go
+++ b/distributor/pkg/config/envconfig_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"github.com/kelseyhightower/envconfig"
+	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
 )
@@ -220,4 +221,16 @@ func Test_getPubSubRecipientURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_ValidateKeptnAPIEndpointURL(t *testing.T) {
+	// valid
+	config := EnvConfig{KeptnAPIEndpoint: "http:1.2.3.4.nip.io/some-path"}
+	assert.Nil(t, config.ValidateKeptnAPIEndpointURL())
+	// not valid
+	config = EnvConfig{KeptnAPIEndpoint: "d"}
+	assert.NotNil(t, config.ValidateKeptnAPIEndpointURL())
+	// not given
+	config = EnvConfig{KeptnAPIEndpoint: ""}
+	assert.Nil(t, config.ValidateKeptnAPIEndpointURL())
 }

--- a/distributor/pkg/lib/events/receiver.go
+++ b/distributor/pkg/lib/events/receiver.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-// EventReceiver is responsible for receive and process events form Keptn
+// EventReceiver is responsible for receive and process events from Keptn
 type EventReceiver interface {
 	Start(ctx *ExecutionContext)
 }


### PR DESCRIPTION
fixes #4516

I was not able to try it out on a cluster with enabled TLS.
 Review carefully.

Signed-off-by: warber <bernd.warmuth@dynatrace.com>