### PR TITLE
chore(bridge): added default task 'evaluation', set task suffixes to available ones

### DIFF
--- a/bridge/client/app/_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component.html
+++ b/bridge/client/app/_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component.html
@@ -16,7 +16,7 @@
           <dt-form-field>
             <dt-label class="required">Task suffix</dt-label>
             <dt-select formControlName="taskSuffix" class="mr-2 item" placeholder="Choose your task suffix" aria-label="Choose your task suffix">
-              <dt-option *ngFor="let affix of affixes" [value]="affix.value" [textContent]="affix.displayValue"></dt-option>
+              <dt-option *ngFor="let affix of suffixes" [value]="affix.value" [textContent]="affix.displayValue"></dt-option>
             </dt-select>
           </dt-form-field>
         </div>

--- a/bridge/client/app/_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component.html
+++ b/bridge/client/app/_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component.html
@@ -16,7 +16,7 @@
           <dt-form-field>
             <dt-label class="required">Task suffix</dt-label>
             <dt-select formControlName="taskSuffix" class="mr-2 item" placeholder="Choose your task suffix" aria-label="Choose your task suffix">
-              <dt-option *ngFor="let affix of suffixes" [value]="affix.value" [textContent]="affix.displayValue"></dt-option>
+              <dt-option *ngFor="let suffix of suffixes" [value]="suffix.value" [textContent]="suffix.displayValue"></dt-option>
             </dt-select>
           </dt-form-field>
         </div>

--- a/bridge/client/app/_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component.spec.ts
+++ b/bridge/client/app/_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component.spec.ts
@@ -8,6 +8,7 @@ import { DataService } from '../../_services/data.service';
 import { DataServiceMock } from '../../_services/data.service.mock';
 import { UniformSubscription } from '../../_models/uniform-subscription';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { UniformRegistrationLocations } from '../../../../shared/interfaces/uniform-registration-locations';
 
 describe('KtbModifyUniformSubscriptionComponent', () => {
   let component: KtbModifyUniformSubscriptionComponent;
@@ -188,7 +189,7 @@ describe('KtbModifyUniformSubscriptionComponent', () => {
     const uniformRegistration = UniformRegistrationsMock[integrationIndex];
     const subscription = subscriptionIndex !== undefined ? uniformRegistration.subscriptions[subscriptionIndex] : new UniformSubscription('sockshop');
     dataService.getUniformSubscription = jest.fn().mockReturnValue(of(subscription));
-    dataService.getIsUniformRegistrationControlPlane = jest.fn().mockReturnValue(of(uniformRegistration.metadata.location === 'control-plane'));
+    dataService.getIsUniformRegistrationControlPlane = jest.fn().mockReturnValue(of(uniformRegistration.metadata.location === UniformRegistrationLocations.CONTROL_PLANE));
     paramMap.next(convertToParamMap({
       projectName: 'sockshop',
       integrationId: uniformRegistration.id,

--- a/bridge/client/app/_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component.ts
+++ b/bridge/client/app/_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component.ts
@@ -25,24 +25,24 @@ export class KtbModifyUniformSubscriptionComponent {
   public subscriptionForm = new FormGroup({
     taskPrefix: this.taskControl,
     taskSuffix: this.taskSuffixControl,
-    isGlobal: this.isGlobalControl
+    isGlobal: this.isGlobalControl,
   });
-  public readonly affixes: { value: string, displayValue: string }[] = [
+  public suffixes: { value: string, displayValue: string }[] = [
     {
       value: '>',
-      displayValue: '*'
+      displayValue: '*',
     },
     {
       value: 'triggered',
-      displayValue: 'triggered'
+      displayValue: 'triggered',
     },
     {
       value: 'started',
-      displayValue: 'started'
+      displayValue: 'started',
     },
     {
       value: 'finished',
-      displayValue: 'finished'
+      displayValue: 'finished',
     }];
 
   constructor(private route: ActivatedRoute, private dataService: DataService, private router: Router) {
@@ -51,7 +51,7 @@ export class KtbModifyUniformSubscriptionComponent {
         return {
           integrationId: paramMap.get('integrationId'),
           subscriptionId: paramMap.get('subscriptionId'),
-          projectName: paramMap.get('projectName')
+          projectName: paramMap.get('projectName'),
         };
       }),
       filter((params): params is  { integrationId: string, subscriptionId: string | null, projectName: string } => !!(params.integrationId && params.projectName)),
@@ -68,40 +68,53 @@ export class KtbModifyUniformSubscriptionComponent {
         this.taskSuffixControl.setValue(subscription.suffix);
         this.isGlobalControl.setValue(subscription.isGlobal);
       }),
-      take(1)
+      take(1),
     );
 
     const integrationId$ = this.route.paramMap
       .pipe(
         map(paramMap => paramMap.get('integrationId')),
         filter((integrationId: string | null): integrationId is string => !!integrationId),
-        take(1)
+        take(1),
       );
+
+    integrationId$.pipe(
+      switchMap(integrationId => this.dataService.getIsUniformRegistrationControlPlane(integrationId)),
+    ).subscribe(isControlPlane => {
+      if (isControlPlane) {
+        this.suffixes = [
+          {
+            value: 'triggered',
+            displayValue: 'triggered',
+          },
+        ];
+      }
+    });
 
     const projectName$ = this.route.paramMap
       .pipe(
         map(paramMap => paramMap.get('projectName')),
-        filter((projectName: string | null): projectName is string => !!projectName)
+        filter((projectName: string | null): projectName is string => !!projectName),
       );
 
     const taskNames$ = projectName$
       .pipe(
         switchMap(projectName => this.dataService.getTaskNames(projectName)),
-        take(1)
+        take(1),
       );
     const project$ = projectName$
       .pipe(
         switchMap(projectName => this.dataService.getProject(projectName)),
         filter((project?: Project): project is Project => !!project),
         tap(project => this.updateDataSource(project)),
-        take(1)
+        take(1),
       );
 
     this.data$ = forkJoin({
       taskNames: taskNames$,
       subscription: subscription$,
       project: project$,
-      integrationId: integrationId$
+      integrationId: integrationId$,
     });
   }
 
@@ -112,19 +125,19 @@ export class KtbModifyUniformSubscriptionComponent {
           name: 'Stage',
           autocomplete: project.stages.map(stage => {
             return {
-              name: stage.stageName
+              name: stage.stageName,
             };
-          })
+          }),
         },
         {
           name: 'Service',
           autocomplete: project.getServices().map(service => {
             return {
-              name: service.serviceName
+              name: service.serviceName,
             };
-          })
-        }
-      ]
+          }),
+        },
+      ],
     } as DtFilterFieldDefaultDataSourceAutocomplete;
   }
 

