### PR TITLE
build(deps): Update go-utils and kubernetes-utils after history change

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-version v1.2.0
 	github.com/keptn/go-utils v0.9.1-0.20210921105323-c6aa0eaeb562
-	github.com/keptn/kubernetes-utils v0.9.1-0.20210921105500-2feef43a5cfe
+	github.com/keptn/kubernetes-utils v0.9.1-0.20210922074106-4fb89e149fe6
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.4.2

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -546,8 +546,8 @@ github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8
 github.com/keptn/go-utils v0.8.5/go.mod h1:FiCd1Dzw6fLhg3hxD0lEfeGXSNVVPUn9EguTWKweyho=
 github.com/keptn/go-utils v0.9.1-0.20210921105323-c6aa0eaeb562 h1:Re+LiiPAq+xTlb1HA8CoJp1u8DtGjn9UGU59gP7yciI=
 github.com/keptn/go-utils v0.9.1-0.20210921105323-c6aa0eaeb562/go.mod h1:YOzlxekwyR8WTXiMg9V8mEX+aZIoztAZpMFMwF5iyng=
-github.com/keptn/kubernetes-utils v0.9.1-0.20210921105500-2feef43a5cfe h1:xt1LuiOpDUEfoCzVHjSiMdLQuLINw8ZSDBvu4hFJGr8=
-github.com/keptn/kubernetes-utils v0.9.1-0.20210921105500-2feef43a5cfe/go.mod h1:aP+xH5Rs0M1kV4Ny/E8gLT9XDXwIUCiAduA2Em76QyA=
+github.com/keptn/kubernetes-utils v0.9.1-0.20210922074106-4fb89e149fe6 h1:YPqkUOoSKkjqGfEPst96SoM835As0zaz4NBLbMTSTCc=
+github.com/keptn/kubernetes-utils v0.9.1-0.20210922074106-4fb89e149fe6/go.mod h1:aP+xH5Rs0M1kV4Ny/E8gLT9XDXwIUCiAduA2Em76QyA=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/configuration-service/go.mod
+++ b/configuration-service/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/google/martian v2.1.0+incompatible
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/keptn/go-utils v0.9.1-0.20210921105323-c6aa0eaeb562
-	github.com/keptn/kubernetes-utils v0.9.1-0.20210921105500-2feef43a5cfe
+	github.com/keptn/kubernetes-utils v0.9.1-0.20210922074106-4fb89e149fe6
 	github.com/mholt/archiver v3.1.1+incompatible
 	github.com/nwaples/rardecode v1.0.0 // indirect
 	github.com/otiai10/copy v1.6.0

--- a/configuration-service/go.sum
+++ b/configuration-service/go.sum
@@ -521,8 +521,8 @@ github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0Lh
 github.com/keptn/go-utils v0.8.5/go.mod h1:FiCd1Dzw6fLhg3hxD0lEfeGXSNVVPUn9EguTWKweyho=
 github.com/keptn/go-utils v0.9.1-0.20210921105323-c6aa0eaeb562 h1:Re+LiiPAq+xTlb1HA8CoJp1u8DtGjn9UGU59gP7yciI=
 github.com/keptn/go-utils v0.9.1-0.20210921105323-c6aa0eaeb562/go.mod h1:YOzlxekwyR8WTXiMg9V8mEX+aZIoztAZpMFMwF5iyng=
-github.com/keptn/kubernetes-utils v0.9.1-0.20210921105500-2feef43a5cfe h1:xt1LuiOpDUEfoCzVHjSiMdLQuLINw8ZSDBvu4hFJGr8=
-github.com/keptn/kubernetes-utils v0.9.1-0.20210921105500-2feef43a5cfe/go.mod h1:aP+xH5Rs0M1kV4Ny/E8gLT9XDXwIUCiAduA2Em76QyA=
+github.com/keptn/kubernetes-utils v0.9.1-0.20210922074106-4fb89e149fe6 h1:YPqkUOoSKkjqGfEPst96SoM835As0zaz4NBLbMTSTCc=
+github.com/keptn/kubernetes-utils v0.9.1-0.20210922074106-4fb89e149fe6/go.mod h1:aP+xH5Rs0M1kV4Ny/E8gLT9XDXwIUCiAduA2Em76QyA=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/gh-actions-scripts/auto-update-utils.sh
+++ b/gh-actions-scripts/auto-update-utils.sh
@@ -9,7 +9,7 @@ ARTIFACT=${2:-go-utils}
 echo "$ARTIFACT Target Commit/Branch/Tag: ${TARGET}"
 
 # update go modules in all directories that contain a go.mod which contains utils
-for file in ./**/*; do
+for file in ./{**/,}*; do
   if [[ -f "$file/go.mod" ]]; then
     echo "Checking if $file/go.mod contains $ARTIFACT"
     if grep "github.com/keptn/$ARTIFACT" "$file/go.mod"; then

--- a/helm-service/go.mod
+++ b/helm-service/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/keptn/go-utils v0.9.1-0.20210921105323-c6aa0eaeb562
-	github.com/keptn/kubernetes-utils v0.9.1-0.20210921105500-2feef43a5cfe
+	github.com/keptn/kubernetes-utils v0.9.1-0.20210922074106-4fb89e149fe6
 	github.com/kinbiko/jsonassert v1.0.2
 	github.com/stretchr/testify v1.7.0
 	gotest.tools v2.2.0+incompatible

