### PR TITLE
style(bridge): added linting rule for return types

### DIFF
--- a/bridge/tslint.json
+++ b/bridge/tslint.json
@@ -117,6 +117,10 @@
     "no-outputs-metadata-property": true,
     "template-banana-in-box": true,
     "template-no-negated-async": true,
+    "typedef": [
+      true,
+      "call-signature"
+    ],
     "typedef-whitespace": {
       "options": [
         {


### PR DESCRIPTION
Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>

## This PR
Adds a linting rule to enforce return types for functions.