### PR TITLE
feat(installer): Add option for ingress to control-plane helm chart keptn installer (#5066)

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/templates/ingress.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/ingress.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+{{- if .Values.ingress.annotations }}
+  annotations:
+  {{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}
+  name: keptn-ingress
+  namespace: keptn
+  labels:
+    app.kubernetes.io/name: ingress
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
+    app.kubernetes.io/component: {{ include "control-plane.name" . }}
+    helm.sh/chart: {{ include "control-plane.chart" . }}
+spec:
+  rules:
+  {{- if .Values.ingress.host }}
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: api-gateway-nginx
+                port:
+                  number: {{ .Values.apiGatewayNginx.port }}
+  {{- else }}
+    - http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: api-gateway-nginx
+                port:
+                  number: {{ .Values.apiGatewayNginx.port }}
+  {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -129,3 +129,12 @@ alpine:
     registry: docker.io
     repository: alpine
     tag: '3.13'
+
+ingress:
+  enabled: false
+  annotations: {}
+  host: {}
+  path: /
+  pathType: Prefix
+  tls:
+    []


### PR DESCRIPTION
Signed-off-by: bradmccoydev <bradmccoydev@gmail.com>


## This PR
This PR is to add the ability to optionally add an ingress of the Keptn Deployment when using the helm chart. 

- add ingress.yaml
- update values file with enabled:false as default

### Related Issues
https://github.com/keptn/keptn/issues/5066

Fixes #5066 

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
Documentation: https://github.com/keptn/keptn/issues/5297

### How to test
This has been tested in different clusters and scenarios and i confirm it works.

helm install control-plane --generate-name --dry-run --debug
```
# Test enabled : false
ingress:
  enabled: true
  annotations: {}
  host:
    []
  path: /
  pathType: Prefix
  tls:
    []
---
null
---

# Test One
ingress:
  enabled: true
  annotations: {}
  host:
    []
  path: /
  pathType: Prefix
  tls:
    []
---
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: ingress
  labels:
    app.kubernetes.io/name: ingress
    app.kubernetes.io/instance: control-plane-1631932093
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: keptn-default
    app.kubernetes.io/component: control-plane
    helm.sh/chart: control-plane-0.1.0
spec:
  rules:
    - http:
        paths:
          - path: /
            pathType: Prefix
            backend:
              service:
                name: api-gateway-nginx
                port:
                  number: 80
---
# Test Two
ingress:
  enabled: true
  annotations:
    kubernetes.io/ingress.class: nginx
    kubernetes.io/tls-acme: "true"
  host:
    []
  path: /
  pathType: Prefix
  tls:
    []
---
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    kubernetes.io/ingress.class: "nginx"
    kubernetes.io/tls-acme: "true"
  name: ingress
  labels:
    app.kubernetes.io/name: ingress
    app.kubernetes.io/instance: control-plane-1631932452
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: keptn-default
    app.kubernetes.io/component: control-plane
    helm.sh/chart: control-plane-0.1.0
spec:
  rules:
    - http:
        paths:
          - path: /
            pathType: Prefix
            backend:
              service:
                name: api-gateway-nginx
                port:
                  number: 80
---
# Test 3
ingress:
  enabled: true
  annotations:
    kubernetes.io/ingress.class: nginx
  host: "keptn.bradmccoy.io"
  path: /
  pathType: Prefix
  tls:
    []
---
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    kubernetes.io/ingress.class: "nginx"
  name: keptn-ingress
  namespace: keptn
  labels:
    app.kubernetes.io/name: ingress
    app.kubernetes.io/instance: control-plane-1631932981
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: keptn-default
    app.kubernetes.io/component: control-plane
    helm.sh/chart: control-plane-0.1.0
spec:
  rules:
    - host: keptn.bradmccoy.io
      http:
        paths:
          - path: /
            pathType: Prefix
            backend:
              service:
                name: api-gateway-nginx
                port:
                  number: 80
---
# Test 4
ingress:
  enabled: true
  annotations:
    kubernetes.io/ingress.class: nginx
    kubernetes.io/tls-acme: "true"
  host: "keptn.bradmccoy.io"
  path: /
  pathType: Prefix
  tls:
    - secretName: keptn-tls-certificate
      hosts:
        - keptn.bradmccoy.io
---
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    kubernetes.io/ingress.class: "nginx"
    kubernetes.io/tls-acme: "true"
  name: keptn-ingress
  namespace: keptn
  labels:
    app.kubernetes.io/name: ingress
    app.kubernetes.io/instance: control-plane-1631933890
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: keptn-default
    app.kubernetes.io/component: control-plane
    helm.sh/chart: control-plane-0.1.0
spec:
  rules:
    - host: keptn.bradmccoy.io
      http:
        paths:
          - path: /
            pathType: Prefix
            backend:
              service:
                name: api-gateway-nginx
                port:
                  number: 80
  tls:
    - hosts:
      - keptn.bradmccoy.io
      secretName: keptn-tls-certificate
---

```
