### PR TITLE
fix(api): Apply rate limiter before token is validated (#4906)

### DIFF
--- a/api/middleware/ratelimiter_test.go
+++ b/api/middleware/ratelimiter_test.go
@@ -121,6 +121,16 @@ func TestRateLimiter(t *testing.T) {
 	wg.Wait()
 	require.Equal(t, 1, mh.calls)
 
+	// now simulate a request with a valid token - this should however still be throttled due to previous burst of invalid requests
+	tokenValidator.ValidateTokenFunc = func(token string) (*models.Principal, error) {
+		return nil, nil
+	}
+	req, err = http.NewRequest(http.MethodGet, "", nil)
+	require.Nil(t, err)
+
+	rl.Apply(&httptest.ResponseRecorder{}, req, mh)
+	require.Equal(t, 1, mh.calls)
+
 	// wait a bit - the next one should pass
 	<-time.After(1 * time.Second)
 	rl.Apply(&httptest.ResponseRecorder{}, req, mh)

--- a/api/middleware/tokenauth.go
+++ b/api/middleware/tokenauth.go
@@ -4,6 +4,7 @@ import (
 	openapierrors "github.com/go-openapi/errors"
 	"github.com/keptn/keptn/api/models"
 	log "github.com/sirupsen/logrus"
+	"net/http"
 	"os"
 )
 
@@ -20,5 +21,5 @@ func (b *BasicTokenValidator) ValidateToken(token string) (*models.Principal, er
 		return &prin, nil
 	}
 	log.Errorf("Access attempt with incorrect api key auth: %s", token)
-	return nil, openapierrors.New(401, "incorrect api key auth")
+	return nil, openapierrors.New(http.StatusUnauthorized, "incorrect api key auth")
 }


### PR DESCRIPTION
## This PR

- Changes the logic of the `/auth` endpoint's rate limiter to be applied before any token validation is done.
- If the incoming API token is valid, this will reset the limiter in order to prevent subsequent valid requests to be throttled
- With this logic, the caller of the API cannot automatically assume that the provided token was invalid when receiving a HTTP 429 (Too many requests) response since now also a request with a valid token can be throttled if there were too many invalid requests before.

### Related Issues

Closes #4906 
