### PR TITLE
feat(bridge): Show dialog when settings / create project is changed (#4677)

### DIFF
--- a/bridge/client/app/_components/ktb-project-settings-git/ktb-project-settings-git.component.html
+++ b/bridge/client/app/_components/ktb-project-settings-git/ktb-project-settings-git.component.html
@@ -20,15 +20,13 @@
       </dt-form-field>
       <dt-form-field>
         <dt-label>Token</dt-label>
-        <input formControlName="gitToken"
-               (focus)="gitTokenControl.value.length > 0 && gitTokenControl.value.includes('*********') ? gitTokenControl.setValue('') : null"
-               type="password" dtInput placeholder="Token"/>
+        <input formControlName="gitToken" type="password" dtInput placeholder="Token"/>
         <dt-error>Must not be empty</dt-error>
       </dt-form-field>
     </div>
   </div>
   <div class="ml-3" *ngIf="!isCreateMode">
-    <button [disabled]="gitUpstreamForm.invalid || !gitUpstreamForm.dirty || isGitUpstreamInProgress" (click)="setGitUpstream()" dt-button>
+    <button [disabled]="isButtonDisabled()" (click)="setGitUpstream()" dt-button>
       <dt-loading-spinner *ngIf="isGitUpstreamInProgress" aria-label="Setting Git upstream URL"></dt-loading-spinner>
       Set Git upstream
     </button>

--- a/bridge/client/app/_components/ktb-project-settings-git/ktb-project-settings-git.component.html
+++ b/bridge/client/app/_components/ktb-project-settings-git/ktb-project-settings-git.component.html
@@ -5,7 +5,7 @@
   <br/>Instructions, how to set your Git provider can be found in the
   <a [href]="'/manage/git_upstream/' | keptnUrl" target="_blank">Git-based upstream documentation</a>
 </p>
-<form [formGroup]="gitUpstreamForm" (change)="onGitUpstreamFormChange()" id="git-upstream-form" fxLayout="row" fxLayoutAlign=" end">
+<form [formGroup]="gitUpstreamForm" (input)="onGitUpstreamFormChange()" id="git-upstream-form" fxLayout="row" fxLayoutAlign=" end">
   <div fxLayout="column" [ngClass]="{'full-width': isCreateMode}">
     <dt-form-field>
       <dt-label>Git remote URL</dt-label>

--- a/bridge/client/app/_components/ktb-project-settings-git/ktb-project-settings-git.component.ts
+++ b/bridge/client/app/_components/ktb-project-settings-git/ktb-project-settings-git.component.ts
@@ -1,5 +1,5 @@
-import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
-import {FormControl, FormGroup, Validators} from '@angular/forms';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
 
 @Component({
   selector: 'ktb-project-settings-git',
@@ -7,6 +7,8 @@ import {FormControl, FormGroup, Validators} from '@angular/forms';
   styleUrls: ['./ktb-project-settings-git.component.scss']
 })
 export class KtbProjectSettingsGitComponent implements OnInit {
+
+  private originalGitData: GitData | undefined;
 
   @Input()
   public isGitUpstreamInProgress = false;
@@ -16,15 +18,14 @@ export class KtbProjectSettingsGitComponent implements OnInit {
 
   @Input()
   set gitData(gitData: GitData) {
-    this.gitUrlControl.setValue(gitData.remoteURI || '');
-    this.gitUrlControl.markAsUntouched();
-    this.gitUrlControl.markAsPristine();
-    this.gitUserControl.setValue(gitData.gitUser || '');
-    this.gitUserControl.markAsUntouched();
-    this.gitUserControl.markAsPristine();
-    this.gitTokenControl.setValue('');
-    this.gitTokenControl.markAsUntouched();
-    this.gitTokenControl.markAsPristine();
+    if (!this.originalGitData && gitData.remoteURI && gitData.gitUser) {
+      this.originalGitData = {
+        remoteURI: gitData.remoteURI,
+        gitUser: gitData.gitUser
+      };
+    }
+
+    this.resetForm(gitData);
   }
 
   @Output()
@@ -51,11 +52,40 @@ export class KtbProjectSettingsGitComponent implements OnInit {
   }
 
   public setGitUpstream() {
-    this.gitUpstreamSubmit.emit({remoteURI: this.gitUrlControl.value, gitUser: this.gitUserControl.value, gitToken: this.gitTokenControl.value});
+    this.gitUpstreamSubmit.emit({
+      remoteURI: this.gitUrlControl.value,
+      gitUser: this.gitUserControl.value,
+      gitToken: this.gitTokenControl.value
+    });
   }
 
   public onGitUpstreamFormChange() {
-    this.gitDataChanged.emit({remoteURI: this.gitUrlControl.value, gitUser: this.gitUserControl.value, gitToken: this.gitTokenControl.value});
+    this.gitDataChanged.emit({
+      remoteURI: this.gitUrlControl.value,
+      gitUser: this.gitUserControl.value,
+      gitToken: this.gitTokenControl.value,
+      gitFormValid: !this.isButtonDisabled()
+    });
+  }
+
+  public isButtonDisabled(): boolean {
+    return this.gitUpstreamForm.invalid || !this.gitUpstreamForm.dirty || this.isGitUpstreamInProgress;
+  }
+
+  public reset() {
+    this.resetForm(this.originalGitData);
+  }
+
+  private resetForm(gitData: GitData | undefined): void {
+    this.gitUrlControl.setValue(gitData?.remoteURI || '');
+    this.gitUrlControl.markAsUntouched();
+    this.gitUrlControl.markAsPristine();
+    this.gitUserControl.setValue(gitData?.gitUser || '');
+    this.gitUserControl.markAsUntouched();
+    this.gitUserControl.markAsPristine();
+    this.gitTokenControl.setValue('');
+    this.gitTokenControl.markAsUntouched();
+    this.gitTokenControl.markAsPristine();
   }
 
 }
@@ -64,4 +94,5 @@ export interface GitData {
   remoteURI?: string;
   gitUser?: string;
   gitToken?: string;
+  gitFormValid?: boolean;
 }

--- a/bridge/client/app/_views/ktb-settings-view/ktb-settings-view.component.html
+++ b/bridge/client/app/_views/ktb-settings-view/ktb-settings-view.component.html
@@ -4,14 +4,16 @@
     <div [formGroup]="projectNameForm" *ngIf="isCreateMode" class="mb-3 settings-section">
       <h2>Project name *</h2>
       <dt-form-field>
-        <input type="text" formControlName="projectName" required dtInput placeholder="e.g. sockshop"/>
+        <input type="text" formControlName="projectName" (input)="unsavedDialogState = 'unsaved'" required dtInput
+               placeholder="e.g. sockshop"/>
         <dt-hint>Project name must start with a lower case letter. Allowed characters: lower case letters, numbers and
           hyphens.
         </dt-hint>
         <dt-error>
           <ng-container *ngIf="projectNameControl.hasError('required')">Must not be empty</ng-container>
           <ng-container *ngIf="projectNameControl.hasError('projectName')">Project name already exists</ng-container>
-          <ng-container *ngIf="projectNameControl.hasError('pattern')">Project name must start with a lower case letter. Allowed characters: lower case letters, numbers and
+          <ng-container *ngIf="projectNameControl.hasError('pattern')">Project name must start with a lower case letter.
+            Allowed characters: lower case letters, numbers and
             hyphens.
           </ng-container>
         </dt-error>
@@ -26,8 +28,10 @@
         (gitUpstreamSubmit)="setGitUpstream()"></ktb-project-settings-git>
     </div>
     <div class="mb-3 settings-section" *ngIf="isCreateMode">
-      <ktb-project-settings-shipyard (shipyardFileChanged)="shipyardFile=$event"
+
+      <ktb-project-settings-shipyard (shipyardFileChanged)="updateShipyardFile($event)"
                                      [isCreateMode]="isCreateMode"></ktb-project-settings-shipyard>
+
     </div>
     <div class="mt-3 settings-section settings-actions" *ngIf="isCreateMode">
       <button
@@ -47,3 +51,15 @@
   </div>
 </div>
 
+<dt-confirmation-dialog [state]="unsavedDialogState" aria-label="Dialog for notifying about unsaved data">
+  <dt-confirmation-dialog-state name="unsaved">
+    <div fxLayout="row" fxLayoutAlign="space-between center">
+      <div>
+        You have unsaved changes. Make sure to save your data before you continue.
+      </div>
+      <div>
+        <button dt-button variant="secondary" (click)="unsavedDialogState = null">Close</button>
+      </div>
+    </div>
+  </dt-confirmation-dialog-state>
+</dt-confirmation-dialog>

--- a/bridge/client/app/_views/ktb-settings-view/ktb-settings-view.component.html
+++ b/bridge/client/app/_views/ktb-settings-view/ktb-settings-view.component.html
@@ -4,7 +4,8 @@
     <div [formGroup]="projectNameForm" *ngIf="isCreateMode" class="mb-3 settings-section">
       <h2>Project name *</h2>
       <dt-form-field>
-        <input type="text" formControlName="projectName" id="projectNameInput" (input)="unsavedDialogState = 'unsaved'" required dtInput
+        <input type="text" formControlName="projectName" id="projectNameInput" (input)="unsavedDialogState = 'unsaved'"
+               required dtInput
                placeholder="e.g. sockshop"/>
         <dt-hint>Project name must start with a lower case letter. Allowed characters: lower case letters, numbers and
           hyphens.
@@ -35,7 +36,7 @@
     </div>
     <div class="mt-3 settings-section settings-actions" *ngIf="isCreateMode">
       <button
-        [disabled]="!shipyardFile || projectNameForm.invalid || !isGitFormValid() || isCreatingProjectInProgress"
+        [disabled]="!shipyardFile || projectNameForm.invalid || !gitData.gitFormValid || isCreatingProjectInProgress"
         (click)="createProject()"
         dt-button>
         <dt-loading-spinner *ngIf="isCreatingProjectInProgress" aria-label="Creating project"></dt-loading-spinner>
@@ -45,21 +46,19 @@
         <span class="small">* fields are required</span>
       </div>
     </div>
-    <div class="mb-3 settings-section settings-section-bottom" *ngIf="!isCreateMode">
+    <div [ngClass]="['mb-3', 'settings-section settings-section-bottom', unsavedDialogState ? 'notification-open' : '']" *ngIf="!isCreateMode">
       <ktb-danger-zone [data]="projectDeletionData"></ktb-danger-zone>
     </div>
   </div>
 </div>
 
-<dt-confirmation-dialog [state]="unsavedDialogState" aria-label="Dialog for notifying about unsaved data">
+<dt-confirmation-dialog [state]="unsavedDialogState" aria-label="Dialog for notifying about unsaved data"
+                        *ngIf="!isCreateMode">
   <dt-confirmation-dialog-state name="unsaved">
-    <div fxLayout="row" fxLayoutAlign="space-between center">
-      <div>
-        You have unsaved changes. Make sure to save your data before you continue.
-      </div>
-      <div>
-        <button dt-button variant="secondary" (click)="unsavedDialogState = null">Close</button>
-      </div>
-    </div>
+    You have pending changes. Make sure to save your data before you continue.
+    <dt-confirmation-dialog-actions>
+      <button dt-button variant="secondary" (click)="reset()">Discard changes</button>
+      <button dt-button (click)="saveAll()">Save changes</button>
+    </dt-confirmation-dialog-actions>
   </dt-confirmation-dialog-state>
 </dt-confirmation-dialog>

--- a/bridge/client/app/_views/ktb-settings-view/ktb-settings-view.component.html
+++ b/bridge/client/app/_views/ktb-settings-view/ktb-settings-view.component.html
@@ -4,7 +4,7 @@
     <div [formGroup]="projectNameForm" *ngIf="isCreateMode" class="mb-3 settings-section">
       <h2>Project name *</h2>
       <dt-form-field>
-        <input type="text" formControlName="projectName" (input)="unsavedDialogState = 'unsaved'" required dtInput
+        <input type="text" formControlName="projectName" id="projectNameInput" (input)="unsavedDialogState = 'unsaved'" required dtInput
                placeholder="e.g. sockshop"/>
         <dt-hint>Project name must start with a lower case letter. Allowed characters: lower case letters, numbers and
           hyphens.

--- a/bridge/client/app/_views/ktb-settings-view/ktb-settings-view.component.scss
+++ b/bridge/client/app/_views/ktb-settings-view/ktb-settings-view.component.scss
@@ -5,4 +5,10 @@
 .settings-section-bottom {
   position: absolute;
   bottom: 0;
+  transition: bottom 200ms;
+
+  &.notification-open {
+    bottom: 100px;
+    transition: bottom 200ms;
+  }
 }

--- a/bridge/client/app/_views/ktb-settings-view/ktb-settings-view.component.spec.ts
+++ b/bridge/client/app/_views/ktb-settings-view/ktb-settings-view.component.spec.ts
@@ -199,9 +199,10 @@ describe('KtbSettingsViewComponent', () => {
     fixture.detectChanges();
 
     // then
-    const notification = document.getElementsByTagName('dt-confirmation-dialog-state');
+    const notification = document.getElementsByTagName('dt-confirmation-dialog-state')[0];
     expect(component.unsavedDialogState).toEqual(UNSAVED_DIALOG_STATE);
-    expect(notification.length).toEqual(0);
+    // It exists in the dom but is hidden - so we test for aria-hidden
+    expect(notification.getAttribute('aria-hidden')).toEqual('true');
   });
 
   it('should not show a notification when not all git data fields are set', () => {

--- a/bridge/client/app/_views/ktb-settings-view/ktb-settings-view.component.spec.ts
+++ b/bridge/client/app/_views/ktb-settings-view/ktb-settings-view.component.spec.ts
@@ -174,6 +174,17 @@ describe('KtbSettingsViewComponent', () => {
     expect(notifications.length).toEqual(0);
   });
 
+  it('should show a notification when "unsaved" is set', () => {
+    // given
+    component.isCreateMode = false;
+    component.unsavedDialogState = UNSAVED_DIALOG_STATE;
+    fixture.detectChanges();
+
+    // then
+    const notification = document.getElementsByTagName('dt-confirmation-dialog-state');
+    expect(notification.length).toEqual(1);
+  });
+
   it('should show a notification for unsaved changes when git data is changed in update mode', () => {
     // given
     component.isCreateMode = false;
@@ -184,9 +195,7 @@ describe('KtbSettingsViewComponent', () => {
     fixture.detectChanges();
 
     // then
-    const notification = document.getElementsByTagName('dt-confirmation-dialog-state');
     expect(component.unsavedDialogState).toEqual(UNSAVED_DIALOG_STATE);
-    expect(notification.length).toEqual(1);
   });
 
   it('should not show a notification for unsaved changes when git data is changed in create mode', () => {

--- a/bridge/client/app/_views/ktb-settings-view/ktb-settings-view.component.spec.ts
+++ b/bridge/client/app/_views/ktb-settings-view/ktb-settings-view.component.spec.ts
@@ -189,6 +189,21 @@ describe('KtbSettingsViewComponent', () => {
     expect(notification.length).toEqual(1);
   });
 
+  it('should not show a notification for unsaved changes when git data is changed in create mode', () => {
+    // given
+    component.isCreateMode = true;
+    fixture.detectChanges();
+
+    // when
+    component.updateGitData({gitUser: 'someUser', remoteURI: 'someUri', gitToken: 'someToken', gitFormValid: true});
+    fixture.detectChanges();
+
+    // then
+    const notification = document.getElementsByTagName('dt-confirmation-dialog-state');
+    expect(component.unsavedDialogState).toEqual(UNSAVED_DIALOG_STATE);
+    expect(notification.length).toEqual(0);
+  });
+
   it('should not show a notification when not all git data fields are set', () => {
     // given
     component.isCreateMode = false;

--- a/bridge/client/app/_views/ktb-settings-view/ktb-settings-view.component.spec.ts
+++ b/bridge/client/app/_views/ktb-settings-view/ktb-settings-view.component.spec.ts
@@ -39,6 +39,15 @@ describe('KtbSettingsViewComponent', () => {
     fixture = TestBed.createComponent(KtbSettingsViewComponent);
     component = fixture.componentInstance;
     dataService = fixture.debugElement.injector.get(DataService);
+
+    const notifications = document.getElementsByTagName('dt-confirmation-dialog-state');
+    if (notifications.length > 0) {
+      // tslint:disable-next-line:prefer-for-of
+      for (let i = 0; i < notifications.length; i++) {
+        notifications[i].remove();
+      }
+    }
+
     fixture.detectChanges();
   });
 

--- a/bridge/client/app/_views/ktb-settings-view/ktb-settings-view.component.spec.ts
+++ b/bridge/client/app/_views/ktb-settings-view/ktb-settings-view.component.spec.ts
@@ -72,6 +72,7 @@ describe('KtbSettingsViewComponent', () => {
     // given
     component.isCreateMode = true;
     component.projectName = 'sockshop';
+    fixture.detectChanges();
 
     // when
     const router = TestBed.inject(Router);
@@ -101,6 +102,10 @@ describe('KtbSettingsViewComponent', () => {
   });
 
   it('should have create mode disabled when routed to route data contains {isCreateMode: false}', () => {
+    // given
+    routeDataSubject.next({isCreateMode: false});
+    fixture.detectChanges();
+
     expect(component.isCreateMode).toBeFalse();
   });
 
@@ -111,6 +116,7 @@ describe('KtbSettingsViewComponent', () => {
   it('should have an pattern validation error when project name does not match: first letter lowercase, only lowercase, numbers and hyphens allowed', () => {
     // given
     component.isCreateMode = true;
+    fixture.detectChanges();
 
     component.projectNameControl.setValue('Sockshop');
     component.projectNameForm.updateValueAndValidity();
@@ -143,7 +149,9 @@ describe('KtbSettingsViewComponent', () => {
 
   it('should delete a project and navigate to dashboard', () => {
     // given
+    component.isCreateMode = false;
     component.projectName = 'sockshop';
+    fixture.detectChanges();
 
     // when
     const router = TestBed.inject(Router);
@@ -156,44 +164,14 @@ describe('KtbSettingsViewComponent', () => {
 
   it('should not show a notification when the component is initialized', () => {
     // given
+    component.isCreateMode = false;
+    fixture.detectChanges();
+
+    // then
     // Has to be retrieved by document, as it is not created at component level
     const notifications = document.getElementsByTagName('dt-confirmation-dialog-state');
-
-    // then
     expect(component.unsavedDialogState).toBeNull();
     expect(notifications.length).toEqual(0);
-  });
-
-  it('should show a notification for unsaved changes when project name is changed', () => {
-    // given
-    component.isCreateMode = true;
-    fixture.detectChanges();
-
-    // when
-    const inputEl = fixture.nativeElement.querySelector('#projectNameInput');
-    inputEl.value = 'sockshop';
-    inputEl.dispatchEvent(new InputEvent('input'));
-    fixture.detectChanges();
-
-    // then
-    const notification = document.getElementsByTagName('dt-confirmation-dialog-state');
-    expect(component.unsavedDialogState).toEqual(UNSAVED_DIALOG_STATE);
-    expect(notification.length).toEqual(1);
-  });
-
-  it('should show a notification for unsaved changes when git data is changed in create mode', () => {
-    // given
-    component.isCreateMode = true;
-    fixture.detectChanges();
-
-    // when
-    component.updateGitData({gitUser: 'someUser'});
-    fixture.detectChanges();
-
-    // then
-    const notification = document.getElementsByTagName('dt-confirmation-dialog-state');
-    expect(component.unsavedDialogState).toEqual(UNSAVED_DIALOG_STATE);
-    expect(notification.length).toEqual(1);
   });
 
   it('should show a notification for unsaved changes when git data is changed in update mode', () => {
@@ -202,7 +180,7 @@ describe('KtbSettingsViewComponent', () => {
     fixture.detectChanges();
 
     // when
-    component.updateGitData({gitUser: 'someUser'});
+    component.updateGitData({gitUser: 'someUser', remoteURI: 'someUri', gitToken: 'someToken', gitFormValid: true});
     fixture.detectChanges();
 
     // then
@@ -211,22 +189,38 @@ describe('KtbSettingsViewComponent', () => {
     expect(notification.length).toEqual(1);
   });
 
-  it('should show a notification for unsaved changes when shipyard file is changed', () => {
+  it('should not show a notification when not all git data fields are set', () => {
     // given
-    component.isCreateMode = true;
+    component.isCreateMode = false;
     fixture.detectChanges();
 
     // when
-    component.updateShipyardFile(new File(['test'], 'test.yaml'));
+    component.updateGitData({gitUser: 'someUser', remoteURI: 'someUri'});
     fixture.detectChanges();
 
     // then
-    const notification = document.getElementsByTagName('dt-confirmation-dialog-state');
-    expect(component.unsavedDialogState).toEqual(UNSAVED_DIALOG_STATE);
-    expect(notification.length).toEqual(1);
+    expect(component.unsavedDialogState).toBeNull();
+
+    // when
+    component.updateGitData({gitUser: 'someUser', gitToken: 'someToken'});
+    fixture.detectChanges();
+
+    // then
+    expect(component.unsavedDialogState).toBeNull();
+
+    // when
+    component.updateGitData({remoteURI: 'someUri', gitToken: 'someToken'});
+    fixture.detectChanges();
+
+    // then
+    expect(component.unsavedDialogState).toBeNull();
   });
 
   it('should not show a notification when the notification was closed', () => {
+    // given
+    component.isCreateMode = false;
+    fixture.detectChanges();
+
     // given
     component.unsavedDialogState = UNSAVED_DIALOG_STATE;
     fixture.detectChanges();

--- a/bridge/client/app/_views/ktb-settings-view/ktb-settings-view.component.spec.ts
+++ b/bridge/client/app/_views/ktb-settings-view/ktb-settings-view.component.spec.ts
@@ -199,10 +199,7 @@ describe('KtbSettingsViewComponent', () => {
     fixture.detectChanges();
 
     // then
-    const notification = document.getElementsByTagName('dt-confirmation-dialog-state')[0];
     expect(component.unsavedDialogState).toEqual(UNSAVED_DIALOG_STATE);
-    // It exists in the dom but is hidden - so we test for aria-hidden
-    expect(notification.getAttribute('aria-hidden')).toEqual('true');
   });
 
   it('should not show a notification when not all git data fields are set', () => {

--- a/bridge/client/app/_views/ktb-settings-view/ktb-settings-view.component.ts
+++ b/bridge/client/app/_views/ktb-settings-view/ktb-settings-view.component.ts
@@ -26,6 +26,7 @@ export class KtbSettingsViewComponent implements OnInit, OnDestroy {
   @ViewChild('deleteProjectDialog')
   private deleteProjectDialog?: TemplateRef<MatDialog>;
 
+  public unsavedDialogState: string | null = null;
   public projectName?: string;
   public projectDeletionData?: DeleteData;
   public isCreateMode = false;
@@ -78,6 +79,7 @@ export class KtbSettingsViewComponent implements OnInit, OnDestroy {
       filter((project: Project | undefined): project is Project => !!project)
     ).subscribe(project => {
       if (project.projectName !== this.projectName) {
+        this.unsavedDialogState = null;
         this.projectName = project.projectName;
 
         this.gitData = {
@@ -96,6 +98,7 @@ export class KtbSettingsViewComponent implements OnInit, OnDestroy {
       takeUntil(this.unsubscribe$)
     ).subscribe((queryParams) => {
       if (queryParams.created) {
+        this.unsavedDialogState = null;
         this.notificationsService.addNotification(NotificationType.Success, TemplateRenderedNotifications.CREATE_PROJECT, undefined, true, {
           projectName: this.projectName,
           routerLink: `/project/${this.projectName}/service`
@@ -120,9 +123,15 @@ export class KtbSettingsViewComponent implements OnInit, OnDestroy {
   }
 
   public updateGitData(gitData: GitData): void {
+    this.unsavedDialogState = 'unsaved';
     this.gitData.remoteURI = gitData.remoteURI;
     this.gitData.gitUser = gitData.gitUser;
     this.gitData.gitToken = gitData.gitToken;
+  }
+
+  public updateShipyardFile(shipyardFile: File | undefined): void {
+    this.unsavedDialogState = 'unsaved';
+    this.shipyardFile = shipyardFile;
   }
 
   public setGitUpstream(): void {
@@ -133,7 +142,7 @@ export class KtbSettingsViewComponent implements OnInit, OnDestroy {
         .subscribe(() => {
           this.isGitUpstreamInProgress = false;
           this.gitData.gitToken = '';
-          this.gitData = {... this.gitData};
+          this.gitData = {...this.gitData};
           this.notificationsService.addNotification(NotificationType.Success, 'The Git upstream was changed successfully.', 5000);
         }, (err) => {
           console.log(err);

--- a/bridge/client/app/_views/ktb-settings-view/ktb-settings-view.component.ts
+++ b/bridge/client/app/_views/ktb-settings-view/ktb-settings-view.component.ts
@@ -130,7 +130,7 @@ export class KtbSettingsViewComponent implements OnInit, OnDestroy {
     this.gitData.gitUser = gitData.gitUser;
     this.gitData.gitToken = gitData.gitToken;
     this.gitData.gitFormValid = gitData.gitFormValid;
-    if (gitData.gitFormValid !== undefined && gitData.gitFormValid) {
+    if (gitData.gitFormValid) {
       this.unsavedDialogState = 'unsaved';
     } else {
       this.unsavedDialogState = null;

--- a/bridge/client/app/_views/ktb-settings-view/ktb-settings-view.component.ts
+++ b/bridge/client/app/_views/ktb-settings-view/ktb-settings-view.component.ts
@@ -6,7 +6,7 @@ import { filter, map, switchMap, take, takeUntil } from 'rxjs/operators';
 import { DtToast } from '@dynatrace/barista-components/toast';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
-import { GitData } from '../../_components/ktb-project-settings-git/ktb-project-settings-git.component';
+import { GitData, KtbProjectSettingsGitComponent } from '../../_components/ktb-project-settings-git/ktb-project-settings-git.component';
 import { FormUtils } from '../../_utils/form.utils';
 import { NotificationType, TemplateRenderedNotifications } from '../../_models/notification';
 import { NotificationsService } from '../../_services/notifications.service';
@@ -25,6 +25,9 @@ export class KtbSettingsViewComponent implements OnInit, OnDestroy {
 
   @ViewChild('deleteProjectDialog')
   private deleteProjectDialog?: TemplateRef<MatDialog>;
+
+  @ViewChild(KtbProjectSettingsGitComponent)
+  private gitSettingsSection?: KtbProjectSettingsGitComponent;
 
   public unsavedDialogState: string | null = null;
   public projectName?: string;
@@ -123,14 +126,18 @@ export class KtbSettingsViewComponent implements OnInit, OnDestroy {
   }
 
   public updateGitData(gitData: GitData): void {
-    this.unsavedDialogState = 'unsaved';
     this.gitData.remoteURI = gitData.remoteURI;
     this.gitData.gitUser = gitData.gitUser;
     this.gitData.gitToken = gitData.gitToken;
+    this.gitData.gitFormValid = gitData.gitFormValid;
+    if (gitData.gitFormValid !== undefined && gitData.gitFormValid) {
+      this.unsavedDialogState = 'unsaved';
+    } else {
+      this.unsavedDialogState = null;
+    }
   }
 
   public updateShipyardFile(shipyardFile: File | undefined): void {
-    this.unsavedDialogState = 'unsaved';
     this.shipyardFile = shipyardFile;
   }
 
@@ -150,13 +157,6 @@ export class KtbSettingsViewComponent implements OnInit, OnDestroy {
           this.notificationsService.addNotification(NotificationType.Error, `<div class="long-note align-left p-3">The Git upstream could not be changed:<br/><span class="small">${err.error}</span></div>`);
         });
     }
-  }
-
-  public isGitFormValid(): boolean {
-    if (!this.gitData.remoteURI && !this.gitData.gitUser && !this.gitData.gitToken) {
-      return true;
-    }
-    return !!(this.gitData.remoteURI?.length && this.gitData.gitUser?.length && this.gitData.gitToken?.length);
   }
 
   public createProject(): void {
@@ -204,5 +204,15 @@ export class KtbSettingsViewComponent implements OnInit, OnDestroy {
           result: DeleteResult.ERROR
         });
       });
+  }
+
+  public reset(): void {
+    this.gitSettingsSection?.reset();
+    this.unsavedDialogState = null;
+  }
+
+  public saveAll(): void {
+    this.setGitUpstream();
+    this.unsavedDialogState = null;
   }
 }

--- a/bridge/client/styles.scss
+++ b/bridge/client/styles.scss
@@ -321,6 +321,10 @@ pre.code {
   }
 }
 
+.dt-confirmation-dialog-wrapper {
+  margin-left: 66px!important;
+}
+
 .ktb-drag-and-drop {
   display: flex;
   flex-direction: column;

--- a/bridge/package-lock.json
+++ b/bridge/package-lock.json
@@ -5951,9 +5951,7 @@
       },
       "dependencies": {
         "glob-parent": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "version": "~5.1.2",
           "dev": true,
           "requires": {
             "is-glob": "^4.0.1"
@@ -6447,9 +6445,7 @@
       },
       "dependencies": {
         "glob-parent": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "version": "~5.1.2",
           "dev": true,
           "requires": {
             "is-glob": "^4.0.1"
@@ -6850,9 +6846,7 @@
       },
       "dependencies": {
         "css-what": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
-          "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
+          "version": "~5.0.1",
           "dev": true
         }
       }
@@ -8353,9 +8347,7 @@
       },
       "dependencies": {
         "glob-parent": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "version": "~5.1.2",
           "dev": true,
           "requires": {
             "is-glob": "^4.0.1"
@@ -10164,9 +10156,7 @@
           },
           "dependencies": {
             "glob-parent": {
-              "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-              "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+              "version": "~5.1.2",
               "dev": true,
               "requires": {
                 "is-glob": "^4.0.1"
@@ -15720,11 +15710,8 @@
           },
           "dependencies": {
             "glob-parent": {
-              "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-              "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+              "version": "~5.1.2",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-glob": "^4.0.1"
               },
@@ -16411,9 +16398,7 @@
           },
           "dependencies": {
             "glob-parent": {
-              "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-              "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+              "version": "~5.1.2",
               "dev": true,
               "requires": {
                 "is-glob": "^4.0.1"


### PR DESCRIPTION
Signed-off-by: Elisabeth Lang <elisabeth.lang@dynatrace.com>

## This PR
Closes #4677 
For create project, there will be no notification.
In the settings, when the git form is set to valid, the user now gets a notification that there are pending changes. In this notification, he/she has the option to save or discard the changes. As the notification would overlay the delete section, the delete section is now moved above the notification.

![image](https://user-images.githubusercontent.com/2674029/129347752-dcf17c73-ac04-4013-9f5a-8a28c69ff202.png)
