### PR TITLE
fix(cli): added missing command description for `keptn create secret`

### DIFF
--- a/cli/cmd/create.go
+++ b/cli/cmd/create.go
@@ -6,8 +6,8 @@ import (
 
 // createCmd implements the create command
 var createCmd = &cobra.Command{
-	Use:   "create [project | service]",
-	Short: `Creates a new project or service`,
+	Use:   "create [project | service | secret]",
+	Short: `Creates a new project, service or secret`,
 }
 
 func init() {


### PR DESCRIPTION
Update `keptn create secret` CLI helper text to indicate that it can also be used to create secrets.

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- adds this new feature

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #5291 

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

