### PR TITLE
ci: Update semantic PR config to take dev deps from npm into account

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -18,6 +18,7 @@ scopes:
   - cli
   - configuration-service
   - deps
+  - deps-dev
   - distributor
   - docs
   - helm-service


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- adds `deps-dev` to the semantic PR allowed scopes. Dependabot uses this scope for npm dev dependencies