--- a/bridge/client/app/_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component.ts
+++ b/bridge/client/app/_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component.ts
@@ -81,7 +81,7 @@ export class KtbModifyUniformSubscriptionComponent {
     integrationId$.pipe(
       switchMap(integrationId => this.dataService.getIsUniformRegistrationControlPlane(integrationId)),
     ).subscribe(isControlPlane => {
-      if (isControlPlane) {
+      if (!isControlPlane) {
         this.suffixes = [
           {
             value: 'triggered',

--- a/bridge/client/app/_models/uniform-registrations.mock.ts
+++ b/bridge/client/app/_models/uniform-registrations.mock.ts
@@ -13,11 +13,11 @@ const services: ur[] = [
       kubernetesmetadata: {
         deploymentname: 'ansible-service',
         namespace: 'keptn-uniform',
-        podname: 'ansible-service-123456789'
+        podname: 'ansible-service-123456789',
       },
       location: 'Execution plane-A',
       status: 'active',
-      lastseen: '2021-08-19T08:37:54.691Z'
+      lastseen: '2021-08-19T08:37:54.691Z',
     },
     name: 'ansible-service',
     subscriptions:
@@ -25,11 +25,11 @@ const services: ur[] = [
         filter: {
           projects: [],
           services: [],
-          stages: []
+          stages: [],
         },
-        event: 'sh.keptn.test.triggered'
+        event: 'sh.keptn.test.triggered',
       }],
-    unreadEventsCount: 10
+    unreadEventsCount: 10,
   },
   {
     id: 'keptn-uniform-helm-service-cc9da31fa4c9f5e58985149029c598c4',
@@ -41,11 +41,11 @@ const services: ur[] = [
       kubernetesmetadata: {
         deploymentname: 'helm-service',
         namespace: 'keptn-uniform',
-        podname: 'helm-service-123456789'
+        podname: 'helm-service-123456789',
       },
       location: 'Execution plane-A',
       status: 'healthy',
-      lastseen: '2021-08-19T08:37:54.691Z'
+      lastseen: '2021-08-19T08:37:54.691Z',
     },
     name: 'ansible-service',
     subscriptions:
@@ -53,11 +53,11 @@ const services: ur[] = [
         filter: {
           projects: [],
           services: ['carts'],
-          stages: ['dev']
+          stages: ['dev'],
         },
         event: 'sh.keptn.event.deployment.triggered',
-        id: 'myHelmSubscriptionId'
-      }]
+        id: 'myHelmSubscriptionId',
+      }],
   },
   {
     id: 'keptn-uniform-jmeter-service-ea9e7b21d21295570fd62adb04592065',
@@ -69,11 +69,11 @@ const services: ur[] = [
       kubernetesmetadata: {
         deploymentname: 'jmeter-service',
         namespace: 'keptn-uniform',
-        podname: 'jmeter-service-123456789'
+        podname: 'jmeter-service-123456789',
       },
       location: 'Execution plane-A',
       status: 'healthy',
-      lastseen: '2021-08-19T08:37:54.691Z'
+      lastseen: '2021-08-19T08:37:54.691Z',
     },
     name: 'jmeter-service',
     subscriptions:
@@ -81,11 +81,11 @@ const services: ur[] = [
         filter: {
           projects: ['sockshop'],
           services: ['carts'],
-          stages: ['dev']
+          stages: ['dev'],
         },
         event: 'sh.keptn.event.test.triggered',
-        id: 'myJmeterSubscriptionId'
-      }]
+        id: 'myJmeterSubscriptionId',
+      }],
   },
   {
     id: 'keptn-lighthouse-service-8feec7146c19fa08bd65664b8d47f153',
@@ -97,11 +97,11 @@ const services: ur[] = [
       kubernetesmetadata: {
         deploymentname: 'lighthouse-service',
         namespace: 'keptn',
-        podname: 'lighthouse-service-123456789'
+        podname: 'lighthouse-service-123456789',
       },
-      location: 'Control plane',
+      location: 'control-plane',
       status: 'healthy',
-      lastseen: '2021-08-19T08:37:54.691Z'
+      lastseen: '2021-08-19T08:37:54.691Z',
     },
     name: 'lighthouse-service',
     subscriptions:
@@ -109,10 +109,10 @@ const services: ur[] = [
         filter: {
           projects: [],
           services: [],
-          stages: []
+          stages: [],
         },
-        event: 'sh.keptn.event.evaluation.triggered'
-      }]
+        event: 'sh.keptn.event.evaluation.triggered',
+      }],
   },
   {
     id: 'keptn-approval-service-bcd13872eb35b0f1f5a730c4c4832af8',
@@ -124,11 +124,11 @@ const services: ur[] = [
       kubernetesmetadata: {
         deploymentname: 'approval-service',
         namespace: 'keptn',
-        podname: 'approval-service-123456789'
+        podname: 'approval-service-123456789',
       },
-      location: 'Control plane',
+      location: 'control-plane',
       status: 'healthy',
-      lastseen: '2021-08-19T08:37:54.691Z'
+      lastseen: '2021-08-19T08:37:54.691Z',
     },
     name: 'lighthouse-service',
     subscriptions:
@@ -136,10 +136,10 @@ const services: ur[] = [
         filter: {
           projects: [],
           services: [],
-          stages: []
+          stages: [],
         },
-        event: 'sh.keptn.event.deployment.triggered'
-      }]
+        event: 'sh.keptn.event.deployment.triggered',
+      }],
   },
   {
     id: 'keptn-remediation-service-10fedadd2e37e75383df1405f9e55d05',
@@ -151,11 +151,11 @@ const services: ur[] = [
       kubernetesmetadata: {
         deploymentname: 'remediation-service',
         namespace: 'keptn',
-        podname: 'remediation-service-123456789'
+        podname: 'remediation-service-123456789',
       },
-      location: 'Control plane',
+      location: 'control-plane',
       status: 'healthy',
-      lastseen: '2021-08-19T08:37:54.691Z'
+      lastseen: '2021-08-19T08:37:54.691Z',
     },
     name: 'remediation-service',
     subscriptions:
@@ -164,27 +164,27 @@ const services: ur[] = [
           filter: {
             projects: [],
             services: [],
-            stages: []
+            stages: [],
           },
-          event: 'sh.keptn.event.test.triggered'
+          event: 'sh.keptn.event.test.triggered',
         },
         {
           filter: {
             projects: [],
             services: [],
-            stages: []
+            stages: [],
           },
-          event: 'sh.keptn.event.evaluation.triggered'
+          event: 'sh.keptn.event.evaluation.triggered',
         },
         {
           filter: {
             projects: [],
             services: [],
-            stages: []
+            stages: [],
           },
-          event: 'sh.keptn.event.deployment.triggered'
+          event: 'sh.keptn.event.deployment.triggered',
         },
-      ]
+      ],
   },
   {
     id: 'keptn-uniform-jenkins-service-9d93d3deeb00f19131e6b56c247d7293',
@@ -196,11 +196,11 @@ const services: ur[] = [
       kubernetesmetadata: {
         deploymentname: 'jenkins-service',
         namespace: 'keptn',
-        podname: 'jenkins-service-123456789'
+        podname: 'jenkins-service-123456789',
       },
       location: 'Execution plane-B',
       status: 'healthy',
-      lastseen: '2021-08-19T08:37:54.691Z'
+      lastseen: '2021-08-19T08:37:54.691Z',
     },
     name: 'jenkins-service',
     subscriptions:
@@ -208,10 +208,10 @@ const services: ur[] = [
         filter: {
           projects: [],
           services: [],
-          stages: []
+          stages: [],
         },
-        event: 'sh.keptn.event.deployment.triggered'
-      }]
+        event: 'sh.keptn.event.deployment.triggered',
+      }],
   },
   {
     id: 'keptn-dynatrace-sli-service-1fc1cf9407a50e8505ef7684e27c7416',
@@ -223,11 +223,11 @@ const services: ur[] = [
       kubernetesmetadata: {
         deploymentname: 'dynatrace-sli-service',
         namespace: 'keptn',
-        podname: 'dynatrace-sli-service-123456789'
+        podname: 'dynatrace-sli-service-123456789',
       },
-      location: 'Control plane',
+      location: 'control-plane',
       status: 'healthy',
-      lastseen: '2021-08-19T08:37:54.691Z'
+      lastseen: '2021-08-19T08:37:54.691Z',
     },
     name: 'dynatrace-sli-service',
     subscriptions:
@@ -235,10 +235,10 @@ const services: ur[] = [
         filter: {
           projects: [],
           services: [],
-          stages: []
+          stages: [],
         },
-        event: 'sh.keptn.event.evaluation.triggered'
-      }]
+        event: 'sh.keptn.event.evaluation.triggered',
+      }],
   },
   {
     id: 'keptn-dynatrace-service-c578c5d7254641d061b5bbb5fb8dd224',
@@ -250,11 +250,11 @@ const services: ur[] = [
       kubernetesmetadata: {
         deploymentname: 'dynatrace-service',
         namespace: 'keptn',
-        podname: 'dynatrace-service-123456789'
+        podname: 'dynatrace-service-123456789',
       },
-      location: 'Control plane',
+      location: 'control-plane',
       status: 'healthy',
-      lastseen: '2021-08-19T08:37:54.691Z'
+      lastseen: '2021-08-19T08:37:54.691Z',
     },
     name: 'dynatrace-service',
     subscriptions:
@@ -262,10 +262,10 @@ const services: ur[] = [
         filter: {
           projects: [],
           services: [],
-          stages: []
+          stages: [],
         },
-        event: 'sh.keptn.event.evaluation.triggered'
-      }]
+        event: 'sh.keptn.event.evaluation.triggered',
+      }],
   },
   {
     id: 'keptn-uniform-servicenow-service-55875464c5b6d3e313e58b99d2ed7e09',
@@ -277,11 +277,11 @@ const services: ur[] = [
       kubernetesmetadata: {
         deploymentname: 'servicenow-service',
         namespace: 'keptn',
-        podname: 'servicenow-service-123456789'
+        podname: 'servicenow-service-123456789',
       },
       location: 'Execution plane-A',
       status: 'healthy',
-      lastseen: '2021-08-19T08:37:54.691Z'
+      lastseen: '2021-08-19T08:37:54.691Z',
     },
     name: 'servicenow-service',
     subscriptions:
@@ -290,12 +290,12 @@ const services: ur[] = [
           filter: {
             projects: [],
             services: [],
-            stages: []
+            stages: [],
           },
-          event: 'sh.keptn.event.deployment.triggered'
-        }
-      ]
-  }
+          event: 'sh.keptn.event.deployment.triggered',
+        },
+      ],
+  },
 ];
 
 const UniformRegistrationsMock: UniformRegistration[] = services.map(registration => UniformRegistration.fromJSON(registration));

