### PR TITLE
fix(configuration-service): Implemented endpoints for deleting service and stage resources (#5136)

### DIFF
--- a/configuration-service/common/common.go
+++ b/configuration-service/common/common.go
@@ -1,0 +1,9 @@
+package common
+
+const ConfigurationServiceName = "configuration-service"
+
+const ProjectDoesNotExistErrorMsg = "Project does not exist"
+const StageDoesNotExistErrorMsg = "Stage does not exist"
+const ServiceDoesNotExistErrorMsg = "Service does not exist"
+
+const CannotCheckOutBranchErrorMsg = "Could not check out branch"

--- a/configuration-service/handlers/project.go
+++ b/configuration-service/handlers/project.go
@@ -25,7 +25,7 @@ type projectMetadata struct {
 
 // PostProjectHandlerFunc creates a new project
 func PostProjectHandlerFunc(params project.PostProjectParams) middleware.Responder {
-	logger := keptncommon.NewLogger("", "", "configuration-service")
+	logger := keptncommon.NewLogger("", "", common.ConfigurationServiceName)
 	projectConfigPath := config.ConfigDir + "/" + params.Project.ProjectName
 
 	// check if the project already exists
@@ -96,7 +96,7 @@ func PostProjectHandlerFunc(params project.PostProjectParams) middleware.Respond
 
 // PutProjectProjectNameHandlerFunc updates a project
 func PutProjectProjectNameHandlerFunc(params project.PutProjectProjectNameParams) middleware.Responder {
-	logger := keptncommon.NewLogger("", "", "configuration-service")
+	logger := keptncommon.NewLogger("", "", common.ConfigurationServiceName)
 
 	projectName := params.Project.ProjectName
 
@@ -114,14 +114,14 @@ func PutProjectProjectNameHandlerFunc(params project.PutProjectProjectNameParams
 
 		}
 	} else {
-		return project.NewPostProjectBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String("Project does not exist")})
+		return project.NewPostProjectBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String(common.ProjectDoesNotExistErrorMsg)})
 	}
 	return project.NewPutProjectProjectNameNoContent()
 }
 
 // DeleteProjectProjectNameHandlerFunc deletes a project
 func DeleteProjectProjectNameHandlerFunc(params project.DeleteProjectProjectNameParams) middleware.Responder {
-	logger := keptncommon.NewLogger("", "", "configuration-service")
+	logger := keptncommon.NewLogger("", "", common.ConfigurationServiceName)
 
 	common.LockProject(params.ProjectName)
 	defer common.UnlockProject(params.ProjectName)

--- a/configuration-service/handlers/project_resource.go
+++ b/configuration-service/handlers/project_resource.go
@@ -16,9 +16,9 @@ import (
 
 // GetProjectProjectNameResourceHandlerFunc get list of project resources
 func GetProjectProjectNameResourceHandlerFunc(params project_resource.GetProjectProjectNameResourceParams) middleware.Responder {
-	logger := keptncommon.NewLogger("", "", "configuration-service")
+	logger := keptncommon.NewLogger("", "", common.ConfigurationServiceName)
 	if !common.ProjectExists(params.ProjectName) {
-		return project_resource.NewGetProjectProjectNameResourceNotFound().WithPayload(&models.Error{Code: 404, Message: swag.String("Project does not exist")})
+		return project_resource.NewGetProjectProjectNameResourceNotFound().WithPayload(&models.Error{Code: 404, Message: swag.String(common.ProjectDoesNotExistErrorMsg)})
 	}
 
 	common.LockProject(params.ProjectName)
@@ -27,13 +27,13 @@ func GetProjectProjectNameResourceHandlerFunc(params project_resource.GetProject
 	defaultBranch, err := common.GetDefaultBranch(params.ProjectName)
 	if err != nil {
 		logger.Error(fmt.Sprintf("Could not determine default branch of project %s: %s", params.ProjectName, err.Error()))
-		return project_resource.NewGetProjectProjectNameResourceDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
+		return project_resource.NewGetProjectProjectNameResourceDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String(common.CannotCheckOutBranchErrorMsg)})
 	}
 
 	err = common.CheckoutBranch(params.ProjectName, defaultBranch, *params.DisableUpstreamSync)
 	if err != nil {
 		logger.Error(fmt.Sprintf("Could not check out %s branch of project %s: %s", defaultBranch, params.ProjectName, err.Error()))
-		return project_resource.NewGetProjectProjectNameResourceDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
+		return project_resource.NewGetProjectProjectNameResourceDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String(common.CannotCheckOutBranchErrorMsg)})
 	}
 
 	projectConfigPath := config.ConfigDir + "/" + params.ProjectName
@@ -44,9 +44,9 @@ func GetProjectProjectNameResourceHandlerFunc(params project_resource.GetProject
 
 // PutProjectProjectNameResourceHandlerFunc update list of project resources
 func PutProjectProjectNameResourceHandlerFunc(params project_resource.PutProjectProjectNameResourceParams) middleware.Responder {
-	logger := keptncommon.NewLogger("", "", "configuration-service")
+	logger := keptncommon.NewLogger("", "", common.ConfigurationServiceName)
 	if !common.ProjectExists(params.ProjectName) {
-		return project_resource.NewPostProjectProjectNameResourceBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String("Project does not exist")})
+		return project_resource.NewPostProjectProjectNameResourceBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String(common.ProjectDoesNotExistErrorMsg)})
 	}
 
 	common.LockProject(params.ProjectName)
@@ -59,14 +59,14 @@ func PutProjectProjectNameResourceHandlerFunc(params project_resource.PutProject
 	defaultBranch, err := common.GetDefaultBranch(params.ProjectName)
 	if err != nil {
 		logger.Error(fmt.Sprintf("Could not determine default branch of project %s: %s", params.ProjectName, err.Error()))
-		return project_resource.NewPutProjectProjectNameResourceDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
+		return project_resource.NewPutProjectProjectNameResourceDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String(common.CannotCheckOutBranchErrorMsg)})
 	}
 
 	err = common.CheckoutBranch(params.ProjectName, defaultBranch, false)
 	if err != nil {
 		logger.Error(fmt.Sprintf("Could not check out %s branch of project %s", defaultBranch, params.ProjectName))
 		logger.Error(err.Error())
-		return project_resource.NewPutProjectProjectNameResourceBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String("Could not check out branch")})
+		return project_resource.NewPutProjectProjectNameResourceBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String(common.CannotCheckOutBranchErrorMsg)})
 	}
 
 	for _, res := range params.Resources.Resources {
@@ -92,9 +92,9 @@ func PutProjectProjectNameResourceHandlerFunc(params project_resource.PutProject
 
 // PostProjectProjectNameResourceHandlerFunc creates a list of new resources
 func PostProjectProjectNameResourceHandlerFunc(params project_resource.PostProjectProjectNameResourceParams) middleware.Responder {
-	logger := keptncommon.NewLogger("", "", "configuration-service")
+	logger := keptncommon.NewLogger("", "", common.ConfigurationServiceName)
 	if !common.ProjectExists(params.ProjectName) {
-		return project_resource.NewPostProjectProjectNameResourceBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String("Project does not exist")})
+		return project_resource.NewPostProjectProjectNameResourceBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String(common.ProjectDoesNotExistErrorMsg)})
 	}
 
 	common.LockProject(params.ProjectName)
