### PR TITLE
feat: Release images are now also on quay.io and ghcr.io (#3314)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -636,6 +636,7 @@ jobs:
             # No previous image was found, need to build from scratch
             echo "No previous image was found, building new image"
             docker build "${DOCKER_FOLDER}" -t "${IMAGE}:${VERSION}.${DATETIME}" -t "${IMAGE}:${VERSION}" --build-arg version="${VERSION}"
+            OLD_IMAGE="${IMAGE}:${VERSION}"
           fi
 
           # Retag previous image

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -547,8 +547,7 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         # only run docker login on pushes; also for PRs, but only if this is not a fork
-        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository)
-#        if: needs.prepare_ci_run.outputs.RELEASE_BUILD == 'true' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: needs.prepare_ci_run.outputs.RELEASE_BUILD == 'true' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository)
         # note: GH does not allow to access secrets for PRs from a forked repositories due to security reasons
         # that's fine, but it means we can't push images to dockerhub
         with:
@@ -559,8 +558,7 @@ jobs:
       - name: Login to Quay.io
         uses: docker/login-action@v1
         # only run docker login on pushes; also for PRs, but only if this is not a fork
-        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository)
-#        if: needs.prepare_ci_run.outputs.RELEASE_BUILD == 'true' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: needs.prepare_ci_run.outputs.RELEASE_BUILD == 'true' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository)
         # note: GH does not allow to access secrets for PRs from a forked repositories due to security reasons
         # that's fine, but it means we can't push images to dockerhub
         with:
@@ -586,8 +584,7 @@ jobs:
           DATETIME: ${{ env.DATETIME }}
           IMAGE: keptn/${{ matrix.config.artifact }}
           DOCKER_FOLDER: ${{ matrix.config.working-dir }}
-          RELEASE_BUILD: "true"
-#          RELEASE_BUILD: ${{ needs.prepare_ci_run.outputs.RELEASE_BUILD }}
+          RELEASE_BUILD: ${{ needs.prepare_ci_run.outputs.RELEASE_BUILD }}
         run: |
           docker build "${DOCKER_FOLDER}" -t "${IMAGE}:${VERSION}.${DATETIME}" -t "${IMAGE}:${VERSION}" --build-arg version="${VERSION}"
           docker push "${IMAGE}:${VERSION}.${DATETIME}" && docker push "${IMAGE}:${VERSION}"
@@ -632,8 +629,7 @@ jobs:
           IMAGE: keptn/${{ matrix.config.artifact }}
           DOCKER_FOLDER: ${{ matrix.config.working-dir }}
           CONTENT_TYPE: "application/vnd.docker.distribution.manifest.v2+json"
-          RELEASE_BUILD: "true"
-#          RELEASE_BUILD: ${{ needs.prepare_ci_run.outputs.RELEASE_BUILD }}
+          RELEASE_BUILD: ${{ needs.prepare_ci_run.outputs.RELEASE_BUILD }}
         run: |
           # Fetch last image datetime from build config
           LAST_DATETIME=$(grep 'DATETIME' "./last-build-config/build-config.env" | cut -d '=' -f2)

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -647,10 +647,11 @@ jobs:
           docker tag "${OLD_IMAGE}" "${NEW_TAG2}"
 
           # Push newly tagged image
+          echo "pushing new tags"
           docker push "${NEW_TAG1}" && docker push "${NEW_TAG2}"
 
           report="* Retagged unchanged image ${IMAGE} with ${NEW_TAG1} and ${NEW_TAG2} (Source: ${DOCKER_FOLDER})"
-          echo "DOCKER_BUILD_REPORT=$report" >> $GITHUB_ENV
+          echo "DOCKER_BUILD_REPORT=$report" >> "$GITHUB_ENV"
 
           if [[ $RELEASE_BUILD == 'true' ]]; then
             DOCKER_REGISTRIES=('ghcr.io')

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -121,6 +121,7 @@ jobs:
       BRANCH: ${{ steps.extract_branch.outputs.BRANCH }}
       BRANCH_SLUG: ${{ steps.extract_branch.outputs.BRANCH_SLUG }}
       VERSION: ${{ steps.get_version.outputs.VERSION }}
