### PR TITLE
ci: Publish draft release without integration tests

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -22,9 +22,45 @@ defaults:
   run:
     shell: bash
 jobs:
+  determine-target-branch:
+    name: "Determine Target Branch"
+    runs-on: ubuntu-20.04
+    outputs:
+      BRANCH: ${{ steps.determine_branch.outputs.BRANCH }}
+    steps:
+      # This step is supposed to determine the target branch where to download the build-artifacts from
+      - name: Determine Target Branch for Integration Tests
+        id: determine_branch
+        run: |
+          if [[ "${{ github.event.inputs.branch }}" != "" ]]; then
+            # branch was manually set by user -> probably a workflow_dispatch action
+            BRANCH=${{ github.event.inputs.branch }}
+            echo "Using $BRANCH as target branch for integration tests"
+          else
+            echo "Determining branch based on what triggered this workflow"
+
+            if [[ "${GITHUB_REF}" == "refs/heads"* ]]; then
+              echo "This is a push to a local branch -> using branch name"
+              BRANCH=${GITHUB_REF#refs/heads/}
+              echo "Branch Name: $BRANCH"
+            else
+              if [[ "${GITHUB_REF}" == "refs/pull/"* ]]; then
+                # usually the format for PRs is: refs/pull/1234/merge
+                echo "::error::This is a Pull Request, and PRs are not supported yet"
+                exit 1
+              else
+                echo "::error This is neither a push, nor a PR, probably something else... Exiting"
+                exit 1
+              fi
+            fi
+          fi
+
+          echo "##[set-output name=BRANCH;]$(echo ${BRANCH})"
+
   integration-test:
     name: "Tests"
     runs-on: ubuntu-20.04
+    needs: determine-target-branch
     strategy:
       fail-fast: false
       matrix:
@@ -83,11 +119,7 @@ jobs:
       KEPTN_EXAMPLES_BRANCH: ${{ github.event.inputs.examples_branch }}
       COLLECT_RESOURCE_LIMITS: ${{ matrix.COLLECT_RESOURCE_LIMITS }}
       GO_VERSION: ^1.16
-    outputs:
-      BRANCH: ${{ steps.determine_branch.outputs.BRANCH }}
-      ARTIFACTS_CI_EVENT_TYPE: ${{ github.event.inputs.artifacts_ci_event_type }}
     steps:
-
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
@@ -105,35 +137,6 @@ jobs:
           path: |
             ~/downloads
           key: ${{ runner.os }}-${{ matrix.CLOUD_PROVIDER }}-downloads
-
-      # This step is supposed to determine the target branch where to download the build-artifacts from
-      - name: Determine Target Branch for Integration Tests
-        id: determine_branch
-        run: |
-          if [[ "${{ github.event.inputs.branch }}" != "" ]]; then
-            # branch was manually set by user -> probably a workflow_dispatch action
-            BRANCH=${{ github.event.inputs.branch }}
-            echo "Using $BRANCH as target branch for integration tests"
-          else
-            echo "Determining branch based on what triggered this workflow"
-
-            if [[ "${GITHUB_REF}" == "refs/heads"* ]]; then
-              echo "This is a push to a local branch -> using branch name"
-              BRANCH=${GITHUB_REF#refs/heads/}
-              echo "Branch Name: $BRANCH"
-            else
-              if [[ "${GITHUB_REF}" == "refs/pull/"* ]]; then
-                # usually the format for PRs is: refs/pull/1234/merge
-                echo "::error::This is a Pull Request, and PRs are not supported yet"
-                exit 1
-              else
-                echo "::error This is neither a push, nor a PR, probably something else... Exiting"
-                exit 1
-              fi
-            fi
-          fi
-
-          echo "##[set-output name=BRANCH;]$(echo ${BRANCH})"
 
       # setup cloud provider kubernetes instance
       - name: Install and start Minishift
@@ -715,12 +718,11 @@ jobs:
   #######################################################################
   publish-draft-release:
     name: Publish Draft release
-    needs: integration-test
+    needs: determine-target-branch
     if: always() # always run, regardless of the outcome of the last job
     runs-on: ubuntu-20.04
     env:
-      ARTIFACTS_CI_EVENT_TYPE: ${{ needs.integration-test.outputs.ARTIFACTS_CI_EVENT_TYPE }}
-      BRANCH: ${{ needs.integration-test.outputs.BRANCH }}
+      BRANCH: ${{ needs.determine-target-branch.outputs.BRANCH }}
     steps:
       - name: Check out code
         uses: actions/checkout@v2.3.4
@@ -774,7 +776,7 @@ jobs:
           # Download last successful artifact from a CI build
           github_token: ${{secrets.GITHUB_TOKEN}}
           workflow: CI.yml
-          event: ${{ env.ARTIFACTS_CI_EVENT_TYPE }} # e.g., push, pull_request
+          event: ${{ github.event.inputs.artifacts_ci_event_type }} # e.g., push, pull_request
           workflow_conclusion: success
           # use the following branch
           branch: ${{ env.BRANCH}}
@@ -1019,11 +1021,11 @@ jobs:
   #######################################################################
   deploy_keptn_with_keptn:
     name: Deploy Keptn with Keptn
-    needs: integration-test
+    needs: [integration-test, determine-target-branch]
     if: github.event_name == 'schedule'
     runs-on: ubuntu-20.04
     env:
-      BRANCH: ${{ needs.integration-test.outputs.BRANCH }}
+      BRANCH: ${{ needs.determine-target-branch.outputs.BRANCH }}
     steps:
       - name: Check out code
         uses: actions/checkout@v2.3.4

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -988,7 +988,11 @@ jobs:
           mkdir -p dist/release
           cp -r dist/keptn-cli/keptn-*.tar.gz dist/release/
           cp -r dist/keptn-installer/*.tgz dist/release/
-          gh release create "${{ env.VERSION }}" --target "${{ env.VERSION }}" --draft --prerelease --notes-file "${{ env.RELEASE_NOTES_FILE }}" dist/release/*
+          if [[ "$BRANCH" == "release-"* ]]; then
+            gh release create "${{ env.VERSION }}" --target "${{ env.VERSION }}" --draft --prerelease --notes-file "${{ env.RELEASE_NOTES_FILE }}" dist/release/*
+          else
+            gh release create "${{ env.VERSION }}" --target "${{ env.BRANCH }}" --draft --prerelease --notes-file "${{ env.RELEASE_NOTES_FILE }}" dist/release/*
+          fi
 
       - name: Upload Helm Charts to Google Cloud
         id: upload_helm_charts

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -713,29 +713,11 @@ jobs:
           name: support-archive
           path: support-archive/*.zip
 
-  #######################################################################
-  # This job publishes a draft release based on the previous steps      #
-  #######################################################################
-  publish-draft-release:
-    name: Publish Draft release
-    needs: determine-target-branch
-    if: always() # always run, regardless of the outcome of the last job
+  test-report:
+    name: "Generate test report"
+    needs: integration-test
     runs-on: ubuntu-20.04
-    env:
-      BRANCH: ${{ needs.determine-target-branch.outputs.BRANCH }}
     steps:
-      - name: Check out code
-        uses: actions/checkout@v2.3.4
-
-      - name: Debug - Output Branch
-        run: echo $BRANCH
-
-      - name: Load CI Environment from .ci_env
-        id: load_ci_env
-        uses: c-py/action-dotenv-to-setenv@v3
-        with:
-          env-file: .ci_env
-
       - name: Download test reports
         uses: actions/download-artifact@v2
         with:
@@ -761,47 +743,6 @@ jobs:
         with:
           name: test-report
           path: final-test-report.txt
-
-      - name: Summarize Resource Usage
-        id: print_resource_usage
-        run: |
-          echo "**Resource Limits**" > final-resource-limits.txt
-          ls -la test-resource-limits*.txt
-          cat test-resource-limits*.txt >> final-resource-limits.txt || echo "No resource reports found" >> final-resource-limits.txt
-          # Todo: some calculations should be done...
-
-      - name: Download all artifacts from last successful build of specified branch
-        uses: dawidd6/action-download-artifact@v2.14.0
-        with:
-          # Download last successful artifact from a CI build
-          github_token: ${{secrets.GITHUB_TOKEN}}
-          workflow: CI.yml
-          event: ${{ github.event.inputs.artifacts_ci_event_type }} # e.g., push, pull_request
-          workflow_conclusion: success
-          # use the following branch
-          branch: ${{ env.BRANCH}}
-          # directory where to extract artifacts to
-          path: ./dist
-
-      - name: Load Build-Config Environment from ./dist/build-config/build-config.env
-        id: load_build_env
-        uses: c-py/action-dotenv-to-setenv@v3
-        with:
-          env-file: ./dist/build-config/build-config.env
-
-      - name: Overwrite VERSION String for nightly builds
-        run: |
-          if [[ "$BRANCH" == "master" ]]; then
-            # use VERSION.DATETIME for the cli version (e.g., nightly build)
-            VERSION=${VERSION}.${DATETIME}
-            # overwrite VERSION
-            echo "VERSION=${VERSION}" >> $GITHUB_ENV
-          fi
-
-      - name: DEBUG Build-Config
-        run: |
-          echo VERSION=${VERSION}
-          echo BRANCH=${BRANCH}
 
       - name: Formulate bug issue on errors
         id: formulate_bug_issue
@@ -856,6 +797,61 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  #######################################################################
+  # This job publishes a draft release based on the previous steps      #
+  #######################################################################
+  publish-draft-release:
+    name: Publish Draft release
+    needs: determine-target-branch
+    if: always() # always run, regardless of the outcome of the last job
+    runs-on: ubuntu-20.04
+    env:
+      BRANCH: ${{ needs.determine-target-branch.outputs.BRANCH }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2.3.4
+
+      - name: Load CI Environment from .ci_env
+        id: load_ci_env
+        uses: c-py/action-dotenv-to-setenv@v3
+        with:
+          env-file: .ci_env
+
+      - name: Summarize Resource Usage
+        id: print_resource_usage
+        run: |
+          echo "**Resource Limits**" > final-resource-limits.txt
+          ls -la test-resource-limits*.txt
+          cat test-resource-limits*.txt >> final-resource-limits.txt || echo "No resource reports found" >> final-resource-limits.txt
+          # Todo: some calculations should be done...
+
+      - name: Download all artifacts from last successful build of specified branch
+        uses: dawidd6/action-download-artifact@v2.14.0
+        with:
+          # Download last successful artifact from a CI build
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          workflow: CI.yml
+          event: ${{ github.event.inputs.artifacts_ci_event_type }} # e.g., push, pull_request
+          workflow_conclusion: success
+          # use the following branch
+          branch: ${{ env.BRANCH}}
+          # directory where to extract artifacts to
+          path: ./dist
+
+      - name: Load Build-Config Environment from ./dist/build-config/build-config.env
+        id: load_build_env
+        uses: c-py/action-dotenv-to-setenv@v3
+        with:
+          env-file: ./dist/build-config/build-config.env
+
+      - name: Overwrite VERSION String for nightly builds
+        run: |
+          if [[ "$BRANCH" == "master" ]]; then
+            # use VERSION.DATETIME for the cli version (e.g., nightly build)
+            VERSION=${VERSION}.${DATETIME}
+            # overwrite VERSION
+            echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          fi
 
       # Part of this job is to check if a releasenotes file exists and to use it as the release message
       - name: Try getting release notes
@@ -893,7 +889,7 @@ jobs:
           cat dist/docker-build-report/docker_build_report.txt  >> release-notes.txt || echo "Failed to open dist/docker-build-report/docker_build_report.txt" >> release-notes.txt
           echo "" >> release-notes.txt
           echo "**Integration Tests**" >> release-notes.txt
-          cat final-test-report.txt >> release-notes.txt
+          cat final-test-report.txt >> release-notes.txt || echo "Failed to open integration test report" >> release-notes.txt
           echo "" >> release-notes.txt
           echo "</p>" >> release-notes.txt
           echo "</details>" >> release-notes.txt

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -991,7 +991,7 @@ jobs:
           if [[ "$BRANCH" == "release-"* ]]; then
             gh release create "${{ env.VERSION }}" --target "${{ env.VERSION }}" --draft --prerelease --notes-file "${{ env.RELEASE_NOTES_FILE }}" dist/release/*
           else
-            gh release create "${{ env.VERSION }}" --target "${{ env.BRANCH }}" --draft --prerelease --notes-file "${{ env.RELEASE_NOTES_FILE }}" dist/release/*
+            gh release create "${{ env.VERSION }}" --target "${{ env.github_ref }}" --draft --prerelease --notes-file "${{ env.RELEASE_NOTES_FILE }}" dist/release/*
           fi
 
       - name: Upload Helm Charts to Google Cloud

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -985,18 +985,14 @@ jobs:
 
       - name: Draft Release with Releasenotes
         id: create_draft_release
-        uses: softprops/action-gh-release@v1
-        with:
-          name: ${{ env.VERSION }}
-          tag_name: ${{ env.VERSION }}
-          draft: true       # we only want to publish draft releases here - a human should review it and push the button eventually
-          prerelease: true  # mark as pre-release for now, a human can always change it to a non-prerelease afterwards
-          body_path: release-notes.txt
-          files: |
-            dist/keptn-cli/keptn-*.tar.gz
-            dist/keptn-installer/*.tgz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_NOTES_FILE: release-notes.txt
+        run: |
+          mkdir -p dist/release
+          cp -r dist/keptn-cli/keptn-*.tar.gz dist/release/
+          cp -r dist/keptn-installer/*.tgz dist/release/
+          gh release create "${{ env.VERSION }}" --target "${{ env.VERSION }}" --draft --prerelease --notes-file "${{ env.RELEASE_NOTES_FILE }}" dist/release/*
 
       - name: Upload Helm Charts to Google Cloud
         id: upload_helm_charts

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -723,6 +723,14 @@ jobs:
         with:
           name: test-report
 
+      - name: Summarize Resource Usage
+        id: print_resource_usage
+        run: |
+          echo "**Resource Limits**" > final-resource-limits.txt
+          ls -la test-resource-limits*.txt
+          cat test-resource-limits*.txt >> final-resource-limits.txt || echo "No resource reports found" >> final-resource-limits.txt
+          # Todo: some calculations should be done...
+
       - name: Print Test Report
         id: print_test_report
         run: |
@@ -817,14 +825,6 @@ jobs:
         with:
           env-file: .ci_env
 
-      - name: Summarize Resource Usage
-        id: print_resource_usage
-        run: |
-          echo "**Resource Limits**" > final-resource-limits.txt
-          ls -la test-resource-limits*.txt
-          cat test-resource-limits*.txt >> final-resource-limits.txt || echo "No resource reports found" >> final-resource-limits.txt
-          # Todo: some calculations should be done...
-
       - name: Download all artifacts from last successful build of specified branch
         uses: dawidd6/action-download-artifact@v2.14.0
         with:
@@ -898,7 +898,7 @@ jobs:
           echo "<details><summary>Kubernetes Resource Data</summary>" >> release-notes.txt
           echo "<p>" >> release-notes.txt
           echo ""  >> release-notes.txt
-          cat $RESOURCE_LIMITS_FILENAME >> release-notes.txt
+          cat $RESOURCE_LIMITS_FILENAME >> release-notes.txt || echo "Failed to open resource usage report" >> release-notes.txt
           echo "</p>" >> release-notes.txt
           echo "</details>" >> release-notes.txt
 


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- changes the integration test pipeline so that a GH draft release is always published regardless of the integration test results