@@ -107,14 +107,14 @@ func PostProjectProjectNameResourceHandlerFunc(params project_resource.PostProje
 	defaultBranch, err := common.GetDefaultBranch(params.ProjectName)
 	if err != nil {
 		logger.Error(fmt.Sprintf("Could not determine default branch of project %s: %s", params.ProjectName, err.Error()))
-		return project_resource.NewPostProjectProjectNameResourceDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
+		return project_resource.NewPostProjectProjectNameResourceDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String(common.CannotCheckOutBranchErrorMsg)})
 	}
 
 	err = common.CheckoutBranch(params.ProjectName, defaultBranch, false)
 	if err != nil {
 		logger.Error(fmt.Sprintf("Could not check out %s branch of project %s", defaultBranch, params.ProjectName))
 		logger.Error(err.Error())
-		return project_resource.NewPostProjectProjectNameResourceBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String("Could not check out branch")})
+		return project_resource.NewPostProjectProjectNameResourceBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String(common.CannotCheckOutBranchErrorMsg)})
 	}
 
 	for _, res := range params.Resources.Resources {
@@ -139,7 +139,7 @@ func PostProjectProjectNameResourceHandlerFunc(params project_resource.PostProje
 
 // GetProjectProjectNameResourceResourceURIHandlerFunc gets the specified resource
 func GetProjectProjectNameResourceResourceURIHandlerFunc(params project_resource.GetProjectProjectNameResourceResourceURIParams) middleware.Responder {
-	logger := keptncommon.NewLogger("", "", "configuration-service")
+	logger := keptncommon.NewLogger("", "", common.ConfigurationServiceName)
 	if !common.ProjectExists(params.ProjectName) {
 		return project_resource.NewGetProjectProjectNameResourceResourceURINotFound().WithPayload(&models.Error{Code: 404, Message: swag.String("Project not found")})
 	}
@@ -151,12 +151,12 @@ func GetProjectProjectNameResourceResourceURIHandlerFunc(params project_resource
 	defaultBranch, err := common.GetDefaultBranch(params.ProjectName)
 	if err != nil {
 		logger.Error(fmt.Sprintf("Could not determine default branch of project %s: %s", params.ProjectName, err.Error()))
-		return project_resource.NewGetProjectProjectNameResourceDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
+		return project_resource.NewGetProjectProjectNameResourceDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String(common.CannotCheckOutBranchErrorMsg)})
 	}
 	err = common.CheckoutBranch(params.ProjectName, defaultBranch, *params.DisableUpstreamSync)
 	if err != nil {
 		logger.Error(fmt.Sprintf("Could not check out %s branch of project %s: %s", defaultBranch, params.ProjectName, err.Error()))
-		return project_resource.NewGetProjectProjectNameResourceResourceURIDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
+		return project_resource.NewGetProjectProjectNameResourceResourceURIDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String(common.CannotCheckOutBranchErrorMsg)})
 	}
 
 	unescapedResourceName, err := url.QueryUnescape(params.ResourceURI)
@@ -193,9 +193,9 @@ func GetProjectProjectNameResourceResourceURIHandlerFunc(params project_resource
 
 // PutProjectProjectNameResourceResourceURIHandlerFunc updates a resource
 func PutProjectProjectNameResourceResourceURIHandlerFunc(params project_resource.PutProjectProjectNameResourceResourceURIParams) middleware.Responder {
-	logger := keptncommon.NewLogger("", "", "configuration-service")
+	logger := keptncommon.NewLogger("", "", common.ConfigurationServiceName)
 	if !common.ProjectExists(params.ProjectName) {
-		return project_resource.NewPutProjectProjectNameResourceResourceURIBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String("Project does not exist")})
+		return project_resource.NewPutProjectProjectNameResourceResourceURIBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String(common.ProjectDoesNotExistErrorMsg)})
 	}
 
 	common.LockProject(params.ProjectName)
@@ -204,7 +204,7 @@ func PutProjectProjectNameResourceResourceURIHandlerFunc(params project_resource
 	defaultBranch, err := common.GetDefaultBranch(params.ProjectName)
 	if err != nil {
 		logger.Error(fmt.Sprintf("Could not determine default branch of project %s: %s", params.ProjectName, err.Error()))
-		return project_resource.NewPutProjectProjectNameResourceResourceURIDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
+		return project_resource.NewPutProjectProjectNameResourceResourceURIDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String(common.CannotCheckOutBranchErrorMsg)})
 	}
 
 	projectConfigPath := config.ConfigDir + "/" + params.ProjectName
@@ -214,7 +214,7 @@ func PutProjectProjectNameResourceResourceURIHandlerFunc(params project_resource
 	err = common.CheckoutBranch(params.ProjectName, defaultBranch, false)
 	if err != nil {
 		logger.Error(fmt.Sprintf("Could not check out %s branch of project %s: %s", defaultBranch, params.ProjectName, err.Error()))
-		return project_resource.NewPutProjectProjectNameResourceResourceURIBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String("Could not check out branch")})
+		return project_resource.NewPutProjectProjectNameResourceResourceURIBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String(common.CannotCheckOutBranchErrorMsg)})
 	}
 
 	filePath := projectConfigPath + "/" + params.ResourceURI
@@ -238,9 +238,9 @@ func PutProjectProjectNameResourceResourceURIHandlerFunc(params project_resource
 
 // DeleteProjectProjectNameResourceResourceURIHandlerFunc deletes a project resource
 func DeleteProjectProjectNameResourceResourceURIHandlerFunc(params project_resource.DeleteProjectProjectNameResourceResourceURIParams) middleware.Responder {
-	logger := keptncommon.NewLogger("", "", "configuration-service")
+	logger := keptncommon.NewLogger("", "", common.ConfigurationServiceName)
 	if !common.ProjectExists(params.ProjectName) {
-		return project_resource.NewDeleteProjectProjectNameResourceResourceURIBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String("Project does not exist")})
+		return project_resource.NewDeleteProjectProjectNameResourceResourceURIBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String(common.ProjectDoesNotExistErrorMsg)})
 	}
 
 	common.LockProject(params.ProjectName)
