### PR TITLE
chore: Add PR template, semantic PR config file, update contribution guidelines (#4585)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,8 +7,8 @@
 - adds this new feature
 
 ### Related Issues
-
 <!-- add here the GitHub issue that this PR resolves if applicable -->
+
 Fixes #1234523
 
 ### Notes

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,9 +2,9 @@
 <!-- Please use the sections that you need and delete other sections -->
 
 ## This PR
+<!-- add the description of the PR here -->
 
 - adds this new feature
-<!-- add the description of the PR here -->
 
 ### Related Issues
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+<!-- Please use this template for your pull request. -->
+<!-- Please use the sections that you need and delete other sections -->
+
+## This PR
+
+- adds this new feature
+<!-- add the description of the PR here -->
+
+### Related Issues
+
+<!-- add here the GitHub issue that this PR resolves if applicable -->
+Fixes #1234523
+
+### Notes
+<!-- any additional notes for this PR -->
+
+### Follow-up Tasks
+<!-- anything that is related to this PR but not done here should be noted under this section -->
+<!-- if there is a need for a new issue, please link it here -->
+
+### How to test
+<!-- if applicable, add testing instructions under this section -->
+

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,30 @@
+titleOnly: true
+types:
+  - feat      # A new feature
+  - fix       # A bug fix
+  - build     # Changes that affect the build system or external dependencies
+  - chore     # Other changes that don't modify src or test files
+  - ci        # Changes to our CI configuration files and scripts
+  - docs      # Documentation only changes
+  - perf      # A code change that improves performance
+  - refactor  # A code change that neither fixes a bug nor adds a feature
+  - revert    # Reverts a previous commit
+  - style     # Changes that do not affect the meaning of the code
+  - test      # Adding missing tests or correcting existing tests
+scopes:
+  - api
+  - approval-service
+  - bridge
+  - cli
+  - configuration-service
+  - distributor
+  - docs
+  - helm-service
+  - installer
+  - jmeter-service
+  - lighthouse-service
+  - mongodb-datestore
+  - remediation-service
+  - secret-service
+  - shipyard-controller
+  - statistics-service

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,7 +179,8 @@ If not, you will find it at `.github/pull_request_template.md`.
 Please describe what this PR is about and add a link to relevant GitHub issues.
 If you changed something that is visible to the user, please add a screenshot.
 Please follow the [conventional commit guidelines](https://www.conventionalcommits.org/en/v1.0.0/) for your PR title.
-If you only have one commit in your PR, please follow the guidelines for the commit message, otherwise the PR title is enough.
+
+If you only have one commit in your PR, please follow the guidelines for the message of that single commit, otherwise the PR title is enough.
 You can find a list of all possible feature types [here](#commit-types-and-scopes).
 
 An example for a pull request title would be:
@@ -213,7 +214,7 @@ In addition, please always ask yourself the following questions:
 Your PR will usually be reviewed by the Keptn team within a couple of days, but feel free to let us know about your PR [via Slack](https://slack.keptn.sh).
 
 ### Commit Types and Scopes
-Please find and up-to-date list of types and scopes [here](https://github.com/keptn/keptn/blob/master/.github/semantic.yml).
+**Please find and up-to-date list of types and scopes [here](https://github.com/keptn/keptn/blob/master/.github/semantic.yml).**
 
 #### Types
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,7 +199,7 @@ feat(bridge): New button that breaks other things (#345)
 BREAKING CHANGE: The new button added with #345 introduces new functionality that is not compatible with the previous type of sent events.
 ```
 
-If your breaking change is explained in a single line you can also use this form:
+If your breaking change can be explained in a single line you can also use this form:
 ```
 feat(bridge)!: New button that breaks other things (#345)
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,16 +81,24 @@ to indicate that this issue is good to get started with contributing to Keptn.
 
 For contributions to Keptn, please fork the Keptn repository and work in a branch. More information about forking is written down in the [docs/fork](docs/fork.md).
 
-We are following the [git branching model described in this blog post](https://nvie.com/posts/a-successful-git-branching-model/) loosely however, we try to avoid the extra step of the `develop` branch and instead work directly on the `master` branch.
+We are loosely following the [Git Flow branching model](https://nvie.com/posts/a-successful-git-branching-model/) however, we try to avoid the extra step of the `develop` branch and instead work directly on the `master` branch.
 
 * If you work on a new feature, [fork the repository](docs/fork.md), branch away from the `master` branch and use the following schema for naming your branches:
+```
+<ticket-type>/<github-issue-number>/<descriptive-name-with-dashes>
 
-  * `feature/###/name` for new features
-  * `patch/###/name` for patches
-  * `bug/###/name` for bugfixes
+Examples:
+feat/1234/my-new-feature
+fix/2235/important-bugfix
+```
 
-* If you work on a hotfix, branch away from the master branch and create a PR to master and the respective release branches.
-  * `hotfix/###/name` for hotfixes (e.g., for releases)
+All possible ticket/commit/PR types and scopes can be found [here](#commit-types-and-scopes).
+
+* If you work on a hotfix and a maintenance branch for the related release(s) doesn't exist yet, please create a maintenance branch with the following naming scheme:
+If the release was e.g. `v0.8.6`, the maintenance branch should be named `0.8.x` and  it should have the faulty release as its base instead of master.
+Then, you can create a bugfix branch from the **master** branch and work on the hotfix. When you are done, please create a PR against the master branch.
+The merged commit should then cherry-picked to the maintenance branch and then the hotfix release can be created.
+
 
 **Note:** The `###` part of the branch has to reference the GitHub issue number, e.g., if you work on feature described in issue `#1234`, the branch name would be: `feature/1234/my-feature`.
 
@@ -179,6 +187,22 @@ An example for a pull request title would be:
 feat(api): New endpoint for feature X (#1234)
 ```
 This would be a PR that adds a new endpoint to the keptn API and the issue number related to this PR is #1234.
+
+If you have **breaking changes** in your PR, it is important to note them in the PR description but also in the merge commit for that PR.
+When pressing "squash and merge", you have the option to fill out the commit message. Please use that feature to add the breaking changes according to the conventional commit guidelines.
+Also, please remove the PR number at the end and just add the issue number.
+
+An example for a PR with breaking changes and the according merge commit:
+```
+feat(bridge): New button that breaks other things (#345)
+
+BREAKING CHANGE: The new button added with #345 introduces new functionality that is not compatible with the previous type of sent events.
+```
+
+If your breaking change is explained in a single line you can also use this form:
+```
+feat(bridge)!: New button that breaks other things (#345)
+```
 
 Following those guidelines helps us create automated releases where the commit and PR messages are directly used in the changelog.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,9 +81,9 @@ to indicate that this issue is good to get started with contributing to Keptn.
 
 For contributions to Keptn, please fork the Keptn repository and work in a branch. More information about forking is written down in the [docs/fork](docs/fork.md).
 
-We are following the [git branching model described in this blog post](https://nvie.com/posts/a-successful-git-branching-model/), however, we try to avoid the extra step of the `develop` branch and instead work directly on the `master` branch.
+We are following the [git branching model described in this blog post](https://nvie.com/posts/a-successful-git-branching-model/) loosely however, we try to avoid the extra step of the `develop` branch and instead work directly on the `master` branch.
 
-* If you work on a new feature, patch, or bugfix, [fork the repository](docs/fork.md), branch away from the `master` branch and use the following schema for naming your branches:
+* If you work on a new feature, [fork the repository](docs/fork.md), branch away from the `master` branch and use the following schema for naming your branches:
 
   * `feature/###/name` for new features
   * `patch/###/name` for patches
@@ -166,10 +166,60 @@ git rebase master
 git push --set-upstream origin feature/123/foo
 ```
 
-Finally, go to GitHub and make a Pull Request. Please describe what this PR is about and add a link to relevant GitHub issues.
+Finally, go to GitHub and create a Pull Request. There should be a PR template already prepared for you.
+If not, you will find it at `.github/pull_request_template.md`.
+Please describe what this PR is about and add a link to relevant GitHub issues.
 If you changed something that is visible to the user, please add a screenshot.
+Please follow the [conventional commit guidelines](https://www.conventionalcommits.org/en/v1.0.0/) for your PR title.
+If you only have one commit in your PR, please follow the guidelines for the commit message, otherwise the PR title is enough.
+You can find a list of all possible feature types [here](#commit-types-and-scopes).
+
+An example for a pull request title would be:
+```
+feat(api): New endpoint for feature X (#1234)
+```
+This would be a PR that adds a new endpoint to the keptn API and the issue number related to this PR is #1234.
+
+Following those guidelines helps us create automated releases where the commit and PR messages are directly used in the changelog.
+
 In addition, please always ask yourself the following questions:
 
 **Based on the linked issue, what changes within the PR would you expect as a reviewer?**
 
 Your PR will usually be reviewed by the Keptn team within a couple of days, but feel free to let us know about your PR [via Slack](https://slack.keptn.sh).
+
+### Commit Types and Scopes
+Please find and up-to-date list of types and scopes [here](https://github.com/keptn/keptn/blob/master/.github/semantic.yml).
+
+#### Types
+
+- `feat    `: A new feature
+- `fix     `: A bug fix
+- `build   `: Changes that affect the build system or external dependencies
+- `chore   `: Other changes that don't modify source or test files
+- `ci      `: Changes to our CI configuration files and scripts
+- `docs    `: Documentation only changes
+- `perf    `: A code change that improves performance
+- `refactor`: A code change that neither fixes a bug nor adds a feature
+- `revert  `: Reverts a previous commit
+- `style   `: Changes that do not affect the meaning of the code
+- `test    `: Adding missing tests or correcting existing tests
+
+#### Scopes
+
+- api
+- approval-service
+- bridge
+- cli
+- configuration-service
+- distributor
+- docs
+- helm-service
+- installer
+- jmeter-service
+- lighthouse-service
+- mongodb-datestore
+- remediation-service
+- secret-service
+- shipyard-controller
+- statistics-service

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ For contributions to Keptn, please fork the Keptn repository and work in a branc
 
 We are loosely following the [Git Flow branching model](https://nvie.com/posts/a-successful-git-branching-model/) however, we try to avoid the extra step of the `develop` branch and instead work directly on the `master` branch.
 
-* If you work on a new feature, [fork the repository](docs/fork.md), branch away from the `master` branch and use the following schema for naming your branches:
+* If you work on an improvement, [fork the repository](docs/fork.md), branch away from the `master` branch and use the following schema for naming your branches:
 ```
 <ticket-type>/<github-issue-number>/<descriptive-name-with-dashes>
 
@@ -190,7 +190,7 @@ feat(api): New endpoint for feature X (#1234)
 This would be a PR that adds a new endpoint to the keptn API and the issue number related to this PR is #1234.
 
 If you have **breaking changes** in your PR, it is important to note them in the PR description but also in the merge commit for that PR.
-When pressing "squash and merge", you have the option to fill out the commit message. Please use that feature to add the breaking changes according to the conventional commit guidelines.
+When pressing "squash and merge", you have the option to fill out the commit message. Please use that feature to add the breaking changes according to the [conventional commit guidelines](https://www.conventionalcommits.org/en/v1.0.0/).
 Also, please remove the PR number at the end and just add the issue number.
 
 An example for a PR with breaking changes and the according merge commit:


### PR DESCRIPTION
## This PR
* adds a PR template
* adds the configuration for the [semantic PR GitHub action](https://github.com/zeke/semantic-pull-requests)
* adds new sections to the contribution guidelines with the updates naming schemes for commits, branches and PRs

### Related Issues
Related to #4585

### Follow-up Tasks
* [x] enable [semantic PR Github action](https://github.com/zeke/semantic-pull-requests) for the keptn/keptn repo
