### PR TITLE
fix(bridge): fixed missing update on sequence screen (#5085)

### DIFF
--- a/bridge/client/app/_components/ktb-root-events-list/ktb-root-events-list.component.ts
+++ b/bridge/client/app/_components/ktb-root-events-list/ktb-root-events-list.component.ts
@@ -1,14 +1,6 @@
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  EventEmitter,
-  Input, OnDestroy,
-  OnInit, Output,
-  ViewEncapsulation
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, OnDestroy, OnInit, Output, ViewEncapsulation } from '@angular/core';
 import { DateUtil } from '../../_utils/date.utils';
-import { filter, map, switchMap, takeUntil } from 'rxjs/operators';
+import { map, switchMap, takeUntil } from 'rxjs/operators';
 import { ActivatedRoute } from '@angular/router';
 import { DataService } from '../../_services/data.service';
 import { Subject } from 'rxjs';
@@ -20,7 +12,7 @@ import { Sequence } from '../../_models/sequence';
   templateUrl: './ktb-root-events-list.component.html',
   styleUrls: ['./ktb-root-events-list.component.scss'],
   host: {
-    class: 'ktb-root-events-list'
+    class: 'ktb-root-events-list',
   },
   encapsulation: ViewEncapsulation.None,
   preserveWhitespaces: false,
