### PR TITLE
fix(shipyard-controller): Adapted HTTP status codes of GET /event endpoint (#5132)

### DIFF
--- a/shipyard-controller/handler/error.go
+++ b/shipyard-controller/handler/error.go
@@ -4,10 +4,10 @@ import "errors"
 
 var ErrProjectAlreadyExists = errors.New("project already exists")
 
-var errServiceAlreadyExists = errors.New("project already exists")
+var ErrServiceAlreadyExists = errors.New("project already exists")
 
-var errServiceNotFound = errors.New("service not found")
+var ErrServiceNotFound = errors.New("service not found")
 
-var errProjectNotFound = errors.New("project not found")
+var ErrProjectNotFound = errors.New("project not found")
 
-var errStageNotFound = errors.New("stage not found")
+var ErrStageNotFound = errors.New("stage not found")

--- a/shipyard-controller/handler/eventhandler.go
+++ b/shipyard-controller/handler/eventhandler.go
@@ -76,8 +76,13 @@ func (eh *EventHandler) GetTriggeredEvents(c *gin.Context) {
 	}
 
 	if err != nil {
-		SetInternalServerErrorResponse(err, c)
-		return
+		if err == ErrProjectNotFound {
+			SetNotFoundErrorResponse(err, c)
+			return
+		} else {
+			SetInternalServerErrorResponse(err, c)
+			return
+		}
 	}
 
 	paginationInfo := common.Paginate(len(events), params.PageSize, params.NextPageKey)

--- a/shipyard-controller/handler/eventhandler_test.go
+++ b/shipyard-controller/handler/eventhandler_test.go
@@ -1,20 +1,23 @@
-package handler
+package handler_test
 
 import (
 	"bytes"
 	"errors"
 	"github.com/gin-gonic/gin"
+	"github.com/keptn/keptn/shipyard-controller/common"
+	"github.com/keptn/keptn/shipyard-controller/handler"
 	"github.com/keptn/keptn/shipyard-controller/handler/fake"
 	"github.com/keptn/keptn/shipyard-controller/models"
 	"github.com/stretchr/testify/require"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
 func TestEventHandler_HandleEvent(t *testing.T) {
 	type fields struct {
-		ShipyardController IShipyardController
+		ShipyardController handler.IShipyardController
 	}
 
 	tests := []struct {
@@ -52,7 +55,7 @@ func TestEventHandler_HandleEvent(t *testing.T) {
 			fields: fields{
 				ShipyardController: &fake.IShipyardControllerMock{
 					HandleIncomingEventFunc: func(event models.Event, waitForCompletion bool) error {
-						return errNoMatchingEvent
+						return handler.ErrNoMatchingEvent
 					},
 				},
 			},
@@ -66,12 +69,109 @@ func TestEventHandler_HandleEvent(t *testing.T) {
 			c, _ := gin.CreateTestContext(w)
 
 			c.Request, _ = http.NewRequest(http.MethodPost, "", bytes.NewBuffer(tt.payload))
-			service := &EventHandler{
+			service := &handler.EventHandler{
 				ShipyardController: tt.fields.ShipyardController,
 			}
 
 			service.HandleEvent(c)
 			require.Equal(t, tt.expectStatusCode, w.Code)
+		})
+	}
+}
+
+func TestEventHandler_GetTriggeredEvents(t *testing.T) {
+	type fields struct {
+		ShipyardController *fake.IShipyardControllerMock
+	}
+	type args struct {
+		c *gin.Context
+	}
+	tests := []struct {
+		name             string
+		fields           fields
+		args             args
+		request          *http.Request
+		expectStatusCode int
+	}{
+		{
+			name: "return 500 in case of an error when retrieving all open events for all projects",
+			fields: fields{
+				ShipyardController: &fake.IShipyardControllerMock{
+					GetAllTriggeredEventsFunc: func(filter common.EventFilter) ([]models.Event, error) {
+						return nil, errors.New("oops")
+					},
+				},
+			},
+			request:          httptest.NewRequest(http.MethodGet, "/event/triggered/sh.keptn.test.triggered", nil),
+			expectStatusCode: http.StatusInternalServerError,
+		},
+		{
+			name: "return 500 in case of an error when retrieving all open events for a specific project",
+			fields: fields{
+				ShipyardController: &fake.IShipyardControllerMock{
+					GetTriggeredEventsOfProjectFunc: func(project string, filter common.EventFilter) ([]models.Event, error) {
+						return nil, errors.New("oops")
+					},
+				},
+			},
+			request:          httptest.NewRequest(http.MethodGet, "/event/triggered/sh.keptn.test.triggered?project=my-project", nil),
+			expectStatusCode: http.StatusInternalServerError,
+		},
+		{
+			name: "return 200 with empty array when no events for a project are available",
+			fields: fields{
+				ShipyardController: &fake.IShipyardControllerMock{
+					GetTriggeredEventsOfProjectFunc: func(project string, filter common.EventFilter) ([]models.Event, error) {
+						return nil, nil
+					},
+				},
+			},
+			request:          httptest.NewRequest(http.MethodGet, "/event/triggered/sh.keptn.test.triggered?project=my-project", nil),
+			expectStatusCode: http.StatusOK,
+		},
+		{
+			name: "return 200 with empty array when no events for any project are available",
+			fields: fields{
+				ShipyardController: &fake.IShipyardControllerMock{
+					GetAllTriggeredEventsFunc: func(filter common.EventFilter) ([]models.Event, error) {
+						return nil, nil
+					},
+				},
+			},
+			request:          httptest.NewRequest(http.MethodGet, "/event/triggered/sh.keptn.test.triggered", nil),
+			expectStatusCode: http.StatusOK,
+		},
+		{
+			name: "return 404 if project could not be found",
+			fields: fields{
+				ShipyardController: &fake.IShipyardControllerMock{
+					GetTriggeredEventsOfProjectFunc: func(project string, filter common.EventFilter) ([]models.Event, error) {
+						return nil, handler.ErrProjectNotFound
+					},
+				},
+			},
+			request:          httptest.NewRequest(http.MethodGet, "/event/triggered/sh.keptn.test.triggered?project=my-project", nil),
+			expectStatusCode: http.StatusNotFound,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := &handler.EventHandler{
+				ShipyardController: tt.fields.ShipyardController,
+			}
+
+			router := gin.Default()
+			router.GET("/event/triggered/:eventType", func(c *gin.Context) {
+				service.GetTriggeredEvents(c)
+			})
+			w := performRequest(router, tt.request)
+			require.Equal(t, tt.expectStatusCode, w.Code)
+			if strings.Contains(tt.request.RequestURI, "?project=") {
+				require.Len(t, tt.fields.ShipyardController.GetTriggeredEventsOfProjectCalls(), 1)
+				require.Equal(t, "my-project", tt.fields.ShipyardController.GetTriggeredEventsOfProjectCalls()[0].Project)
+			} else {
+				require.Len(t, tt.fields.ShipyardController.GetAllTriggeredEventsCalls(), 1)
+			}
 		})
 	}
 }

--- a/shipyard-controller/handler/projecthandler.go
+++ b/shipyard-controller/handler/projecthandler.go
@@ -100,7 +100,7 @@ func (ph *ProjectHandler) GetProjectByName(c *gin.Context) {
 
 	project, err := ph.ProjectManager.GetByName(projectName)
 	if err != nil {
-		if project == nil && err == errProjectNotFound {
+		if project == nil && err == ErrProjectNotFound {
 			SetNotFoundErrorResponse(nil, c, "Project not found: "+projectName)
 			return
 		}

--- a/shipyard-controller/handler/projecthandler_test.go
+++ b/shipyard-controller/handler/projecthandler_test.go
@@ -173,7 +173,7 @@ func TestGetProjectByName(t *testing.T) {
 			fields: fields{
 				ProjectManager: &fake.IProjectManagerMock{
 					GetByNameFunc: func(projectName string) (*models.ExpandedProject, error) {
-						return nil, errProjectNotFound
+						return nil, ErrProjectNotFound
 					},
 				},
 				EventSender: &fake.IEventSenderMock{},

--- a/shipyard-controller/handler/projectmanager.go
+++ b/shipyard-controller/handler/projectmanager.go
@@ -79,7 +79,7 @@ func (pm *ProjectManager) GetByName(projectName string) (*models.ExpandedProject
 		return nil, err
 	}
 	if project == nil {
-		return nil, errProjectNotFound
+		return nil, ErrProjectNotFound
 	}
 	return project, err
 }

--- a/shipyard-controller/handler/projectmanager_test.go
+++ b/shipyard-controller/handler/projectmanager_test.go
@@ -109,7 +109,7 @@ func TestGetByNameNotFound(t *testing.T) {
 	instance := NewProjectManager(configStore, secretStore, projectsDBOperations, taskSequenceRepo, eventRepo, sequenceQueueRepo, eventQueueRepo)
 	project, err := instance.GetByName("my-project")
 	assert.NotNil(t, err)
-	assert.Equal(t, errProjectNotFound, err)
+	assert.Equal(t, ErrProjectNotFound, err)
 	assert.Nil(t, project)
 	assert.Equal(t, "my-project", projectsDBOperations.GetProjectCalls()[0].ProjectName)
 }

--- a/shipyard-controller/handler/servicehandler.go
+++ b/shipyard-controller/handler/servicehandler.go
@@ -68,7 +68,7 @@ func (sh *ServiceHandler) CreateService(c *gin.Context) {
 			log.Errorf("could not send service.create.finished event: %s", err.Error())
 		}
 
-		if err == errServiceAlreadyExists {
+		if err == ErrServiceAlreadyExists {
 			SetConflictErrorResponse(err, c)
 			return
 		}
@@ -152,7 +152,7 @@ func (sh *ServiceHandler) GetService(c *gin.Context) {
 
 	service, err := sh.serviceManager.GetService(projectName, stageName, serviceName)
 	if err != nil {
-		if err == errProjectNotFound || err == errStageNotFound || err == errServiceNotFound {
+		if err == ErrProjectNotFound || err == ErrStageNotFound || err == ErrServiceNotFound {
 			SetNotFoundErrorResponse(err, c)
 			return
 		}
@@ -190,7 +190,7 @@ func (sh *ServiceHandler) GetServices(c *gin.Context) {
 
 	services, err := sh.serviceManager.GetAllServices(projectName, stageName)
 	if err != nil {
-		if err == errProjectNotFound || err == errStageNotFound {
+		if err == ErrProjectNotFound || err == ErrStageNotFound {
 			SetNotFoundErrorResponse(err, c)
 			return
 		}

--- a/shipyard-controller/handler/servicehandler_test.go
+++ b/shipyard-controller/handler/servicehandler_test.go
@@ -61,7 +61,7 @@ func TestServiceHandler_CreateService(t *testing.T) {
 			fields: fields{
 				serviceManager: &fake.IServiceManagerMock{
 					CreateServiceFunc: func(projectName string, params *operations.CreateServiceParams) error {
-						return errServiceAlreadyExists
+						return ErrServiceAlreadyExists
 					},
 				},
 				EventSender: &fake.IEventSenderMock{
@@ -79,7 +79,7 @@ func TestServiceHandler_CreateService(t *testing.T) {
 			expectJSONResponse: &operations.CreateServiceResponse{},
 			expectJSONError: &models.Error{
 				Code:    http.StatusConflict,
-				Message: stringp(errServiceAlreadyExists.Error()),
+				Message: stringp(ErrServiceAlreadyExists.Error()),
 			},
 		},
 		{
@@ -342,7 +342,7 @@ func TestServiceHandler_GetService(t *testing.T) {
 			fields: fields{
 				serviceManager: &fake.IServiceManagerMock{
 					GetServiceFunc: func(projectName string, stageName string, serviceName string) (*models.ExpandedService, error) {
-						return nil, errServiceNotFound
+						return nil, ErrServiceNotFound
 					},
 				},
 				EventSender: &fake.IEventSenderMock{},
@@ -352,7 +352,7 @@ func TestServiceHandler_GetService(t *testing.T) {
 			expectJSONResponse:         nil,
 			expectJSONError: &models.Error{
 				Code:    http.StatusNotFound,
-				Message: stringp(errServiceNotFound.Error()),
+				Message: stringp(ErrServiceNotFound.Error()),
 			},
 		},
 		{
@@ -360,7 +360,7 @@ func TestServiceHandler_GetService(t *testing.T) {
 			fields: fields{
 				serviceManager: &fake.IServiceManagerMock{
 					GetServiceFunc: func(projectName string, stageName string, serviceName string) (*models.ExpandedService, error) {
-						return nil, errStageNotFound
+						return nil, ErrStageNotFound
 					},
 				},
 				EventSender: &fake.IEventSenderMock{},
@@ -370,7 +370,7 @@ func TestServiceHandler_GetService(t *testing.T) {
 			expectJSONResponse:         nil,
 			expectJSONError: &models.Error{
 				Code:    http.StatusNotFound,
-				Message: stringp(errStageNotFound.Error()),
+				Message: stringp(ErrStageNotFound.Error()),
 			},
 		},
 		{
@@ -378,7 +378,7 @@ func TestServiceHandler_GetService(t *testing.T) {
 			fields: fields{
 				serviceManager: &fake.IServiceManagerMock{
 					GetServiceFunc: func(projectName string, stageName string, serviceName string) (*models.ExpandedService, error) {
-						return nil, errProjectNotFound
+						return nil, ErrProjectNotFound
 					},
 				},
 				EventSender: &fake.IEventSenderMock{},
@@ -388,7 +388,7 @@ func TestServiceHandler_GetService(t *testing.T) {
 			expectJSONResponse:         nil,
 			expectJSONError: &models.Error{
 				Code:    http.StatusNotFound,
-				Message: stringp(errProjectNotFound.Error()),
+				Message: stringp(ErrProjectNotFound.Error()),
 			},
 		},
 		{
@@ -503,7 +503,7 @@ func TestServiceHandler_GetServices(t *testing.T) {
 			fields: fields{
 				serviceManager: &fake.IServiceManagerMock{
 					GetAllServicesFunc: func(projectName string, stageName string) ([]*models.ExpandedService, error) {
-						return nil, errStageNotFound
+						return nil, ErrStageNotFound
 					},
 				},
 				EventSender: &fake.IEventSenderMock{},
@@ -513,7 +513,7 @@ func TestServiceHandler_GetServices(t *testing.T) {
 			expectJSONResponse:         nil,
 			expectJSONError: &models.Error{
 				Code:    http.StatusNotFound,
-				Message: stringp(errStageNotFound.Error()),
+				Message: stringp(ErrStageNotFound.Error()),
 			},
 		},
 		{
@@ -521,7 +521,7 @@ func TestServiceHandler_GetServices(t *testing.T) {
 			fields: fields{
 				serviceManager: &fake.IServiceManagerMock{
 					GetAllServicesFunc: func(projectName string, stageName string) ([]*models.ExpandedService, error) {
-						return nil, errProjectNotFound
+						return nil, ErrProjectNotFound
 					},
 				},
 				EventSender: &fake.IEventSenderMock{},
@@ -531,7 +531,7 @@ func TestServiceHandler_GetServices(t *testing.T) {
 			expectJSONResponse:         nil,
 			expectJSONError: &models.Error{
 				Code:    http.StatusNotFound,
-				Message: stringp(errProjectNotFound.Error()),
+				Message: stringp(ErrProjectNotFound.Error()),
 			},
 		},
 		{

--- a/shipyard-controller/handler/servicemanager.go
+++ b/shipyard-controller/handler/servicemanager.go
@@ -40,7 +40,7 @@ func (sm *serviceManager) GetAllStages(projectName string) ([]*models.ExpandedSt
 		return nil, err
 	}
 	if project == nil {
-		return nil, errProjectNotFound
+		return nil, ErrProjectNotFound
 	}
 
 	return project.Stages, nil
@@ -53,7 +53,7 @@ func (sm *serviceManager) GetService(projectName, stageName, serviceName string)
 		return nil, err
 	}
 	if project == nil {
-		return nil, errProjectNotFound
+		return nil, ErrProjectNotFound
 	}
 
 	for _, stg := range project.Stages {
@@ -63,10 +63,10 @@ func (sm *serviceManager) GetService(projectName, stageName, serviceName string)
 					return svc, nil
 				}
 			}
-			return nil, errServiceNotFound
+			return nil, ErrServiceNotFound
 		}
 	}
-	return nil, errStageNotFound
+	return nil, ErrStageNotFound
 }
 
 func (sm *serviceManager) GetAllServices(projectName, stageName string) ([]*models.ExpandedService, error) {
@@ -75,7 +75,7 @@ func (sm *serviceManager) GetAllServices(projectName, stageName string) ([]*mode
 		return nil, err
 	}
 	if project == nil {
-		return nil, errProjectNotFound
+		return nil, ErrProjectNotFound
 	}
 
 	for _, stg := range project.Stages {
@@ -83,7 +83,7 @@ func (sm *serviceManager) GetAllServices(projectName, stageName string) ([]*mode
 			return stg.Services, nil
 		}
 	}
-	return nil, errStageNotFound
+	return nil, ErrStageNotFound
 }
 
 func (sm *serviceManager) CreateService(projectName string, params *operations.CreateServiceParams) error {
@@ -106,7 +106,7 @@ func (sm *serviceManager) CreateService(projectName string, params *operations.C
 		service, _ := sm.GetService(projectName, stage.StageName, *params.ServiceName)
 		if service != nil {
 			log.Infof("Service %s already exists in project %s", *params.ServiceName, projectName)
-			return errServiceAlreadyExists
+			return ErrServiceAlreadyExists
 		}
 
 		log.Infof("Creating service %s in project %s", *params.ServiceName, projectName)

--- a/shipyard-controller/handler/shipyardcontroller.go
+++ b/shipyard-controller/handler/shipyardcontroller.go
@@ -19,7 +19,7 @@ import (
 
 const maxRepoReadRetries = 5
 
-var errNoMatchingEvent = errors.New("no matching event found")
+var ErrNoMatchingEvent = errors.New("no matching event found")
 var shipyardControllerInstance *shipyardController
 
 //go:generate moq -pkg fake -skip-ensure -out ./fake/shipyardcontroller.go . IShipyardController
@@ -413,7 +413,7 @@ func (sc *shipyardController) handleStartedEvent(event models.Event) error {
 	} else if len(events) == 0 {
 		msg := "no matching '.triggered' event for event " + event.ID + " with triggeredid " + event.Triggeredid
 		log.Error(msg)
-		return errNoMatchingEvent
+		return ErrNoMatchingEvent
 	}
 
 	sc.onSequenceTaskStarted(event)
@@ -569,7 +569,7 @@ func (sc *shipyardController) handleFinishedEvent(event models.Event) error {
 	} else if len(startedEvents) == 0 {
 		msg := "no matching '.started' event for event " + event.ID + " with triggeredid " + event.Triggeredid
 		log.Error(msg)
-		return errNoMatchingEvent
+		return ErrNoMatchingEvent
 	}
 
 	// persist the .finished event
@@ -608,7 +608,7 @@ func (sc *shipyardController) handleFinishedEvent(event models.Event) error {
 		if len(triggeredEvents) == 0 {
 			msg := "no matching '.triggered' event for event " + event.ID + " with triggeredid " + event.Triggeredid
 			log.Error(msg)
-			return errNoMatchingEvent
+			return ErrNoMatchingEvent
 		}
 		// if the previously deleted '.started' event was the last, the '.triggered' event can be removed
 		log.Info("triggered event will be deleted")
@@ -721,8 +721,20 @@ func (sc *shipyardController) GetAllTriggeredEvents(filter common.EventFilter) (
 	return allEvents, nil
 }
 
-func (sc *shipyardController) GetTriggeredEventsOfProject(project string, filter common.EventFilter) ([]models.Event, error) {
-	return sc.eventRepo.GetEvents(project, filter, common.TriggeredEvent)
+func (sc *shipyardController) GetTriggeredEventsOfProject(projectName string, filter common.EventFilter) ([]models.Event, error) {
+	project, err := sc.projectRepo.GetProject(projectName)
+	if err != nil {
+		return nil, err
+	} else if project == nil {
+		return nil, ErrProjectNotFound
+	}
+	events, err := sc.eventRepo.GetEvents(projectName, filter, common.TriggeredEvent)
+	if err != nil && err != db.ErrNoEventFound {
+		return nil, err
+	} else if err != nil && err == db.ErrNoEventFound {
+		return []models.Event{}, nil
+	}
+	return events, nil
 }
 
 func (sc *shipyardController) getEvents(project string, filter common.EventFilter, status common.EventStatus, nrRetries int) ([]models.Event, error) {

--- a/shipyard-controller/handler/shipyardcontroller_test.go
+++ b/shipyard-controller/handler/shipyardcontroller_test.go
@@ -375,8 +375,8 @@ func Test_eventManager_handleStartedEvent(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Errorf("handleStartedEvent() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			if tt.wantErrNoMatchingEvent && (err != errNoMatchingEvent) {
-				t.Errorf("handleStartedEvent() expected errNoMatchingEvent but got %v", err)
+			if tt.wantErrNoMatchingEvent && (err != ErrNoMatchingEvent) {
+				t.Errorf("handleStartedEvent() expected ErrNoMatchingEvent but got %v", err)
 			}
 		})
 	}

--- a/shipyard-controller/handler/shipyardcontroller_test.go
+++ b/shipyard-controller/handler/shipyardcontroller_test.go
@@ -188,7 +188,9 @@ func Test_eventManager_GetTriggeredEventsOfProject(t *testing.T) {
 		{
 			name: "Get triggered events for project",
 			fields: fields{
-				projectRepo: nil,
+				projectRepo: &db_mock.ProjectRepoMock{GetProjectFunc: func(projectName string) (*models.ExpandedProject, error) {
+					return &models.ExpandedProject{ProjectName: projectName}, nil
+				}},
 				triggeredEventRepo: &db_mock.EventRepoMock{
 					GetEventsFunc: func(project string, filter common.EventFilter, status ...common.EventStatus) ([]models.Event, error) {
 						return []models.Event{fake.GetTestTriggeredEvent()}, nil

--- a/shipyard-controller/handler/stagehandler.go
+++ b/shipyard-controller/handler/stagehandler.go
@@ -52,7 +52,7 @@ func (sh *StageHandler) GetAllStages(c *gin.Context) {
 
 	allStages, err := sh.StageManager.GetAllStages(params.ProjectName)
 	if err != nil {
-		if err == errProjectNotFound {
+		if err == ErrProjectNotFound {
 			SetNotFoundErrorResponse(err, c)
 			return
 		}
@@ -103,11 +103,11 @@ func (sh *StageHandler) GetStage(c *gin.Context) {
 
 	stage, err := sh.StageManager.GetStage(projectName, stageName)
 	if err != nil {
-		if err == errProjectNotFound {
+		if err == ErrProjectNotFound {
 			SetNotFoundErrorResponse(err, c)
 			return
 		}
-		if err == errStageNotFound {
+		if err == ErrStageNotFound {
 			SetNotFoundErrorResponse(err, c)
 		}
 

--- a/shipyard-controller/handler/stagehandler_test.go
+++ b/shipyard-controller/handler/stagehandler_test.go
@@ -30,7 +30,7 @@ func TestGetStage(t *testing.T) {
 			fields: fields{
 				StageManager: &fake.IStageManagerMock{
 					GetStageFunc: func(projectName string, stageName string) (*models.ExpandedStage, error) {
-						return nil, errProjectNotFound
+						return nil, ErrProjectNotFound
 					},
 				},
 			},
@@ -41,7 +41,7 @@ func TestGetStage(t *testing.T) {
 			fields: fields{
 				StageManager: &fake.IStageManagerMock{
 					GetStageFunc: func(projectName string, stageName string) (*models.ExpandedStage, error) {
-						return nil, errStageNotFound
+						return nil, ErrStageNotFound
 					},
 				},
 			},
@@ -106,7 +106,7 @@ func TestGetStages(t *testing.T) {
 			fields: fields{
 				StageManager: &fake.IStageManagerMock{
 					GetAllStagesFunc: func(projectName string) ([]*models.ExpandedStage, error) {
-						return nil, errProjectNotFound
+						return nil, ErrProjectNotFound
 					},
 				},
 			},

--- a/shipyard-controller/handler/stagemanager.go
+++ b/shipyard-controller/handler/stagemanager.go
@@ -27,7 +27,7 @@ func (sm *StageManager) GetAllStages(projectName string) ([]*models.ExpandedStag
 		return nil, err
 	}
 	if project == nil {
-		return nil, errProjectNotFound
+		return nil, ErrProjectNotFound
 	}
 
 	return project.Stages, nil
@@ -39,7 +39,7 @@ func (sm *StageManager) GetStage(projectName, stageName string) (*models.Expande
 		return nil, err
 	}
 	if project == nil {
-		return nil, errProjectNotFound
+		return nil, ErrProjectNotFound
 	}
 
 	for _, stg := range project.Stages {
@@ -47,6 +47,6 @@ func (sm *StageManager) GetStage(projectName, stageName string) (*models.Expande
 			return stg, nil
 		}
 	}
-	return nil, errStageNotFound
+	return nil, ErrStageNotFound
 
 }

--- a/shipyard-controller/handler/stagemanager_test.go
+++ b/shipyard-controller/handler/stagemanager_test.go
@@ -32,7 +32,7 @@ func TestGetAllStages_ProjectNotFound(t *testing.T) {
 
 	stage, err := instance.GetAllStages("my-project")
 	assert.Nil(t, stage)
-	assert.Equal(t, errProjectNotFound, err)
+	assert.Equal(t, ErrProjectNotFound, err)
 
 }
 
@@ -84,7 +84,7 @@ func TestGetStage_ProjectNotFound(t *testing.T) {
 
 	stage, err := instance.GetStage("my-project", "the-stage")
 	assert.Nil(t, stage)
-	assert.Equal(t, errProjectNotFound, err)
+	assert.Equal(t, ErrProjectNotFound, err)
 
 }
 
@@ -108,5 +108,5 @@ func TestGetStage_StageNotFound(t *testing.T) {
 	}
 	stage, err := instance.GetStage("my-project", "unknown-stage")
 	assert.Nil(t, stage)
-	assert.Equal(t, errStageNotFound, err)
+	assert.Equal(t, ErrStageNotFound, err)
 }


### PR DESCRIPTION
Closes #5132

This PR introduces the following behavior:
Instead of returning a 500 error code when no available .triggered events for a particular project are found, now either a 200 response with an empty result set ist returned, if the project is available. If a query for a non-existing project is sent, a 404 response with the message that the project could not be found is sent.