--- a/bridge/client/app/_models/uniform-registrations.mock.ts
+++ b/bridge/client/app/_models/uniform-registrations.mock.ts
@@ -1,5 +1,6 @@
 import { UniformRegistration as ur } from '../../../server/interfaces/uniform-registration';
 import { UniformRegistration } from './uniform-registration';
+import { UniformRegistrationLocations } from '../../../shared/interfaces/uniform-registration-locations';
 
 
 const services: ur[] = [
@@ -99,7 +100,7 @@ const services: ur[] = [
         namespace: 'keptn',
         podname: 'lighthouse-service-123456789',
       },
-      location: 'control-plane',
+      location: UniformRegistrationLocations.CONTROL_PLANE,
       status: 'healthy',
       lastseen: '2021-08-19T08:37:54.691Z',
     },
@@ -126,7 +127,7 @@ const services: ur[] = [
         namespace: 'keptn',
         podname: 'approval-service-123456789',
       },
-      location: 'control-plane',
+      location: UniformRegistrationLocations.CONTROL_PLANE,
       status: 'healthy',
       lastseen: '2021-08-19T08:37:54.691Z',
     },
@@ -153,7 +154,7 @@ const services: ur[] = [
         namespace: 'keptn',
         podname: 'remediation-service-123456789',
       },
