### PR TITLE
fix(shipyard-controller): Adapted log output when no queued sequence is found (#5138)

### DIFF
--- a/shipyard-controller/handler/sequencedispatcher.go
+++ b/shipyard-controller/handler/sequencedispatcher.go
@@ -77,6 +77,10 @@ func (sd *SequenceDispatcher) Run(ctx context.Context) {
 func (sd *SequenceDispatcher) dispatchSequences() {
 	queuedSequences, err := sd.sequenceQueue.GetQueuedSequences()
 	if err != nil {
+		if err == db.ErrNoEventFound {
+			// if no sequences are in the queue, we can return here
+			return
+		}
 		log.WithError(err).Error("could not load queued sequences")
 		return
 	}


### PR DESCRIPTION
Closes #5138

This PR adapts the log output of the shipyard controller by distinguishing between an ErrNoEventFound and any other type of error that might happen when retrieving queued sequences from the mongodb collection. In the case of an ErrNoEventFound, which of course can always be the case when there are currently no events in the queue, it doesn't make sense to generate an error log - in this case, no log output is generated to reduce the noise in the logs.