### PR TITLE
fix(cli): Fixed `KubeConfigCheck` configuration flag

### DIFF
--- a/cli/cmd/set_config.go
+++ b/cli/cmd/set_config.go
@@ -20,7 +20,10 @@ var setConfigCmd = &cobra.Command{
 	Short: "Sets flags of the CLI configuration",
 	Long: `Sets flags of the CLI configuration, which is stored in $HOME/.keptn/config.
 
-*	This command takes a key and a new value as arguments. 
+This command takes a key and a new value as arguments and applies them to the local keptn CLI configuration
+Supported keys:
+ * AutomaticVersionCheck: true|false
+ * KubeContextCheck: true|false
 `,
 	Example:      `keptn set config AutomaticVersionCheck false`,
 	SilenceUsage: true,
@@ -33,7 +36,6 @@ var setConfigCmd = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-
 		cliConfig, err := configMng.LoadCLIConfig()
 		if err != nil {
 			return err

--- a/cli/pkg/credentialmanager/handler.go
+++ b/cli/pkg/credentialmanager/handler.go
@@ -178,9 +178,9 @@ func getCurrentContextFromKubeConfig() {
 	fileContent, err := fileutils.ReadFile(kubeconfig)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: could not parse KUBECONFIG file: "+err.Error()+"\n")
-		fmt.Println("Hint: you can disable this check via 'keptn set config KubeContextCheck true'")
-	} else if err = yaml.Unmarshal(fileContent, &kubeConfigFile); err != nil {
 		fmt.Println("Hint: If you don't have 'kubectl' installed you can disable this check via 'keptn-local set config KubeContextCheck false'")
+	} else if err = yaml.Unmarshal(fileContent, &kubeConfigFile); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not parse KUBECONFIG file: "+err.Error()+"\n")
 	}
 }
 

--- a/cli/pkg/credentialmanager/handler.go
+++ b/cli/pkg/credentialmanager/handler.go
@@ -147,22 +147,23 @@ func handleCustomCreds(configLocation string, namespace string) (url.URL, string
 
 // initChecks needs to be run when credentialManager is called or initialized
 func initChecks(autoApplyNewContext bool) {
-	if !GlobalCheckForContextChange {
-		cliConfigManager := config.NewCLIConfigManager()
-		err := getCurrentContextFromKubeConfig()
-		if err != nil {
-			log.Fatal(err)
-		}
+	cliConfigManager := config.NewCLIConfigManager()
+	cliConfig, err := cliConfigManager.LoadCLIConfig()
+	if err != nil {
+		log.Fatal(err)
+	}
+	if cliConfig.KubeContextCheck && !GlobalCheckForContextChange {
+		getCurrentContextFromKubeConfig()
 		checkForContextChange(cliConfigManager, autoApplyNewContext)
 		GlobalCheckForContextChange = true
 	}
 }
 
-func getCurrentContextFromKubeConfig() error {
+func getCurrentContextFromKubeConfig() {
 	kubeConfigFile.CurrentContext = ""
 	keptnContext = ""
 	if MockAuthCreds || MockKubeConfigCheck {
-		return nil
+		return
 	}
 
 	var kubeconfig string
@@ -176,16 +177,11 @@ func getCurrentContextFromKubeConfig() error {
 
 	fileContent, err := fileutils.ReadFile(kubeconfig)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: could not open KUBECONFIG file: "+err.Error()+"\n")
-		return nil
-	}
-
-	err = yaml.Unmarshal(fileContent, &kubeConfigFile)
-	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: could not parse KUBECONFIG file: "+err.Error()+"\n")
-		return nil
+		fmt.Println("Hint: you can disable this check via 'keptn set config KubeContextCheck true'")
+	} else if err = yaml.Unmarshal(fileContent, &kubeConfigFile); err != nil {
+		fmt.Println("Hint: If you don't have 'kubectl' installed you can disable this check via 'keptn-local set config KubeContextCheck false'")
 	}
-	return nil
 }
 
 func checkForContextChange(cliConfigManager *config.CLIConfigManager, autoApplyNewContext bool) error {

--- a/cli/pkg/credentialmanager/handler.go
+++ b/cli/pkg/credentialmanager/handler.go
@@ -178,7 +178,7 @@ func getCurrentContextFromKubeConfig() {
 	fileContent, err := fileutils.ReadFile(kubeconfig)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: could not parse KUBECONFIG file: "+err.Error()+"\n")
-		fmt.Println("Hint: If you don't have 'kubectl' installed you can disable this check via 'keptn-local set config KubeContextCheck false'")
+		fmt.Println("Hint: If you don't have a 'kubeconfig' file, you can disable this check via 'keptn set config KubeContextCheck false'")
 	} else if err = yaml.Unmarshal(fileContent, &kubeConfigFile); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: could not parse KUBECONFIG file: "+err.Error()+"\n")
 	}


### PR DESCRIPTION
fixes #4553 

With this PR without having a`~/.kube/config` file, the CLI behaves as follows.

**`KubeContextCheck` enabled (default)**
```
$ ~ ./keptn set config KubeContextCheck true
$ ~ ./keptn get project
Warning: could not parse KUBECONFIG file: Cannot find file /home/bernd/.kube/config
Hint: If you don't have 'kubectl' installed you can disable this check via 'keptn-local set config KubeContextCheck false'
NAME			CREATION DATE			SHIPYARD VERSION
...
```

**`KubeCOntextCheck` disabled**
```
$ ~ ./keptn set config KubeContextCheck false
$ ~ ./keptn get project
NAME			CREATION DATE			SHIPYARD VERSION
...
```

**`--help` text**
```
$ ~ keptn set config --help
Sets flags of the CLI configuration, which is stored in $HOME/.keptn/config.

This command takes a key and a new value as arguments and applies them to the local keptn CLI configuration
Supported keys:
 * AutomaticVersionCheck: true|false
 * KubeContextCheck: true|false

Usage:
  keptn set config [flags]

Examples:
keptn set config AutomaticVersionCheck false

Global Flags:
  -h, --help               help
      --mock               Disables communication to a Keptn endpoint
  -n, --namespace string   Specify the namespace where Keptn should be installed, used and uninstalled in (default "keptn")
  -q, --quiet              Suppresses debug and info messages
  -v, --verbose            Enables verbose logging to print debug messages
  -y, --yes                Assume yes for all user prompts

```

Signed-off-by: warber <bernd.warmuth@dynatrace.com>