### PR TITLE
fix(cli): added zones to times format according to (ISO8601) (#4788)

### DIFF
--- a/cli/cmd/send_event_evaluationStart_test.go
+++ b/cli/cmd/send_event_evaluationStart_test.go
@@ -43,7 +43,7 @@ func TestEvaluationStartTimeSpecified(t *testing.T) {
 	*evaluationStart.End = ""
 
 	cmd := fmt.Sprintf("send event start-evaluation --project=%s --stage=%s --service=%s "+
-		"--timeframe=%s --start=%s --mock", "sockshop", "hardening", "carts", "5m", "2019-07-24T10:17:12")
+		"--timeframe=%s --start=%s --mock", "sockshop", "hardening", "carts", "5m", "2019-07-24T10:17:12.000Z")
 	_, err := executeActionCommandC(cmd)
 
 	if err != nil {
@@ -61,7 +61,7 @@ func TestEvaluationStartAndEndTimeSpecified(t *testing.T) {
 	*evaluationStart.End = ""
 
 	cmd := fmt.Sprintf("send event start-evaluation --project=%s --stage=%s --service=%s "+
-		"--start=%s --end=%s --mock", "sockshop", "hardening", "carts", "2019-07-24T10:17:12", "2019-07-24T10:20:12")
+		"--start=%s --end=%s --mock", "sockshop", "hardening", "carts", "2019-07-24T10:17:12.000Z", "2019-07-24T10:20:12.000Z")
 	_, err := executeActionCommandC(cmd)
 
 	if err != nil {
@@ -79,8 +79,8 @@ func TestEvaluationStartAndEndTimeAndTimeframeSpecified(t *testing.T) {
 	*evaluationStart.End = ""
 
 	cmd := fmt.Sprintf("send event start-evaluation --project=%s --stage=%s --service=%s "+
-		"--start=%s --end=%s --timeframe=%s --mock", "sockshop", "hardening", "carts", "2019-07-24T10:17:12",
-		"2019-07-24T10:20:12", "5m")
+		"--start=%s --end=%s --timeframe=%s --mock", "sockshop", "hardening", "carts", "2019-07-24T10:17:12.000Z",
+		"2019-07-24T10:20:12.000Z", "5m")
 	_, err := executeActionCommandC(cmd)
 
 	if err == nil {
@@ -100,7 +100,7 @@ func TestEvaluationStartAndEndTimeWrongOrder(t *testing.T) {
 	*evaluationStart.End = ""
 
 	cmd := fmt.Sprintf("send event start-evaluation --project=%s --stage=%s --service=%s "+
-		"--start=%s --end=%s  --mock", "sockshop", "hardening", "carts", "2019-07-24T10:17:12", "2019-07-24T10:10:12")
+		"--start=%s --end=%s  --mock", "sockshop", "hardening", "carts", "2019-07-24T10:17:12.000Z", "2019-07-24T10:10:12.000Z")
 	_, err := executeActionCommandC(cmd)
 
 	if err == nil {

--- a/cli/cmd/trigger_evaluation.go
+++ b/cli/cmd/trigger_evaluation.go
@@ -63,7 +63,7 @@ keptn trigger evaluation --project=sockshop --stage=hardening --service=carts --
 }
 
 func doTriggerEvaluation(triggerEvaluationData triggerEvaluationStruct) error {
-	const userFriendlyDateLayout = "2006-01-02T15:04:05"
+	const userFriendlyDateLayout = "2006-01-02T15:04:05.000Z"
 
 	endPoint, apiToken, err := credentialmanager.NewCredentialManager(assumeYes).GetCreds(namespace)
 	if err != nil {

--- a/cli/cmd/trigger_evaluation_test.go
+++ b/cli/cmd/trigger_evaluation_test.go
@@ -60,7 +60,7 @@ func TestTriggerEvaluationStartTimeSpecified(t *testing.T) {
 	*triggerEvaluation.End = ""
 
 	cmd := fmt.Sprintf("trigger evaluation --project=%s --stage=%s --service=%s "+
-		"--timeframe=%s --start=%s --mock", "sockshop", "hardening", "carts", "5m", "2019-07-24T10:17:12")
+		"--timeframe=%s --start=%s --mock", "sockshop", "hardening", "carts", "5m", "2019-07-24T10:17:12.000Z")
 	_, err := executeActionCommandC(cmd)
 
 	if err != nil {
@@ -78,7 +78,7 @@ func TestTriggerEvaluationStartAndEndTimeSpecified(t *testing.T) {
 	*triggerEvaluation.End = ""
 
 	cmd := fmt.Sprintf("trigger evaluation --project=%s --stage=%s --service=%s "+
-		"--start=%s --end=%s --mock", "sockshop", "hardening", "carts", "2019-07-24T10:17:12", "2019-07-24T10:20:12")
+		"--start=%s --end=%s --mock", "sockshop", "hardening", "carts", "2019-07-24T10:17:12.000Z", "2019-07-24T10:20:12.000Z")
 	_, err := executeActionCommandC(cmd)
 
 	if err != nil {
@@ -96,8 +96,8 @@ func TestTriggerEvaluationStartAndEndTimeAndTimeframeSpecified(t *testing.T) {
 	*triggerEvaluation.End = ""
 
 	cmd := fmt.Sprintf("trigger evaluation --project=%s --stage=%s --service=%s "+
-		"--start=%s --end=%s --timeframe=%s --mock", "sockshop", "hardening", "carts", "2019-07-24T10:17:12",
-		"2019-07-24T10:20:12", "5m")
+		"--start=%s --end=%s --timeframe=%s --mock", "sockshop", "hardening", "carts", "2019-07-24T10:17:12.000Z",
+		"2019-07-24T10:20:12.000Z", "5m")
 	_, err := executeActionCommandC(cmd)
 
 	if err == nil {
@@ -117,7 +117,7 @@ func TestTriggerEvaluationStartAndEndTimeWrongOrder(t *testing.T) {
 	*triggerEvaluation.End = ""
 
 	cmd := fmt.Sprintf("trigger evaluation --project=%s --stage=%s --service=%s "+
-		"--start=%s --end=%s  --mock", "sockshop", "hardening", "carts", "2019-07-24T10:17:12", "2019-07-24T10:10:12")
+		"--start=%s --end=%s  --mock", "sockshop", "hardening", "carts", "2019-07-24T10:17:12.000Z", "2019-07-24T10:10:12.000Z")
 	_, err := executeActionCommandC(cmd)
 
 	if err == nil {

--- a/shipyard-controller/handler/evaluationmanager.go
+++ b/shipyard-controller/handler/evaluationmanager.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-const userFriendlyTimeFormat = "2006-01-02T15:04:05"
+const userFriendlyTimeFormat = "2006-01-02T15:04:05.000Z"
 
 const (
 	evaluationErrInvalidTimeframe = iota

--- a/shipyard-controller/handler/evaluationmanager_test.go
+++ b/shipyard-controller/handler/evaluationmanager_test.go
@@ -50,8 +50,8 @@ func TestEvaluationManager_CreateEvaluation(t *testing.T) {
 				service: "test-service",
 				params: &operations.CreateEvaluationParams{
 					Labels:    map[string]string{"foo": "bar"},
-					Start:     "2020-01-02T15:00:00",
-					End:       "2020-01-02T16:00:00",
+					Start:     "2020-01-02T15:00:00.000Z",
+					End:       "2020-01-02T16:00:00.000Z",
 					Timeframe: "",
 				},
 			},

--- a/shipyard-controller/handler/evaluationmanager_test.go
+++ b/shipyard-controller/handler/evaluationmanager_test.go
@@ -89,8 +89,8 @@ func TestEvaluationManager_CreateEvaluation(t *testing.T) {
 				service: "test-service",
 				params: &operations.CreateEvaluationParams{
 					Labels:    map[string]string{"foo": "bar"},
-					Start:     "2030-01-02T15:00:00",
-					End:       "2020-01-02T16:00:00",
+					Start:     "2030-01-02T15:00:00.000Z",
+					End:       "2020-01-02T16:00:00.000Z",
 					Timeframe: "",
 				},
 			},
@@ -118,8 +118,8 @@ func TestEvaluationManager_CreateEvaluation(t *testing.T) {
 				service: "test-service",
 				params: &operations.CreateEvaluationParams{
 					Labels:    map[string]string{"foo": "bar"},
-					Start:     "2020-01-02T15:00:00",
-					End:       "2020-01-02T16:00:00",
+					Start:     "2020-01-02T15:00:00.000Z",
+					End:       "2020-01-02T16:00:00.000Z",
 					Timeframe: "",
 				},
 			},


### PR DESCRIPTION
Signed-off-by: RealAnna <anna.reale@dynatrace.com>

## This PR

Checked that all calls to our timeutils uses time.Now().UTC() or that the time constant passed has zones
Changed a couple of those when missing
Fixed CLI and Shipyard controller tests 
### Related Issues
Fixes #4788 

