### PR TITLE
feat(bridge): Prevent expanding empty tile (#4057)

### DIFF
--- a/bridge/client/app/_components/ktb-expandable-tile/ktb-expandable-tile.component.html
+++ b/bridge/client/app/_components/ktb-expandable-tile/ktb-expandable-tile.component.html
@@ -5,10 +5,10 @@
     ktb-expandable-tile-header,
     [ktb-expandable-tile-header],
     [ktbTileHeader]"></ng-content>
-    <button class="show-more" dt-show-more [showLess]="expanded"></button>
+    <button class="show-more" dt-show-more [disabled]="disabled" [showLess]="!disabled && expanded"></button>
   </div>
   <div class="ktb-expandable-tile-content">
-    <dt-expandable-panel [expanded]="expanded">
+    <dt-expandable-panel [disabled]="disabled" [expanded]="!disabled && expanded">
       <div class="container">
         <ng-content></ng-content>
       </div>

--- a/bridge/client/app/_components/ktb-expandable-tile/ktb-expandable-tile.component.scss
+++ b/bridge/client/app/_components/ktb-expandable-tile/ktb-expandable-tile.component.scss
@@ -33,6 +33,12 @@
     }
   }
 
+  &.ktb-tile-disabled {
+    .ktb-expandable-tile-container {
+      cursor: default;
+    }
+  }
+
   &:hover .ktb-expandable-tile-container {
     border-color: $gray-300;
   }

