### PR TITLE
fix(bridge): moved 'View evaluation button' to the next row (#4760)

### DIFF
--- a/bridge/client/app/_components/ktb-stage-details/ktb-stage-details.component.html
+++ b/bridge/client/app/_components/ktb-stage-details/ktb-stage-details.component.html
@@ -84,8 +84,8 @@
                     <ktb-evaluation-details [evaluationData]="evaluation.getFinishedEvent()" [showChart]="false"></ktb-evaluation-details>
                   </ng-template>
                 </dt-tag-list>
-                <button dt-button variant="secondary" [routerLink]="['/project', failedRootEvent.project, 'service', service.serviceName, 'context', failedRootEvent.shkeptncontext, 'stage', selectedStage.stageName]">View evaluation result</button>
               </div>
+              <button dt-button variant="secondary" [routerLink]="['/project', failedRootEvent.project, 'service', service.serviceName, 'context', failedRootEvent.shkeptncontext, 'stage', selectedStage.stageName]">View evaluation result</button>
               <p class="m-0" *ngIf="project.getLatestDeployment(service, selectedStage) as deployment">
                 Rollback to <span [textContent]="deployment.image"></span> performed.
               </p>


### PR DESCRIPTION
Fixes #4760 
![image](https://user-images.githubusercontent.com/11599148/129192855-e7a422ee-bca4-47e6-8385-9857e7cafdae.png)

small screen:
![image](https://user-images.githubusercontent.com/11599148/129192891-fcbfca71-9caf-40ea-ab6a-f275d96b187a.png)


Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>