### PR TITLE
feat(cli): Adapt output for configure bridge command (#4435)

### DIFF
--- a/cli/cmd/configure_bridge.go
+++ b/cli/cmd/configure_bridge.go
@@ -3,17 +3,13 @@ package cmd
 import (
 	"fmt"
 	"github.com/spf13/cobra"
+	"strings"
 )
 
 type configureBridgeCmdParams struct {
 	User     *string
 	Password *string
 	Read     *bool
-}
-
-type configureBridgeAPIPayload struct {
-	User     string `json:"user"`
-	Password string `json:"password"`
 }
 
 var configureBridgeParams *configureBridgeCmdParams
@@ -27,13 +23,14 @@ var bridgeCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fmt.Println("Warning: From version 0.9.0 of Keptn this command is not supported anymore!")
 		fmt.Println()
-		fmt.Println("You can get your login credentials e.g. by using the following kubectl commands:")
-		fmt.Println("Username - kubectl get secret -n keptn bridge-credentials -o jsonpath=\"{.data.BASIC_AUTH_USERNAME}\" | base64 --decode")
-		fmt.Println("Password - kubectl get secret -n keptn bridge-credentials -o jsonpath=\"{.data.BASIC_AUTH_PASSWORD}\" | base64 --decode")
-		fmt.Println()
-		fmt.Println("For editing the login credentials please use: 'kubectl edit secrets -n keptn bridge-credentials'")
-		fmt.Println("In order to apply the new credentials you need to restart the Keptn bridge:")
-		fmt.Println("kubectl -n keptn rollout restart deployment bridge")
+		if isBoolFlagSet(configureBridgeParams.Read) {
+			fmt.Println("You can get your login credentials e.g. by using the following kubectl commands:")
+			fmt.Println("Username - kubectl get secret -n keptn bridge-credentials -o jsonpath=\"{.data.BASIC_AUTH_USERNAME}\" | base64 --decode")
+			fmt.Println("Password - kubectl get secret -n keptn bridge-credentials -o jsonpath=\"{.data.BASIC_AUTH_PASSWORD}\" | base64 --decode")
+		} else {
+			fmt.Println(getReplaceSecretCommand(*configureBridgeParams))
+		}
+
 		fmt.Println()
 		fmt.Println("The URL to your Keptn Bridge can be retrieved using 'keptn status'")
 		return nil
@@ -46,4 +43,23 @@ func init() {
 	configureBridgeParams.Read = bridgeCmd.Flags().BoolP("output", "o", false, "Print the current credentials")
 	configureBridgeParams.User = bridgeCmd.Flags().StringP("user", "u", "", "The user name to login to the bridge")
 	configureBridgeParams.Password = bridgeCmd.Flags().StringP("password", "p", "", "The password to login to the bridge")
+}
+
+func getReplaceSecretCommand(cmdParams configureBridgeCmdParams) string {
+	user := "${BRIDGE_USER}"
+	password := "${BRIDGE_PASSWORD}"
+	if isStringFlagSet(cmdParams.User) {
+		user = *cmdParams.User
+	}
+	if isStringFlagSet(cmdParams.Password) {
+		password = *cmdParams.Password
+	}
+
+	builder := strings.Builder{}
+
+	builder.WriteString("For editing the login credentials please use the following command:\n\n")
+	builder.WriteString(fmt.Sprintf("kubectl create secret -n ${KEPTN_NAMESPACE} generic bridge-credentials --from-literal=\"BASIC_AUTH_USERNAME=%s\" --from-literal=\"BASIC_AUTH_PASSWORD=%s\" -oyaml --dry-run=client | kubectl replace -f -\n", user, password))
+	builder.WriteString("kubectl -n keptn rollout restart deployment bridge")
+
+	return builder.String()
 }

--- a/cli/cmd/configure_bridge.go
+++ b/cli/cmd/configure_bridge.go
@@ -21,12 +21,8 @@ var bridgeCmd = &cobra.Command{
 	Example:      `keptn configure bridge --user=<user> --password=<password>`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fmt.Println("Warning: From version 0.9.0 of Keptn this command is not supported anymore!")
-		fmt.Println()
 		if isBoolFlagSet(configureBridgeParams.Read) {
-			fmt.Println("You can get your login credentials e.g. by using the following kubectl commands:")
-			fmt.Println("Username - kubectl get secret -n keptn bridge-credentials -o jsonpath=\"{.data.BASIC_AUTH_USERNAME}\" | base64 --decode")
-			fmt.Println("Password - kubectl get secret -n keptn bridge-credentials -o jsonpath=\"{.data.BASIC_AUTH_PASSWORD}\" | base64 --decode")
+			fmt.Println(getPrintSecretCommand())
 		} else {
 			fmt.Println(getReplaceSecretCommand(*configureBridgeParams))
 		}
@@ -45,6 +41,16 @@ func init() {
 	configureBridgeParams.Password = bridgeCmd.Flags().StringP("password", "p", "", "The password to login to the bridge")
 }
 
+func getPrintSecretCommand() string {
+	builder := strings.Builder{}
+
+	builder.WriteString("You can get your login credentials e.g. by using the following kubectl commands:\n\n")
+	builder.WriteString("Username - kubectl get secret -n keptn bridge-credentials -o jsonpath=\"{.data.BASIC_AUTH_USERNAME}\" | base64 --decode\n")
+	builder.WriteString("Password - kubectl get secret -n keptn bridge-credentials -o jsonpath=\"{.data.BASIC_AUTH_PASSWORD}\" | base64 --decode\n")
+
+	return builder.String()
+}
+
 func getReplaceSecretCommand(cmdParams configureBridgeCmdParams) string {
 	user := "${BRIDGE_USER}"
 	password := "${BRIDGE_PASSWORD}"
@@ -57,8 +63,8 @@ func getReplaceSecretCommand(cmdParams configureBridgeCmdParams) string {
 
 	builder := strings.Builder{}
 
-	builder.WriteString("For editing the login credentials please use the following command:\n\n")
-	builder.WriteString(fmt.Sprintf("kubectl create secret -n ${KEPTN_NAMESPACE} generic bridge-credentials --from-literal=\"BASIC_AUTH_USERNAME=%s\" --from-literal=\"BASIC_AUTH_PASSWORD=%s\" -oyaml --dry-run=client | kubectl replace -f -\n", user, password))
+	builder.WriteString("For editing the bridge login credentials please use the following command:\n\n")
+	builder.WriteString(fmt.Sprintf("kubectl create secret -n keptn generic bridge-credentials --from-literal=\"BASIC_AUTH_USERNAME=%s\" --from-literal=\"BASIC_AUTH_PASSWORD=%s\" -oyaml --dry-run=client | kubectl replace -f -\n", user, password))
 	builder.WriteString("kubectl -n keptn rollout restart deployment bridge")
 
 	return builder.String()

--- a/cli/cmd/configure_bridge_test.go
+++ b/cli/cmd/configure_bridge_test.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func Test_getReplaceSecretCommand(t *testing.T) {
+	type args struct {
+		cmdParams configureBridgeCmdParams
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "print output with placeholders",
+			args: args{
+				cmdParams: configureBridgeCmdParams{},
+			},
+			want: "kubectl create secret -n keptn generic bridge-credentials --from-literal=\"BASIC_AUTH_USERNAME=${BRIDGE_USER}\" --from-literal=\"BASIC_AUTH_PASSWORD=${BRIDGE_PASSWORD}\" -oyaml --dry-run=client | kubectl replace -f -\n",
+		},
+		{
+			name: "print output with provided values",
+			args: args{
+				cmdParams: configureBridgeCmdParams{
+					User:     stringp("my-user"),
+					Password: stringp("my-password"),
+				},
+			},
+			want: "kubectl create secret -n keptn generic bridge-credentials --from-literal=\"BASIC_AUTH_USERNAME=my-user\" --from-literal=\"BASIC_AUTH_PASSWORD=my-password\" -oyaml --dry-run=client | kubectl replace -f -\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getReplaceSecretCommand(tt.args.cmdParams)
+
+			require.Contains(t, got, tt.want)
+		})
+	}
+}


### PR DESCRIPTION
Closes #4435 

This PR prints the commands needed for reading or updating the login credentials for the bridge