--- a/bridge/client/app/_components/ktb-expandable-tile/ktb-expandable-tile.component.spec.ts
+++ b/bridge/client/app/_components/ktb-expandable-tile/ktb-expandable-tile.component.spec.ts
@@ -1,29 +1,66 @@
-import { ComponentFixture, fakeAsync, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
 
-import {KtbExpandableTileComponent, KtbExpandableTileHeader} from './ktb-expandable-tile.component';
+import {KtbExpandableTileComponent} from './ktb-expandable-tile.component';
 import {AppModule} from '../../app.module';
-import {HttpClientTestingModule} from "@angular/common/http/testing";
-import {KtbEventsListComponent} from "../ktb-events-list/ktb-events-list.component";
+import { KtbDangerZoneComponent } from '../ktb-danger-zone/ktb-danger-zone.component';
+import { DeleteType } from '../../_interfaces/delete';
 
 describe('KtbExpandableTileComponent', () => {
   let component: KtbExpandableTileComponent;
   let fixture: ComponentFixture<KtbExpandableTileComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      declarations: [],
-      imports: [
-        AppModule,
-        HttpClientTestingModule,
-      ],
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [KtbDangerZoneComponent],
+      imports: [AppModule],
     })
-      .compileComponents()
-      .then(() => {
-        fixture = TestBed.createComponent(KtbExpandableTileComponent);
-        component = fixture.componentInstance;
-        fixture.detectChanges();
-      });
-  }));
+      .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(KtbExpandableTileComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should be expandable by default', () => {
+    // given
+    fixture.detectChanges();
+    const showMoreButton = fixture.nativeElement.querySelector('.dt-show-more');
+    const expandablePanel = fixture.nativeElement.querySelector('.dt-expandable-panel');
+
+    // when
+    showMoreButton.click();
+    fixture.detectChanges();
+
+    // then
+    // expect(component).not.toHaveClass('ktb-tile-disabled');
+    expect(showMoreButton).not.toHaveClass('dt-show-more-disabled');
+    expect(showMoreButton.disabled).toBeFalse();
+    expect(expandablePanel).toHaveClass('dt-expandable-panel-opened');
+  });
+
+  it('should not be expandable if disabled', () => {
+    // given
+    component.disabled = true;
+    fixture.detectChanges();
+    const showMoreButton = fixture.nativeElement.querySelector('.dt-show-more');
+    const expandablePanel = fixture.nativeElement.querySelector('.dt-expandable-panel');
+
+    // when
+    showMoreButton.click();
+    fixture.detectChanges();
+
+    // then
+    // expect(component).toHaveClass('ktb-tile-disabled');
+    expect(showMoreButton).toHaveClass('dt-show-more-disabled');
+    expect(showMoreButton.disabled).toBeTrue();
+    expect(expandablePanel).not.toHaveClass('dt-expandable-panel-opened');
+  });
 
   afterEach(fakeAsync(() => {
     fixture.destroy();

--- a/bridge/client/app/_components/ktb-expandable-tile/ktb-expandable-tile.component.ts
+++ b/bridge/client/app/_components/ktb-expandable-tile/ktb-expandable-tile.component.ts
@@ -97,8 +97,11 @@ export class KtbExpandableTileComponent {
     return this._disabled;
   }
   set disabled(value: boolean) {
-    if (this._disabled && this._selected) {
-      this._selected = false;
+    if (this._disabled !== value) {
+      this._disabled = value;
+      if (this._disabled) {
+        this.selected = false;
+      }
       this._changeDetectorRef.markForCheck();
     }
   }

--- a/bridge/client/app/_components/ktb-expandable-tile/ktb-expandable-tile.component.ts
+++ b/bridge/client/app/_components/ktb-expandable-tile/ktb-expandable-tile.component.ts
@@ -23,8 +23,6 @@ export class KtbExpandableTileHeader {}
     '[class.ktb-tile-error]': 'error',
     '[attr.aria-success]': 'success',
     '[class.ktb-tile-success]': 'success',
-    '[attr.aria-selected]': 'selected',
-    '[class.ktb-tile-selected]': 'selected',
     '[attr.aria-disabled]': 'disabled',
     '[class.ktb-tile-disabled]': 'disabled',
     '[attr.aria-warning]': 'warning',
@@ -41,7 +39,6 @@ export class KtbExpandableTileComponent {
   private _error = false;
   private _success = false;
   private _expanded = false;
-  private _selected = false;
   private _disabled = false;
   private _warning = false;
   private _highlight = false;
@@ -79,18 +76,6 @@ export class KtbExpandableTileComponent {
     }
   }
 
-  /** Whether the tile is selected. */
-  @Input()
-  get selected(): boolean {
-    return this._selected && !this.disabled;
-  }
-  set selected(value: boolean) {
-    if (this._selected !== value) {
-      this._selected = value;
-      this._changeDetectorRef.markForCheck();
-    }
-  }
-
   /** Whether the tile is disabled. */
   @Input()
   get disabled(): boolean {
@@ -99,9 +84,6 @@ export class KtbExpandableTileComponent {
   set disabled(value: boolean) {
     if (this._disabled !== value) {
       this._disabled = value;
-      if (this._disabled) {
-        this.selected = false;
-      }
       this._changeDetectorRef.markForCheck();
     }
   }

--- a/bridge/client/app/_components/ktb-stage-details/ktb-stage-details.component.html
+++ b/bridge/client/app/_components/ktb-stage-details/ktb-stage-details.component.html
@@ -30,6 +30,7 @@
 
         <ng-container *ngFor="let service of filterServices(selectedStage.services)">
           <ktb-expandable-tile class="mt-1" [expanded]="service.getOpenApprovals().length > 0"
+                               [disabled]="!service.hasFailedEvaluation() && !service.hasRemediations() && service.getOpenApprovals().length == 0"
                                *ngIf="!filterEventType || filterEventType == 'problem' && service.hasRemediations() || filterEventType == 'evaluation' && service.hasFailedEvaluation() || filterEventType == 'approval' && service.getOpenApprovals().length > 0">
             <ktb-expandable-tile-header>
               <dt-info-group>

--- a/bridge/client/app/_components/ktb-task-item/ktb-task-item.component.html
+++ b/bridge/client/app/_components/ktb-task-item/ktb-task-item.component.html
@@ -1,4 +1,4 @@
-<ktb-expandable-tile [expanded]="isExpanded" [error]="task.isFaulty()" [warning]="task.isWarning()" [success]="task.isSuccessful()" [highlight]="!!task.isApproval()" *ngIf="task && (project$ | async) as project">
+<ktb-expandable-tile [disabled]="task.traces.length == 0" [expanded]="isExpanded" [error]="task.isFaulty()" [warning]="task.isWarning()" [success]="task.isSuccessful()" [highlight]="!!task.isApproval()" *ngIf="task && (project$ | async) as project">
   <ktb-expandable-tile-header>
     <div fxLayout="row">
       <div fxFlex>

--- a/bridge/client/app/_views/ktb-service-view/ktb-service-view.component.html
+++ b/bridge/client/app/_views/ktb-service-view/ktb-service-view.component.html
@@ -14,7 +14,7 @@
         <ktb-no-service-info></ktb-no-service-info>
       </ng-container>
 
-      <ktb-expandable-tile *ngFor="let service of project.getServices()" [expanded]="service.serviceName == serviceName" (click)="selectService(project.projectName, service.serviceName)">
+      <ktb-expandable-tile *ngFor="let service of project.getServices()" [disabled]="service.deployments?.length == 0" [expanded]="service.serviceName == serviceName" (click)="selectService(project.projectName, service.serviceName)">
         <ktb-expandable-tile-header [attr.uitestid]="'keptn-service-view-service-' + service.serviceName">
           <dt-info-group>
             <dt-info-group-title>


### PR DESCRIPTION
## This PR
- allows to set expandable tile as disabled, which will prevent the user to expand an empty tile
- sets all expandable tiles (environments screen, service screen and sequence screen) to disabled if empty

![image](https://user-images.githubusercontent.com/6098219/129218573-38b4b0de-0b32-489b-bc35-d6a49b7bb030.png)

### Related Issues
Closes #4057 
