### PR TITLE
ci: Fix bug where CI pipeline does not build all docker images on push to master (#4825)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -154,7 +154,7 @@ jobs:
           echo "##[set-output name=BUILD_EVERYTHING;]$(echo ${BUILD_EVERYTHING})"
 
       - name: Process only certain artifacts based on changed files (for PRs only)
-        if: github.event_name == 'pull_request'
+        if: (github.event_name == 'pull_request') || (github.event_name == 'push')
         id: check_modified_files
         env:
           BUILD_EVERYTHING: ${{ steps.build_everything.outputs.BUILD_EVERYTHING }}


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- fixes the CI pipeline when building master on push