-      location: 'control-plane',
+      location: UniformRegistrationLocations.CONTROL_PLANE,
       status: 'healthy',
       lastseen: '2021-08-19T08:37:54.691Z',
     },
@@ -225,7 +226,7 @@ const services: ur[] = [
         namespace: 'keptn',
         podname: 'dynatrace-sli-service-123456789',
       },
-      location: 'control-plane',
+      location: UniformRegistrationLocations.CONTROL_PLANE,
       status: 'healthy',
       lastseen: '2021-08-19T08:37:54.691Z',
     },
@@ -252,7 +253,7 @@ const services: ur[] = [
         namespace: 'keptn',
         podname: 'dynatrace-service-123456789',
       },
-      location: 'control-plane',
+      location: UniformRegistrationLocations.CONTROL_PLANE,
       status: 'healthy',
       lastseen: '2021-08-19T08:37:54.691Z',
     },

--- a/bridge/client/app/_services/api.service.ts
+++ b/bridge/client/app/_services/api.service.ts
@@ -12,7 +12,6 @@ import { Deployment } from '../_models/deployment';
 import moment from 'moment';
 import { SequenceResult } from '../_models/sequence-result';
 import { Project } from '../_models/project';
-import { UniformRegistration } from '../../../server/interfaces/uniform-registration';
 import { UniformRegistrationLogResponse } from '../../../server/interfaces/uniform-registration-log';
 import { Secret } from '../_models/secret';
 import { KeptnInfoResult } from '../_models/keptn-info-result';
@@ -20,9 +19,10 @@ import { KeptnVersions } from '../_models/keptn-versions';
 import { EventResult } from '../_interfaces/event-result';
 import { ProjectResult } from '../_interfaces/project-result';
 import { UniformSubscription } from '../_models/uniform-subscription';
+import { UniformRegistration } from '../_models/uniform-registration';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class ApiService {
 
@@ -121,7 +121,7 @@ export class ApiService {
       gitToken,
       gitUser,
       name: projectName,
-      shipyard
+      shipyard,
     });
   }
 
