### PR TITLE
feat: Run Jmeter-Service using job executor

### DIFF
--- a/jmeter-service/jmeterUtils.go
+++ b/jmeter-service/jmeterUtils.go
@@ -133,14 +133,20 @@ func parseJMeterResult(jmeterCommandResult string, testInfo *TestInfo, workload 
  * Status: true or false
  * Error: error details if status was false
  */
-func executeJMeter(testInfo *TestInfo, workload *Workload, resultsDir string, url *url.URL, LTN string, funcValidation bool, logger *keptncommon.Logger) (bool, error) {
+func executeJMeter(testInfo *TestInfo, workload *Workload, resultsDir string, url *url.URL, LTN string, funcValidation bool, logger *keptncommon.Logger, job bool) (bool, error) {
 	os.RemoveAll(resultsDir)
 	os.MkdirAll(resultsDir, 0644)
 
 	// Step 1: Lets download all files that match /jmeter/ into a local temp directory
 	// Due to current limitations of the REST API we also fall-back and always load a specific file referenced in workload on service, stage or project level
 	// Implementing https://github.com/keptn/keptn/issues/2756
-	localTempDir := testInfo.Context
+	var localTempDir string = ""
+	if job {
+		localTempDir = "/keptn"
+	} else {
+		localTempDir = testInfo.Context
+	}
+
 	os.RemoveAll(localTempDir)
 	os.MkdirAll(localTempDir, 0644)
 	fileMatchPattern := JMeterConfigDirectory

--- a/jmeter-service/jmeterUtils_test.go
+++ b/jmeter-service/jmeterUtils_test.go
@@ -128,7 +128,7 @@ func Test_executeJMeter(t *testing.T) {
 					ResourceURI: &res,
 				})
 			}
-			got, err := executeJMeter(tt.args.testInfo, tt.args.workload, tt.args.resultsDir, tt.args.url, tt.args.LTN, tt.args.funcValidation, tt.args.logger)
+			got, err := executeJMeter(tt.args.testInfo, tt.args.workload, tt.args.resultsDir, tt.args.url, tt.args.LTN, tt.args.funcValidation, tt.args.logger, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("executeJMeter() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/jmeter-service/main.go
+++ b/jmeter-service/main.go
@@ -15,7 +15,6 @@ import (
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/kelseyhightower/envconfig"
-
 	keptnapi "github.com/keptn/go-utils/pkg/api/utils"
 	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
@@ -32,38 +31,6 @@ type envConfig struct {
 	Job bool `envconfig:"JOB" default:"false"`
 	Event string `envconfig:"EVENT" default:""`
 }
-
-var testevent string = `
-{
-  "specversion": "1.0",
-  "id": "c4d3a334-6cb9-4e8c-a372-7e0b45942f53",
-  "source": "source-service",
-  "type": "sh.keptn.event.test.triggered",
-  "datacontenttype": "application/json",
-  "data": {
-    "project": "sockshop",
-    "stage": "dev",
-    "service": "carts",
-    "labels": {
-      "label-key": "label-value"
-    },
-    "status": "succeeded",
-    "result": "pass",
-    "message": "a message",
-    "test": {
-      "teststrategy": "functional"
-    },
-    "deployment": {
-      "deploymentURIsLocal": [
-        "http://carts.sockshop-staging.svc.cluster.local"
-      ],
-      "deploymentURIsPublic": [
-        "http://carts.sockshot.local:80"
-      ]
-    }
-  },
-  "shkeptncontext": "a3e5f16d-8888-4720-82c7-6995062905c1"
-}`
 
 var env envConfig
 
@@ -83,7 +50,9 @@ func main() {
 		ctx = cloudevents.WithEncodingStructured(ctx)
 
 		var event cloudevents.Event
-		json.Unmarshal([]byte(testevent), &event)
+		if err := json.Unmarshal([]byte(env.Event), &event); err != nil {
+			log.Fatalf("Error converting event: %e", err)
+		}
 
 		gotEvent(ctx, event)
 	}


### PR DESCRIPTION
## This PR

This PR enables the user to run the `jmeter-service` as a Kubernetes job using the [Job-executor-service](https://github.com/keptn-sandbox/job-executor-service), which reduces the resource usage on the cluster since the `jmeter-service` will only run if a test is triggered. 

### How to test

You can test the implementation by running the [job-executor-service](https://github.com/keptn-sandbox/job-executor-service/pull/63) with the following configuration:

```
apiVersion: v2
actions:
  - name: "Run JMeter"
    events:
      - name: "sh.keptn.event.test.triggered"
        jsonpath:
          property: "$.data.test.teststrategy"
          match: "functional"
      - name: "sh.keptn.event.test.triggered"
        jsonpath:
          property: "$.data.test.teststrategy"
          match: "performance"
    tasks:
      - name: "Run jmeter smoke tests"
        image: "gabrieltanner/jmeter-service:latest"
        workingDir: "/keptn"
        env:
          - name: HOST
            value: "$.data.deployment.deploymentURIsLocal[0]"
            valueFrom: event
          - name: JOB
            value: "true"
            valueFrom: string
          - name: EVENT
            value: "$"
            valueFrom: event
            as: json
```

