### PR TITLE
fix: Use correct artifact name for mongodb-datastore in semantic PR setup

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -25,7 +25,7 @@ scopes:
   - installer
   - jmeter-service
   - lighthouse-service
-  - mongodb-datestore
+  - mongodb-datastore
   - remediation-service
   - secret-service
   - shipyard-controller


### PR DESCRIPTION
Signed-off-by: Moritz Wiesinger <moritz.wiesinger@dynatrace.com>