+      RELEASE_BUILD: ${{ steps.get_version.outputs.RELEASE_BUILD }}
       KEPTN_SPEC_VERSION: ${{ steps.get_version.outputs.KEPTN_SPEC_VERSION }}
       DATE: ${{ steps.get_datetime.outputs.DATE }}
       TIME: ${{ steps.get_datetime.outputs.TIME }}
@@ -207,10 +208,12 @@ jobs:
           GIT_LAST_TAG=${{ steps.get_previous_tag.outputs.tag }}
           GIT_NEXT_TAG=${{ steps.get_next_semver_tag.outputs.patch }}
           echo "GIT_LAST_TAG=${GIT_LAST_TAG}, GIT_NEXT_TAG=${GIT_NEXT_TAG}"
+          RELEASE_BUILD=false
 
           if [[ "$BRANCH" == "release-"* ]]; then
             # Release Branch: extract version from branch name
             VERSION=${BRANCH#"release-"}
+            RELEASE_BUILD=true
           elif [[ "$BRANCH" == "master" ]]; then
             # master branch = latest
             VERSION="${GIT_NEXT_TAG}-dev"
@@ -227,8 +230,9 @@ jobs:
           echo "VERSION=${VERSION}"
           echo "KEPTN_SPEC_VERSION=${KEPTN_SPEC_VERSION}"
 
-          echo "##[set-output name=VERSION;]$(echo ${VERSION})"
-          echo "##[set-output name=KEPTN_SPEC_VERSION;]$(echo ${KEPTN_SPEC_VERSION})"
+          echo "::set-output name=VERSION::${VERSION}"
+          echo "::set-output name=KEPTN_SPEC_VERSION::${KEPTN_SPEC_VERSION}"
+          echo "::set-output name=RELEASE_BUILD::${RELEASE_BUILD}"
       - name: Get current date and time
         id: get_datetime
         run: |
@@ -530,16 +534,26 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2.3.4
 
-      - id: docker_login
-        name: Docker Login
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
         # only run docker login on pushes; also for PRs, but only if this is not a fork
         if: (github.event_name == 'push') || (github.event_name == 'workflow_dispatch') || (github.event.pull_request.head.repo.full_name == github.repository)
         # note: GH does not allow to access secrets for PRs from a forked repositories due to security reasons
         # that's fine, but it means we can't push images to dockerhub
-        env:
-          REGISTRY_USER: ${{ secrets.REGISTRY_USER }}
-          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
-        run: echo "$REGISTRY_PASSWORD" | docker login --username $REGISTRY_USER --password-stdin
+        with:
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        # only run docker login on pushes; also for PRs, but only if this is not a fork
+        if: needs.prepare_ci_run.outputs.RELEASE_BUILD == 'true' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository)
+        # note: GH does not allow to access secrets for PRs from a forked repositories due to security reasons
+        # that's fine, but it means we can't push images to dockerhub
+        with:
+          registry: ghcr.io
+          username: keptn-bot
+          password: ${{ secrets.KEPTN_BOT_TOKEN }}
 
       - id: docker_cache
         name: Docker Cache
@@ -559,6 +573,8 @@ jobs:
           DATETIME: ${{ env.DATETIME }}
           IMAGE: keptn/${{ matrix.config.artifact }}
           DOCKER_FOLDER: ${{ matrix.config.working-dir }}
+          RELEASE_BUILD: "true"
+#          RELEASE_BUILD: ${{ needs.prepare_ci_run.outputs.RELEASE_BUILD }}
         run: |
           docker build "${DOCKER_FOLDER}" -t "${IMAGE}:${VERSION}.${DATETIME}" -t "${IMAGE}:${VERSION}" --build-arg version="${VERSION}"
           docker push "${IMAGE}:${VERSION}.${DATETIME}" && docker push "${IMAGE}:${VERSION}"
@@ -571,6 +587,15 @@ jobs:
           fi
 
           echo "DOCKER_BUILD_REPORT=${report}" >> $GITHUB_ENV