@@ -129,7 +129,7 @@ export class ApiService {
     const url = `${this._baseUrl}/project/${projectName}`;
     const params = {
       approval: 'true',
-      remediation: 'true'
+      remediation: 'true',
     };
     return this.http
       .get<Project>(url, {params});
@@ -139,7 +139,7 @@ export class ApiService {
     const url = `${this._baseUrl}/controlPlane/v1/project`;
     const params = {
       disableUpstreamSync: 'true',
-      ...pageSize && {pageSize: pageSize.toString()}
+      ...pageSize && {pageSize: pageSize.toString()},
     };
     return this.http
       .get<ProjectResult>(url, {params});
@@ -148,6 +148,11 @@ export class ApiService {
   public getUniformRegistrations(uniformDates: { [key: string]: string }): Observable<UniformRegistration[]> {
     const url = `${this._baseUrl}/uniform/registration`;
     return this.http.post<UniformRegistration[]>(url, uniformDates);
+  }
+
+  public getIsUniformRegistrationControlPlane(integrationId: string): Observable<boolean> {
+    const url = `${this._baseUrl}/uniform/registration/${integrationId}/isControlPlane`;
+    return this.http.get<boolean>(url);
   }
 
   public getUniformSubscription(integrationId: string, subscriptionId: string): Observable<UniformSubscription> {
@@ -189,7 +194,7 @@ export class ApiService {
     const url = `${this._baseUrl}/secrets/v1/secret`;
     const params = {
       name,
-      scope
+      scope,
     };
     return this.http.delete(url, {params});
   }
@@ -230,7 +235,7 @@ export class ApiService {
   public getServices(projectName: string, stageName: string, pageSize: number): Observable<ServiceResult> {
     const url = `${this._baseUrl}/controlPlane/v1/project/${projectName}/stage/${stageName}/service`;
     const params = {
-      pageSize: pageSize.toString()
+      pageSize: pageSize.toString(),
     };
     return this.http
       .get<ServiceResult>(url, {params});
@@ -249,7 +254,7 @@ export class ApiService {
       ...(state && {state}),
       ...(fromTime && {fromTime}),
       ...(beforeTime && {beforeTime}),
-      ...(keptnContext && {keptnContext})
+      ...(keptnContext && {keptnContext}),
     };
 
     return this.http
@@ -279,7 +284,7 @@ export class ApiService {
       pageSize: '100',
       keptnContext,
       ...projectName && {project: projectName},
-      ...fromTime && {fromTime}
+      ...fromTime && {fromTime},
     };
 
     return this.http
@@ -296,7 +301,7 @@ export class ApiService {
       filter: `data.project:${projectName} AND data.service:${serviceName} AND data.stage:${stageName}`,
       excludeInvalidated: 'true',
       limit: '50',
-      ...fromTime && {fromTime}
+      ...fromTime && {fromTime},
     };
     return this.http
       .get<EventResult>(url, {params});
@@ -306,7 +311,7 @@ export class ApiService {
     const url = `${this._baseUrl}/mongodb-datastore/event/type/${EventTypes.EVALUATION_FINISHED}`;
     const params = {
       filter: `shkeptncontext:${shkeptncontext}`,
-      limit: '1'
+      limit: '1',
     };
     return this.http
       .get<EventResult>(url, {params});
@@ -318,7 +323,7 @@ export class ApiService {
       gitRemoteURL: gitUrl,
       gitToken,
       gitUser,
-      name: projectName
+      name: projectName,
     });
   }
 
@@ -338,8 +343,8 @@ export class ApiService {
           labels: approval.data.labels,
           message: approval.data.message,
           result: approve ? ApprovalStates.APPROVED : ApprovalStates.DECLINED,
-          status: 'succeeded'
-        }
+          status: 'succeeded',
+        },
       });
   }
 
@@ -357,9 +362,9 @@ export class ApiService {
           stage: evaluation.data.stage,
           service: evaluation.data.service,
           evaluation: {
-            reason
-          }
-        }
+            reason,
+          },
+        },
       });
   }
 
@@ -368,7 +373,7 @@ export class ApiService {
 
     return this.http
       .post<unknown>(url, {
-        state
+        state,
       });
   }
 