@@ -63,18 +55,17 @@ export class KtbRootEventsListComponent implements OnInit, OnDestroy {
               private route: ActivatedRoute, private dataService: DataService) {
   }
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.route.params.pipe(
       map(params => params.projectName),
       switchMap(projectName => this.dataService.getProject(projectName)),
-      takeUntil(this.unsubscribe$)
+      takeUntil(this.unsubscribe$),
     ).subscribe(project => {
       this.project = project;
     });
 
     this.dataService.sequences.pipe(
       takeUntil(this.unsubscribe$),
-      filter(sequences => !!sequences)
     ).subscribe(() => {
       this.loading = false;
       this._changeDetectorRef.markForCheck();
@@ -90,7 +81,7 @@ export class KtbRootEventsListComponent implements OnInit, OnDestroy {
     return item?.time;
   }
 
-  loadOldSequences() {
+  loadOldSequences(): void {
     if (this.project) {
       this.loading = true;
       this._changeDetectorRef.markForCheck();
@@ -103,7 +94,7 @@ export class KtbRootEventsListComponent implements OnInit, OnDestroy {
     this.unsubscribe$.complete();
   }
 
-  public getShortType(type: string | undefined): string | undefined{
+  public getShortType(type: string | undefined): string | undefined {
     return type ? Sequence.getShortType(type) : undefined;
   }
 }

--- a/bridge/client/app/_components/ktb-root-events-list/ktb-root-events-list.component.ts
+++ b/bridge/client/app/_components/ktb-root-events-list/ktb-root-events-list.component.ts
@@ -64,7 +64,7 @@ export class KtbRootEventsListComponent implements OnInit, OnDestroy {
       this.project = project;
     });
 
-    this.dataService.sequences.pipe(
+    this.dataService.sequencesUpdated.pipe(
       takeUntil(this.unsubscribe$),
     ).subscribe(() => {
       this.loading = false;

--- a/bridge/client/app/_services/data.service.mock.ts
+++ b/bridge/client/app/_services/data.service.mock.ts
@@ -57,7 +57,7 @@ export class DataServiceMock extends DataService {
     project.stages.forEach(stage => {
       this.stageSequenceMapper(stage, project);
     });
-    this._sequences.next(project.sequences);
+    this._sequences.next();
   }
 
   public getProject(projectName: string): Observable<Project | undefined> {
@@ -76,7 +76,7 @@ export class DataServiceMock extends DataService {
 
   public loadTraces(sequence: Sequence): void {
     sequence.traces = [...Traces || [], ...sequence.traces || []];
-    this._sequences.next([...this._sequences.getValue() || []]);
+    this._sequences.next();
   }
 
   public loadTracesByContext(shkeptncontext: string): void {

--- a/bridge/client/app/_services/data.service.mock.ts
+++ b/bridge/client/app/_services/data.service.mock.ts
@@ -57,7 +57,7 @@ export class DataServiceMock extends DataService {
     project.stages.forEach(stage => {
       this.stageSequenceMapper(stage, project);
     });
-    this._sequences.next();
+    this._sequencesUpdated.next();
   }
 
   public getProject(projectName: string): Observable<Project | undefined> {
@@ -76,7 +76,7 @@ export class DataServiceMock extends DataService {
 
   public loadTraces(sequence: Sequence): void {
     sequence.traces = [...Traces || [], ...sequence.traces || []];
-    this._sequences.next();
+    this._sequencesUpdated.next();
   }
 
   public loadTracesByContext(shkeptncontext: string): void {

--- a/bridge/client/app/_services/data.service.ts
+++ b/bridge/client/app/_services/data.service.ts
@@ -29,7 +29,7 @@ import { FileTree } from '../../../shared/interfaces/resourceFileTree';
 export class DataService {
 
   protected _projects = new BehaviorSubject<Project[] | undefined>(undefined);
-  protected _sequences = new BehaviorSubject<Sequence[] | undefined>(undefined);
+  protected _sequences = new Subject<void>();
   protected _traces = new BehaviorSubject<Trace[] | undefined>(undefined);
   protected _openApprovals = new BehaviorSubject<Trace[]>([]);
   protected _keptnInfo = new BehaviorSubject<KeptnInfo | undefined>(undefined);
@@ -55,7 +55,7 @@ export class DataService {
     return this._projects.asObservable();
   }
 
-  get sequences(): Observable<Sequence[] | undefined> {
+  get sequences(): Observable<void> {
     return this._sequences.asObservable();
   }
 
@@ -395,7 +395,7 @@ export class DataService {
       project.stages.forEach(stage => {
         this.stageSequenceMapper(stage, project);
       });
-      this._sequences.next(project.sequences);
+      this._sequences.next();
     });
   }
 
@@ -459,13 +459,14 @@ export class DataService {
       map(response => response.body?.states || []),
       map(sequences => sequences.map(sequence => Sequence.fromJSON(sequence)).shift()),
     ).subscribe(sequence => {
-      const sequences = this._sequences.getValue();
+      const project = this._projects.getValue()?.find(p => p.projectName === projectName);
+      const sequences = project?.sequences;
       const oldSequence = sequences?.find(seq => seq.shkeptncontext === keptnContext);
       if (oldSequence && sequence) {
         const {traces, ...copySequence} = sequence; // don't overwrite loaded traces
         Object.assign(oldSequence, copySequence);
       }
-      this._sequences.next(sequences);
+      this._sequences.next();
     });
   }
 
@@ -498,7 +499,7 @@ export class DataService {
               });
             }
           });
-        this._sequences.next([...this._sequences.getValue() ?? []]);
+        this._sequences.next();
       });
   }
 

--- a/bridge/client/app/_services/data.service.ts
+++ b/bridge/client/app/_services/data.service.ts
@@ -29,7 +29,7 @@ import { FileTree } from '../../../shared/interfaces/resourceFileTree';
 export class DataService {
 
   protected _projects = new BehaviorSubject<Project[] | undefined>(undefined);
-  protected _sequences = new Subject<void>();
+  protected _sequencesUpdated = new Subject<void>();
   protected _traces = new BehaviorSubject<Trace[] | undefined>(undefined);
   protected _openApprovals = new BehaviorSubject<Trace[]>([]);
   protected _keptnInfo = new BehaviorSubject<KeptnInfo | undefined>(undefined);
@@ -55,8 +55,8 @@ export class DataService {
     return this._projects.asObservable();
   }
 
-  get sequences(): Observable<void> {
-    return this._sequences.asObservable();
+  get sequencesUpdated(): Observable<void> {
+    return this._sequencesUpdated.asObservable();
   }
 
   get traces(): Observable<Trace[] | undefined> {
@@ -395,7 +395,7 @@ export class DataService {
       project.stages.forEach(stage => {
         this.stageSequenceMapper(stage, project);
       });
-      this._sequences.next();
+      this._sequencesUpdated.next();
     });
   }
 
@@ -466,7 +466,7 @@ export class DataService {
         const {traces, ...copySequence} = sequence; // don't overwrite loaded traces
         Object.assign(oldSequence, copySequence);
       }
-      this._sequences.next();
+      this._sequencesUpdated.next();
     });
   }
 
@@ -499,7 +499,7 @@ export class DataService {
               });
             }
           });