+
+          if [[ $RELEASE_BUILD == 'true' ]]; then
+            DOCKER_REGISTRIES=(ghcr.io)
+            for DOCKER_REGISTRY in "${DOCKER_REGISTRIES}"; do
+              TAG="$DOCKER_REGISTRY/$IMAGE:$VERSION"
+              docker build "$DOCKER_FOLDER" -t "$TAG" --build-arg version="$VERSION"
+              docker push "$TAG"
+            done
+          fi
 
       - name: "Download Build Config from last successful build"
         uses: dawidd6/action-download-artifact@v2.14.1
@@ -595,6 +620,8 @@ jobs:
           DOCKER_FOLDER: ${{ matrix.config.working-dir }}
           REGISTRY_NAME: "https://registry.hub.docker.com"
           CONTENT_TYPE: "application/vnd.docker.distribution.manifest.v2+json"
+          RELEASE_BUILD: "true"
+#          RELEASE_BUILD: ${{ needs.prepare_ci_run.outputs.RELEASE_BUILD }}
         run: |
           # Fetch last image datetime from build config
           LAST_DATETIME=$(grep 'DATETIME' "./last-build-config/build-config.env" | cut -d '=' -f2)
@@ -620,6 +647,17 @@ jobs:
 
           report="* Retagged unchanged image ${IMAGE} with ${NEW_TAG1} and ${NEW_TAG2} (Source: ${DOCKER_FOLDER})"
           echo "DOCKER_BUILD_REPORT=${report}" >> $GITHUB_ENV
+
+          if [[ $RELEASE_BUILD == 'true' ]]; then
+            DOCKER_REGISTRIES=(ghcr.io)
+            for DOCKER_REGISTRY in "${DOCKER_REGISTRIES}"; do
+              # Retag previous image
+              NEW_TAG="$DOCKER_REGISTRY/${IMAGE}:${VERSION}"
+
+              docker tag "${OLD_IMAGE}" "${NEW_TAG}"
+              docker push "${NEW_TAG}"
+            done
+          fi
 
       - name: Report Docker Build to PR
         if: always() && (github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name == github.repository)

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -648,7 +648,6 @@ jobs:
           docker tag "${OLD_IMAGE}" "${NEW_TAG2}"
 
           # Push newly tagged image
-          echo "pushing new tags"
           docker push "${NEW_TAG1}" && docker push "${NEW_TAG2}"
 
           report="* Retagged unchanged image ${IMAGE} with ${NEW_TAG1} and ${NEW_TAG2} (Source: ${DOCKER_FOLDER})"
@@ -658,11 +657,8 @@ jobs:
             DOCKER_REGISTRIES=('ghcr.io')
             for DOCKER_REGISTRY in "${DOCKER_REGISTRIES[@]}"; do
               NEW_TAG="$DOCKER_REGISTRY/${IMAGE}:${VERSION}"
-              echo "new tag: $NEW_TAG"
               docker tag "${OLD_IMAGE}" "${NEW_TAG}"
-              echo "tagged image"
               docker push "${NEW_TAG}"
-              echo "pushed image"
             done
           fi
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -601,9 +601,9 @@ jobs:
           if [[ $RELEASE_BUILD == 'true' ]]; then
             DOCKER_REGISTRIES=('ghcr.io' 'quay.io')
             for DOCKER_REGISTRY in "${DOCKER_REGISTRIES}"; do
-              TAG="$DOCKER_REGISTRY/$IMAGE:$VERSION"
-              docker build "$DOCKER_FOLDER" -t "$TAG" --build-arg version="$VERSION"
-              docker push "$TAG"
+              NEW_TAG="$DOCKER_REGISTRY/$IMAGE:$VERSION"
+              docker tag "$IMAGE:$VERSION" "$NEW_TAG"
+              docker push "$NEW_TAG"
             done
           fi
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -651,11 +651,12 @@ jobs:
           if [[ $RELEASE_BUILD == 'true' ]]; then
             DOCKER_REGISTRIES=('ghcr.io')
             for DOCKER_REGISTRY in "${DOCKER_REGISTRIES[@]}"; do
-              # Retag previous image
               NEW_TAG="$DOCKER_REGISTRY/${IMAGE}:${VERSION}"
-
+              echo "new tag: $NEW_TAG"
               docker tag "${OLD_IMAGE}" "${NEW_TAG}"
+              echo "tagged image"
               docker push "${NEW_TAG}"
