### PR TITLE
fix(cli): skip version check on install

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -152,8 +152,11 @@ func runVersionCheck(vChecker *version.VersionChecker, flags []string) {
 	}
 }
 
-func isInstallSubCommand(flags []string) bool {
-	for _, arg := range flags {
+// isInstallSubCommand checks if the subcommand is `install`
+// args here does not contain the main command
+// e.g., For `keptn -q install`, args would be just ['-q', 'install']
+func isInstallSubCommand(args []string) bool {
+	for _, arg := range args {
 		switch {
 		// skip flags
 		// e.g., keptn -q install

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -34,7 +34,7 @@ func NewRootCommand(vChecker *version.VersionChecker) *cobra.Command {
 		Long: `The CLI allows interaction with a Keptn installation to manage Keptn, to trigger workflows, and to get details.
 	`,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			runVersionCheck(vChecker, os.Args)
+			runVersionCheck(vChecker, os.Args[1:])
 		},
 	}
 	return rootCmd
@@ -113,10 +113,10 @@ func (s *options) appendIfNotEmpty(newOption string) {
 	}
 }
 
-func runVersionCheck(vChecker *version.VersionChecker, osArgs []string) {
+func runVersionCheck(vChecker *version.VersionChecker, flags []string) {
 	// Server version won't be available during `install`
 	// because the Server is not installed yet
-	if isInstallSubCommand(osArgs) {
+	if isInstallSubCommand(flags) {
 		return
 	}
 
@@ -152,8 +152,8 @@ func runVersionCheck(vChecker *version.VersionChecker, osArgs []string) {
 	}
 }
 
-func isInstallSubCommand(osArgs []string) bool {
-	for _, arg := range osArgs[1:] {
+func isInstallSubCommand(flags []string) bool {
+	for _, arg := range flags {
 		switch {
 		// skip flags
 		// e.g., keptn -q install

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -2,12 +2,14 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/keptn/keptn/cli/pkg/logging"
 	"github.com/keptn/keptn/cli/pkg/version"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"os"
 )
 
 var cfgFile string
@@ -32,7 +34,11 @@ func NewRootCommand(vChecker *version.VersionChecker) *cobra.Command {
 		Long: `The CLI allows interaction with a Keptn installation to manage Keptn, to trigger workflows, and to get details.
 	`,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			runVersionCheck(vChecker)
+			// Server version won't be available during `install`
+			// because the Server is not installed yet
+			if !isInstallSubCommand() {
+				runVersionCheck(vChecker)
+			}
 		},
 	}
 	return rootCmd
@@ -142,4 +148,20 @@ func runVersionCheck(vChecker *version.VersionChecker) {
 	if cliChecked || keptnChecked {
 		updateLastVersionCheck()
 	}
+}
+
+func isInstallSubCommand() bool {
+	for _, arg := range os.Args[1:] {
+		switch {
+		// skip flags
+		// e.g., keptn -q install
+		case strings.HasPrefix(arg, "-"):
+			continue
+		case arg == "install":
+			return true
+		default:
+			return false
+		}
+	}
+	return false
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -34,11 +34,7 @@ func NewRootCommand(vChecker *version.VersionChecker) *cobra.Command {
 		Long: `The CLI allows interaction with a Keptn installation to manage Keptn, to trigger workflows, and to get details.
 	`,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			// Server version won't be available during `install`
-			// because the Server is not installed yet
-			if !isInstallSubCommand() {
-				runVersionCheck(vChecker)
-			}
+			runVersionCheck(vChecker, os.Args)
 		},
 	}
 	return rootCmd
@@ -117,7 +113,13 @@ func (s *options) appendIfNotEmpty(newOption string) {
 	}
 }
 
-func runVersionCheck(vChecker *version.VersionChecker) {
+func runVersionCheck(vChecker *version.VersionChecker, osArgs []string) {
+	// Server version won't be available during `install`
+	// because the Server is not installed yet
+	if isInstallSubCommand(osArgs) {
+		return
+	}
+
 	var cliMsgPrinted, cliChecked, keptnMsgPrinted, keptnChecked bool
 
 	cliChecked, cliMsgPrinted = vChecker.CheckCLIVersion(Version, true)
@@ -150,8 +152,8 @@ func runVersionCheck(vChecker *version.VersionChecker) {
 	}
 }
 
-func isInstallSubCommand() bool {
-	for _, arg := range os.Args[1:] {
+func isInstallSubCommand(osArgs []string) bool {
+	for _, arg := range osArgs[1:] {
 		switch {
 		// skip flags
 		// e.g., keptn -q install

--- a/cli/cmd/root_test.go
+++ b/cli/cmd/root_test.go
@@ -178,9 +178,11 @@ func Test_runVersionCheck(t *testing.T) {
 		metadataStatus   int
 		metadataResponse keptnapimodels.Metadata
 		cliVersion       string
-		flags            []string
-		wantOutput       string
-		doNotWantOutput  string
+		// args excludes the main `keptn` command
+		// e.g., keptn -q install, args would be ['-q', 'install']
+		args            []string
+		wantOutput      string
+		doNotWantOutput string
 	}{
 		{
 			name:           "get version",
@@ -201,14 +203,14 @@ func Test_runVersionCheck(t *testing.T) {
 			name:            "skip version check for 'keptn install'",
 			cliVersion:      "0.8.0",
 			metadataStatus:  http.StatusServiceUnavailable,
-			flags:           []string{"install"},
+			args:            []string{"install"},
 			doNotWantOutput: "* Warning: could not check Keptn server version: Error connecting to server:",
 		},
 		{
 			name:            "skip version check for 'keptn --any-flag install'",
 			cliVersion:      "0.8.0",
 			metadataStatus:  http.StatusServiceUnavailable,
-			flags:           []string{"--any-flag", "install"},
+			args:            []string{"--any-flag", "install"},
 			doNotWantOutput: "* Warning: could not check Keptn server version: Error connecting to server:",
 		},
 		{
@@ -218,7 +220,7 @@ func Test_runVersionCheck(t *testing.T) {
 			metadataResponse: keptnapimodels.Metadata{
 				Keptnversion: "0.8.1-dev",
 			},
-			flags:      []string{"command-other-than-install"},
+			args:       []string{"command-other-than-install"},
 			wantOutput: "* Warning: Your Keptn CLI version (0.8.0) and Keptn cluster version (0.8.1-dev) don't match.",
 		},
 		{
@@ -228,7 +230,7 @@ func Test_runVersionCheck(t *testing.T) {
 			metadataResponse: keptnapimodels.Metadata{
 				Keptnversion: "0.8.1-dev",
 			},
-			flags:      []string{"--any-flag", "command-other-than-install"},
+			args:       []string{"--any-flag", "command-other-than-install"},
 			wantOutput: "* Warning: Your Keptn CLI version (0.8.0) and Keptn cluster version (0.8.1-dev) don't match.",
 		},
 		{
@@ -260,7 +262,7 @@ func Test_runVersionCheck(t *testing.T) {
 					VersionURL: ts.URL,
 				},
 			}
-			runVersionCheck(vChecker, tt.flags)
+			runVersionCheck(vChecker, tt.args)
 
 			// reset version
 			Version = ""

--- a/cli/cmd/root_test.go
+++ b/cli/cmd/root_test.go
@@ -12,7 +12,7 @@ import (
 
 	keptnapimodels "github.com/keptn/go-utils/pkg/api/models"
 	"github.com/keptn/keptn/cli/pkg/version"
-	"github.com/mattn/go-shellwords"
+	shellwords "github.com/mattn/go-shellwords"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/root_test.go
+++ b/cli/cmd/root_test.go
@@ -71,7 +71,7 @@ func executeActionCommandC(cmd string) (string, error) {
 		},
 	}
 	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
-		runVersionCheck(vChecker, os.Args)
+		runVersionCheck(vChecker, os.Args[1:])
 	}
 
 	rootCmd.SetOut(buf)

--- a/cli/cmd/root_test.go
+++ b/cli/cmd/root_test.go
@@ -178,7 +178,7 @@ func Test_runVersionCheck(t *testing.T) {
 		metadataStatus   int
 		metadataResponse keptnapimodels.Metadata
 		cliVersion       string
-		osArgs           []string
+		flags            []string
 		wantOutput       string
 		doNotWantOutput  string
 	}{
@@ -198,11 +198,47 @@ func Test_runVersionCheck(t *testing.T) {
 			wantOutput:     "* Warning: could not check Keptn server version: received invalid response from Keptn API\n",
 		},
 		{
-			name:            "skip version check for 'install'",
+			name:            "skip version check for 'keptn install'",
 			cliVersion:      "0.8.0",
 			metadataStatus:  http.StatusServiceUnavailable,
-			osArgs:          []string{"keptn", "install"},
+			flags:           []string{"install"},
 			doNotWantOutput: "* Warning: could not check Keptn server version: Error connecting to server:",
+		},
+		{
+			name:            "skip version check for 'keptn --any-flag install'",
+			cliVersion:      "0.8.0",
+			metadataStatus:  http.StatusServiceUnavailable,
+			flags:           []string{"--any-flag", "install"},
+			doNotWantOutput: "* Warning: could not check Keptn server version: Error connecting to server:",
+		},
+		{
+			name:           "show version check for 'keptn command-other-than-install'",
+			cliVersion:     "0.8.0",
+			metadataStatus: http.StatusOK,
+			metadataResponse: keptnapimodels.Metadata{
+				Keptnversion: "0.8.1-dev",
+			},
+			flags:      []string{"command-other-than-install"},
+			wantOutput: "* Warning: Your Keptn CLI version (0.8.0) and Keptn cluster version (0.8.1-dev) don't match.",
+		},
+		{
+			name:           "show version check for 'keptn --any-flag command-other-than-install'",
+			cliVersion:     "0.8.0",
+			metadataStatus: http.StatusOK,
+			metadataResponse: keptnapimodels.Metadata{
+				Keptnversion: "0.8.1-dev",
+			},
+			flags:      []string{"--any-flag", "command-other-than-install"},
+			wantOutput: "* Warning: Your Keptn CLI version (0.8.0) and Keptn cluster version (0.8.1-dev) don't match.",
+		},
+		{
+			name:           "don't show warning if the versions match",
+			cliVersion:     "0.8.0",
+			metadataStatus: http.StatusOK,
+			metadataResponse: keptnapimodels.Metadata{
+				Keptnversion: "0.8.0",
+			},
+			doNotWantOutput: "* Warning: Your Keptn CLI version (0.8.0) and Keptn cluster version (0.8.0) don't match.",
 		},
 	}
 	for _, tt := range tests {
@@ -224,7 +260,7 @@ func Test_runVersionCheck(t *testing.T) {
 					VersionURL: ts.URL,
 				},
 			}
-			runVersionCheck(vChecker, tt.osArgs)
+			runVersionCheck(vChecker, tt.flags)
 
 			// reset version
 			Version = ""


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- skips version check on `keptn install`

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #3158

<!--  ### Notes  -->
<!-- any additional notes for this PR -->

<!-- ### Follow-up Tasks -->
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->
1. Run `keptn install` locally without a cluster running. You should not see a `Warning` message like [this](https://user-images.githubusercontent.com/31009634/106847806-ace9c200-66d5-11eb-96c8-1b3a5540de79.png).
2. Run any other command like `keptn auth` or `keptn uninstall` without a cluster running and you should see a `Warning` message like [this](https://user-images.githubusercontent.com/31009634/106847806-ace9c200-66d5-11eb-96c8-1b3a5540de79.png).