### PR TITLE
fix(bridge): delete confirmation dialog did not show up (#5052)

### DIFF
--- a/bridge/client/app/_components/_dialogs/ktb-delete-confirmation/ktb-delete-confirmation.component.ts
+++ b/bridge/client/app/_components/_dialogs/ktb-delete-confirmation/ktb-delete-confirmation.component.ts
@@ -34,13 +34,16 @@ export class KtbDeleteConfirmationComponent {
   @Input() name?: string;
   @Input() deleteMessage?: string;
   @Output() confirmClicked: EventEmitter<void> = new EventEmitter<void>();
+  @Output() dialogStateChange: EventEmitter<DeleteDialogState> = new EventEmitter<DeleteDialogState>();
 
-  public closeDialog() {
+  public closeDialog(): void {
     this.dialogState = null;
+    this.dialogStateChange.emit(this.dialogState);
   }
 
-  public deleteAction() {
+  public deleteAction(): void {
     this.dialogState = 'deleting';
+    this.dialogStateChange.emit(this.dialogState);
     this.confirmClicked.emit();
   }
 }

--- a/bridge/client/app/_components/ktb-secrets-list/ktb-secrets-list.component.html
+++ b/bridge/client/app/_components/ktb-secrets-list/ktb-secrets-list.component.html
@@ -43,8 +43,8 @@
   </div>
 </div>
 <ktb-delete-confirmation
-                         type="secret"
-                         [dialogState]="deleteState"
-                         [name]="currentSecret?.name"
-                         (confirmClicked)="deleteSecret(currentSecret)"
+  type="secret"
+  [(dialogState)]="deleteState"
+  [name]="currentSecret?.name"
+  (confirmClicked)="deleteSecret(currentSecret)"
 ></ktb-delete-confirmation>

--- a/bridge/client/app/_components/ktb-subscription-item/ktb-subscription-item.component.html
+++ b/bridge/client/app/_components/ktb-subscription-item/ktb-subscription-item.component.html
@@ -33,7 +33,7 @@
 
   <ktb-delete-confirmation
     type="subscription"
-    [dialogState]="deleteState"
+    [(dialogState)]="deleteState"
     [deleteMessage]="subscription.isGlobal ? 'Deleting this subscription will affect all projects. Please be certain.' : undefined"
     [name]="name"
     (confirmClicked)="deleteSubscription()"


### PR DESCRIPTION
## This PR
- Fixes the bug that the delete confirmation dialog did not show up anymore after it was cancelled

### Related Issues
Fixes #5052 

Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>