+              echo "pushed image"
             done
           fi
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -632,6 +632,10 @@ jobs:
             OLD_IMAGE="${IMAGE}:${VERSION}.${LAST_DATETIME}"
           elif docker pull "${IMAGE}:${VERSION}" -q; then
             OLD_IMAGE="${IMAGE}:${VERSION}"
+          else
+            # No previous image was found, need to build from scratch
+            echo "No previous image was found, building new image"
+            docker build "${DOCKER_FOLDER}" -t "${IMAGE}:${VERSION}.${DATETIME}" -t "${IMAGE}:${VERSION}" --build-arg version="${VERSION}"
           fi
 
           # Retag previous image

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -547,7 +547,8 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         # only run docker login on pushes; also for PRs, but only if this is not a fork
-        if: needs.prepare_ci_run.outputs.RELEASE_BUILD == 'true' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository)
+#        if: needs.prepare_ci_run.outputs.RELEASE_BUILD == 'true' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository)
         # note: GH does not allow to access secrets for PRs from a forked repositories due to security reasons
         # that's fine, but it means we can't push images to dockerhub
         with:
@@ -618,7 +619,6 @@ jobs:
           DATETIME: ${{ env.DATETIME }}
           IMAGE: keptn/${{ matrix.config.artifact }}
           DOCKER_FOLDER: ${{ matrix.config.working-dir }}
-          REGISTRY_NAME: "https://registry.hub.docker.com"
           CONTENT_TYPE: "application/vnd.docker.distribution.manifest.v2+json"
           RELEASE_BUILD: "true"
 #          RELEASE_BUILD: ${{ needs.prepare_ci_run.outputs.RELEASE_BUILD }}
@@ -649,8 +649,8 @@ jobs:
           echo "DOCKER_BUILD_REPORT=${report}" >> $GITHUB_ENV
 
           if [[ $RELEASE_BUILD == 'true' ]]; then
-            DOCKER_REGISTRIES=(ghcr.io)
-            for DOCKER_REGISTRY in "${DOCKER_REGISTRIES}"; do
+            DOCKER_REGISTRIES=('ghcr.io')
+            for DOCKER_REGISTRY in "${DOCKER_REGISTRIES[@]}"; do
               # Retag previous image
               NEW_TAG="$DOCKER_REGISTRY/${IMAGE}:${VERSION}"
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -537,7 +537,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         # only run docker login on pushes; also for PRs, but only if this is not a fork
-        if: (github.event_name == 'push') || (github.event_name == 'workflow_dispatch') || (github.event.pull_request.head.repo.full_name == github.repository)
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository)
         # note: GH does not allow to access secrets for PRs from a forked repositories due to security reasons
         # that's fine, but it means we can't push images to dockerhub
         with:
@@ -552,9 +552,21 @@ jobs:
         # note: GH does not allow to access secrets for PRs from a forked repositories due to security reasons
         # that's fine, but it means we can't push images to dockerhub
         with:
-          registry: ghcr.io
-          username: keptn-bot
+          registry: "ghcr.io"
+          username: "keptn-bot"
           password: ${{ secrets.KEPTN_BOT_TOKEN }}
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v1
+        # only run docker login on pushes; also for PRs, but only if this is not a fork
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository)
+#        if: needs.prepare_ci_run.outputs.RELEASE_BUILD == 'true' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository)
+        # note: GH does not allow to access secrets for PRs from a forked repositories due to security reasons
+        # that's fine, but it means we can't push images to dockerhub
+        with:
+          registry: "quay.io"
+          username: ${{ secrest.QUAY_USER }}
+          password: ${{ secrets.QUAY_TOKEN }}
 
       - id: docker_cache
         name: Docker Cache
@@ -590,7 +602,7 @@ jobs:
           echo "DOCKER_BUILD_REPORT=${report}" >> $GITHUB_ENV
 
           if [[ $RELEASE_BUILD == 'true' ]]; then
-            DOCKER_REGISTRIES=(ghcr.io)
+            DOCKER_REGISTRIES=('quay.io')
             for DOCKER_REGISTRY in "${DOCKER_REGISTRIES}"; do
               TAG="$DOCKER_REGISTRY/$IMAGE:$VERSION"
               docker build "$DOCKER_FOLDER" -t "$TAG" --build-arg version="$VERSION"
