### PR TITLE
fix(bridge): grouping sequence after pause #5154

### DIFF
--- a/bridge/client/app/_components/ktb-root-events-list/ktb-root-events-list.component.html
+++ b/bridge/client/app/_components/ktb-root-events-list/ktb-root-events-list.component.html
@@ -10,14 +10,15 @@
         <div class="container">
           <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px">
             <div fxFlex fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px">
-              <dt-icon *ngIf="!sequence.isLoading() || sequence.hasPendingApproval(); else showLoading" class="event-icon"
+              <dt-icon *ngIf="(!sequence.isLoading() && !sequence.isWaiting()) || sequence.hasPendingApproval(); else showLoading" class="event-icon"
                        [name]="sequence.getIcon()"
                        [class.error]="sequence.isFaulty()"
                        [class.highlight]="sequence.hasPendingApproval()"></dt-icon>
               <ng-template #showLoading>
-                <button class="m-0 p-0" dt-button disabled variant="nested">
+                <button class="m-0 p-0" dt-button disabled variant="nested" *ngIf="sequence.isLoading() && !sequence.isWaiting()">
                   <dt-loading-spinner aria-label="Task is running..."></dt-loading-spinner>
                 </button>
+                <dt-icon *ngIf="sequence.isWaiting()" class="event-icon" name="idle"></dt-icon>
               </ng-template>
               <div class="mt-1 mb-1" fxLayout="row" fxLayoutAlign="start center">
                 <p class="m-0">

--- a/bridge/client/app/_components/ktb-root-events-list/ktb-root-events-list.component.html
+++ b/bridge/client/app/_components/ktb-root-events-list/ktb-root-events-list.component.html
@@ -46,8 +46,8 @@
           </div>
         </div>
       </ktb-selectable-tile-header>
-      <p class="m-0 small" *ngIf="sequence.isWaiting(sequence.getLastStage()), else notWaiting">
-        Waiting for previous sequences to be finished.
+      <p class="m-0 small" *ngIf="sequence.isWaiting(), else notWaiting">
+        Sequence might be waiting for previous sequences to be finished.
       </p>
       <ng-template #notWaiting>
         <p class="m-0 small" uitestid="keptn-root-events-list-eventTiming">

--- a/bridge/client/app/_components/ktb-root-events-list/ktb-root-events-list.component.html
+++ b/bridge/client/app/_components/ktb-root-events-list/ktb-root-events-list.component.html
@@ -46,8 +46,8 @@
           </div>
         </div>
       </ktb-selectable-tile-header>
-      <p class="m-0 small" *ngIf="sequence.isWaiting(), else notWaiting">
-        Waiting for previous sequences to be finished in the {{sequence.getLastStage()}} stage.
+      <p class="m-0 small" *ngIf="sequence.isWaiting(sequence.getLastStage()), else notWaiting">
+        Waiting for previous sequences to be finished.
       </p>
       <ng-template #notWaiting>
         <p class="m-0 small" uitestid="keptn-root-events-list-eventTiming">

--- a/bridge/client/app/_components/ktb-sequence-timeline/ktb-sequence-timeline.component.html
+++ b/bridge/client/app/_components/ktb-sequence-timeline/ktb-sequence-timeline.component.html
@@ -4,15 +4,16 @@
     <div fxLayout="row" fxLayoutAlign="space-between">
       <div class="text-center pointer stage-item" *ngFor="let stage of currentSequence.getStages(); last as isLast" (click)="selectStage(stage)">
         <div class="stage-info">
-          <dt-icon *ngIf="!currentSequence.isLoading(stage) || currentSequence.hasPendingApproval(stage); else showLoading" class="event-icon"
+          <dt-icon *ngIf="(!currentSequence.isLoading(stage) && !currentSequence.isWaiting()) || currentSequence.hasPendingApproval(stage); else showLoading" class="event-icon"
                    [name]="currentSequence.getIcon(stage)"
                    [class.error]="currentSequence.isFaulty(stage)"
                    [class.success]="currentSequence.isSuccessful(stage)"
                    [class.highlight]="currentSequence.hasPendingApproval(stage)"></dt-icon>
           <ng-template #showLoading>
-            <button class="m-0 p-0" dt-button disabled variant="nested">
+            <button class="m-0 p-0" dt-button disabled variant="nested" *ngIf="currentSequence.isLoading() && !currentSequence.isWaiting()">
               <dt-loading-spinner aria-label="Task is running..."></dt-loading-spinner>
             </button>
+            <dt-icon *ngIf="currentSequence.isWaiting()" class="event-icon" name="idle"></dt-icon>
           </ng-template>
           <span class="stage-text"
                 [class.error]="currentSequence.isFaulty(stage)"

--- a/bridge/client/app/_models/sequence.ts
+++ b/bridge/client/app/_models/sequence.ts
@@ -83,8 +83,6 @@ export class Sequence extends sq {
       } else {
         status = 'succeeded';
       }
