### PR TITLE
fix(shipyard-controller): Adapted sequence state representation for case where sequence can not be started (#5137)

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -494,7 +494,7 @@ jobs:
         continue-on-error: true
         env:
           KEPTN_ENDPOINT: ${{ steps.authenticate_keptn_cli.outputs.KEPTN_ENDPOINT }}
-        run: cd test/go-tests && go test -run SequenceStateIntegrationTest -v
+        run: cd test/go-tests && go test -run SequenceState -v
 
       - name: Test Sequence Loop
         # do not run this test for the airgapped scenario

--- a/shipyard-controller/handler/sequence_migrator.go
+++ b/shipyard-controller/handler/sequence_migrator.go
@@ -192,6 +192,9 @@ func getSequenceStageStates(stageEvents []stageEventTrace) ([]*models.SequenceSt
 			if shouldAddLatestEvent(*stageState) {
 				stageState.LatestEvent = latestEvent
 			}
+			if shouldAddLatestFailedEvent(*scope, *stageState) {
+				stageState.LatestFailedEvent = latestEvent
+			}
 			if keptnv2.IsTaskEventType(scope.EventType) {
 				// not a <stage>.<sequence>.(triggered|finished), but a task event
 				stageState, err = processTaskEventTaskEvent(*scope, event, *stageState)

--- a/shipyard-controller/handler/sequence_migrator_test.go
+++ b/shipyard-controller/handler/sequence_migrator_test.go
@@ -325,8 +325,8 @@ func TestSequenceMigrator_MigrateSequences(t *testing.T) {
 							Time: timestampForAllEvents,
 						},
 						LatestFailedEvent: &models.SequenceStateEvent{
-							Type: keptnv2.GetFinishedEventType(keptnv2.EvaluationTaskName),
-							ID:   "staging-task-2-finished-id",
+							Type: keptnv2.GetFinishedEventType("staging.delivery"),
+							ID:   "my-root-event-id-1",
 							Time: timestampForAllEvents,
 						},
 					},

--- a/shipyard-controller/handler/shipyardcontroller.go
+++ b/shipyard-controller/handler/shipyardcontroller.go
@@ -531,7 +531,24 @@ func (sc *shipyardController) startTaskSequence(event models.Event) error {
 
 	taskSequence, err := sc.getTaskSequenceInStage(eventScope.Stage, taskSequenceName, shipyard)
 	if err != nil {
-		return err
+		msg := fmt.Sprintf("could not get definition of task sequence %s: %s", taskSequenceName, err.Error())
+		finishedEvent := event
+		finishedEventData := keptnv2.EventData{
+			Project: eventScope.Project,
+			Stage:   eventScope.Stage,
+			Service: eventScope.Service,
+			Labels:  eventScope.Labels,
+			Status:  keptnv2.StatusErrored,
+			Result:  keptnv2.ResultFailed,
+			Message: msg,
+		}
+		finishedEvent.Data = finishedEventData
+
+		sc.onSequenceFinished(finishedEvent)
+		return sc.sendTaskSequenceFinishedEvent(&models.EventScope{
+			EventData:    finishedEventData,
+			KeptnContext: event.Shkeptncontext,
+		}, taskSequenceName, event.ID)
 	}
 	sc.onSequenceStarted(event)
 

--- a/shipyard-controller/handler/shipyardcontroller.go
+++ b/shipyard-controller/handler/shipyardcontroller.go
@@ -445,7 +445,7 @@ func (sc *shipyardController) handleTriggeredEvent(event models.Event) error {
 		return err
 	}
 
-	// fetching cached shipyard file from project repo (materialized view)
+	// fetching cached shipyard file from project git repo
 	shipyard, err := common.GetShipyard(eventScope.Project)
 	if err != nil {
 		msg := "could not retrieve shipyard: " + err.Error()

--- a/shipyard-controller/handler/shipyardcontroller.go
+++ b/shipyard-controller/handler/shipyardcontroller.go
@@ -477,7 +477,10 @@ func (sc *shipyardController) handleTriggeredEvent(event models.Event) error {
 	_, err = sc.getTaskSequenceInStage(eventScope.Stage, taskSequenceName, shipyard)
 	if err != nil {
 		// return an error if no task sequence is available
-		return err
+		msg := fmt.Sprintf("could not start sequence %s: %s", taskSequenceName, err.Error())
+		log.Error(msg)
+
+		return sc.onTriggerSequenceFailed(event, eventScope, msg, taskSequenceName)
 	}
 
 	if err := sc.eventRepo.InsertEvent(eventScope.Project, event, common.TriggeredEvent); err != nil {

--- a/shipyard-controller/handler/shipyardcontroller.go
+++ b/shipyard-controller/handler/shipyardcontroller.go
@@ -543,23 +543,7 @@ func (sc *shipyardController) startTaskSequence(event models.Event) error {
 	taskSequence, err := sc.getTaskSequenceInStage(eventScope.Stage, taskSequenceName, shipyard)
 	if err != nil {
 		msg := fmt.Sprintf("could not get definition of task sequence %s: %s", taskSequenceName, err.Error())
-		finishedEvent := event
-		finishedEventData := keptnv2.EventData{
-			Project: eventScope.Project,
-			Stage:   eventScope.Stage,
-			Service: eventScope.Service,
-			Labels:  eventScope.Labels,
-			Status:  keptnv2.StatusErrored,
-			Result:  keptnv2.ResultFailed,
-			Message: msg,
-		}
-		finishedEvent.Data = finishedEventData
-
-		sc.onSequenceFinished(finishedEvent)
-		return sc.sendTaskSequenceFinishedEvent(&models.EventScope{
-			EventData:    finishedEventData,
-			KeptnContext: event.Shkeptncontext,
-		}, taskSequenceName, event.ID)
+		return sc.onTriggerSequenceFailed(event, eventScope, msg, taskSequenceName)
 	}
 	sc.onSequenceStarted(event)
 

--- a/shipyard-controller/handler/shipyardcontroller_test.go
+++ b/shipyard-controller/handler/shipyardcontroller_test.go
@@ -1341,9 +1341,9 @@ func Test_shipyardController_SequenceForUnavailableStage(t *testing.T) {
 	// send unknown.artifact-delivery.triggered event
 	err := sc.HandleIncomingEvent(getArtifactDeliveryTriggeredEvent("unknown"), true)
 
-	require.NotNil(t, err)
-
-	require.Empty(t, len(mockEventDispatcher.AddCalls()))
+	require.Nil(t, err)
+	require.Len(t, mockEventDispatcher.AddCalls(), 1)
+	require.Equal(t, keptnv2.GetFinishedEventType("unknown.artifact-delivery"), mockEventDispatcher.AddCalls()[0].Event.Event.Type())
 	require.Empty(t, mockSequenceDispatcher.AddCalls())
 }
 

--- a/test/go-tests/go.sum
+++ b/test/go-tests/go.sum
@@ -763,6 +763,7 @@ go.mongodb.org/mongo-driver v1.0.3/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qL
 go.mongodb.org/mongo-driver v1.1.1/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 go.mongodb.org/mongo-driver v1.1.2/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 go.mongodb.org/mongo-driver v1.7.1/go.mod h1:Q4oFMbo1+MSNqICAdYMlC/zSTrwCogR4R8NzkI+yfU8=
+go.mongodb.org/mongo-driver v1.7.2/go.mod h1:Q4oFMbo1+MSNqICAdYMlC/zSTrwCogR4R8NzkI+yfU8=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.20.2/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/test/go-tests/sequencestate_test.go
+++ b/test/go-tests/sequencestate_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -384,28 +385,69 @@ func Test_SequenceState_CannotRetrieveShipyard(t *testing.T) {
 	require.Nil(t, err)
 
 	// delete the shipyard file
-	//_, err = ApiDELETERequest(fmt.Sprintf("/configuration-service/v1/project/%s/resource/shipyard.yaml", projectName))
-	//require.Nil(t, err)
-
-	_, err = TriggerSequence(projectName, serviceName, "dev", "evaluation", nil)
-	require.Nil(t, err)
-
-	states, _, err := GetState(projectName)
-
-	require.Nil(t, err)
-	require.NotEmpty(t, states)
-
-	// delete the shipyard file
 	_, err = ApiDELETERequest(fmt.Sprintf("/configuration-service/v1/project/%s/resource/shipyard.yaml", projectName))
 	require.Nil(t, err)
 
 	_, err = TriggerSequence(projectName, serviceName, "dev", "evaluation", nil)
 	require.Nil(t, err)
 
-	states, _, err = GetState(projectName)
+	var states *scmodels.SequenceStates
+	require.Eventually(t, func() bool {
+		states, _, err = GetState(projectName)
+		if err != nil {
+			return false
+		} else if states == nil || len(states.States) == 0 {
+			return false
+		}
+		return true
+	}, 20*time.Second, 3*time.Second)
 
 	require.Nil(t, err)
-	require.NotEmpty(t, states)
+	require.Len(t, states.States, 1)
+	require.Equal(t, scmodels.SequenceFinished, states.States[0].State)
+}
+
+func Test_SequenceState_InvalidShipyard(t *testing.T) {
+	projectName := "state-invalid-shipyard"
+	serviceName := "my-service"
+	sequenceStateShipyardFilePath, err := CreateTmpShipyardFile(sequenceStateShipyard)
+	require.Nil(t, err)
+	defer os.Remove(sequenceStateShipyardFilePath)
+
+	err = CreateProject(projectName, sequenceStateShipyardFilePath, true)
+	require.Nil(t, err)
+
+	_, err = ExecuteCommand(fmt.Sprintf("keptn create service %s --project=%s", serviceName, projectName))
+
+	require.Nil(t, err)
+
+	// upload a shipyard with an invalid version
+	invalidShipyardString := strings.Replace(sequenceQueueShipyard, "spec.keptn.sh/0.2.2", "0.1.7", 1)
+
+	invalidShipyardFile, err := CreateTmpShipyardFile(invalidShipyardString)
+	require.Nil(t, err)
+	defer os.Remove(invalidShipyardFile)
+
+	_, err = ExecuteCommand(fmt.Sprintf("keptn add-resource --project=%s --resource=%s --resourceUri=shipyard.yaml", projectName, invalidShipyardFile))
+	require.Nil(t, err)
+
+	_, err = TriggerSequence(projectName, serviceName, "dev", "evaluation", nil)
+	require.Nil(t, err)
+
+	var states *scmodels.SequenceStates
+	require.Eventually(t, func() bool {
+		states, _, err = GetState(projectName)
+		if err != nil {
+			return false
+		} else if states == nil || len(states.States) == 0 {
+			return false
+		}
+		return true
+	}, 20*time.Second, 3*time.Second)
+
+	require.Nil(t, err)
+	require.Len(t, states.States, 1)
+	require.Equal(t, scmodels.SequenceFinished, states.States[0].State)
 }
 
 func copyEventTrace(events []*models.KeptnContextExtendedCE) (string, error) {


### PR DESCRIPTION
Closes #5137

This PR makes sure that event when a sequence cannot be started by a `<sequence>.triggered` event, the state of the failed attempt is properly reflected and can be displayed by the bridge.
The following scenarios have been handled and are covered by integration tests:

- Shipyard file could not be retrieved
- Shipyard could be retrieved, but does not have the correct version
- Valid Shipyard is available, but no matching sequence definition found

In these cases, a sequence state will be created and immediately be set to `finished`, and the `lastFailedEvent` property will be set, so the bridge can display it as a failed sequence. The resulting `<sequence>.finished` event then contains information about why it has failed in the `data.message` property.