### PR TITLE
fix(cli): Check if kubectl context matches Keptn CLI context before applying upgrade (#4583)

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"github.com/keptn/keptn/cli/pkg/credentialmanager"
 	"strings"
 
 	"github.com/keptn/keptn/cli/pkg/common"
@@ -105,7 +106,7 @@ keptn install --hide-sensitive-data                                    # install
 				logging.PrintLog("Note: The --use-case=quality-gates option is now deprecated and is now a synonym for the default installation of Keptn.", logging.InfoLevel)
 			}
 
-			installPlatformManager, err := platform.NewPlatformManager(*installParams.PlatformIdentifier)
+			installPlatformManager, err := platform.NewPlatformManager(*installParams.PlatformIdentifier, credentialmanager.NewCredentialManager(assumeYes))
 			if err != nil {
 				return err
 			}

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"github.com/keptn/keptn/cli/pkg/credentialmanager"
 	"os"
 	"strings"
 
@@ -118,7 +119,15 @@ func doUpgradePreRunCheck(vChecker *version.KeptnVersionChecker) error {
 
 	logging.PrintLog(fmt.Sprintf("Helm Chart used for Keptn upgrade: %s", chartRepoURL), logging.InfoLevel)
 
-	platformManager, err := platform.NewPlatformManager(*upgradeParams.PlatformIdentifier)
+	cm := credentialmanager.NewCredentialManager(assumeYes)
+	currentKeptnCLIContext := cm.GetCurrentKeptnCLIConfig().CurrentContext
+	currentKubernetesContext := cm.GetCurrentKubeConfig().CurrentContext
+
+	if currentKeptnCLIContext != currentKubernetesContext {
+		return fmt.Errorf("your current Keptn CLI context '%s' does not match current Kubeconfig '%s'. Please ensure your kubectl CLI is connected to '%s' before upgrading your Keptn cluster", currentKeptnCLIContext, currentKubernetesContext, currentKubernetesContext)
+	}
+
+	platformManager, err := platform.NewPlatformManager(*upgradeParams.PlatformIdentifier, cm)
 	if err != nil {
 		return err
 	}

--- a/cli/pkg/credentialmanager/fake/credential_manager_mock.go
+++ b/cli/pkg/credentialmanager/fake/credential_manager_mock.go
@@ -4,6 +4,8 @@
 package credentialmanager_mock
 
 import (
+	"github.com/keptn/keptn/cli/pkg/config"
+	"github.com/keptn/keptn/cli/pkg/credentialmanager"
 	"net/url"
 	"sync"
 )
@@ -17,11 +19,23 @@ import (
 // 			GetCredsFunc: func(namespace string) (url.URL, string, error) {
 // 				panic("mock out the GetCreds method")
 // 			},
+// 			GetCurrentKeptnCLIConfigFunc: func() config.CLIConfig {
+// 				panic("mock out the GetCurrentKeptnCLIConfig method")
+// 			},
+// 			GetCurrentKubeConfigFunc: func() credentialmanager.kubeConfigFileType {
+// 				panic("mock out the GetCurrentKubeConfig method")
+// 			},
 // 			GetInstallCredsFunc: func() (string, error) {
 // 				panic("mock out the GetInstallCreds method")
 // 			},
 // 			SetCredsFunc: func(endPoint url.URL, apiToken string, namespace string) error {
 // 				panic("mock out the SetCreds method")
+// 			},
+// 			SetCurrentKeptnCLIConfigFunc: func(cliConfig config.CLIConfig)  {
+// 				panic("mock out the SetCurrentKeptnCLIConfig method")
+// 			},
+// 			SetCurrentKubeConfigFunc: func(kubeConfig credentialmanager.kubeConfigFileType)  {
+// 				panic("mock out the SetCurrentKubeConfig method")
 // 			},
 // 			SetInstallCredsFunc: func(creds string) error {
 // 				panic("mock out the SetInstallCreds method")
@@ -36,11 +50,23 @@ type CredentialManagerInterfaceMock struct {
 	// GetCredsFunc mocks the GetCreds method.
 	GetCredsFunc func(namespace string) (url.URL, string, error)
 
+	// GetCurrentKeptnCLIConfigFunc mocks the GetCurrentKeptnCLIConfig method.
+	GetCurrentKeptnCLIConfigFunc func() config.CLIConfig
+
+	// GetCurrentKubeConfigFunc mocks the GetCurrentKubeConfig method.
+	GetCurrentKubeConfigFunc func() credentialmanager.kubeConfigFileType
+
 	// GetInstallCredsFunc mocks the GetInstallCreds method.
 	GetInstallCredsFunc func() (string, error)
 
 	// SetCredsFunc mocks the SetCreds method.
 	SetCredsFunc func(endPoint url.URL, apiToken string, namespace string) error
+
+	// SetCurrentKeptnCLIConfigFunc mocks the SetCurrentKeptnCLIConfig method.
+	SetCurrentKeptnCLIConfigFunc func(cliConfig config.CLIConfig)
+
+	// SetCurrentKubeConfigFunc mocks the SetCurrentKubeConfig method.
+	SetCurrentKubeConfigFunc func(kubeConfig credentialmanager.kubeConfigFileType)
 
 	// SetInstallCredsFunc mocks the SetInstallCreds method.
 	SetInstallCredsFunc func(creds string) error
@@ -51,6 +77,12 @@ type CredentialManagerInterfaceMock struct {
 		GetCreds []struct {
 			// Namespace is the namespace argument value.
 			Namespace string
+		}
+		// GetCurrentKeptnCLIConfig holds details about calls to the GetCurrentKeptnCLIConfig method.
+		GetCurrentKeptnCLIConfig []struct {
+		}
+		// GetCurrentKubeConfig holds details about calls to the GetCurrentKubeConfig method.
+		GetCurrentKubeConfig []struct {
 		}
 		// GetInstallCreds holds details about calls to the GetInstallCreds method.
 		GetInstallCreds []struct {
@@ -64,16 +96,30 @@ type CredentialManagerInterfaceMock struct {
 			// Namespace is the namespace argument value.
 			Namespace string
 		}
+		// SetCurrentKeptnCLIConfig holds details about calls to the SetCurrentKeptnCLIConfig method.
+		SetCurrentKeptnCLIConfig []struct {
+			// CliConfig is the cliConfig argument value.
+			CliConfig config.CLIConfig
+		}
+		// SetCurrentKubeConfig holds details about calls to the SetCurrentKubeConfig method.
+		SetCurrentKubeConfig []struct {
+			// KubeConfig is the kubeConfig argument value.
+			KubeConfig credentialmanager.kubeConfigFileType
+		}
 		// SetInstallCreds holds details about calls to the SetInstallCreds method.
 		SetInstallCreds []struct {
 			// Creds is the creds argument value.
 			Creds string
 		}
 	}
-	lockGetCreds        sync.RWMutex
-	lockGetInstallCreds sync.RWMutex
-	lockSetCreds        sync.RWMutex
-	lockSetInstallCreds sync.RWMutex
+	lockGetCreds                 sync.RWMutex
+	lockGetCurrentKeptnCLIConfig sync.RWMutex
+	lockGetCurrentKubeConfig     sync.RWMutex
+	lockGetInstallCreds          sync.RWMutex
+	lockSetCreds                 sync.RWMutex
+	lockSetCurrentKeptnCLIConfig sync.RWMutex
+	lockSetCurrentKubeConfig     sync.RWMutex
+	lockSetInstallCreds          sync.RWMutex
 }
 
 // GetCreds calls GetCredsFunc.
@@ -104,6 +150,58 @@ func (mock *CredentialManagerInterfaceMock) GetCredsCalls() []struct {
 	mock.lockGetCreds.RLock()
 	calls = mock.calls.GetCreds
 	mock.lockGetCreds.RUnlock()
+	return calls
+}
+
+// GetCurrentKeptnCLIConfig calls GetCurrentKeptnCLIConfigFunc.
+func (mock *CredentialManagerInterfaceMock) GetCurrentKeptnCLIConfig() config.CLIConfig {
+	if mock.GetCurrentKeptnCLIConfigFunc == nil {
+		panic("CredentialManagerInterfaceMock.GetCurrentKeptnCLIConfigFunc: method is nil but CredentialManagerInterface.GetCurrentKeptnCLIConfig was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockGetCurrentKeptnCLIConfig.Lock()
+	mock.calls.GetCurrentKeptnCLIConfig = append(mock.calls.GetCurrentKeptnCLIConfig, callInfo)
+	mock.lockGetCurrentKeptnCLIConfig.Unlock()
+	return mock.GetCurrentKeptnCLIConfigFunc()
+}
+
+// GetCurrentKeptnCLIConfigCalls gets all the calls that were made to GetCurrentKeptnCLIConfig.
+// Check the length with:
+//     len(mockedCredentialManagerInterface.GetCurrentKeptnCLIConfigCalls())
+func (mock *CredentialManagerInterfaceMock) GetCurrentKeptnCLIConfigCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockGetCurrentKeptnCLIConfig.RLock()
+	calls = mock.calls.GetCurrentKeptnCLIConfig
+	mock.lockGetCurrentKeptnCLIConfig.RUnlock()
+	return calls
+}
+
+// GetCurrentKubeConfig calls GetCurrentKubeConfigFunc.
+func (mock *CredentialManagerInterfaceMock) GetCurrentKubeConfig() credentialmanager.kubeConfigFileType {
+	if mock.GetCurrentKubeConfigFunc == nil {
+		panic("CredentialManagerInterfaceMock.GetCurrentKubeConfigFunc: method is nil but CredentialManagerInterface.GetCurrentKubeConfig was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockGetCurrentKubeConfig.Lock()
+	mock.calls.GetCurrentKubeConfig = append(mock.calls.GetCurrentKubeConfig, callInfo)
+	mock.lockGetCurrentKubeConfig.Unlock()
+	return mock.GetCurrentKubeConfigFunc()
+}
+
+// GetCurrentKubeConfigCalls gets all the calls that were made to GetCurrentKubeConfig.
+// Check the length with:
+//     len(mockedCredentialManagerInterface.GetCurrentKubeConfigCalls())
+func (mock *CredentialManagerInterfaceMock) GetCurrentKubeConfigCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockGetCurrentKubeConfig.RLock()
+	calls = mock.calls.GetCurrentKubeConfig
+	mock.lockGetCurrentKubeConfig.RUnlock()
 	return calls
 }
 
@@ -169,6 +267,68 @@ func (mock *CredentialManagerInterfaceMock) SetCredsCalls() []struct {
 	mock.lockSetCreds.RLock()
 	calls = mock.calls.SetCreds
 	mock.lockSetCreds.RUnlock()
+	return calls
+}
+
+// SetCurrentKeptnCLIConfig calls SetCurrentKeptnCLIConfigFunc.
+func (mock *CredentialManagerInterfaceMock) SetCurrentKeptnCLIConfig(cliConfig config.CLIConfig) {
+	if mock.SetCurrentKeptnCLIConfigFunc == nil {
+		panic("CredentialManagerInterfaceMock.SetCurrentKeptnCLIConfigFunc: method is nil but CredentialManagerInterface.SetCurrentKeptnCLIConfig was just called")
+	}
+	callInfo := struct {
+		CliConfig config.CLIConfig
+	}{
+		CliConfig: cliConfig,
+	}
+	mock.lockSetCurrentKeptnCLIConfig.Lock()
+	mock.calls.SetCurrentKeptnCLIConfig = append(mock.calls.SetCurrentKeptnCLIConfig, callInfo)
+	mock.lockSetCurrentKeptnCLIConfig.Unlock()
+	mock.SetCurrentKeptnCLIConfigFunc(cliConfig)
+}
+
+// SetCurrentKeptnCLIConfigCalls gets all the calls that were made to SetCurrentKeptnCLIConfig.
+// Check the length with:
+//     len(mockedCredentialManagerInterface.SetCurrentKeptnCLIConfigCalls())
+func (mock *CredentialManagerInterfaceMock) SetCurrentKeptnCLIConfigCalls() []struct {
+	CliConfig config.CLIConfig
+} {
+	var calls []struct {
+		CliConfig config.CLIConfig
+	}
+	mock.lockSetCurrentKeptnCLIConfig.RLock()
+	calls = mock.calls.SetCurrentKeptnCLIConfig
+	mock.lockSetCurrentKeptnCLIConfig.RUnlock()
+	return calls
+}
+
+// SetCurrentKubeConfig calls SetCurrentKubeConfigFunc.
+func (mock *CredentialManagerInterfaceMock) SetCurrentKubeConfig(kubeConfig credentialmanager.kubeConfigFileType) {
+	if mock.SetCurrentKubeConfigFunc == nil {
+		panic("CredentialManagerInterfaceMock.SetCurrentKubeConfigFunc: method is nil but CredentialManagerInterface.SetCurrentKubeConfig was just called")
+	}
+	callInfo := struct {
+		KubeConfig credentialmanager.kubeConfigFileType
+	}{
+		KubeConfig: kubeConfig,
+	}
+	mock.lockSetCurrentKubeConfig.Lock()
+	mock.calls.SetCurrentKubeConfig = append(mock.calls.SetCurrentKubeConfig, callInfo)
+	mock.lockSetCurrentKubeConfig.Unlock()
+	mock.SetCurrentKubeConfigFunc(kubeConfig)
+}
+
+// SetCurrentKubeConfigCalls gets all the calls that were made to SetCurrentKubeConfig.
+// Check the length with:
+//     len(mockedCredentialManagerInterface.SetCurrentKubeConfigCalls())
+func (mock *CredentialManagerInterfaceMock) SetCurrentKubeConfigCalls() []struct {
+	KubeConfig credentialmanager.kubeConfigFileType
+} {
+	var calls []struct {
+		KubeConfig credentialmanager.kubeConfigFileType
+	}
+	mock.lockSetCurrentKubeConfig.RLock()
+	calls = mock.calls.SetCurrentKubeConfig
+	mock.lockSetCurrentKubeConfig.RUnlock()
 	return calls
 }
 

--- a/cli/pkg/credentialmanager/fake/credential_manager_mock.go
+++ b/cli/pkg/credentialmanager/fake/credential_manager_mock.go
@@ -22,7 +22,7 @@ import (
 // 			GetCurrentKeptnCLIConfigFunc: func() config.CLIConfig {
 // 				panic("mock out the GetCurrentKeptnCLIConfig method")
 // 			},
-// 			GetCurrentKubeConfigFunc: func() credentialmanager.kubeConfigFileType {
+// 			GetCurrentKubeConfigFunc: func() credentialmanager.KubeConfigFileType {
 // 				panic("mock out the GetCurrentKubeConfig method")
 // 			},
 // 			GetInstallCredsFunc: func() (string, error) {
@@ -34,7 +34,7 @@ import (
 // 			SetCurrentKeptnCLIConfigFunc: func(cliConfig config.CLIConfig)  {
 // 				panic("mock out the SetCurrentKeptnCLIConfig method")
 // 			},
-// 			SetCurrentKubeConfigFunc: func(kubeConfig credentialmanager.kubeConfigFileType)  {
+// 			SetCurrentKubeConfigFunc: func(kubeConfig credentialmanager.KubeConfigFileType)  {
 // 				panic("mock out the SetCurrentKubeConfig method")
 // 			},
 // 			SetInstallCredsFunc: func(creds string) error {
@@ -54,7 +54,7 @@ type CredentialManagerInterfaceMock struct {
 	GetCurrentKeptnCLIConfigFunc func() config.CLIConfig
 
 	// GetCurrentKubeConfigFunc mocks the GetCurrentKubeConfig method.
-	GetCurrentKubeConfigFunc func() credentialmanager.kubeConfigFileType
+	GetCurrentKubeConfigFunc func() credentialmanager.KubeConfigFileType
 
 	// GetInstallCredsFunc mocks the GetInstallCreds method.
 	GetInstallCredsFunc func() (string, error)
@@ -66,7 +66,7 @@ type CredentialManagerInterfaceMock struct {
 	SetCurrentKeptnCLIConfigFunc func(cliConfig config.CLIConfig)
 
 	// SetCurrentKubeConfigFunc mocks the SetCurrentKubeConfig method.
-	SetCurrentKubeConfigFunc func(kubeConfig credentialmanager.kubeConfigFileType)
+	SetCurrentKubeConfigFunc func(kubeConfig credentialmanager.KubeConfigFileType)
 
 	// SetInstallCredsFunc mocks the SetInstallCreds method.
 	SetInstallCredsFunc func(creds string) error
@@ -104,7 +104,7 @@ type CredentialManagerInterfaceMock struct {
 		// SetCurrentKubeConfig holds details about calls to the SetCurrentKubeConfig method.
 		SetCurrentKubeConfig []struct {
 			// KubeConfig is the kubeConfig argument value.
-			KubeConfig credentialmanager.kubeConfigFileType
+			KubeConfig credentialmanager.KubeConfigFileType
 		}
 		// SetInstallCreds holds details about calls to the SetInstallCreds method.
 		SetInstallCreds []struct {
@@ -180,7 +180,7 @@ func (mock *CredentialManagerInterfaceMock) GetCurrentKeptnCLIConfigCalls() []st
 }
 
 // GetCurrentKubeConfig calls GetCurrentKubeConfigFunc.
-func (mock *CredentialManagerInterfaceMock) GetCurrentKubeConfig() credentialmanager.kubeConfigFileType {
+func (mock *CredentialManagerInterfaceMock) GetCurrentKubeConfig() credentialmanager.KubeConfigFileType {
 	if mock.GetCurrentKubeConfigFunc == nil {
 		panic("CredentialManagerInterfaceMock.GetCurrentKubeConfigFunc: method is nil but CredentialManagerInterface.GetCurrentKubeConfig was just called")
 	}
@@ -302,12 +302,12 @@ func (mock *CredentialManagerInterfaceMock) SetCurrentKeptnCLIConfigCalls() []st
 }
 
 // SetCurrentKubeConfig calls SetCurrentKubeConfigFunc.
-func (mock *CredentialManagerInterfaceMock) SetCurrentKubeConfig(kubeConfig credentialmanager.kubeConfigFileType) {
+func (mock *CredentialManagerInterfaceMock) SetCurrentKubeConfig(kubeConfig credentialmanager.KubeConfigFileType) {
 	if mock.SetCurrentKubeConfigFunc == nil {
 		panic("CredentialManagerInterfaceMock.SetCurrentKubeConfigFunc: method is nil but CredentialManagerInterface.SetCurrentKubeConfig was just called")
 	}
 	callInfo := struct {
-		KubeConfig credentialmanager.kubeConfigFileType
+		KubeConfig credentialmanager.KubeConfigFileType
 	}{
 		KubeConfig: kubeConfig,
 	}
@@ -321,10 +321,10 @@ func (mock *CredentialManagerInterfaceMock) SetCurrentKubeConfig(kubeConfig cred
 // Check the length with:
 //     len(mockedCredentialManagerInterface.SetCurrentKubeConfigCalls())
 func (mock *CredentialManagerInterfaceMock) SetCurrentKubeConfigCalls() []struct {
-	KubeConfig credentialmanager.kubeConfigFileType
+	KubeConfig credentialmanager.KubeConfigFileType
 } {
 	var calls []struct {
-		KubeConfig credentialmanager.kubeConfigFileType
+		KubeConfig credentialmanager.KubeConfigFileType
 	}
 	mock.lockSetCurrentKubeConfig.RLock()
 	calls = mock.calls.SetCurrentKubeConfig

--- a/cli/pkg/credentialmanager/handler.go
+++ b/cli/pkg/credentialmanager/handler.go
@@ -162,8 +162,12 @@ func initChecks(autoApplyNewContext bool, cm CredentialManagerInterface) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		cm.SetCurrentKeptnCLIConfig(*updatedCLIConfig)
-		cm.SetCurrentKubeConfig(*kubeConfig)
+		if updatedCLIConfig != nil {
+			cm.SetCurrentKeptnCLIConfig(*updatedCLIConfig)
+		}
+		if kubeConfig != nil {
+			cm.SetCurrentKubeConfig(*kubeConfig)
+		}
 		GlobalCheckForContextChange = true
 	} else {
 		cm.SetCurrentKeptnCLIConfig(cliConfig)

--- a/cli/pkg/credentialmanager/handler_darwin.go
+++ b/cli/pkg/credentialmanager/handler_darwin.go
@@ -1,18 +1,22 @@
 package credentialmanager
 
 import (
+	"github.com/keptn/keptn/cli/pkg/config"
 	"net/url"
 
 	"github.com/docker/docker-credential-helpers/osxkeychain"
 )
 
 type CredentialManager struct {
+	cliConfig  config.CLIConfig
+	kubeConfig KubeConfigFileType
 }
 
 // NewCredentialManager creates a new credential manager
-func NewCredentialManager(autoApplyNewContext bool) (cm *CredentialManager) {
-	initChecks(autoApplyNewContext)
-	return &CredentialManager{}
+func NewCredentialManager(autoApplyNewContext bool) *CredentialManager {
+	cm := &CredentialManager{}
+	initChecks(autoApplyNewContext, cm)
+	return cm
 }
 
 // SetCreds stores the credentials consisting of an endpoint and an api token in the keychain.
@@ -33,4 +37,20 @@ func (cm *CredentialManager) SetInstallCreds(creds string) error {
 // GetInstallCreds gets the install credentials
 func (cm *CredentialManager) GetInstallCreds() (string, error) {
 	return getInstallCreds(osxkeychain.Osxkeychain{})
+}
+
+func (cm *CredentialManager) SetCurrentKubeConfig(kubeConfig KubeConfigFileType) {
+	cm.kubeConfig = kubeConfig
+}
+
+func (cm *CredentialManager) GetCurrentKubeConfig() KubeConfigFileType {
+	return cm.kubeConfig
+}
+
+func (cm *CredentialManager) SetCurrentKeptnCLIConfig(cliConfig config.CLIConfig) {
+	cm.cliConfig = cliConfig
+}
+
+func (cm *CredentialManager) GetCurrentKeptnCLIConfig() config.CLIConfig {
+	return cm.cliConfig
 }

--- a/cli/pkg/credentialmanager/handler_linux.go
+++ b/cli/pkg/credentialmanager/handler_linux.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 
 	"github.com/docker/docker-credential-helpers/pass"
+	"github.com/keptn/keptn/cli/pkg/config"
 	keptnutils "github.com/keptn/kubernetes-utils/pkg"
 )
 

--- a/cli/pkg/credentialmanager/handler_linux.go
+++ b/cli/pkg/credentialmanager/handler_linux.go
@@ -38,8 +38,9 @@ func NewCredentialManager(autoApplyNewContext bool) (cm *CredentialManager) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	initChecks(autoApplyNewContext)
-	return &CredentialManager{apiTokenFile: dir + ".keptn", credsFile: dir + ".keptn-creds"}
+	cm := &CredentialManager{apiTokenFile: dir + ".keptn", credsFile: dir + ".keptn-creds"}
+	initChecks(autoApplyNewContext, cm)
+	return cm
 }
 
 // SetCreds stores the credentials consisting of an endpoint and an api token using pass or into a file in case
@@ -116,4 +117,20 @@ func (cm *CredentialManager) GetInstallCreds() (string, error) {
 func (cm *CredentialManager) getLinuxApiTokenFile(namespace string) string {
 	sanitizedCurrentContext := strings.ReplaceAll(keptnContext, "/", "-")
 	return cm.apiTokenFile + "__" + sanitizedCurrentContext + "__" + namespace
+}
+
+func (cm *CredentialManager) SetCurrentKubeConfig(kubeConfig KubeConfigFileType) {
+	cm.kubeConfig = kubeConfig
+}
+
+func (cm *CredentialManager) GetCurrentKubeConfig() KubeConfigFileType {
+	return cm.kubeConfig
+}
+
+func (cm *CredentialManager) SetCurrentKeptnCLIConfig(cliConfig config.CLIConfig) {
+	cm.cliConfig = cliConfig
+}
+
+func (cm *CredentialManager) GetCurrentKeptnCLIConfig() config.CLIConfig {
+	return cm.cliConfig
 }

--- a/cli/pkg/credentialmanager/handler_linux.go
+++ b/cli/pkg/credentialmanager/handler_linux.go
@@ -29,10 +29,12 @@ type CredentialManager struct {
 	// MockAuthCreds shows whether the get and set for the auth-creds should be mocked
 	apiTokenFile string
 	credsFile    string
+	cliConfig    config.CLIConfig
+	kubeConfig   KubeConfigFileType
 }
 
 // NewCredentialManager creates a new credential manager
-func NewCredentialManager(autoApplyNewContext bool) (cm *CredentialManager) {
+func NewCredentialManager(autoApplyNewContext bool) *CredentialManager {
 
 	dir, err := keptnutils.GetKeptnDirectory()
 	if err != nil {

--- a/cli/pkg/credentialmanager/handler_windows.go
+++ b/cli/pkg/credentialmanager/handler_windows.go
@@ -16,7 +16,7 @@ type CredentialManager struct {
 func NewCredentialManager(autoApplyNewContext bool) *CredentialManager {
 	cm := &CredentialManager{}
 	initChecks(autoApplyNewContext, cm)
-	return
+	return cm
 }
 
 // SetCreds stores the credentials consisting of an endpoint and an api token in the keychain.

--- a/cli/pkg/credentialmanager/handler_windows.go
+++ b/cli/pkg/credentialmanager/handler_windows.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 
 	"github.com/docker/docker-credential-helpers/wincred"
+	"github.com/keptn/keptn/cli/pkg/config"
 )
 
 type CredentialManager struct {

--- a/cli/pkg/credentialmanager/handler_windows.go
+++ b/cli/pkg/credentialmanager/handler_windows.go
@@ -7,10 +7,12 @@ import (
 )
 
 type CredentialManager struct {
+	cliConfig  config.CLIConfig
+	kubeConfig KubeConfigFileType
 }
 
 // NewCredentialManager creates a new credential manager
-func NewCredentialManager(autoApplyNewContext bool) (cm *CredentialManager) {
+func NewCredentialManager(autoApplyNewContext bool) *CredentialManager {
 	cm := &CredentialManager{}
 	initChecks(autoApplyNewContext, cm)
 	return

--- a/cli/pkg/credentialmanager/handler_windows.go
+++ b/cli/pkg/credentialmanager/handler_windows.go
@@ -11,8 +11,9 @@ type CredentialManager struct {
 
 // NewCredentialManager creates a new credential manager
 func NewCredentialManager(autoApplyNewContext bool) (cm *CredentialManager) {
-	initChecks(autoApplyNewContext)
-	return &CredentialManager{}
+	cm := &CredentialManager{}
+	initChecks(autoApplyNewContext, cm)
+	return
 }
 
 // SetCreds stores the credentials consisting of an endpoint and an api token in the keychain.
@@ -33,4 +34,20 @@ func (cm *CredentialManager) SetInstallCreds(creds string) error {
 // GetInstallCreds gets the install credentials
 func (cm *CredentialManager) GetInstallCreds() (string, error) {
 	return getInstallCreds(wincred.Wincred{})
+}
+
+func (cm *CredentialManager) SetCurrentKubeConfig(kubeConfig KubeConfigFileType) {
+	cm.kubeConfig = kubeConfig
+}
+
+func (cm *CredentialManager) GetCurrentKubeConfig() KubeConfigFileType {
+	return cm.kubeConfig
+}
+
+func (cm *CredentialManager) SetCurrentKeptnCLIConfig(cliConfig config.CLIConfig) {
+	cm.cliConfig = cliConfig
+}
+
+func (cm *CredentialManager) GetCurrentKeptnCLIConfig() config.CLIConfig {
+	return cm.cliConfig
 }

--- a/cli/pkg/platform/platform_manager_test.go
+++ b/cli/pkg/platform/platform_manager_test.go
@@ -3,6 +3,7 @@
 package platform
 
 import (
+	"github.com/keptn/keptn/cli/pkg/credentialmanager"
 	"reflect"
 	"testing"
 )
@@ -19,7 +20,7 @@ var iskeptnVersions = []struct {
 func TestSetPlatform(t *testing.T) {
 	for _, tt := range iskeptnVersions {
 		t.Run(tt.platform, func(t *testing.T) {
-			p, err := NewPlatformManager(tt.platform)
+			p, err := NewPlatformManager(tt.platform, credentialmanager.NewCredentialManager(false))
 			if err != tt.expectedErr {
 				t.Errorf("got %t, want %t", err, tt.expectedErr)
 			}


### PR DESCRIPTION
Closes #4583

This PR adds a check whether the current Kubectl context matches the current Keptn CLI context before starting with the execution of the helm chart upgrade. If those contexts do not match, the upgrade will not be performed. 

Follow up tasks: The CLI needs some refactoring as it is currently really hard to add any unit tests. Some work has already been done for making the `install` command more testable by introducing a struct that handles the install command and provides the means to inject its dependencies. A similar approach should be done for the `upgrade` command.
Also, the `CredentialManager` stuff that checks for context changes in the kubectl CLI and the current Keptn context is hard to maintain and to understand (relies heavily on global state, effects of functions on the execution of the commands is not easy to comprehend)