--- a/bridge/client/app/_services/data.service.ts
+++ b/bridge/client/app/_services/data.service.ts
@@ -23,7 +23,7 @@ import { UniformSubscription } from '../_models/uniform-subscription';
 import { SequenceState } from '../../../shared/models/sequence';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class DataService {
 
@@ -109,7 +109,7 @@ export class DataService {
 
   public getProject(projectName: string): Observable<Project | undefined> {
     return this.projects.pipe(
-      map(projects => projects?.find(project => project.projectName === projectName))
+      map(projects => projects?.find(project => project.projectName === projectName)),
     );
   }
 
@@ -123,13 +123,17 @@ export class DataService {
 
   public getUniformRegistrations(): Observable<UniformRegistration[]> {
     return this.apiService.getUniformRegistrations(this._uniformDates).pipe(
-      map(uniformRegistrations => uniformRegistrations.map(registration => UniformRegistration.fromJSON(registration)))
+      map(uniformRegistrations => uniformRegistrations.map(registration => UniformRegistration.fromJSON(registration))),
     );
+  }
+
+  public getIsUniformRegistrationControlPlane(integrationId: string): Observable<boolean> {
+    return this.apiService.getIsUniformRegistrationControlPlane(integrationId);
   }
 
   public getUniformSubscription(integrationId: string, subscriptionId: string): Observable<UniformSubscription> {
     return this.apiService.getUniformSubscription(integrationId, subscriptionId).pipe(
-      map(uniformSubscription => UniformSubscription.fromJSON(uniformSubscription))
+      map(uniformSubscription => UniformSubscription.fromJSON(uniformSubscription)),
     );
   }
 
@@ -143,7 +147,7 @@ export class DataService {
 
   public getUniformRegistrationLogs(uniformRegistrationId: string, pageSize?: number): Observable<UniformRegistrationLog[]> {
     return this.apiService.getUniformRegistrationLogs(uniformRegistrationId, pageSize).pipe(
-      map((response) => response.logs)
+      map((response) => response.logs),
     );
   }
 
@@ -157,13 +161,13 @@ export class DataService {
     return this.apiService.getSecrets()
       .pipe(
         map(res => res.Secrets),
-        map(secrets => secrets.map(secret => Secret.fromJSON(secret)))
+        map(secrets => secrets.map(secret => Secret.fromJSON(secret))),
       );
   }
 
   public addSecret(secret: Secret): Observable<object> {
     return this.apiService.addSecret(Object.assign({}, secret, {
-      data: secret.data.reduce((result, item) => Object.assign(result, {[item.key]: item.value}), {})
+      data: secret.data.reduce((result, item) => Object.assign(result, {[item.key]: item.value}), {}),
     }));
   }
 
@@ -196,7 +200,7 @@ export class DataService {
       forkJoin({
         availableVersions: bridgeInfo.enableVersionCheckFeature ? this.apiService.getAvailableVersions() : of(undefined),
         versionCheckEnabled: of(this.apiService.isVersionCheckEnabled()),
-        metadata: this.apiService.getMetadata()
+        metadata: this.apiService.getMetadata(),
       }).subscribe((result) => {
         const keptnInfo: KeptnInfo = {...result, bridgeInfo: {...bridgeInfo}};
         if (keptnInfo.bridgeInfo.showApiToken) {
@@ -229,7 +233,7 @@ export class DataService {
   public loadProject(projectName: string): void {
     this.apiService.getProject(projectName)
       .pipe(
-        map(project => Project.fromJSON(project))
+        map(project => Project.fromJSON(project)),
       ).subscribe((project: Project) => {
       const projects = this._projects.getValue();
       const existingProject = projects?.find(p => p.projectName === project.projectName);
@@ -256,8 +260,8 @@ export class DataService {
       .pipe(
         map(result => result.projects),
         map(projects =>
-          projects.map(project => Project.fromJSON(project))
-        )
+          projects.map(project => Project.fromJSON(project)),
+        ),
       ).subscribe((projects: Project[]) => {
       const existingProjects = this._projects.getValue();
       projects = projects.map(project => {
@@ -330,7 +334,7 @@ export class DataService {
                       map(resource => {
                         stage.config = atob(resource.resourceContent);
                         return stage;
-                      })
+                      }),
                     );
                   }
                   result = forkJoin([_root, _resourceContent]).pipe(switchMap(() => of(deployment)));
@@ -349,9 +353,9 @@ export class DataService {
               }
             }
             return deployments;
-          })
-        )
-      )
+          }),
+        ),
+      ),
     ).subscribe((deployments: Deployment[]) => {
       this._changedDeployments.next(deployments);
     });
@@ -423,8 +427,8 @@ export class DataService {
     return this.apiService.getRoots(projectName, 1, undefined, undefined, undefined, shkeptncontext).pipe(
       map(response => response.body?.events || []),
       switchMap(roots => this.rootMapper(roots).pipe(
-        map(sequences => sequences.pop())
-      ))
+        map(sequences => sequences.pop()),
+      )),
     );
   }
 
@@ -437,7 +441,7 @@ export class DataService {
       map(response => response.body?.states || []),
       map(sequences => sequences.map(sequence => Sequence.fromJSON(sequence)).shift()),
       switchMap(sequence => sequence ? this.sequenceMapper([sequence]) : []),
-      map(sequences => sequences.shift())
+      map(sequences => sequences.shift()),
     );
   }
 
@@ -473,7 +477,7 @@ export class DataService {
           return response.body;
         }),
         map(result => result?.events || []),
-        map(traces => traces.map(trace => Trace.fromJSON(trace)))
+        map(traces => traces.map(trace => Trace.fromJSON(trace))),
       )
       .subscribe((traces: Trace[]) => {
         sequence.traces = Trace.traceMapper([...traces || [], ...sequence.traces || []]);
@@ -494,7 +498,7 @@ export class DataService {
       .pipe(
         map(response => response.body),
         map(result => result?.events || []),
-        map(traces => traces.map(trace => Trace.fromJSON(trace)))
+        map(traces => traces.map(trace => Trace.fromJSON(trace))),
       )
       .subscribe((traces: Trace[]) => {
         this._traces.next(traces);
@@ -511,13 +515,13 @@ export class DataService {
       this.apiService.getEvaluationResults(event.data.project, event.data.service, event.data.stage, fromTime?.toISOString())
         .pipe(
           map(result => result.events || []),
-          map(traces => traces.map(trace => Trace.fromJSON(trace)))
+          map(traces => traces.map(trace => Trace.fromJSON(trace))),
         )
         .subscribe((traces: Trace[]) => {
           this._evaluationResults.next({
             type: 'evaluationHistory',
             triggerEvent: event,
-            traces
+            traces,
           });
         });
     }
@@ -527,7 +531,7 @@ export class DataService {
     return this.apiService.getEvaluationResult(shkeptncontext)
       .pipe(
         map(result => result.events || []),
-        map(traces => traces.map(trace => Trace.fromJSON(trace)).find(() => true))
+        map(traces => traces.map(trace => Trace.fromJSON(trace)).find(() => true)),
       );
   }
 
@@ -557,7 +561,7 @@ export class DataService {
       .subscribe(() => {
         this._evaluationResults.next({
           type: 'invalidateEvaluation',
-          triggerEvent: evaluation
+          triggerEvent: evaluation,
         });
       });
   }
@@ -565,7 +569,7 @@ export class DataService {
   public getTaskNames(projectName: string): Observable<string[]> {
     return this.apiService.getTaskNames(projectName)
       .pipe(
-        map(taskNames => taskNames.sort((taskA, taskB) => taskA.localeCompare(taskB)))
+        map(taskNames => taskNames.sort((taskA, taskB) => taskA.localeCompare(taskB))),
       );
   }
 
@@ -584,9 +588,9 @@ export class DataService {
               map(traces => {
                 sequence.traces = traces;
                 return sequence;
-              })
+              }),
             );
-        }
+        },
       ),
       toArray(),
     );