@@ -654,7 +666,7 @@ jobs:
           echo "DOCKER_BUILD_REPORT=$report" >> "$GITHUB_ENV"
 
           if [[ $RELEASE_BUILD == 'true' ]]; then
-            DOCKER_REGISTRIES=('ghcr.io')
+            DOCKER_REGISTRIES=('ghcr.io' 'quay.io')
             for DOCKER_REGISTRY in "${DOCKER_REGISTRIES[@]}"; do
               NEW_TAG="$DOCKER_REGISTRY/${IMAGE}:${VERSION}"
               docker tag "${OLD_IMAGE}" "${NEW_TAG}"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -565,7 +565,7 @@ jobs:
         # that's fine, but it means we can't push images to dockerhub
         with:
           registry: "quay.io"
-          username: ${{ secrest.QUAY_USER }}
+          username: ${{ secrets.QUAY_USER }}
           password: ${{ secrets.QUAY_TOKEN }}
 
       - id: docker_cache

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -650,7 +650,7 @@ jobs:
           docker push "${NEW_TAG1}" && docker push "${NEW_TAG2}"
 
           report="* Retagged unchanged image ${IMAGE} with ${NEW_TAG1} and ${NEW_TAG2} (Source: ${DOCKER_FOLDER})"
-          echo "DOCKER_BUILD_REPORT=${report}" >> $GITHUB_ENV
+          echo "DOCKER_BUILD_REPORT=$report" >> $GITHUB_ENV
 
           if [[ $RELEASE_BUILD == 'true' ]]; then
             DOCKER_REGISTRIES=('ghcr.io')

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -599,7 +599,7 @@ jobs:
           echo "DOCKER_BUILD_REPORT=${report}" >> $GITHUB_ENV
 
           if [[ $RELEASE_BUILD == 'true' ]]; then
-            DOCKER_REGISTRIES=('quay.io')
+            DOCKER_REGISTRIES=('ghcr.io' 'quay.io')
             for DOCKER_REGISTRY in "${DOCKER_REGISTRIES}"; do
               TAG="$DOCKER_REGISTRY/$IMAGE:$VERSION"
               docker build "$DOCKER_FOLDER" -t "$TAG" --build-arg version="$VERSION"

--- a/README.md
+++ b/README.md
@@ -43,7 +43,13 @@ Please find details on regular hosted community events as well as our Slack work
 
 ## Keptn Versions compatibilities
 
