### PR TITLE
ci: Fix bug where docker image and helm chart version datetime were not the same

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -668,7 +668,6 @@ jobs:
           IMAGE: keptn/${{ matrix.config.artifact }}
           DOCKER_FOLDER: ${{ matrix.config.working-dir }}
         run: |
-          DATETIME=$(date +'%Y%m%d')$(date +'%H%M')
           docker build "${DOCKER_FOLDER}" -t "${IMAGE}:${VERSION}.${DATETIME}" -t "${IMAGE}:${VERSION}" --build-arg version="${VERSION}"
           docker push "${IMAGE}:${VERSION}.${DATETIME}" && docker push "${IMAGE}:${VERSION}"
 


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- fixes a bug where the docker image version in the helm chart and on dockerhub were not the same resulting in fails to pull docker images from dockerhub