@@ -606,12 +610,12 @@ export class DataService {
             .pipe(
               map(result => result.body?.events || []),
               map(Trace.traceMapper),
-              map(traces => ({...root, traces}))
+              map(traces => ({...root, traces})),
             );
-        }
+        },
       ),
       toArray(),
-      map(rs => rs.map(root => Root.fromJSON(root)))
+      map(rs => rs.map(root => Root.fromJSON(root))),
     );
   }
 }

--- a/bridge/server/api/index.ts
+++ b/bridge/server/api/index.ts
@@ -7,7 +7,7 @@ import { DataService } from '../services/data-service';
 const router = Router();
 
 function apiRouter(params:
-                     { apiUrl: string, apiToken: string, cliDownloadLink: string, integrationsPageLink: string, authType: string }
+                     { apiUrl: string, apiToken: string, cliDownloadLink: string, integrationsPageLink: string, authType: string },
 ): Router {
   // fetch parameters for bridgeInfo endpoint
   const {apiUrl, apiToken, cliDownloadLink, integrationsPageLink, authType} = params;
@@ -32,7 +32,7 @@ function apiRouter(params:
       projectsPageSize,
       servicesPageSize,
       authType,
-      ...user && {user}
+      ...user && {user},
     };
 
     try {
@@ -61,8 +61,8 @@ function apiRouter(params:
         method: req.method as Method,
         url: `${apiUrl}${req.url}`,
         headers: {
-          'Content-Type': 'application/json'
-        }
+          'Content-Type': 'application/json',
+        },
       });
       return res.json(result.data);
     } catch (err) {
@@ -77,8 +77,8 @@ function apiRouter(params:
         url: `https://get.keptn.sh/version.json`,
         headers: {
           'Content-Type': 'application/json',
-          'User-Agent': `keptn/bridge:${process.env.VERSION}`
-        }
+          'User-Agent': `keptn/bridge:${process.env.VERSION}`,
+        },
       });
       return res.json(result.data);
     } catch (err) {
@@ -116,6 +116,15 @@ function apiRouter(params:
     }
   });
 
+  router.get('/uniform/registration/:integrationId/isControlPlane', async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const isControlPlane = await dataService.getIsUniformRegistrationControlPlane(req.params.integrationId);
+      return res.json(isControlPlane);
+    } catch (error) {
+      return next(error);
+    }
+  });
+
   router.post('/hasUnreadUniformRegistrationLogs', async (req: Request, res: Response, next: NextFunction) => {
     try {
       const uniformDates: { [key: string]: string } = req.body;
@@ -134,8 +143,8 @@ function apiRouter(params:
         ...req.method !== 'GET' && {data: req.body},
         headers: {
           'x-token': apiToken,
-          'Content-Type': 'application/json'
-        }
+          'Content-Type': 'application/json',
+        },
       });
 
       return res.json(result.data);

--- a/bridge/server/services/api-service.ts
+++ b/bridge/server/services/api-service.ts
@@ -16,12 +16,12 @@ export class ApiService {
     this.axios = Axios.create({
       // accepts self-signed ssl certificate
       httpsAgent: new https.Agent({
-        rejectUnauthorized: false
+        rejectUnauthorized: false,
       }),
       headers: {
         'x-token': apiToken,
-        'Content-Type': 'application/json'
-      }
+        'Content-Type': 'application/json',
+      },
     });
   }
 
@@ -38,7 +38,7 @@ export class ApiService {
       ...(state && {state}),
       ...(fromTime && {fromTime}),
       ...(beforeTime && {beforeTime}),
-      ...(keptnContext && {keptnContext})
+      ...(keptnContext && {keptnContext}),
     };
 
     return this.axios.get<SequenceResult>(`${this.baseUrl}/controlPlane/v1/sequence/${projectName}`, {params});
@@ -51,7 +51,7 @@ export class ApiService {
       stage: stageName,
       type: eventType,
       limit: pageSize.toString(),
-      ...keptnContext && {keptnContext}
+      ...keptnContext && {keptnContext},
     };
     return this.axios.get<EventResult>(`${this.baseUrl}/mongodb-datastore/event`, {params});
   }
@@ -60,7 +60,7 @@ export class ApiService {
     const params = {
       filter: `data.project:${projectName} AND data.service:${serviceName} AND data.stage:${stageName} AND data.result:${resultType}`,
       excludeInvalidated: 'true',
-      limit: pageSize.toString()
+      limit: pageSize.toString(),
     };
     return this.axios.get<EventResult>(`${this.baseUrl}/mongodb-datastore/event/type/${eventType}`, {params});
   }