-We manage the Keptn *core components* in versions. The respective images in their versions are stored on [DockerHub](https://hub.docker.com/?namespace=keptn).
+We manage the Keptn *core components* in versions.
+The respective images in their versions are stored on the  following container registries:
+
+* [DockerHub](https://hub.docker.com/?namespace=keptn)
+* [GitHub Container Registry](https://github.com/orgs/keptn/packages?repo_name=keptn)
+* [Quay.io Container Registry](https://quay.io/organization/keptn)
+
 The versions of the Keptn *core components* and the services are compatible with each other. However, contributed services
 as well as services that are not considered *core components* might not follow the same versioning schema.
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -19,6 +19,9 @@ COPY go.mod go.sum ./
 # Download dependencies
 RUN go mod download
 
+
+
+
 ARG debugBuild
 
 # set buildflags for debug build

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -19,9 +19,6 @@ COPY go.mod go.sum ./
 # Download dependencies
 RUN go mod download
 
-
-
-
 ARG debugBuild
 
 # set buildflags for debug build

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -41,6 +41,13 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v cmd/api-ser
 
 # Use a Docker multi-stage build to create a lean production image.
 FROM alpine:3.14
+LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
+    org.opencontainers.image.url = "https://keptn.sh" \
+    org.opencontainers.image.title="Keptn API" \
+    org.opencontainers.image.vendor="Keptn" \
+    org.opencontainers.image.documentation="https://keptn.sh/docs/" \
+    org.opencontainers.image.licenses="Apache-2.0"
+
 
 # we need to install ca-certificates and libc6-compat for go programs to work properly
 RUN apk add --no-cache ca-certificates libc6-compat

--- a/approval-service/Dockerfile
+++ b/approval-service/Dockerfile
@@ -35,6 +35,13 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o approval
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.14
+LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
+    org.opencontainers.image.url = "https://keptn.sh" \
+    org.opencontainers.image.title="Keptn Approval Service" \
+    org.opencontainers.image.vendor="Keptn" \
+    org.opencontainers.image.documentation="https://keptn.sh/docs/" \
+    org.opencontainers.image.licenses="Apache-2.0"
+
 # we need to install ca-certificates and libc6-compat for go programs to work properly
 RUN apk add --no-cache ca-certificates libc6-compat
 

--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -31,6 +31,13 @@ RUN npm run build && \
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM node:14-alpine3.14 as bridgeProduction
+LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
+    org.opencontainers.image.url = "https://keptn.sh" \
+    org.opencontainers.image.title="Keptn Bridge" \
+    org.opencontainers.image.vendor="Keptn" \
+    org.opencontainers.image.documentation="https://keptn.sh/docs/" \
+    org.opencontainers.image.licenses="Apache-2.0"
+
 
 EXPOSE 3000
 

--- a/configuration-service/Dockerfile
+++ b/configuration-service/Dockerfile
@@ -35,6 +35,13 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 
 # Use a Docker multi-stage build to create a lean production image.
 FROM alpine:3.14
+LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
+    org.opencontainers.image.url = "https://keptn.sh" \
+    org.opencontainers.image.title="Keptn Configuration Service" \
+    org.opencontainers.image.vendor="Keptn" \
+    org.opencontainers.image.documentation="https://keptn.sh/docs/" \
+    org.opencontainers.image.licenses="Apache-2.0"
+
 
 ENV env=production
 

--- a/distributor/Dockerfile
+++ b/distributor/Dockerfile
@@ -36,6 +36,13 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.14
+LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
+    org.opencontainers.image.url = "https://keptn.sh" \
+    org.opencontainers.image.title="Keptn Distributor" \
+    org.opencontainers.image.vendor="Keptn" \
+    org.opencontainers.image.documentation="https://keptn.sh/docs/" \
+    org.opencontainers.image.licenses="Apache-2.0"
+
 RUN apk add --no-cache ca-certificates libc6-compat
 
 # Copy the binary to the production image from the builder stage.

--- a/helm-service/Dockerfile
+++ b/helm-service/Dockerfile
@@ -33,6 +33,13 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.14
+LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
+    org.opencontainers.image.url = "https://keptn.sh" \
+    org.opencontainers.image.title="Keptn Helm Service" \
+    org.opencontainers.image.vendor="Keptn" \
+    org.opencontainers.image.documentation="https://keptn.sh/docs/" \
+    org.opencontainers.image.licenses="Apache-2.0"
+
 # we need to install ca-certificates and libc6-compat for go programs to work properly
 RUN apk add --no-cache ca-certificates libc6-compat
 

--- a/jmeter-service/Dockerfile
+++ b/jmeter-service/Dockerfile
@@ -33,6 +33,13 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.14
+LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
+    org.opencontainers.image.url = "https://keptn.sh" \
+    org.opencontainers.image.title="Keptn JMeter Service" \
+    org.opencontainers.image.vendor="Keptn" \
+    org.opencontainers.image.documentation="https://keptn.sh/docs/" \
+    org.opencontainers.image.licenses="Apache-2.0"
+
 ENV env=production
 ARG JMETER_VERSION="5.1.1"
 ENV JMETER_HOME /opt/apache-jmeter-${JMETER_VERSION}

--- a/lighthouse-service/Dockerfile
+++ b/lighthouse-service/Dockerfile
@@ -33,6 +33,13 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.14
+LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
+    org.opencontainers.image.url = "https://keptn.sh" \
+    org.opencontainers.image.title="Keptn Lighthouse Service" \
+    org.opencontainers.image.vendor="Keptn" \
+    org.opencontainers.image.documentation="https://keptn.sh/docs/" \
+    org.opencontainers.image.licenses="Apache-2.0"
+
 # we need to install ca-certificates and libc6-compat for go programs to work properly
 RUN apk add --no-cache ca-certificates libc6-compat
 

--- a/mongodb-datastore/Dockerfile
+++ b/mongodb-datastore/Dockerfile
@@ -38,6 +38,13 @@ RUN cd cmd/mongodb-datastore-server && GOOS=linux go build -ldflags '-linkmode=e
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.14
+LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
+    org.opencontainers.image.url = "https://keptn.sh" \
+    org.opencontainers.image.title="Keptn MongoDB Datastore" \
+    org.opencontainers.image.vendor="Keptn" \
+    org.opencontainers.image.documentation="https://keptn.sh/docs/" \
+    org.opencontainers.image.licenses="Apache-2.0"
+
 # we need to install ca-certificates and libc6-compat for go programs to work properly
 RUN apk add --no-cache ca-certificates libc6-compat
 

--- a/platform-support/openshift-route-service/Dockerfile
+++ b/platform-support/openshift-route-service/Dockerfile
@@ -35,6 +35,13 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o  openshi
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.14
+LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
+    org.opencontainers.image.url = "https://keptn.sh" \
+    org.opencontainers.image.title="Keptn OpenShift Route Service" \
+    org.opencontainers.image.vendor="Keptn" \
+    org.opencontainers.image.documentation="https://keptn.sh/docs/" \
+    org.opencontainers.image.licenses="Apache-2.0"
+
 RUN apk add --no-cache ca-certificates libc6-compat
 
 ARG OC_VERSION=3.11.0

--- a/remediation-service/Dockerfile
+++ b/remediation-service/Dockerfile
@@ -33,6 +33,13 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.14
+LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
+    org.opencontainers.image.url = "https://keptn.sh" \
+    org.opencontainers.image.title="Keptn Remediation Service" \
+    org.opencontainers.image.vendor="Keptn" \
+    org.opencontainers.image.documentation="https://keptn.sh/docs/" \
+    org.opencontainers.image.licenses="Apache-2.0"
+
 # we need to install ca-certificates and libc6-compat for go programs to work properly
 RUN apk add --no-cache ca-certificates libc6-compat
 

--- a/secret-service/Dockerfile
+++ b/secret-service/Dockerfile
@@ -46,6 +46,13 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 
 # Use a Docker multi-stage build to create a lean production image.
 FROM alpine:3.14
+LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
+    org.opencontainers.image.url = "https://keptn.sh" \
+    org.opencontainers.image.title="Keptn Secret Service" \
+    org.opencontainers.image.vendor="Keptn" \
+    org.opencontainers.image.documentation="https://keptn.sh/docs/" \
+    org.opencontainers.image.licenses="Apache-2.0"
+
 
 ENV env=production
 

--- a/shipyard-controller/Dockerfile
+++ b/shipyard-controller/Dockerfile
@@ -46,6 +46,13 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 
 # Use a Docker multi-stage build to create a lean production image.
 FROM alpine:3.14
+LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
+    org.opencontainers.image.url = "https://keptn.sh" \
+    org.opencontainers.image.title="Keptn Shipyard Controller" \
+    org.opencontainers.image.vendor="Keptn" \
+    org.opencontainers.image.documentation="https://keptn.sh/docs/" \
+    org.opencontainers.image.licenses="Apache-2.0"
+
 
 ENV env=production
 

--- a/statistics-service/Dockerfile
+++ b/statistics-service/Dockerfile
@@ -46,6 +46,13 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 
 # Use a Docker multi-stage build to create a lean production image.
 FROM alpine:3.14
+LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
+    org.opencontainers.image.url = "https://keptn.sh" \
+    org.opencontainers.image.title="Keptn Statistics Service" \
+    org.opencontainers.image.vendor="Keptn" \
+    org.opencontainers.image.documentation="https://keptn.sh/docs/" \
+    org.opencontainers.image.licenses="Apache-2.0"
+
 
 ENV env=production
 


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- introduces 2 additional container registries for releases (GH container registry, quay.io)
- release images are pushed to the new registries as well
- adds a readme paragraph to describe the new feature
- adds OCI labels to all dockerfiles

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Closes #3314 

### Notes
Previous release images were pushed by hand starting from version `0.8.0`.
They can be found on [quay.io](https://quay.io/organization/keptn) and [GHCR](https://github.com/orgs/keptn/packages?repo_name=keptn)