### PR TITLE
fix(bridge): 'show older sequences' was not displayed (#5054)

### DIFF
--- a/bridge/client/app/_models/project.ts
+++ b/bridge/client/app/_models/project.ts
@@ -23,11 +23,17 @@ export class Project extends pj {
     return project;
   }
 
+  // returns a project without default values
+  get reduced(): Partial<Project> {
+    const {sequences, allSequencesLoaded, ...copyProject} = this;
+    return copyProject;
+  }
+
   getServices(stageName?: string): Service[] {
     if (!stageName) {
       if (!this.services) {
         let services: Service[] = [];
-        for (const currentStage of this.stages){
+        for (const currentStage of this.stages) {
           services = services.concat(
             currentStage.services.filter(s => !services.some(ss => ss.serviceName === s.serviceName))
           );
@@ -35,8 +41,7 @@ export class Project extends pj {
         this.services = services;
       }
       return this.services;
-    }
-    else {
+    } else {
       return this.stages.find(s => s.stageName === stageName)?.services ?? [];
     }
   }
@@ -63,15 +68,14 @@ export class Project extends pj {
     if (service) {
       if (stage) {
         currentService = this.getServices(stage.stageName)?.find(s => s.serviceName === service.serviceName);
-      }
-      else {
+      } else {
         currentService = this.getService(service.serviceName);
       }
     }
     return currentService?.deploymentInformation;
   }
 
-  getLatestDeploymentTraceOfSequence(service: Service | undefined, stage?: Stage): Trace | undefined{
+  getLatestDeploymentTraceOfSequence(service: Service | undefined, stage?: Stage): Trace | undefined {
     const currentService = service ? this.getService(service.serviceName) : undefined;
 
     return currentService?.sequences
@@ -128,7 +132,7 @@ export class Project extends pj {
       if (service?.deploymentContext &&
         (!lastService
           || service.deploymentTime && lastService.deploymentTime
-            && moment.unix(service.deploymentTime).isAfter(moment.unix(lastService.deploymentTime)))) {
+          && moment.unix(service.deploymentTime).isAfter(moment.unix(lastService.deploymentTime)))) {
         lastService = service;
       }
     });
@@ -137,7 +141,7 @@ export class Project extends pj {
 
   public getStages(parent: string[] | null): Stage[] {
     return this.stages.filter(s => (
-      parent && s.parentStages?.every((element, i) => element === parent[i]))
+        parent && s.parentStages?.every((element, i) => element === parent[i]))
       || (!parent && !s.parentStages));
   }
 

--- a/bridge/client/app/_services/data.service.ts
+++ b/bridge/client/app/_services/data.service.ts
@@ -98,7 +98,7 @@ export class DataService {
     this._projectName.next(projectName);
   }
 
-  public setUniformDate(integrationId: string, lastSeen?: string) {
+  public setUniformDate(integrationId: string, lastSeen?: string): void {
     this._uniformDates[integrationId] = lastSeen || new Date().toISOString();
     this.apiService.uniformLogDates = this._uniformDates;
   }
@@ -234,8 +234,7 @@ export class DataService {
       const projects = this._projects.getValue();
       const existingProject = projects?.find(p => p.projectName === project.projectName);
       if (existingProject) {
-        const {sequences, ...copyProject} = project;
-        Object.assign(existingProject, copyProject);
+        Object.assign(existingProject, project.reduced);
         this._projects.next(projects);
       }
     }, err => {
@@ -264,8 +263,7 @@ export class DataService {
       projects = projects.map(project => {
         const existingProject = existingProjects?.find(p => p.projectName === project.projectName);
         if (existingProject) {
-          const {sequences, ...copyProject} = project;
-          return Object.assign(existingProject, copyProject);
+          return Object.assign(existingProject, project.reduced);
         } else {
           return project;
         }
@@ -417,7 +415,7 @@ export class DataService {
   }
 
   protected allSequencesLoaded(sequences: number, totalCount: number, fromTime?: Date, beforeTime?: Date): boolean {
-    return !!fromTime && !beforeTime && sequences >= totalCount
+    return !fromTime && !beforeTime && sequences >= totalCount
       || !!beforeTime && !fromTime && totalCount < this.DEFAULT_NEXT_SEQUENCE_PAGE_SIZE;
   }
 


### PR DESCRIPTION
## This PR
- displays "Show older sequences" if there are older sequences

### Related Issues
Fixes #5054 

Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>