@@ -70,7 +70,7 @@ export class ApiService {
     const params = {
       filter: `data.project:${projectName} AND data.service:${serviceName} AND data.stage:${stageName}${contextString}`,
       excludeInvalidated: 'true',
-      limit: pageSize.toString()
+      limit: pageSize.toString(),
     };
     return this.axios.get<EventResult>(`${this.baseUrl}/mongodb-datastore/event/type/${EventTypes.EVALUATION_FINISHED}`, {params});
   }
@@ -84,15 +84,19 @@ export class ApiService {
     return this.axios.get<EventResult>(`${this.baseUrl}/controlPlane/v1/event/triggered/${eventType}`, {params});
   }
 
-  public getUniformRegistrations(): Promise<AxiosResponse<UniformRegistration[]>> {
-    return this.axios.get<UniformRegistration[]>(`${this.baseUrl}/controlPlane/v1/uniform/registration`);
+  public getUniformRegistrations(integrationId?: string): Promise<AxiosResponse<UniformRegistration[]>> {
+    return this.axios.get<UniformRegistration[]>(`${this.baseUrl}/controlPlane/v1/uniform/registration`, {
+      params: {
+        ...integrationId && {id: integrationId},
+      },
+    });
   }
 
   public getUniformRegistrationLogs(integrationId: string, fromTime?: string, pageSize = 100): Promise<AxiosResponse<UniformRegistrationLogResponse>> {
     const params = {
       integrationId,
       ...fromTime && {fromTime: new Date(new Date(fromTime).getTime() + 1).toISOString()}, // > fromTime instead of >= fromTime
-      pageSize: pageSize.toString()
+      pageSize: pageSize.toString(),
     };
     return this.axios.get<UniformRegistrationLogResponse>(`${this.baseUrl}/controlPlane/v1/log`, {params});
   }

--- a/bridge/server/services/data-service.ts
+++ b/bridge/server/services/data-service.ts
@@ -93,7 +93,7 @@ export class DataService {
       const trace = Trace.fromJSON(traceData);
       deploymentInformation = {
         deploymentUrl: trace.getDeploymentUrl(),
-        image: trace.getShortImageName()
+        image: trace.getShortImageName(),
       };
     }
     return deploymentInformation;
@@ -171,7 +171,7 @@ export class DataService {
       const evaluationTrace = await this.getTrace(trace.shkeptncontext, projectName, stageName, serviceName, EventTypes.EVALUATION_FINISHED);
       approvals.push({
         evaluationTrace,
-        trace
+        trace,
       });
     }
     return approvals;
@@ -207,9 +207,15 @@ export class DataService {
     return validRegistrations;
   }
 
+  public async getIsUniformRegistrationControlPlane(integrationId: string): Promise<boolean> {
+    const response = await this.apiService.getUniformRegistrations(integrationId);
+    const uniformRegistration = response.data.shift();
+    return uniformRegistration?.metadata.location === 'control-plane';
+  }
+
   public async getTasks(projectName: string): Promise<string[]> {
     const shipyard = await this.getShipyard(projectName);
-    const tasks: string[] = ['service.delete', 'service.create'];
+    const tasks: string[] = ['service.delete', 'service.create', 'evaluation', 'test'];
     for (const stage of shipyard.spec.stages) {
       for (const sequence of stage.sequences) {
         for (const task of sequence.tasks) {

--- a/bridge/server/services/data-service.ts
+++ b/bridge/server/services/data-service.ts
@@ -12,6 +12,7 @@ import { ResultTypes } from '../../shared/models/result-types';
 import { UniformRegistration } from '../interfaces/uniform-registration';
 import Yaml from 'yaml';
 import { Shipyard } from '../interfaces/shipyard';
+import { UniformRegistrationLocations } from '../../shared/interfaces/uniform-registration-locations';
 
 export class DataService {
   private apiService: ApiService;
@@ -210,7 +211,8 @@ export class DataService {
   public async getIsUniformRegistrationControlPlane(integrationId: string): Promise<boolean> {
     const response = await this.apiService.getUniformRegistrations(integrationId);
     const uniformRegistration = response.data.shift();
-    return uniformRegistration?.metadata.location === 'control-plane';
+
+    return uniformRegistration?.metadata.location === UniformRegistrationLocations.CONTROL_PLANE;
   }
 
   public async getTasks(projectName: string): Promise<string[]> {

--- a/bridge/server/services/data-service.ts
+++ b/bridge/server/services/data-service.ts
@@ -215,7 +215,7 @@ export class DataService {
 
   public async getTasks(projectName: string): Promise<string[]> {
     const shipyard = await this.getShipyard(projectName);
-    const tasks: string[] = ['service.delete', 'service.create', 'evaluation', 'test'];
+    const tasks: string[] = ['service.delete', 'service.create', 'evaluation'];
     for (const stage of shipyard.spec.stages) {
       for (const sequence of stage.sequences) {
         for (const task of sequence.tasks) {

--- a/bridge/shared/interfaces/uniform-registration-locations.ts
+++ b/bridge/shared/interfaces/uniform-registration-locations.ts
@@ -1,0 +1,3 @@
+export enum UniformRegistrationLocations {
+  CONTROL_PLANE = 'control-plane'
+}


### PR DESCRIPTION
## This PR
- Adds default tasks `evaluation` and `test`.
- Limits task suffixes to `triggered` if the uniform registration is not in the control-plane.

Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>