### PR TITLE
chore(bridge): adapt retry-mechanism (#4867)

### DIFF
--- a/bridge/client/app/_interceptors/http-generic-retry-strategy.ts
+++ b/bridge/client/app/_interceptors/http-generic-retry-strategy.ts
@@ -1,36 +1,37 @@
-import { timer, throwError, Observable } from 'rxjs';
+import { Observable, throwError, timer } from 'rxjs';
 import { mergeMap } from 'rxjs/operators';
+import { HttpErrorResponse } from '@angular/common/http';
 
 export interface RetryParams {
-  maxAttempts?: number;
-  scalingDuration?: number;
-  shouldRetry?: ({status}: {status: number}) => boolean;
+  maxAttempts: number;
+  scalingDuration: number;
+  shouldRetry: ({status}: { status: number }) => boolean;
 }
 
 /**
- * Avoid retry for status codes which are part of a logical flow
- *
- *  - 401 : Unauthorized. Login flow get triggered with this status.
+ * Retry for the following status codes
+ *  - 500: Internal Server Error
+ *  - 502: Bad Gateway
+ *  - 503: Service Unavailable
+ *  - 504: Gateway Timeout
  */
-const avoidRetryFor = [401];
+const retryFor = [500, 502, 503, 504];
 
 const defaultParams: RetryParams = {
   maxAttempts: 3,
   scalingDuration: 1000,
-  shouldRetry: ({status}) => (status >= 400 && !avoidRetryFor.includes(status))
+  shouldRetry: ({status}) => (retryFor.includes(status)),
 };
 
-// tslint:disable-next-line:no-any
-export const genericRetryStrategy = (params: RetryParams = {}) => (attempts: Observable<any>) => attempts.pipe(
+export const genericRetryStrategy = (params?: RetryParams) => (attempts: Observable<HttpErrorResponse>) => attempts.pipe(
   mergeMap((error, i) => {
-    const { maxAttempts, scalingDuration, shouldRetry } = { ...defaultParams, ...params };
+    const {maxAttempts, scalingDuration, shouldRetry} = {...defaultParams, ...params};
     const retryAttempt = i + 1;
-    // @ts-ignore
+
     if (retryAttempt > maxAttempts || !shouldRetry(error)) {
       return throwError(error);
     }
-    // @ts-ignore
     return timer(retryAttempt * scalingDuration);
-  })
+  }),
 );
 


### PR DESCRIPTION
## This PR
- adapts the retry mechanism for HTTP calls to only retry if they are one of the following status codes: 500, 502, 503, 504

### Related Issues
Closes #4867 

Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>