### PR TITLE
fix(jmeter-service): prevent failure if deploymentURIs does not end with a '/'(#3612)

### DIFF
--- a/jmeter-service/main.go
+++ b/jmeter-service/main.go
@@ -196,10 +196,18 @@ func getTestInfo(data keptnv2.TestTriggeredEventData, shkeptncontext string) *Te
 //
 func getServiceURL(data keptnv2.TestTriggeredEventData) (*url.URL, error) {
 	if len(data.Deployment.DeploymentURIsLocal) > 0 && data.Deployment.DeploymentURIsLocal[0] != "" {
-		return url.Parse(data.Deployment.DeploymentURIsLocal[0])
+		newurl, err := url.Parse(data.Deployment.DeploymentURIsLocal[0])
+		if newurl.Path == "" {
+			newurl.Path += "/"
+		}
+		return newurl, err
 
 	} else if len(data.Deployment.DeploymentURIsPublic) > 0 && data.Deployment.DeploymentURIsPublic[0] != "" {
-		return url.Parse(data.Deployment.DeploymentURIsPublic[0])
+		newurl, err := url.Parse(data.Deployment.DeploymentURIsPublic[0])
+		if newurl.Path == "" {
+			newurl.Path += "/"
+		}
+		return newurl, err
 	}
 
 	return nil, errors.New("no deployment URI included in event")

--- a/jmeter-service/main_test.go
+++ b/jmeter-service/main_test.go
@@ -19,6 +19,7 @@ var serviceURLTests = []struct {
 }{
 	{"local", deploymentFinishedEventInitHelper("sockshop", "carts", "dev", "direct", "https://carts.sockshop-dev.svc.cluster.local/test", "carts.sockshop-dev.mydomain.com"), getURL("https://carts.sockshop-dev.svc.cluster.local/test")},
 	{"public", deploymentFinishedEventInitHelper("sockshop", "carts", "dev", "direct", "", "http://carts.sockshop-dev.mydomain.com:8080/myendpoint"), getURL("http://carts.sockshop-dev.mydomain.com:8080/myendpoint")},
+	{"no path but valid uri", deploymentFinishedEventInitHelper("sockshop", "carts", "dev", "direct", "", "http://carts.sockshop-dev.mydomain.com:8080"), getURL("http://carts.sockshop-dev.mydomain.com:8080/")},
 }
 
 func getURL(urlString string) *url.URL {


### PR DESCRIPTION


## This PR
If a valid parsed deployment url has an empty path add '/' to it, added corresponding one line in the unit test to check this 


Fixes #3612 