@@ -249,13 +249,13 @@ func DeleteProjectProjectNameResourceResourceURIHandlerFunc(params project_resou
 	defaultBranch, err := common.GetDefaultBranch(params.ProjectName)
 	if err != nil {
 		logger.Error(fmt.Sprintf("Could not determine default branch of project %s: %s", params.ProjectName, err.Error()))
-		return project_resource.NewDeleteProjectProjectNameResourceResourceURIDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
+		return project_resource.NewDeleteProjectProjectNameResourceResourceURIDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String(common.CannotCheckOutBranchErrorMsg)})
 	}
 
 	err = common.CheckoutBranch(params.ProjectName, defaultBranch, false)
 	if err != nil {
 		logger.Error(fmt.Sprintf("Could not check out %s branch of project %s: %s", defaultBranch, params.ProjectName, err.Error()))
-		return project_resource.NewDeleteProjectProjectNameResourceResourceURIDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
+		return project_resource.NewDeleteProjectProjectNameResourceResourceURIDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String(common.CannotCheckOutBranchErrorMsg)})
 	}
 
 	unescapedResourceName, err := url.QueryUnescape(params.ResourceURI)

--- a/configuration-service/handlers/service.go
+++ b/configuration-service/handlers/service.go
@@ -22,7 +22,7 @@ type serviceMetadata struct {
 
 // PostProjectProjectNameStageStageNameServiceHandlerFunc creates a new service
 func PostProjectProjectNameStageStageNameServiceHandlerFunc(params service.PostProjectProjectNameStageStageNameServiceParams) middleware.Responder {
-	logger := keptncommon.NewLogger("", "", "configuration-service")
+	logger := keptncommon.NewLogger("", "", common.ConfigurationServiceName)
 
 	common.LockProject(params.ProjectName)
 	defer common.UnlockProject(params.ProjectName)
@@ -44,7 +44,7 @@ func PostProjectProjectNameStageStageNameServiceHandlerFunc(params service.PostP
 	if err != nil {
 		logger.Error(fmt.Sprintf("Could not check out %s branch of project %s", params.StageName, params.ProjectName))
 		logger.Error(err.Error())
-		return service.NewPostProjectProjectNameStageStageNameServiceDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
+		return service.NewPostProjectProjectNameStageStageNameServiceDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String(common.CannotCheckOutBranchErrorMsg)})
 	}
 
 	err = os.MkdirAll(servicePath, os.ModePerm)
@@ -73,7 +73,7 @@ func PutProjectProjectNameStageStageNameServiceServiceNameHandlerFunc(params ser
 
 // DeleteProjectProjectNameStageStageNameServiceServiceNameHandlerFunc deletes a service
 func DeleteProjectProjectNameStageStageNameServiceServiceNameHandlerFunc(params service.DeleteProjectProjectNameStageStageNameServiceServiceNameParams) middleware.Responder {
-	logger := keptncommon.NewLogger("", "", "configuration-service")
+	logger := keptncommon.NewLogger("", "", common.ConfigurationServiceName)
 
 	common.LockProject(params.ProjectName)
 	defer common.UnlockProject(params.ProjectName)
@@ -94,7 +94,7 @@ func DeleteProjectProjectNameStageStageNameServiceServiceNameHandlerFunc(params 
 	err := common.CheckoutBranch(params.ProjectName, params.StageName, false)
 	if err != nil {
 		logger.Error(fmt.Sprintf("Could not check out %s branch of project %s: %s", params.StageName, params.ProjectName, err.Error()))
-		return service.NewDeleteProjectProjectNameStageStageNameServiceServiceNameDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
+		return service.NewDeleteProjectProjectNameStageStageNameServiceServiceNameDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String(common.CannotCheckOutBranchErrorMsg)})
 	}
 
 	err = os.RemoveAll(servicePath)

--- a/configuration-service/handlers/service_default_resource.go
+++ b/configuration-service/handlers/service_default_resource.go
@@ -23,9 +23,9 @@ func GetProjectProjectNameServiceServiceNameResourceResourceURIHandlerFunc(param
 
 // PostProjectProjectNameServiceServiceNameResourceHandlerFunc creates a list of new default resources
 func PostProjectProjectNameServiceServiceNameResourceHandlerFunc(params service_default_resource.PostProjectProjectNameServiceServiceNameResourceParams) middleware.Responder {
-	logger := keptncommon.NewLogger("", "", "configuration-service")
+	logger := keptncommon.NewLogger("", "", common.ConfigurationServiceName)
 	if !common.ProjectExists(params.ProjectName) {
-		return service_default_resource.NewPostProjectProjectNameServiceServiceNameResourceDefault(404).WithPayload(&models.Error{Code: 400, Message: swag.String("Project does not exist")})
+		return service_default_resource.NewPostProjectProjectNameServiceServiceNameResourceDefault(404).WithPayload(&models.Error{Code: 400, Message: swag.String(common.ProjectDoesNotExistErrorMsg)})
 	}
 
 	common.LockProject(params.ProjectName)
@@ -40,7 +40,7 @@ func PostProjectProjectNameServiceServiceNameResourceHandlerFunc(params service_
 	defaultBranch, err := common.GetDefaultBranch(params.ProjectName)
 	if err != nil {
 		logger.Error(fmt.Sprintf("Could not determine default branch of project %s: %s", params.ProjectName, err.Error()))
-		return service_default_resource.NewPostProjectProjectNameServiceServiceNameResourceDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
+		return service_default_resource.NewPostProjectProjectNameServiceServiceNameResourceDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String(common.CannotCheckOutBranchErrorMsg)})
 	}
 	if defaultBranch == "" {
 		defaultBranch = "master"
@@ -50,7 +50,7 @@ func PostProjectProjectNameServiceServiceNameResourceHandlerFunc(params service_
 			continue
 		}
 		if !common.ServiceExists(params.ProjectName, branch, params.ServiceName, false) {
-			return service_default_resource.NewPostProjectProjectNameServiceServiceNameResourceDefault(404).WithPayload(&models.Error{Code: 400, Message: swag.String("Service does not exist")})
+			return service_default_resource.NewPostProjectProjectNameServiceServiceNameResourceDefault(404).WithPayload(&models.Error{Code: 400, Message: swag.String(common.ServiceDoesNotExistErrorMsg)})
 		}
 		serviceConfigPath := config.ConfigDir + "/" + params.ProjectName + "/" + params.ServiceName
 
@@ -60,7 +60,7 @@ func PostProjectProjectNameServiceServiceNameResourceHandlerFunc(params service_
 		if err != nil {
 			logger.Error(fmt.Sprintf("Could not check out %s branch of project %s", branch, params.ProjectName))
 			logger.Error(err.Error())
-			return service_default_resource.NewPostProjectProjectNameServiceServiceNameResourceBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String("Could not check out branch")})
+			return service_default_resource.NewPostProjectProjectNameServiceServiceNameResourceBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String(common.CannotCheckOutBranchErrorMsg)})
 		}
 
 		for _, res := range params.Resources.Resources {
@@ -84,9 +84,9 @@ func PostProjectProjectNameServiceServiceNameResourceHandlerFunc(params service_
 
 // PutProjectProjectNameServiceServiceNameResourceHandlerFunc updates a list of default resources
 func PutProjectProjectNameServiceServiceNameResourceHandlerFunc(params service_default_resource.PutProjectProjectNameServiceServiceNameResourceParams) middleware.Responder {
-	logger := keptncommon.NewLogger("", "", "configuration-service")
+	logger := keptncommon.NewLogger("", "", common.ConfigurationServiceName)
 	if !common.ProjectExists(params.ProjectName) {
-		return service_default_resource.NewPutProjectProjectNameServiceServiceNameResourceDefault(404).WithPayload(&models.Error{Code: 400, Message: swag.String("Project does not exist")})
+		return service_default_resource.NewPutProjectProjectNameServiceServiceNameResourceDefault(404).WithPayload(&models.Error{Code: 400, Message: swag.String(common.ProjectDoesNotExistErrorMsg)})
 	}
 
 	common.LockProject(params.ProjectName)
@@ -101,7 +101,7 @@ func PutProjectProjectNameServiceServiceNameResourceHandlerFunc(params service_d
 	defaultBranch, err := common.GetDefaultBranch(params.ProjectName)
 	if err != nil {
 		logger.Error(fmt.Sprintf("Could not determine default branch of project %s: %s", params.ProjectName, err.Error()))
-		return service_default_resource.NewPutProjectProjectNameServiceServiceNameResourceDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
+		return service_default_resource.NewPutProjectProjectNameServiceServiceNameResourceDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String(common.CannotCheckOutBranchErrorMsg)})
 	}
 	if defaultBranch == "" {
 		defaultBranch = "master"
@@ -111,7 +111,7 @@ func PutProjectProjectNameServiceServiceNameResourceHandlerFunc(params service_d
 			continue
 		}
 		if !common.ServiceExists(params.ProjectName, branch, params.ServiceName, false) {
-			return service_default_resource.NewPutProjectProjectNameServiceServiceNameResourceDefault(404).WithPayload(&models.Error{Code: 400, Message: swag.String("Service does not exist")})
+			return service_default_resource.NewPutProjectProjectNameServiceServiceNameResourceDefault(404).WithPayload(&models.Error{Code: 400, Message: swag.String(common.ServiceDoesNotExistErrorMsg)})
 		}
 		serviceConfigPath := config.ConfigDir + "/" + params.ProjectName + "/" + params.ServiceName
 
@@ -121,7 +121,7 @@ func PutProjectProjectNameServiceServiceNameResourceHandlerFunc(params service_d
 		if err != nil {
 			logger.Error(fmt.Sprintf("Could not check out %s branch of project %s", branch, params.ProjectName))
 			logger.Error(err.Error())
-			return service_default_resource.NewPutProjectProjectNameServiceServiceNameResourceDefault(500).WithPayload(&models.Error{Code: 400, Message: swag.String("Could not check out branch")})
+			return service_default_resource.NewPutProjectProjectNameServiceServiceNameResourceDefault(500).WithPayload(&models.Error{Code: 400, Message: swag.String(common.CannotCheckOutBranchErrorMsg)})
 		}
 
 		for _, res := range params.Resources.Resources {
@@ -145,9 +145,9 @@ func PutProjectProjectNameServiceServiceNameResourceHandlerFunc(params service_d
 
 // PutProjectProjectNameServiceServiceNameResourceResourceURIHandlerFunc updates the specified resource for the service
 func PutProjectProjectNameServiceServiceNameResourceResourceURIHandlerFunc(params service_default_resource.PutProjectProjectNameServiceServiceNameResourceResourceURIParams) middleware.Responder {
-	logger := keptncommon.NewLogger("", "", "configuration-service")
+	logger := keptncommon.NewLogger("", "", common.ConfigurationServiceName)
 	if !common.ProjectExists(params.ProjectName) {
-		return service_default_resource.NewPutProjectProjectNameServiceServiceNameResourceResourceURIDefault(404).WithPayload(&models.Error{Code: 400, Message: swag.String("Project does not exist")})
+		return service_default_resource.NewPutProjectProjectNameServiceServiceNameResourceResourceURIDefault(404).WithPayload(&models.Error{Code: 400, Message: swag.String(common.ProjectDoesNotExistErrorMsg)})
 	}
 
 	common.LockProject(params.ProjectName)
@@ -162,7 +162,7 @@ func PutProjectProjectNameServiceServiceNameResourceResourceURIHandlerFunc(param
 	defaultBranch, err := common.GetDefaultBranch(params.ProjectName)
 	if err != nil {
 		logger.Error(fmt.Sprintf("Could not determine default branch of project %s: %s", params.ProjectName, err.Error()))
-		return service_default_resource.NewPutProjectProjectNameServiceServiceNameResourceResourceURIDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
+		return service_default_resource.NewPutProjectProjectNameServiceServiceNameResourceResourceURIDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String(common.CannotCheckOutBranchErrorMsg)})
 	}
 	if defaultBranch == "" {
 		defaultBranch = "master"
@@ -172,7 +172,7 @@ func PutProjectProjectNameServiceServiceNameResourceResourceURIHandlerFunc(param
 			continue
 		}
 		if !common.ServiceExists(params.ProjectName, branch, params.ServiceName, false) {
-			return service_default_resource.NewPutProjectProjectNameServiceServiceNameResourceResourceURIDefault(404).WithPayload(&models.Error{Code: 400, Message: swag.String("Service does not exist")})
+			return service_default_resource.NewPutProjectProjectNameServiceServiceNameResourceResourceURIDefault(404).WithPayload(&models.Error{Code: 400, Message: swag.String(common.ServiceDoesNotExistErrorMsg)})
 		}
 		serviceConfigPath := config.ConfigDir + "/" + params.ProjectName + "/" + params.ServiceName
 
@@ -182,7 +182,7 @@ func PutProjectProjectNameServiceServiceNameResourceResourceURIHandlerFunc(param
 		if err != nil {
 			logger.Error(fmt.Sprintf("Could not check out %s branch of project %s", branch, params.ProjectName))
 			logger.Error(err.Error())
-			return service_default_resource.NewPutProjectProjectNameServiceServiceNameResourceResourceURIDefault(500).WithPayload(&models.Error{Code: 400, Message: swag.String("Could not check out branch")})
+			return service_default_resource.NewPutProjectProjectNameServiceServiceNameResourceResourceURIDefault(500).WithPayload(&models.Error{Code: 400, Message: swag.String(common.CannotCheckOutBranchErrorMsg)})
 		}
 
 		filePath := serviceConfigPath + "/" + params.ResourceURI
@@ -203,9 +203,9 @@ func PutProjectProjectNameServiceServiceNameResourceResourceURIHandlerFunc(param
 
 // DeleteProjectProjectNameServiceServiceNameResourceResourceURIHandlerFunc deletes the specified resource from the service
 func DeleteProjectProjectNameServiceServiceNameResourceResourceURIHandlerFunc(params service_default_resource.DeleteProjectProjectNameServiceServiceNameResourceResourceURIParams) middleware.Responder {
-	logger := keptncommon.NewLogger("", "", "configuration-service")
+	logger := keptncommon.NewLogger("", "", common.ConfigurationServiceName)
 	if !common.ProjectExists(params.ProjectName) {
-		return service_default_resource.NewDeleteProjectProjectNameServiceServiceNameResourceResourceURIDefault(404).WithPayload(&models.Error{Code: 400, Message: swag.String("Project does not exist")})
+		return service_default_resource.NewDeleteProjectProjectNameServiceServiceNameResourceResourceURIDefault(404).WithPayload(&models.Error{Code: 400, Message: swag.String(common.ProjectDoesNotExistErrorMsg)})
 	}
 
 	common.LockProject(params.ProjectName)
@@ -220,7 +220,7 @@ func DeleteProjectProjectNameServiceServiceNameResourceResourceURIHandlerFunc(pa
 	defaultBranch, err := common.GetDefaultBranch(params.ProjectName)
 	if err != nil {
 		logger.Error(fmt.Sprintf("Could not determine default branch of project %s: %s", params.ProjectName, err.Error()))
-		return service_default_resource.NewDeleteProjectProjectNameServiceServiceNameResourceResourceURIDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
+		return service_default_resource.NewDeleteProjectProjectNameServiceServiceNameResourceResourceURIDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String(common.CannotCheckOutBranchErrorMsg)})
 	}
 	if defaultBranch == "" {
 		defaultBranch = "master"
@@ -230,7 +230,7 @@ func DeleteProjectProjectNameServiceServiceNameResourceResourceURIHandlerFunc(pa
 			continue
 		}
 		if !common.ServiceExists(params.ProjectName, branch, params.ServiceName, false) {
-			return service_default_resource.NewDeleteProjectProjectNameServiceServiceNameResourceResourceURIDefault(404).WithPayload(&models.Error{Code: 400, Message: swag.String("Service does not exist")})
+			return service_default_resource.NewDeleteProjectProjectNameServiceServiceNameResourceResourceURIDefault(404).WithPayload(&models.Error{Code: 400, Message: swag.String(common.ServiceDoesNotExistErrorMsg)})
 		}
 		serviceConfigPath := config.ConfigDir + "/" + params.ProjectName + "/" + params.ServiceName
 
@@ -240,7 +240,7 @@ func DeleteProjectProjectNameServiceServiceNameResourceResourceURIHandlerFunc(pa
 		if err != nil {
 			logger.Error(fmt.Sprintf("Could not check out %s branch of project %s", branch, params.ProjectName))
 			logger.Error(err.Error())
-			return service_default_resource.NewDeleteProjectProjectNameServiceServiceNameResourceResourceURIDefault(500).WithPayload(&models.Error{Code: 400, Message: swag.String("Could not check out branch")})
+			return service_default_resource.NewDeleteProjectProjectNameServiceServiceNameResourceResourceURIDefault(500).WithPayload(&models.Error{Code: 400, Message: swag.String(common.CannotCheckOutBranchErrorMsg)})
 		}
 
 		filePath := serviceConfigPath + "/" + params.ResourceURI

--- a/configuration-service/handlers/service_resource.go
+++ b/configuration-service/handlers/service_resource.go
@@ -25,7 +25,7 @@ import (
 // GetProjectProjectNameStageStageNameServiceServiceNameResourceHandlerFunc get list of resources for the service
 func GetProjectProjectNameStageStageNameServiceServiceNameResourceHandlerFunc(
 	params service_resource.GetProjectProjectNameStageStageNameServiceServiceNameResourceParams) middleware.Responder {
-	logger := keptncommon.NewLogger("", "", "configuration-service")
+	logger := keptncommon.NewLogger("", "", common.ConfigurationServiceName)
 
 	common.LockProject(params.ProjectName)
 	defer common.UnlockProject(params.ProjectName)
@@ -41,7 +41,7 @@ func GetProjectProjectNameStageStageNameServiceServiceNameResourceHandlerFunc(
 		logger.Error(fmt.Sprintf("Could not check out %s branch of project %s", params.StageName, params.ProjectName))
 		logger.Error(err.Error())
 		return service_resource.NewGetProjectProjectNameStageStageNameServiceServiceNameResourceDefault(500).
-			WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
+			WithPayload(&models.Error{Code: 500, Message: swag.String(common.CannotCheckOutBranchErrorMsg)})
 	}
 
 	serviceConfigPath := config.ConfigDir + "/" + params.ProjectName + "/" + params.ServiceName
@@ -52,7 +52,7 @@ func GetProjectProjectNameStageStageNameServiceServiceNameResourceHandlerFunc(
 // GetProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIHandlerFunc gets the specified resource
 func GetProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIHandlerFunc(
 	params service_resource.GetProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIParams) middleware.Responder {
-	logger := keptncommon.NewLogger("", "", "configuration-service")
+	logger := keptncommon.NewLogger("", "", common.ConfigurationServiceName)
 
 	common.LockProject(params.ProjectName)
 	defer common.UnlockProject(params.ProjectName)
@@ -75,7 +75,7 @@ func GetProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIHan
 		logger.Error(fmt.Sprintf("Could not check out %s branch of project %s", params.StageName, params.ProjectName))
 		logger.Error(err.Error())
 		return service_resource.NewGetProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIDefault(500).
-			WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
+			WithPayload(&models.Error{Code: 500, Message: swag.String(common.CannotCheckOutBranchErrorMsg)})
 	}
 
 	// archive the Helm chart
@@ -134,7 +134,7 @@ func GetProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIHan
 // DeleteProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIHandlerFunc deletes the specified resource
 func DeleteProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIHandlerFunc(
 	params service_resource.DeleteProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIParams) middleware.Responder {
-	logger := keptncommon.NewLogger("", "", "configuration-service")
+	logger := keptncommon.NewLogger("", "", common.ConfigurationServiceName)
 
 	common.LockProject(params.ProjectName)
 	defer common.UnlockProject(params.ProjectName)
@@ -150,7 +150,7 @@ func DeleteProjectProjectNameStageStageNameServiceServiceNameResourceResourceURI
 		logger.Error(fmt.Sprintf("Could not check out %s branch of project %s", params.StageName, params.ProjectName))
 		logger.Error(err.Error())
 		return service_resource.NewGetProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIDefault(500).
-			WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
+			WithPayload(&models.Error{Code: 500, Message: swag.String(common.CannotCheckOutBranchErrorMsg)})
 	}
 
 	serviceConfigPath := config.ConfigDir + "/" + params.ProjectName + "/" + params.ServiceName
@@ -184,7 +184,7 @@ func DeleteProjectProjectNameStageStageNameServiceServiceNameResourceResourceURI
 // PostProjectProjectNameStageStageNameServiceServiceNameResourceHandlerFunc creates a new resource
 func PostProjectProjectNameStageStageNameServiceServiceNameResourceHandlerFunc(
 	params service_resource.PostProjectProjectNameStageStageNameServiceServiceNameResourceParams) middleware.Responder {
-	logger := keptncommon.NewLogger("", "", "configuration-service")
+	logger := keptncommon.NewLogger("", "", common.ConfigurationServiceName)
 	if !common.ProjectExists(params.ProjectName) {
 		return service_resource.NewPostProjectProjectNameStageStageNameServiceServiceNameResourceBadRequest().
 			WithPayload(&models.Error{Code: 400, Message: swag.String("Project " + params.ProjectName + " does not exist")})
@@ -211,7 +211,7 @@ func PostProjectProjectNameStageStageNameServiceServiceNameResourceHandlerFunc(
 		logger.Error(fmt.Sprintf("Could not check out %s branch of project %s", params.StageName, params.ProjectName))
 		logger.Error(err.Error())
 		return service_resource.NewPostProjectProjectNameStageStageNameServiceServiceNameResourceBadRequest().
-			WithPayload(&models.Error{Code: 400, Message: swag.String("Could not check out branch")})
+			WithPayload(&models.Error{Code: 400, Message: swag.String(common.CannotCheckOutBranchErrorMsg)})
 	}
 
 	for _, res := range params.Resources.Resources {
@@ -309,7 +309,7 @@ func untarHelm(res *models.Resource, logger *keptncommon.Logger, filePath string
 // PutProjectProjectNameStageStageNameServiceServiceNameResourceHandlerFunc updates a list of resources
 func PutProjectProjectNameStageStageNameServiceServiceNameResourceHandlerFunc(
 	params service_resource.PutProjectProjectNameStageStageNameServiceServiceNameResourceParams) middleware.Responder {
-	logger := keptncommon.NewLogger("", "", "configuration-service")
+	logger := keptncommon.NewLogger("", "", common.ConfigurationServiceName)
 	if !common.ProjectExists(params.ProjectName) {
 		return service_resource.NewPutProjectProjectNameStageStageNameServiceServiceNameResourceBadRequest().
 			WithPayload(&models.Error{Code: 400, Message: swag.String("Project " + params.ProjectName + " does not exist")})
@@ -336,7 +336,7 @@ func PutProjectProjectNameStageStageNameServiceServiceNameResourceHandlerFunc(
 		logger.Error(fmt.Sprintf("Could not check out %s branch of project %s", params.StageName, params.ProjectName))
 		logger.Error(err.Error())
 		return service_resource.NewPutProjectProjectNameStageStageNameServiceServiceNameResourceBadRequest().
-			WithPayload(&models.Error{Code: 400, Message: swag.String("Could not check out branch")})
+			WithPayload(&models.Error{Code: 400, Message: swag.String(common.CannotCheckOutBranchErrorMsg)})
 	}
 
 	for _, res := range params.Resources.Resources {
@@ -364,7 +364,7 @@ func PutProjectProjectNameStageStageNameServiceServiceNameResourceHandlerFunc(
 	defaultBranch, err := common.GetDefaultBranch(params.ProjectName)
 	if err != nil {
 		logger.Error(fmt.Sprintf("Could not determine default branch of project %s: %s", params.ProjectName, err.Error()))
-		return service_resource.NewPutProjectProjectNameStageStageNameServiceServiceNameResourceDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
+		return service_resource.NewPutProjectProjectNameStageStageNameServiceServiceNameResourceDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String(common.CannotCheckOutBranchErrorMsg)})
 	}
 	if defaultBranch == "" {
 		defaultBranch = "master"
@@ -376,14 +376,14 @@ func PutProjectProjectNameStageStageNameServiceServiceNameResourceHandlerFunc(
 // PutProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIHandlerFunc updates a specified resource
 func PutProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIHandlerFunc(
 	params service_resource.PutProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIParams) middleware.Responder {
-	logger := keptncommon.NewLogger("", "", "configuration-service")
+	logger := keptncommon.NewLogger("", "", common.ConfigurationServiceName)
 
 	common.LockProject(params.ProjectName)
 	defer common.UnlockProject(params.ProjectName)
 
 	if !common.ServiceExists(params.ProjectName, params.StageName, params.ServiceName, false) {
 		return service_resource.NewPutProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIBadRequest().
-			WithPayload(&models.Error{Code: 400, Message: swag.String("Service does not exist")})
+			WithPayload(&models.Error{Code: 400, Message: swag.String(common.ServiceDoesNotExistErrorMsg)})
 	}
 
 	serviceConfigPath := config.ConfigDir + "/" + params.ProjectName + "/" + params.ServiceName
@@ -395,7 +395,7 @@ func PutProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIHan
 		logger.Error(fmt.Sprintf("Could not check out %s branch of project %s", params.StageName, params.ProjectName))
 		logger.Error(err.Error())
 		return service_resource.NewPutProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIBadRequest().
-			WithPayload(&models.Error{Code: 400, Message: swag.String("Could not check out branch")})
+			WithPayload(&models.Error{Code: 400, Message: swag.String(common.CannotCheckOutBranchErrorMsg)})
 	}
 
 	filePath := serviceConfigPath + "/" + params.ResourceURI
@@ -415,7 +415,7 @@ func PutProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIHan
 	defaultBranch, err := common.GetDefaultBranch(params.ProjectName)
 	if err != nil {
 		logger.Error(fmt.Sprintf("Could not determine default branch of project %s: %s", params.ProjectName, err.Error()))
-		return service_resource.NewPutProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String("Could not check out branch")})
+		return service_resource.NewPutProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String(common.CannotCheckOutBranchErrorMsg)})
 	}
 	if defaultBranch == "" {
 		defaultBranch = "master"

--- a/configuration-service/handlers/stage.go
+++ b/configuration-service/handlers/stage.go
@@ -12,7 +12,7 @@ import (
 
 // PostProjectProjectNameStageHandlerFunc creates a new stage
 func PostProjectProjectNameStageHandlerFunc(params stage.PostProjectProjectNameStageParams) middleware.Responder {
-	logger := keptncommon.NewLogger("", "", "configuration-service")
+	logger := keptncommon.NewLogger("", "", common.ConfigurationServiceName)
 	if !common.ProjectExists(params.ProjectName) {
 		return stage.NewPostProjectProjectNameStageBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String("Project does not exist.")})
 	}

--- a/configuration-service/handlers/stage_resource.go
+++ b/configuration-service/handlers/stage_resource.go
@@ -18,12 +18,12 @@ import (
 
 // GetProjectProjectNameStageStageNameResourceHandlerFunc get list of stage resources
 func GetProjectProjectNameStageStageNameResourceHandlerFunc(params stage_resource.GetProjectProjectNameStageStageNameResourceParams) middleware.Responder {
-	logger := keptncommon.NewLogger("", "", "configuration-service")
+	logger := keptncommon.NewLogger("", "", common.ConfigurationServiceName)
 	common.LockProject(params.ProjectName)
 	defer common.UnlockProject(params.ProjectName)
 
 	if !common.StageExists(params.ProjectName, params.StageName, false) {
-		return stage_resource.NewGetProjectProjectNameStageStageNameResourceNotFound().WithPayload(&models.Error{Code: 404, Message: swag.String("Stage does not exist")})
+		return stage_resource.NewGetProjectProjectNameStageStageNameResourceNotFound().WithPayload(&models.Error{Code: 404, Message: swag.String(common.StageDoesNotExistErrorMsg)})
 	}
 
 	logger.Debug("Checking out " + params.StageName + " branch")
@@ -41,7 +41,7 @@ func GetProjectProjectNameStageStageNameResourceHandlerFunc(params stage_resourc
 
 // GetProjectProjectNameStageStageNameResourceResourceURIHandlerFunc get the specified resource
 func GetProjectProjectNameStageStageNameResourceResourceURIHandlerFunc(params stage_resource.GetProjectProjectNameStageStageNameResourceResourceURIParams) middleware.Responder {
-	logger := keptncommon.NewLogger("", "", "configuration-service")
+	logger := keptncommon.NewLogger("", "", common.ConfigurationServiceName)
 	common.LockProject(params.ProjectName)
 	defer common.UnlockProject(params.ProjectName)
 
@@ -92,12 +92,12 @@ func GetProjectProjectNameStageStageNameResourceResourceURIHandlerFunc(params st
 
 // PostProjectProjectNameStageStageNameResourceHandlerFunc creates list of new resources in a stage
 func PostProjectProjectNameStageStageNameResourceHandlerFunc(params stage_resource.PostProjectProjectNameStageStageNameResourceParams) middleware.Responder {
-	logger := keptncommon.NewLogger("", "", "configuration-service")
+	logger := keptncommon.NewLogger("", "", common.ConfigurationServiceName)
 	common.LockProject(params.ProjectName)
 	defer common.UnlockProject(params.ProjectName)
 
 	if !common.StageExists(params.ProjectName, params.StageName, false) {
-		return stage_resource.NewPostProjectProjectNameStageStageNameResourceBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String("Stage does not exist")})
+		return stage_resource.NewPostProjectProjectNameStageStageNameResourceBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String(common.StageDoesNotExistErrorMsg)})
 	}
 
 	projectConfigPath := config.ConfigDir + "/" + params.ProjectName
@@ -134,12 +134,12 @@ func PostProjectProjectNameStageStageNameResourceHandlerFunc(params stage_resour
 
 // PutProjectProjectNameStageStageNameResourceHandlerFunc updates list of stage resources
 func PutProjectProjectNameStageStageNameResourceHandlerFunc(params stage_resource.PutProjectProjectNameStageStageNameResourceParams) middleware.Responder {
-	logger := keptncommon.NewLogger("", "", "configuration-service")
+	logger := keptncommon.NewLogger("", "", common.ConfigurationServiceName)
 	common.LockProject(params.ProjectName)
 	defer common.UnlockProject(params.ProjectName)
 
 	if !common.StageExists(params.ProjectName, params.StageName, false) {
-		return stage_resource.NewPutProjectProjectNameStageStageNameResourceBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String("Stage does not exist")})
+		return stage_resource.NewPutProjectProjectNameStageStageNameResourceBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String(common.StageDoesNotExistErrorMsg)})
 	}
 
 	projectConfigPath := config.ConfigDir + "/" + params.ProjectName
@@ -151,7 +151,7 @@ func PutProjectProjectNameStageStageNameResourceHandlerFunc(params stage_resourc
 	if err != nil {
 		logger.Error(fmt.Sprintf("Could not check out %s branch for project %s", params.StageName, params.ProjectName))
 		logger.Error(err.Error())
-		return stage_resource.NewPutProjectProjectNameStageStageNameResourceBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String("Could not check out branch")})
+		return stage_resource.NewPutProjectProjectNameStageStageNameResourceBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String(common.CannotCheckOutBranchErrorMsg)})
 	}
 
 	for _, res := range params.Resources.Resources {
@@ -176,12 +176,12 @@ func PutProjectProjectNameStageStageNameResourceHandlerFunc(params stage_resourc
 
 // PutProjectProjectNameStageStageNameResourceResourceURIHandlerFunc updates the specified stage resource
 func PutProjectProjectNameStageStageNameResourceResourceURIHandlerFunc(params stage_resource.PutProjectProjectNameStageStageNameResourceResourceURIParams) middleware.Responder {
-	logger := keptncommon.NewLogger("", "", "configuration-service")
+	logger := keptncommon.NewLogger("", "", common.ConfigurationServiceName)
 	common.LockProject(params.ProjectName)
 	defer common.UnlockProject(params.ProjectName)
 
 	if !common.StageExists(params.ProjectName, params.StageName, false) {
-		return stage_resource.NewPutProjectProjectNameStageStageNameResourceResourceURIBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String("Stage does not exist")})
+		return stage_resource.NewPutProjectProjectNameStageStageNameResourceResourceURIBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String(common.StageDoesNotExistErrorMsg)})
 	}
 
 	projectConfigPath := config.ConfigDir + "/" + params.ProjectName
@@ -192,7 +192,7 @@ func PutProjectProjectNameStageStageNameResourceResourceURIHandlerFunc(params st
 	if err != nil {
 		logger.Error(fmt.Sprintf("Could not check out %s branch for project %s", params.StageName, params.ProjectName))
 		logger.Error(err.Error())
-		return stage_resource.NewPutProjectProjectNameStageStageNameResourceResourceURIBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String("Could not check out branch")})
+		return stage_resource.NewPutProjectProjectNameStageStageNameResourceResourceURIBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String(common.CannotCheckOutBranchErrorMsg)})
 	}
 
 	filePath := projectConfigPath + "/" + params.ResourceURI
@@ -214,12 +214,12 @@ func PutProjectProjectNameStageStageNameResourceResourceURIHandlerFunc(params st
 
 // DeleteProjectProjectNameStageStageNameResourceResourceURIHandlerFunc deletes the specified stage resource
 func DeleteProjectProjectNameStageStageNameResourceResourceURIHandlerFunc(params stage_resource.DeleteProjectProjectNameStageStageNameResourceResourceURIParams) middleware.Responder {
-	logger := keptncommon.NewLogger("", "", "configuration-service")
+	logger := keptncommon.NewLogger("", "", common.ConfigurationServiceName)
 	common.LockProject(params.ProjectName)
 	defer common.UnlockProject(params.ProjectName)
 
 	if !common.StageExists(params.ProjectName, params.StageName, false) {
-		return stage_resource.NewDeleteProjectProjectNameStageStageNameResourceResourceURIBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String("Stage does not exist")})
+		return stage_resource.NewDeleteProjectProjectNameStageStageNameResourceResourceURIBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String(common.StageDoesNotExistErrorMsg)})
 	}
 
 	projectConfigPath := config.ConfigDir + "/" + params.ProjectName
@@ -230,7 +230,7 @@ func DeleteProjectProjectNameStageStageNameResourceResourceURIHandlerFunc(params
 	if err != nil {
 		logger.Error(fmt.Sprintf("Could not check out %s branch for project %s", params.StageName, params.ProjectName))
 		logger.Error(err.Error())
-		return stage_resource.NewDeleteProjectProjectNameStageStageNameResourceResourceURIBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String("Could not check out branch")})
+		return stage_resource.NewDeleteProjectProjectNameStageStageNameResourceResourceURIBadRequest().WithPayload(&models.Error{Code: 400, Message: swag.String(common.CannotCheckOutBranchErrorMsg)})
 	}
 
 	unescapedResourceName, err := url.QueryUnescape(params.ResourceURI)

--- a/configuration-service/restapi/embedded_spec.go
+++ b/configuration-service/restapi/embedded_spec.go
@@ -471,6 +471,11 @@ func init() {
           "Service Default Resource"
         ],
         "summary": "Update the specified default resource for the service",
+        "parameters": [
+          {
+            "$ref": "#/parameters/resource"
+          }
+        ],
         "responses": {
           "201": {
             "description": "Success. Service default resource has been updated. The version of the new configuration is returned.",
@@ -1965,6 +1970,16 @@ func init() {
           "Service Default Resource"
         ],
         "summary": "Update the specified default resource for the service",
+        "parameters": [
+          {
+            "description": "Resource",
+            "name": "resource",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/Resource"
+            }
+          }
+        ],
         "responses": {
           "201": {
             "description": "Success. Service default resource has been updated. The version of the new configuration is returned.",

--- a/configuration-service/restapi/operations/service_default_resource/put_project_project_name_service_service_name_resource_resource_uri_parameters.go
+++ b/configuration-service/restapi/operations/service_default_resource/put_project_project_name_service_service_name_resource_resource_uri_parameters.go
@@ -9,8 +9,11 @@ import (
 	"net/http"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/keptn/keptn/configuration-service/models"
 )
 
 // NewPutProjectProjectNameServiceServiceNameResourceResourceURIParams creates a new PutProjectProjectNameServiceServiceNameResourceResourceURIParams object
@@ -34,6 +37,10 @@ type PutProjectProjectNameServiceServiceNameResourceResourceURIParams struct {
 	  In: path
 	*/
 	ProjectName string
+	/*Resource
+	  In: body
+	*/
+	Resource *models.Resource
 	/*Resource URI
 	  Required: true
 	  In: path
@@ -60,6 +67,22 @@ func (o *PutProjectProjectNameServiceServiceNameResourceResourceURIParams) BindR
 		res = append(res, err)
 	}
 
+	if runtime.HasBody(r) {
+		defer r.Body.Close()
+		var body models.Resource
+		if err := route.Consumer.Consume(r.Body, &body); err != nil {
+			res = append(res, errors.NewParseError("resource", "body", "", err))
+		} else {
+			// validate body object
+			if err := body.Validate(route.Formats); err != nil {
+				res = append(res, err)
+			}
+
+			if len(res) == 0 {
+				o.Resource = &body
+			}
+		}
+	}
 	rResourceURI, rhkResourceURI, _ := route.Params.GetOK("resourceURI")
 	if err := o.bindResourceURI(rResourceURI, rhkResourceURI, route.Formats); err != nil {
 		res = append(res, err)

--- a/configuration-service/swagger.yaml
+++ b/configuration-service/swagger.yaml
@@ -857,6 +857,8 @@ paths:
       tags:
         - Service Default Resource
       summary: Update the specified default resource for the service
+      parameters:
+        - $ref: '#/parameters/resource'
       responses:
         '201':
           description: Success. Service default resource has been updated. The version of the new configuration is returned.


### PR DESCRIPTION
Closes #5136

Note: The code of the configuration service in general needs some refactoring - hence the relatively high number of Sonar Code smells (most of them are about multiple occurrences for various string literals that are used for logging, so nothing critical). The refactoring should be done in a separate issue.