### PR TITLE
fix: Increase memory limits for mongodb-datastore and mongodb (#5196)

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/charts/mongodb/templates/deployment.yaml
+++ b/installer/manifests/keptn/charts/control-plane/charts/mongodb/templates/deployment.yaml
@@ -61,8 +61,8 @@ spec:
               memory: "64Mi"
               cpu: "50m"
             limits:
-              memory: "300Mi"
-              cpu: "100m"
+              memory: "512Mi"
+              cpu: "200m"
           volumeMounts:
             - mountPath: /var/lib/mongodb/data
               name: mongodata

--- a/installer/manifests/keptn/charts/control-plane/templates/mongodb-datastore.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/mongodb-datastore.yaml
@@ -57,8 +57,8 @@ spec:
             memory: "32Mi"
             cpu: "50m"
           limits:
-            memory: "128Mi"
-            cpu: "200m"
+            memory: "512Mi"
+            cpu: "300m"
         env:
         - name: PREFIX_PATH
           value: "{{ .Values.prefixPath }}"


### PR DESCRIPTION
Signed-off-by: Andreas Grimmer <andreas.grimmer@dynatrace.com>

Fixes #5196

## This PR
This PR increases the memory limits of the mongodb and mongodb-datastore based on monitoring data.
<img width="1615" alt="Screen Shot 2021-09-08 at 16 06 15" src="https://user-images.githubusercontent.com/10980861/132525155-96047ff9-b7f0-4e06-862c-08cb9d1de505.png">
<img width="1608" alt="Screen Shot 2021-09-08 at 16 06 30" src="https://user-images.githubusercontent.com/10980861/132525168-84e8538a-d975-492a-bf2a-662af41732ef.png">
