### PR TITLE
fix(distributor): Only interpret events with status=errored as error logs (#5170)

### DIFF
--- a/distributor/pkg/lib/controlplane/uniformlog.go
+++ b/distributor/pkg/lib/controlplane/uniformlog.go
@@ -59,7 +59,7 @@ func (l *EventUniformLog) OnEvent(event cloudevents.Event) error {
 
 		taskName, _, _ := keptnv2.ParseTaskEventType(*keptnEvent.Type)
 
-		if eventData.Status == keptnv2.StatusErrored || eventData.Result == keptnv2.ResultFailed {
+		if eventData.Status == keptnv2.StatusErrored {
 			logger.Info("UniformLogger: received .finished event with status errored. forwarding log message to log ingestion API")
 			l.Log(keptnapimodels.LogEntry{
 				IntegrationID: l.IntegrationID,

--- a/distributor/pkg/lib/controlplane/uniformlog_test.go
+++ b/distributor/pkg/lib/controlplane/uniformlog_test.go
@@ -10,26 +10,8 @@ import (
 	"testing"
 )
 
-func TestEventUniformLog_Start(t *testing.T) {
-	fakeLogHandler := &fakeapi.ILogHandlerMock{
-		FlushFunc: func() error {
-			return nil
-		},
-		LogFunc: func(logs []models.LogEntry) {
-
-		},
-		StartFunc: func(ctx context.Context) {
-
-		},
-	}
-	uniformLog := NewEventUniformLog(
-		"my-id",
-		fakeLogHandler,
-	)
-
-	eventsChannel := make(chan event.Event)
-
-	uniformLog.Start(context.TODO(), eventsChannel)
+func TestEventUniformLog_LogEvent(t *testing.T) {
+	fakeLogHandler, uniformLog := getTestUniformLogger()
 
 	// send a new event with unhandled type -> should not be logged
 	newEvent := event.New()
@@ -62,16 +44,30 @@ func TestEventUniformLog_Start(t *testing.T) {
 		Task:          "my-task",
 		TriggeredID:   "my-triggered-id",
 	}, fakeLogHandler.LogCalls()[0].Logs[0])
+}
+
+func TestEventUniformLog_LogEventInvalidPayload(t *testing.T) {
+	fakeLogHandler, uniformLog := getTestUniformLogger()
+
+	newEvent := event.New()
+	newEvent.SetType(keptnv2.ErrorLogEventName)
 
 	// send sh.keptn.log.error event with invalid payload -> should result in an error
 	newEvent.SetData(event.TextJSON, "invalid")
 
-	err = uniformLog.OnEvent(newEvent)
+	err := uniformLog.OnEvent(newEvent)
 
 	require.NotNil(t, err)
+	require.Empty(t, fakeLogHandler.LogCalls())
+}
 
-	// send sh.keptn.event.<task>.finished event
+func TestEventUniformLog_TaskFinishedWithErroredStatus(t *testing.T) {
+	fakeLogHandler, uniformLog := getTestUniformLogger()
+
+	newEvent := event.New()
 	newEvent.SetType(keptnv2.GetFinishedEventType(keptnv2.DeploymentTaskName))
+	newEvent.SetExtension("shkeptncontext", "my-context")
+	newEvent.SetExtension("triggeredid", "my-triggered-id")
 
 	finishedData := &keptnv2.EventData{
 		Status:  keptnv2.StatusErrored,
@@ -79,31 +75,89 @@ func TestEventUniformLog_Start(t *testing.T) {
 	}
 	newEvent.SetData(event.ApplicationJSON, finishedData)
 
-	err = uniformLog.OnEvent(newEvent)
+	err := uniformLog.OnEvent(newEvent)
 
 	require.Nil(t, err)
-	require.NotEmpty(t, fakeLogHandler.LogCalls())
+	require.Len(t, fakeLogHandler.LogCalls(), 1)
 	require.Equal(t, models.LogEntry{
 		IntegrationID: "my-id",
 		Message:       "my-message",
 		KeptnContext:  "my-context",
 		Task:          keptnv2.DeploymentTaskName,
 		TriggeredID:   "my-triggered-id",
-	}, fakeLogHandler.LogCalls()[1].Logs[0])
+	}, fakeLogHandler.LogCalls()[0].Logs[0])
+}
 
-	// send sh.keptn.event.<task>.finished event with status "succeeded" -> should not be logged
-	finishedData = &keptnv2.EventData{
+func TestEventUniformLog_TaskFinishedWithSucceedStatus(t *testing.T) {
+	fakeLogHandler, uniformLog := getTestUniformLogger()
+
+	newEvent := event.New()
+	newEvent.SetType(keptnv2.GetFinishedEventType(keptnv2.DeploymentTaskName))
+
+	finishedData := &keptnv2.EventData{
 		Status:  keptnv2.StatusSucceeded,
 		Message: "my-message",
 	}
 	newEvent.SetData(event.ApplicationJSON, finishedData)
 
-	require.Len(t, fakeLogHandler.LogCalls(), 2)
+	err := uniformLog.OnEvent(newEvent)
 
-	// send sh.keptn.event.<task>.finished event with invalid payload -> should result in an error
+	require.Nil(t, err)
+	require.Empty(t, fakeLogHandler.LogCalls())
+}
+
+func TestEventUniformLog_TaskFinishedWithSucceedStatusAndResultFail(t *testing.T) {
+	fakeLogHandler, uniformLog := getTestUniformLogger()
+
+	newEvent := event.New()
+	newEvent.SetType(keptnv2.GetFinishedEventType(keptnv2.DeploymentTaskName))
+
+	finishedData := &keptnv2.EventData{
+		Status:  keptnv2.StatusSucceeded,
+		Result:  keptnv2.ResultFailed,
+		Message: "my-message",
+	}
+	newEvent.SetData(event.ApplicationJSON, finishedData)
+
+	err := uniformLog.OnEvent(newEvent)
+
+	require.Nil(t, err)
+	require.Empty(t, fakeLogHandler.LogCalls())
+}
+
+func TestEventUniformLog_TaskFinishedWithInvalidData(t *testing.T) {
+	fakeLogHandler, uniformLog := getTestUniformLogger()
+
+	newEvent := event.New()
+	newEvent.SetType(keptnv2.GetFinishedEventType(keptnv2.DeploymentTaskName))
+
 	newEvent.SetData(event.TextJSON, "invalid")
 
-	err = uniformLog.OnEvent(newEvent)
+	err := uniformLog.OnEvent(newEvent)
 
 	require.NotNil(t, err)
+	require.Empty(t, fakeLogHandler.LogCalls())
+}
+
+func getTestUniformLogger() (*fakeapi.ILogHandlerMock, *EventUniformLog) {
+	fakeLogHandler := &fakeapi.ILogHandlerMock{
+		FlushFunc: func() error {
+			return nil
+		},
+		LogFunc: func(logs []models.LogEntry) {
+
+		},
+		StartFunc: func(ctx context.Context) {
+
+		},
+	}
+	uniformLog := NewEventUniformLog(
+		"my-id",
+		fakeLogHandler,
+	)
+
+	eventsChannel := make(chan event.Event)
+
+	uniformLog.Start(context.TODO(), eventsChannel)
+	return fakeLogHandler, uniformLog
 }


### PR DESCRIPTION
Backport of #5170