### PR TITLE
feat(cli): allow to specify local directory as a chart-path

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"net/url"
 	"strings"
 
 	"github.com/keptn/keptn/cli/pkg/common"
@@ -34,6 +33,7 @@ import (
 
 	"github.com/keptn/keptn/cli/pkg/logging"
 
+	goutils "github.com/keptn/go-utils/pkg/common/httputils"
 	keptnutils "github.com/keptn/kubernetes-utils/pkg"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -197,26 +197,13 @@ type InstallCmdHandler struct {
 	userInput        common.IUserInput
 }
 
-func isValidURL(chartURL string) bool {
-	_, err := url.ParseRequestURI(chartURL)
-	if err != nil {
-		return false
-	}
-
-	u, err := url.Parse(chartURL)
-	if err != nil || u.Scheme == "" || u.Host == "" {
-		return false
-	}
-	return true
-}
-
 func (i *InstallCmdHandler) doInstallation(installParams installCmdParams) error {
 	keptnNamespace := namespace
 	showFallbackConnectMessage := true
 
 	keptnChartRepoURL := getKeptnHelmChartRepoURL(installParams.ChartRepoURL)
 	var err error
-	if isValidURL(keptnChartRepoURL) {
+	if goutils.IsValidURL(keptnChartRepoURL) {
 		keptnChart, err = i.helmHelper.DownloadChart(keptnChartRepoURL)
 		if err != nil {
 			return err

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -308,11 +308,20 @@ func (i *InstallCmdHandler) doInstallation(installParams installCmdParams) error
 
 func fetchContinuousDeliveryCharts(helmHelper helm.IHelper, chartRepoURL *string) ([]*chart.Chart, error) {
 	charts := []*chart.Chart{}
+	var serviceChart *chart.Chart
+	var err error
 	for _, service := range continuousDeliveryServices {
 		chartURL := getExecutionPlaneServiceChartRepoURL(chartRepoURL, service)
-		serviceChart, err := helmHelper.DownloadChart(chartURL)
-		if err != nil {
-			return nil, err
+		if goutils.IsValidURL(chartURL) {
+			serviceChart, err = helmHelper.DownloadChart(chartURL)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			serviceChart, err = keptnutils.LoadChartFromPath(chartURL)
+			if err != nil {
+				return nil, err
+			}
 		}
 		charts = append(charts, serviceChart)
 	}


### PR DESCRIPTION
Signed-off-by: Jimil Desai <jimildesai42@gmail.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- Allows users to install Keptn from a draft release by pointing to a chart repo on the local filesystem, eg:
```
download keptn-installer-0.8.4-dev.tgz # download or build helm charts
keptn install --chart-repo=./dist/keptn-installer-0.8.4-dev.tgz
```

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #4325 

### How to test
<!-- if applicable, add testing instructions under this section -->
1. Download Keptn
2. Install Keptn by pointing to chart repo in the local filesystem: `keptn install --chart-repo=./keptn-0.8.7.tgz`
