### PR TITLE
chore: Reduce amount of overhead in codecov report comment

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -27,6 +27,7 @@ ignore:
   - "**/*.sh"         # ignore shell scripts
 
 comment:
+  layout: "diff, files"
   show_carryforward_flags: true # see https://docs.codecov.io/docs/carryforward-flags
 
 github_checks:


### PR DESCRIPTION
**This PR**
* reduces the sections in the PR comment from codecov. Now only the diff and impacted files show up and the heatmap and flags table are ommitted.

Signed-off-by: Moritz Wiesinger <moritz.wiesinger@dynatrace.com>