### PR TITLE
fix(approval-service): skip timeout for manual approvements (#4620)

### DIFF
--- a/approval-service/pkg/handler/approval_triggered_event_handler.go
+++ b/approval-service/pkg/handler/approval_triggered_event_handler.go
@@ -55,11 +55,9 @@ func (a *ApprovalTriggeredEventHandler) Handle(event cloudevents.Event, keptnHan
 
 func (a *ApprovalTriggeredEventHandler) handleApprovalTriggeredEvent(inputEvent keptnv2.ApprovalTriggeredEventData,
 	triggeredID, shkeptncontext string) []cloudevents.Event {
-
 	outgoingEvents := make([]cloudevents.Event, 0)
 	if inputEvent.Result == keptnv2.ResultPass && inputEvent.Approval.Pass == keptnv2.ApprovalAutomatic ||
 		inputEvent.Result == keptnv2.ResultWarning && inputEvent.Approval.Warning == keptnv2.ApprovalAutomatic {
-
 		startedEvent := a.getApprovalStartedEvent(inputEvent, triggeredID, shkeptncontext)
 		outgoingEvents = append(outgoingEvents, *startedEvent)
 		a.keptn.Logger.Info(fmt.Sprintf("Automatically approve release of service %s of project %s and current stage %s",
@@ -69,7 +67,6 @@ func (a *ApprovalTriggeredEventHandler) handleApprovalTriggeredEvent(inputEvent 
 		outgoingEvents = append(outgoingEvents, *finishedEvent)
 	} else if inputEvent.Result == keptnv2.ResultFailed {
 		// Handle case if an ApprovalTriggered event was sent even the evaluation result is failed
-
 		startedEvent := a.getApprovalStartedEvent(inputEvent, triggeredID, shkeptncontext)
 		outgoingEvents = append(outgoingEvents, *startedEvent)
 
@@ -77,6 +74,9 @@ func (a *ApprovalTriggeredEventHandler) handleApprovalTriggeredEvent(inputEvent 
 			"the previous step failed", inputEvent.Service, inputEvent.Project, inputEvent.Stage))
 		finishedEvent := a.getApprovalFinishedEvent(inputEvent, keptnv2.ResultFailed, triggeredID, shkeptncontext)
 		outgoingEvents = append(outgoingEvents, *finishedEvent)
+	} else if inputEvent.Approval.Pass == keptnv2.ApprovalManual || inputEvent.Approval.Warning == keptnv2.ApprovalManual {
+		startedEvent := a.getApprovalStartedEvent(inputEvent, triggeredID, shkeptncontext)
+		outgoingEvents = append(outgoingEvents, *startedEvent)
 	}
 
 	return outgoingEvents

--- a/approval-service/pkg/handler/approval_triggered_event_handler_test.go
+++ b/approval-service/pkg/handler/approval_triggered_event_handler_test.go
@@ -41,16 +41,22 @@ var approvalTriggeredTests = []struct {
 		},
 	},
 	{
-		name:        "pass-with-approval-strategy-manual-auto",
-		image:       "docker.io/keptnexamples/carts:0.11.1",
-		inputEvent:  getApprovalTriggeredTestData(keptnv2.ResultPass, keptnv2.ApprovalManual, keptnv2.ApprovalAutomatic),
-		outputEvent: []cloudevents.Event{},
+		name:       "pass-with-approval-strategy-manual-auto",
+		image:      "docker.io/keptnexamples/carts:0.11.1",
+		inputEvent: getApprovalTriggeredTestData(keptnv2.ResultPass, keptnv2.ApprovalManual, keptnv2.ApprovalAutomatic),
+		outputEvent: []cloudevents.Event{
+			*getCloudEvent(getApprovalStartedTestData("succeeded"),
+				keptnv2.GetStartedEventType(keptnv2.ApprovalTaskName), shkeptncontext, eventID),
+		},
 	},
 	{
-		name:        "pass-with-approval-strategy-manual-manual",
-		image:       "docker.io/keptnexamples/carts:0.11.1",
-		inputEvent:  getApprovalTriggeredTestData(keptnv2.ResultPass, keptnv2.ApprovalManual, keptnv2.ApprovalManual),
-		outputEvent: []cloudevents.Event{},
+		name:       "pass-with-approval-strategy-manual-manual",
+		image:      "docker.io/keptnexamples/carts:0.11.1",
+		inputEvent: getApprovalTriggeredTestData(keptnv2.ResultPass, keptnv2.ApprovalManual, keptnv2.ApprovalManual),
+		outputEvent: []cloudevents.Event{
+			*getCloudEvent(getApprovalStartedTestData("succeeded"),
+				keptnv2.GetStartedEventType(keptnv2.ApprovalTaskName), shkeptncontext, eventID),
+		},
 	},
 
 	{
@@ -65,10 +71,13 @@ var approvalTriggeredTests = []struct {
 		},
 	},
 	{
-		name:        "warning-with-approval-strategy-auto-manual",
-		image:       "docker.io/keptnexamples/carts:0.11.1",
-		inputEvent:  getApprovalTriggeredTestData(keptnv2.ResultWarning, keptnv2.ApprovalAutomatic, keptnv2.ApprovalManual),
-		outputEvent: []cloudevents.Event{},
+		name:       "warning-with-approval-strategy-auto-manual",
+		image:      "docker.io/keptnexamples/carts:0.11.1",
+		inputEvent: getApprovalTriggeredTestData(keptnv2.ResultWarning, keptnv2.ApprovalAutomatic, keptnv2.ApprovalManual),
+		outputEvent: []cloudevents.Event{
+			*getCloudEvent(getApprovalStartedTestData("succeeded"),
+				keptnv2.GetStartedEventType(keptnv2.ApprovalTaskName), shkeptncontext, eventID),
+		},
 	},
 	{
 		name:       "warning-with-approval-strategy-manual-auto",
@@ -82,10 +91,13 @@ var approvalTriggeredTests = []struct {
 		},
 	},
 	{
-		name:        "warning-with-approval-strategy-manual-manual",
-		image:       "docker.io/keptnexamples/carts:0.11.1",
-		inputEvent:  getApprovalTriggeredTestData(keptnv2.ResultWarning, keptnv2.ApprovalManual, keptnv2.ApprovalManual),
-		outputEvent: []cloudevents.Event{},
+		name:       "warning-with-approval-strategy-manual-manual",
+		image:      "docker.io/keptnexamples/carts:0.11.1",
+		inputEvent: getApprovalTriggeredTestData(keptnv2.ResultWarning, keptnv2.ApprovalManual, keptnv2.ApprovalManual),
+		outputEvent: []cloudevents.Event{
+			*getCloudEvent(getApprovalStartedTestData("succeeded"),
+				keptnv2.GetStartedEventType(keptnv2.ApprovalTaskName), shkeptncontext, eventID),
+		},
 	},
 
 	{
@@ -150,7 +162,6 @@ func TestHandleApprovalTriggeredEvent(t *testing.T) {
 			if len(tt.outputEvent) > 0 {
 				for i, r := range res {
 					if !compareEventContext(r, tt.outputEvent[i]) {
-
 						fmt.Println(string(r.Data()))
 						fmt.Println(string(tt.outputEvent[i].Data()))
 						t.Errorf("output events do not match for %s", tt.name)

--- a/approval-service/pkg/handler/handler.go
+++ b/approval-service/pkg/handler/handler.go
@@ -11,15 +11,6 @@ import (
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 )
 
-const (
-	PassResult                  = "pass"
-	WarningResult               = "warning"
-	FailResult                  = "fail"
-	TestStrategyRealUser        = "real-user"
-	DeploymentStrategyBlueGreen = "blue_green_service"
-	SucceededResult             = "succeeded"
-)
-
 type Handler interface {
 	IsTypeHandled(event cloudevents.Event) bool
 	Handle(event cloudevents.Event, keptnHandler *keptnv2.Keptn)

--- a/bridge/client/app/_components/ktb-task-item/ktb-task-item.component.html
+++ b/bridge/client/app/_components/ktb-task-item/ktb-task-item.component.html
@@ -61,18 +61,7 @@
       </div>
     </div>
   </ktb-expandable-tile-header>
-  <div *ngIf="task.isApproval() && task.isApprovalPending()">
-    <table>
-      <tr>
-        <td><p class="m-0">Currently deployed artifact: </p></td>
-        <td><p class="m-0" [textContent]="project.getLatestDeploymentTraceOfSequence(project.getService(task.data.service), project.getStage(task.data.stage))?.getShortImageName() || 'N/A'"></p></td>
-      </tr>
-      <tr>
-        <td><p class="m-0">Deployable artifact: </p></td>
-        <td><ktb-approval-item [event]="task" [isSequence]="true"></ktb-approval-item></td>
-      </tr>
-    </table>
-  </div>
+
   <div class="sub-task-item pt-2 pb-2" #subTaskRef *ngFor="let subTask of task.traces">
     <ktb-task-item *ngIf="subTask.isTriggered(); else taskLine" [task]="subTask" (itemClicked)="onClick($event)" (click)="$event.stopPropagation();onClick(subTask)"></ktb-task-item>
     <ng-template #taskLine>
@@ -96,6 +85,18 @@
     select="ktb-task-item-detail,
         [ktb-task-item-detail],
         [ktbEventItemDetail]"></ng-content>
+  <div *ngIf="task.isApproval() && task.isApprovalPending()">
+    <table>
+      <tr>
+        <td><p class="m-0">Currently deployed artifact: </p></td>
+        <td><p class="m-0" [textContent]="project.getLatestDeploymentTraceOfSequence(project.getService(task.data.service), project.getStage(task.data.stage))?.getShortImageName() || 'N/A'"></p></td>
+      </tr>
+      <tr>
+        <td><p class="m-0">Deployable artifact: </p></td>
+        <td><ktb-approval-item [event]="task" [isSequence]="true"></ktb-approval-item></td>
+      </tr>
+    </table>
+  </div>
 </ktb-expandable-tile>
 <ng-template #taskPayloadDialog let-data>
   <h1 mat-dialog-title>Event payload</h1>

--- a/bridge/client/app/_models/sequence.ts
+++ b/bridge/client/app/_models/sequence.ts
@@ -78,8 +78,8 @@ export class Sequence {
 
   public hasPendingApproval(stageName?: string): boolean {
     return stageName ?
-        this.getStage(stageName)?.latestEvent?.type === EventTypes.APPROVAL_TRIGGERED
-      : this.stages.some(stage => stage.latestEvent?.type === EventTypes.APPROVAL_TRIGGERED);
+        this.getStage(stageName)?.latestEvent?.type === EventTypes.APPROVAL_TRIGGERED || this.getStage(stageName)?.latestEvent?.type === EventTypes.APPROVAL_STARTED
+      : this.stages.some(stage => stage.latestEvent?.type === EventTypes.APPROVAL_TRIGGERED || stage.latestEvent?.type === EventTypes.APPROVAL_STARTED);
   }
 
   public getStatus(): string {

--- a/bridge/client/app/_models/trace.ts
+++ b/bridge/client/app/_models/trace.ts
@@ -272,7 +272,7 @@ class Trace {
   }
 
   public isApproval(): string | undefined {
-    return this.type === EventTypes.APPROVAL_TRIGGERED ? this.data.stage : undefined;
+    return this.type === EventTypes.APPROVAL_TRIGGERED || this.type === EventTypes.APPROVAL_STARTED ? this.data.stage : undefined;
   }
 
   public isApprovalPending(): boolean {

--- a/bridge/client/app/_services/data.service.ts
+++ b/bridge/client/app/_services/data.service.ts
@@ -539,10 +539,7 @@ export class DataService {
   }
 
   public sendApprovalEvent(approval: Trace, approve: boolean): void {
-    this.apiService.sendApprovalEvent(approval, approve, EventTypes.APPROVAL_STARTED, 'approval.started')
-      .pipe(
-        mergeMap(() => this.apiService.sendApprovalEvent(approval, approve, EventTypes.APPROVAL_FINISHED, 'approval.finished'))
-      )
+    this.apiService.sendApprovalEvent(approval, approve, EventTypes.APPROVAL_FINISHED, 'approval.finished')
       .subscribe(() => {
         const sequence = this._projects.getValue()?.find(p => p.projectName === approval.data.project)
                         ?.getServices().find(s => s.serviceName === approval.data.service)

--- a/cli/cmd/send_event_approvalFinished.go
+++ b/cli/cmd/send_event_approvalFinished.go
@@ -109,10 +109,6 @@ func sendApprovalFinishedEvent(sendApprovalFinishedOptions sendApprovalFinishedS
 		return nil
 	}
 
-	startedEvent := getApprovalStartedEvent(approvalFinishedEvent.EventData)
-	if _, err := sendEvent(keptnContext, triggeredID, keptnv2.GetStartedEventType(keptnv2.ApprovalTaskName), startedEvent, apiHandler); err != nil {
-		return err
-	}
 	responseEvent, err := sendEvent(keptnContext, triggeredID, keptnv2.GetFinishedEventType(keptnv2.ApprovalTaskName), approvalFinishedEvent, apiHandler)
 	if err != nil {
 		return err
@@ -156,19 +152,6 @@ func sendEvent(keptnContext, triggeredID, eventType string, approvalFinishedEven
 		return nil, fmt.Errorf("Send %s was unsuccessful. %s", eventType, *errorObj.Message)
 	}
 	return responseEvent, nil
-}
-
-func getApprovalStartedEvent(inputEvent keptnv2.EventData) *keptnv2.ApprovalStartedEventData {
-	startedEvent := &keptnv2.ApprovalStartedEventData{
-		EventData: keptnv2.EventData{
-			Project: inputEvent.Project,
-			Stage:   inputEvent.Stage,
-			Service: inputEvent.Service,
-			Labels:  inputEvent.Labels,
-			Status:  inputEvent.Status,
-		},
-	}
-	return startedEvent
 }
 
 func getApprovalFinishedForService(eventHandler *apiutils.EventHandler, scHandler *apiutils.ShipyardControllerHandler,


### PR DESCRIPTION
Changes: 

* [x] The `approval-service` will now send a `approval.started` event when processing `approval.triggered` events
* [x] The `CLI` and bridge will *not* send a `approval.started` event anymore 
* [x] Integration tests adpated

fixes #4620 