-        this._sequences.next();
+        this._sequencesUpdated.next();
       });
   }
 

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.html
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.html
@@ -1,9 +1,9 @@
 <div fxFlexFill>
-  <div class="container p-0" fxFlex="40" fxLayout="column" fxLayoutGap="15px" *ngIf="sequences$ | async as sequences">
+  <div class="container p-0" fxFlex="40" fxLayout="column" fxLayoutGap="15px" *ngIf="project$ | async as project">
     <div fxFlex fxLayout="column" fxLayoutGap="15px" uitestid="keptn-sequence-view-filter">
       <dt-quick-filter [dataSource]="_filterDataSource" [filters]="_seqFilters" (filterChanges)="filtersChanged($event)" aria-label="Filter By Input value" label="Filter by" clearAllLabel="Clear all" fxFlex>
         <div class="container" fxFlex fxLayout="column">
-          <ktb-root-events-list uitestid="keptn-sequence-view-roots" [events]="getFilteredSequences(sequences)" [selectedEvent]="currentSequence" (selectedEventChange)="selectSequence($event)" fxFlex></ktb-root-events-list>
+          <ktb-root-events-list uitestid="keptn-sequence-view-roots" [events]="getFilteredSequences(project.sequences)" [selectedEvent]="currentSequence" (selectedEventChange)="selectSequence($event)" fxFlex></ktb-root-events-list>
           <div class="mb-3"></div>
         </div>
       </dt-quick-filter>
@@ -21,7 +21,9 @@
                     <span class="bold" [textContent]="currentSequence.name"></span>&nbsp;
                     <span [textContent]="currentSequence.getStatus()"></span>
                   </p>
-                  <button *ngIf="currentSequence.isFaulty()" dt-icon-button disabled variant="nested"><dt-icon name="criticalevent"></dt-icon></button>
+                  <button *ngIf="currentSequence.isFaulty()" dt-icon-button disabled variant="nested">
+                    <dt-icon name="criticalevent"></dt-icon>
+                  </button>
                 </div>
               </div>
               <div>
@@ -42,7 +44,10 @@
       <ktb-sequence-tasks-list [tasks]="currentSequence.traces" [stage]="selectedStage"></ktb-sequence-tasks-list>
       <div class="mb-3" fxLayout="row" fxLayoutAlign="end center">
         <dt-tag>Last time fetched: <span [textContent]="getTracesLastUpdated(currentSequence) | amCalendar:dateUtil.getCalendarFormats(true)"></span></dt-tag>
-        <button class="ml-2" dt-button (click)="loadTraces(currentSequence)" *ngIf="showReloadButton(currentSequence)"><dt-icon name="refresh"></dt-icon> Reload</button>
+        <button class="ml-2" dt-button (click)="loadTraces(currentSequence)" *ngIf="showReloadButton(currentSequence)">
+          <dt-icon name="refresh"></dt-icon>
+          Reload
+        </button>
       </div>
     </div>
   </div>

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
@@ -88,7 +88,7 @@ export class KtbSequenceViewComponent implements OnInit, OnDestroy {
         map(params => params.projectName),
       );
 
-    this.sequencesUpdated$ = this.dataService.sequences
+    this.sequencesUpdated$ = this.dataService.sequencesUpdated
       .pipe(
         takeUntil(this.unsubscribe$),
       );


### PR DESCRIPTION
Fixes #5085
This also changes the `sequence` `BehaviorSubject` to `Subject` in order to reduce redundancy and just emit update notifications.

Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>