--- a/helm-service/go.sum
+++ b/helm-service/go.sum
@@ -498,8 +498,8 @@ github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa
 github.com/keptn/go-utils v0.8.5/go.mod h1:FiCd1Dzw6fLhg3hxD0lEfeGXSNVVPUn9EguTWKweyho=
 github.com/keptn/go-utils v0.9.1-0.20210921105323-c6aa0eaeb562 h1:Re+LiiPAq+xTlb1HA8CoJp1u8DtGjn9UGU59gP7yciI=
 github.com/keptn/go-utils v0.9.1-0.20210921105323-c6aa0eaeb562/go.mod h1:YOzlxekwyR8WTXiMg9V8mEX+aZIoztAZpMFMwF5iyng=
-github.com/keptn/kubernetes-utils v0.9.1-0.20210921105500-2feef43a5cfe h1:xt1LuiOpDUEfoCzVHjSiMdLQuLINw8ZSDBvu4hFJGr8=
-github.com/keptn/kubernetes-utils v0.9.1-0.20210921105500-2feef43a5cfe/go.mod h1:aP+xH5Rs0M1kV4Ny/E8gLT9XDXwIUCiAduA2Em76QyA=
+github.com/keptn/kubernetes-utils v0.9.1-0.20210922074106-4fb89e149fe6 h1:YPqkUOoSKkjqGfEPst96SoM835As0zaz4NBLbMTSTCc=
+github.com/keptn/kubernetes-utils v0.9.1-0.20210922074106-4fb89e149fe6/go.mod h1:aP+xH5Rs0M1kV4Ny/E8gLT9XDXwIUCiAduA2Em76QyA=
 github.com/kinbiko/jsonassert v1.0.2 h1:UzNDYv5K8UsSHXS3Opsf0ZNz2NQCHl96OC3dlTytUtE=
 github.com/kinbiko/jsonassert v1.0.2/go.mod h1:QRwBwiAsrcJpjw+L+Q4WS8psLxuUY+HylVZS/4j74TM=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/platform-support/openshift-route-service/go.mod
+++ b/platform-support/openshift-route-service/go.mod
@@ -5,6 +5,6 @@ go 1.16
 require (
 	github.com/cloudevents/sdk-go/v2 v2.4.1
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.9.0
+	github.com/keptn/go-utils v0.9.1-0.20210921105323-c6aa0eaeb562
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/platform-support/openshift-route-service/go.sum
+++ b/platform-support/openshift-route-service/go.sum
@@ -17,8 +17,8 @@ github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
-github.com/keptn/go-utils v0.9.0 h1:UVRB6GEvcjszSCdszYccLzEcAVbBD8Jv+vBl5uy9ZNo=
-github.com/keptn/go-utils v0.9.0/go.mod h1:YOzlxekwyR8WTXiMg9V8mEX+aZIoztAZpMFMwF5iyng=
+github.com/keptn/go-utils v0.9.1-0.20210921105323-c6aa0eaeb562 h1:Re+LiiPAq+xTlb1HA8CoJp1u8DtGjn9UGU59gP7yciI=
+github.com/keptn/go-utils v0.9.1-0.20210921105323-c6aa0eaeb562/go.mod h1:YOzlxekwyR8WTXiMg9V8mEX+aZIoztAZpMFMwF5iyng=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/test/go-tests/go.mod
+++ b/test/go-tests/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/imroc/req v0.3.0
 	github.com/keptn/go-utils v0.9.1-0.20210921105323-c6aa0eaeb562
 	github.com/keptn/keptn/shipyard-controller v0.0.0-20210503133401-8c1194432b46
-	github.com/keptn/kubernetes-utils v0.9.1-0.20210921105500-2feef43a5cfe
+	github.com/keptn/kubernetes-utils v0.9.1-0.20210922074106-4fb89e149fe6
 	github.com/stretchr/testify v1.7.0
 	k8s.io/api v0.22.1
 	k8s.io/apimachinery v0.22.1

--- a/test/go-tests/go.sum
+++ b/test/go-tests/go.sum
@@ -467,8 +467,8 @@ github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0Lh
 github.com/keptn/go-utils v0.8.5/go.mod h1:FiCd1Dzw6fLhg3hxD0lEfeGXSNVVPUn9EguTWKweyho=
 github.com/keptn/go-utils v0.9.1-0.20210921105323-c6aa0eaeb562 h1:Re+LiiPAq+xTlb1HA8CoJp1u8DtGjn9UGU59gP7yciI=
 github.com/keptn/go-utils v0.9.1-0.20210921105323-c6aa0eaeb562/go.mod h1:YOzlxekwyR8WTXiMg9V8mEX+aZIoztAZpMFMwF5iyng=
-github.com/keptn/kubernetes-utils v0.9.1-0.20210921105500-2feef43a5cfe h1:xt1LuiOpDUEfoCzVHjSiMdLQuLINw8ZSDBvu4hFJGr8=
-github.com/keptn/kubernetes-utils v0.9.1-0.20210921105500-2feef43a5cfe/go.mod h1:aP+xH5Rs0M1kV4Ny/E8gLT9XDXwIUCiAduA2Em76QyA=
+github.com/keptn/kubernetes-utils v0.9.1-0.20210922074106-4fb89e149fe6 h1:YPqkUOoSKkjqGfEPst96SoM835As0zaz4NBLbMTSTCc=
+github.com/keptn/kubernetes-utils v0.9.1-0.20210922074106-4fb89e149fe6/go.mod h1:aP+xH5Rs0M1kV4Ny/E8gLT9XDXwIUCiAduA2Em76QyA=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=


### PR DESCRIPTION
### This PR
* updates `go-utils` and `kubernetes-utils` after the history change that happened due to release automation being enabled now