### PR TITLE
fix(bridge): load sequence with more than 100 events correctly #5056

### DIFF
--- a/bridge/client/app/_services/api.service.ts
+++ b/bridge/client/app/_services/api.service.ts
@@ -300,7 +300,6 @@ export class ApiService {
   public getTraces(keptnContext: string, projectName?: string, fromTime?: string): Observable<HttpResponse<EventResult>> {
     const url = `${this._baseUrl}/mongodb-datastore/event`;
     const params = {
-      pageSize: '100',
       keptnContext,
       ...projectName && {project: projectName},
       ...fromTime && {fromTime},

--- a/bridge/server/api/index.ts
+++ b/bridge/server/api/index.ts
@@ -144,6 +144,27 @@ function apiRouter(params:
     }
   });
 
+  router.get('/mongodb-datastore/event', async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      if (req.params.roots === 'true') {
+        const response = await dataService.getRoots(req.query.project?.toString(), req.query.pageSize?.toString(), req.query.serviceName?.toString(), req.query.fromTime?.toString(), req.query.beforeTime?.toString(), req.query.keptnContext?.toString());
+        return res.json(response);
+      } else {
+        const response = await dataService.getTracesByContext(req.query.keptnContext?.toString(), req.query.project?.toString(), req.query.fromTime?.toString());
+        while (response.totalCount > response.pageSize) {
+          const nextResponse = await dataService.getTracesByContext(req.query.keptnContext?.toString(), req.query.project?.toString(), req.query.fromTime?.toString());
+          response.pageSize = response.pageSize + nextResponse.pageSize;
+          response.totalCount = nextResponse.totalCount;
+          response.events = response.events.concat(nextResponse.events);
+        }
+
+        return res.json(response);
+      }
+    } catch (error) {
+      return next(error);
+    }
+  });
+
   router.all('*', async (req, res, next) => {
     try {
       const result = await axios({

--- a/bridge/server/api/index.ts
+++ b/bridge/server/api/index.ts
@@ -151,13 +151,6 @@ function apiRouter(params:
         return res.json(response);
       } else {
         const response = await dataService.getTracesByContext(req.query.keptnContext?.toString(), req.query.project?.toString(), req.query.fromTime?.toString());
-        while (response.totalCount > response.pageSize) {
-          const nextResponse = await dataService.getTracesByContext(req.query.keptnContext?.toString(), req.query.project?.toString(), req.query.fromTime?.toString());
-          response.pageSize = response.pageSize + nextResponse.pageSize;
-          response.totalCount = nextResponse.totalCount;
-          response.events = response.events.concat(nextResponse.events);
-        }
-
         return res.json(response);
       }
     } catch (error) {

--- a/bridge/server/services/api-service.ts
+++ b/bridge/server/services/api-service.ts
@@ -56,10 +56,11 @@ export class ApiService {
     return this.axios.get<EventResult>(`${this.baseUrl}/mongodb-datastore/event`, {params});
   }
 
-  public getTracesByContext(keptnContext: string | undefined, projectName?: string | undefined, fromTime?: string | undefined): Promise<AxiosResponse<EventResult>> {
+  public getTracesByContext(keptnContext: string | undefined, projectName?: string | undefined, fromTime?: string | undefined, nextPageKey?: string | undefined): Promise<AxiosResponse<EventResult>> {
     const params = {
       keptnContext,
       pageSize: '100',
+      ...nextPageKey && {nextPageKey},
       ...projectName && {project: projectName},
       ...fromTime && {fromTime},
     };

--- a/bridge/server/services/api-service.ts
+++ b/bridge/server/services/api-service.ts
@@ -56,6 +56,29 @@ export class ApiService {
     return this.axios.get<EventResult>(`${this.baseUrl}/mongodb-datastore/event`, {params});
   }
 
+  public getTracesByContext(keptnContext: string | undefined, projectName?: string | undefined, fromTime?: string | undefined): Promise<AxiosResponse<EventResult>> {
+    const params = {
+      keptnContext,
+      pageSize: '100',
+      ...projectName && {project: projectName},
+      ...fromTime && {fromTime},
+    };
+    return this.axios.get<EventResult>(`${this.baseUrl}/mongodb-datastore/event`, {params});
+  }
+
+  public getRoots(projectName: string | undefined, pageSize: string | undefined, serviceName: string | undefined, fromTime?: string | undefined, beforeTime?: string | undefined, keptnContext?: string | undefined): Promise<AxiosResponse<EventResult>> {
+    const params = {
+      root: 'true',
+      project: projectName,
+      limit: pageSize,
+      ...(serviceName && {serviceName}),
+      ...(fromTime && {fromTime}),
+      ...(beforeTime && {beforeTime}),
+      ...(keptnContext && {keptnContext}),
+    };
+    return this.axios.get<EventResult>(`${this.baseUrl}/mongodb-datastore/event`, {params});
+  }
+
   public getTracesWithResult(eventType: EventTypes, pageSize: number, projectName: string, stageName: string, serviceName: string, resultType: ResultTypes): Promise<AxiosResponse<EventResult>> {
     const params = {
       filter: `data.project:${projectName} AND data.service:${serviceName} AND data.stage:${stageName} AND data.result:${resultType}`,

--- a/bridge/server/services/data-service.ts
+++ b/bridge/server/services/data-service.ts
@@ -15,6 +15,7 @@ import { Shipyard } from '../interfaces/shipyard';
 import { UniformRegistrationLocations } from '../../shared/interfaces/uniform-registration-locations';
 import { Resource } from '../../shared/interfaces/resource';
 import { FileTree, TreeEntry } from '../../shared/interfaces/resourceFileTree';
+import { EventResult } from '../interfaces/event-result';
 
 type TreeDirectory = ({ _: string[] } & { [key: string]: TreeDirectory }) | { _: string[] };
 
@@ -238,6 +239,16 @@ export class DataService {
       }
     }
     return tasks;
+  }
+
+  public async getRoots(projectName: string | undefined, pageSize: string | undefined, serviceName: string | undefined, fromTime?: string | undefined, beforeTime?: string | undefined, keptnContext?: string | undefined): Promise<EventResult> {
+    const response = await this.apiService.getRoots(projectName, pageSize, serviceName, fromTime, beforeTime, keptnContext);
+    return response.data;
+  }
+
+  public async getTracesByContext(keptnContext: string | undefined, projectName?: string | undefined, fromTime?: string | undefined): Promise<EventResult> {
+    const response = await this.apiService.getTracesByContext(keptnContext, projectName, fromTime);
+    return response.data;
   }
 
   public async getResourceFileTreesForService(projectName: string, serviceName: string): Promise<FileTree[]> {

--- a/bridge/server/services/data-service.ts
+++ b/bridge/server/services/data-service.ts
@@ -247,8 +247,25 @@ export class DataService {
   }
 
   public async getTracesByContext(keptnContext: string | undefined, projectName?: string | undefined, fromTime?: string | undefined): Promise<EventResult> {
-    const response = await this.apiService.getTracesByContext(keptnContext, projectName, fromTime);
-    return response.data;
+    let result: EventResult = {
+      events: [],
+      pageSize: 0,
+      nextPageKey: 0,
+      totalCount: 0
+    };
+    let nextPage = 0;
+    do {
+      const response = await this.apiService.getTracesByContext(keptnContext, projectName, fromTime, nextPage.toString());
+      nextPage = response.data.nextPageKey || 0;
+      result = {
+        events: [...result?.events, ...response.data.events],
+        pageSize: result.pageSize + response.data.pageSize,
+        nextPageKey: response.data.nextPageKey,
+        totalCount: response.data.totalCount
+      };
+    } while (nextPage !== 0);
+
+    return result;
   }
 
   public async getResourceFileTreesForService(projectName: string, serviceName: string): Promise<FileTree[]> {

--- a/bridge/shared/interfaces/event-result.ts
+++ b/bridge/shared/interfaces/event-result.ts
@@ -5,4 +5,5 @@ export interface EventResult {
   events: Trace[];
   totalCount: number;
   pageSize: number;
+  nextPageKey: number;
 }

--- a/bridge/shared/interfaces/event-result.ts
+++ b/bridge/shared/interfaces/event-result.ts
@@ -4,4 +4,5 @@ import { Trace } from '../models/trace';
 export interface EventResult {
   events: Trace[];
   totalCount: number;
+  pageSize: number;
 }


### PR DESCRIPTION
## This PR
- makes sure that all traces of a sequence are loaded without pageSize limit

### Related Issues
Fixes #5056 