-    } else if (this.state === SequenceState.TRIGGERED) {
-      status = 'started';
     }
     return status;
   }
@@ -103,7 +101,7 @@ export class Sequence extends sq {
   }
 
   public isWaiting(stageName?: string): boolean {
-    return stageName ? !this.isFinished(stageName) && this.state === SequenceState.WAITING : this.state === SequenceState.WAITING;
+    return stageName ? this.isFinished(stageName) && !this.isFinished() : this.state === SequenceState.WAITING || this.state === SequenceState.TRIGGERED;
   }
 
   public isRemediation(): boolean {

--- a/bridge/client/app/_models/sequence.ts
+++ b/bridge/client/app/_models/sequence.ts
@@ -58,7 +58,7 @@ export class Sequence extends sq {
   }
 
   public isFinished(stageName?: string): boolean {
-    return stageName ? (this.getStage(stageName)?.latestEvent?.type.endsWith(SequenceState.FINISHED) ?? false) : this.state === SequenceState.FINISHED;
+    return stageName ? (this.getStage(stageName)?.latestEvent?.type.endsWith(SequenceState.FINISHED) ?? false) : this.state === SequenceState.FINISHED || this.state === SequenceState.TIMEDOUT;
   }
 
   public getEvaluation(stage: string): EvaluationResult | undefined {

--- a/bridge/client/app/_models/sequence.ts
+++ b/bridge/client/app/_models/sequence.ts
@@ -101,7 +101,7 @@ export class Sequence extends sq {
   }
 
   public isWaiting(stageName?: string): boolean {
-    return stageName ? this.isFinished(stageName) && !this.isFinished() : this.state === SequenceState.WAITING || this.state === SequenceState.TRIGGERED;
+    return stageName ? this.isFinished(stageName) && !this.isFinished() : this.state === SequenceState.TRIGGERED;
   }
 
   public isRemediation(): boolean {
@@ -121,14 +121,8 @@ export class Sequence extends sq {
   }
 
   public getIcon(stageName?: string): DtIconType {
-    let icon;
-    if (this.state === SequenceState.WAITING) {
-      icon = EVENT_ICONS.waiting;
-    } else {
-      const stage = stageName ? this.getStage(stageName) : this.stages[this.stages.length - 1];
-      icon = stage?.latestEvent?.type ? EVENT_ICONS[Sequence.getShortType(stage?.latestEvent?.type)] || EVENT_ICONS.default : EVENT_ICONS.default;
-    }
-    return icon;
+    const stage = stageName ? this.getStage(stageName) : this.stages[this.stages.length - 1];
+    return stage?.latestEvent?.type ? EVENT_ICONS[Sequence.getShortType(stage?.latestEvent?.type)] || EVENT_ICONS.default : EVENT_ICONS.default;
   }
 
   public getShortImageName(): string | undefined {

--- a/bridge/client/app/_models/sequence.ts
+++ b/bridge/client/app/_models/sequence.ts
@@ -83,6 +83,8 @@ export class Sequence extends sq {
       } else {
         status = 'succeeded';
       }
+    } else if(this.isWaiting()) {
+      status = 'waiting';
     }
     return status;
   }

--- a/bridge/client/app/_models/sequence.ts
+++ b/bridge/client/app/_models/sequence.ts
@@ -101,7 +101,7 @@ export class Sequence extends sq {
   }
 
   public isWaiting(stageName?: string): boolean {
-    return stageName ? this.isFinished(stageName) && !this.isFinished() : this.state === SequenceState.TRIGGERED;
+    return stageName ? this.getStage(stageName)?.state === SequenceState.TRIGGERED : this.state === SequenceState.TRIGGERED;
   }
 
   public isRemediation(): boolean {

--- a/bridge/client/app/_models/sequence.ts
+++ b/bridge/client/app/_models/sequence.ts
@@ -101,7 +101,7 @@ export class Sequence extends sq {
   }
 
   public isWaiting(stageName?: string): boolean {
-    return stageName ? this.getStage(stageName)?.state === SequenceState.TRIGGERED : this.state === SequenceState.TRIGGERED;
+    return stageName ? (this.getStage(stageName)?.state === SequenceState.FINISHED && this.state === SequenceState.STARTED) : this.state === SequenceState.TRIGGERED;
   }
 
   public isRemediation(): boolean {

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.html
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.html
@@ -38,7 +38,7 @@
               <dt-tag class="mr-1" [textContent]="currentSequence.service"></dt-tag>
             </ng-template>
           </p>
-          <dt-alert *ngIf="currentSequence.isWaiting(currentSequence.getLastStage())" severity="warning">Waiting for previous sequences to be finished.</dt-alert>
+          <dt-alert class="mt-1" *ngIf="currentSequence.isWaiting(currentSequence.getLastStage())" severity="warning">Waiting for previous sequences to be finished.</dt-alert>
         </dt-info-group>
       </div>
       <ktb-sequence-timeline *ngIf="currentSequence.getStages().length > 0" [currentSequence]="currentSequence" [selectedStage]="selectedStage" (selectedStageChange)="selectStage($event)"></ktb-sequence-timeline>

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.html
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.html
@@ -38,6 +38,7 @@
               <dt-tag class="mr-1" [textContent]="currentSequence.service"></dt-tag>
             </ng-template>
           </p>
+          <dt-alert *ngIf="currentSequence.isWaiting(currentSequence.getLastStage())" severity="warning">Waiting for previous sequences to be finished.</dt-alert>
         </dt-info-group>
       </div>
       <ktb-sequence-timeline *ngIf="currentSequence.getStages().length > 0" [currentSequence]="currentSequence" [selectedStage]="selectedStage" (selectedStageChange)="selectStage($event)"></ktb-sequence-timeline>

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.html
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.html
@@ -38,7 +38,7 @@
               <dt-tag class="mr-1" [textContent]="currentSequence.service"></dt-tag>
             </ng-template>
           </p>
-          <dt-alert class="mt-1" *ngIf="currentSequence.isWaiting(currentSequence.getLastStage())" severity="warning">Waiting for previous sequences to be finished.</dt-alert>
+          <dt-alert class="mt-1" *ngIf="currentSequence.isWaiting()" severity="warning">Sequence might be waiting for previous sequences to be finished.</dt-alert>
         </dt-info-group>
       </div>
       <ktb-sequence-timeline *ngIf="currentSequence.getStages().length > 0" [currentSequence]="currentSequence" [selectedStage]="selectedStage" (selectedStageChange)="selectStage($event)"></ktb-sequence-timeline>

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
@@ -48,7 +48,6 @@ export class KtbSequenceViewComponent implements OnInit, OnDestroy {
           {name: 'Active', value: 'started'},
           {name: 'Failed', value: 'failed'},
           {name: 'Succeeded', value: 'succeeded'},
-          {name: 'Waiting', value: 'waiting'},
         ],
       },
     ],

--- a/bridge/client/app/app.module.ts
+++ b/bridge/client/app/app.module.ts
@@ -115,6 +115,7 @@ import { POLLING_INTERVAL_MILLIS, RETRY_ON_HTTP_ERROR } from './_utils/app.utils
 import { KtbSequenceControlsComponent } from './_components/ktb-sequence-controls/ktb-sequence-controls.component';
 import { environment } from '../environments/environment';
 import { KtbProjectSettingsComponent } from './_components/ktb-project-settings/ktb-project-settings.component';
+import { DtAlertModule } from '@dynatrace/barista-components/alert';
 
 registerLocaleData(localeEn, 'en');
 
@@ -242,6 +243,7 @@ export function init_app(appLoadService: AppInitService): () => Promise<unknown>
     BrowserAnimationsModule,
     DtFilterFieldModule,
     ReactiveFormsModule,
+    DtAlertModule,
   ],
   entryComponents: [
     KtbDeletionDialogComponent,

--- a/bridge/shared/models/sequence.ts
+++ b/bridge/shared/models/sequence.ts
@@ -18,7 +18,6 @@ export enum SequenceState {
   TRIGGERED = 'triggered',
   STARTED = 'started',
   FINISHED = 'finished',
-  WAITING = 'waiting',
   PAUSED = 'paused',
   TIMEDOUT = 'timedOut',
   UNKNOWN = ''

--- a/bridge/shared/models/sequence.ts
+++ b/bridge/shared/models/sequence.ts
@@ -20,6 +20,7 @@ export enum SequenceState {
   FINISHED = 'finished',
   WAITING = 'waiting',
   PAUSED = 'paused',
+  TIMEDOUT = 'timedOut',
   UNKNOWN = ''
 }
 

--- a/bridge/shared/models/sequence.ts
+++ b/bridge/shared/models/sequence.ts
@@ -11,6 +11,7 @@ export type SequenceStage = {
   latestEvaluation?: EvaluationResult,
   latestEvent?: SequenceEvent,
   latestFailedEvent?: SequenceEvent,
+  state: SequenceState,
   name: string,
 };
 


### PR DESCRIPTION
## This PR
- makes sure that the abort/resume/pause buttons are disabled correctly in case sequence is timedOut
- notifies the user about waiting status in case other sequences are blocking the execution

I could not reproduce the issue with grouping sequence tasks, which feels actually like a bug in the shipyard-controller.
But I reported another bug to the shipyard-controller, see #5259.

### Related Issues
Fixes #5154 

![image](https://user-images.githubusercontent.com/6098219/133739640-976d6428-aa49-4651-9d93-f20941666b8d.png)
