### PR TITLE
feat(bridge): Align the way how sequence states are displayed #5150

### DIFF
--- a/bridge/client/app/_components/ktb-root-events-list/ktb-root-events-list.component.html
+++ b/bridge/client/app/_components/ktb-root-events-list/ktb-root-events-list.component.html
@@ -8,8 +8,8 @@
                          *ngIf="sequence">
       <ktb-selectable-tile-header>
         <div class="container">
-          <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px">
-            <ktb-sequence-state-info [sequence]="sequence" (stageClicked)="stageClick($event)"></ktb-sequence-state-info>
+          <div fxLayout="row" fxLayoutAlign="start start" fxLayoutGap="5px">
+            <ktb-sequence-state-info fxFlex fxFlexFill [sequence]="sequence" (stageClicked)="selectEvent($event.sequence, $event.stage)"></ktb-sequence-state-info>
             <ktb-sequence-controls [sequence]="sequence" [smallButtons]="true"></ktb-sequence-controls>
           </div>
         </div>

--- a/bridge/client/app/_components/ktb-root-events-list/ktb-root-events-list.component.html
+++ b/bridge/client/app/_components/ktb-root-events-list/ktb-root-events-list.component.html
@@ -9,41 +9,8 @@
       <ktb-selectable-tile-header>
         <div class="container">
           <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px">
-            <div fxFlex fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px">
-              <dt-icon *ngIf="(!sequence.isLoading() && !sequence.isWaiting()) || sequence.hasPendingApproval(); else showLoading" class="event-icon"
-                       [name]="sequence.getIcon()"
-                       [class.error]="sequence.isFaulty()"
-                       [class.highlight]="sequence.hasPendingApproval()"></dt-icon>
-              <ng-template #showLoading>
-                <button class="m-0 p-0" dt-button disabled variant="nested" *ngIf="sequence.isLoading() && !sequence.isWaiting()">
-                  <dt-loading-spinner aria-label="Task is running..."></dt-loading-spinner>
-                </button>
-                <dt-icon *ngIf="sequence.isWaiting()" class="event-icon" name="idle"></dt-icon>
-              </ng-template>
-              <div class="mt-1 mb-1" fxLayout="row" fxLayoutAlign="start center">
-                <p class="m-0">
-                  <span class="bold" [textContent]="sequence.name"></span>
-                  of <span [textContent]="sequence.service"></span>&nbsp;<span [textContent]="sequence.getStatus()"></span>
-                </p>
-              </div>
-            </div>
-            <div class="mb-2">
-              <ktb-sequence-controls [sequence]="sequence" [smallButtons]="true"></ktb-sequence-controls>
-            </div>
-          </div>
-          <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px" uitestid="keptn-root-events-list-stageDetails">
-            <p class="m-0 mr-1 small bold" *ngIf="sequence.getShortImageName(); else noImageName" [textContent]="sequence.getShortImageName()"></p>
-            <ng-template #noImageName>
-              <p class="m-0 mr-1 small bold" *ngIf="sequence.service" [textContent]="sequence.service"></p>
-            </ng-template>
-            <p class="m-0 mr-1 small" *ngIf="sequence.getStages().length > 0">in</p>
-            <ng-container *ngFor="let stage of sequence.getStages();">
-              <ktb-stage-badge [stage]="stage" [evaluationResult]="sequence.getEvaluation(stage)"
-                               [success]="sequence.isSuccessful(stage)"
-                               [error]="sequence.isFaulty(stage)" [class.warning]="sequence.isWarning(stage)"
-                               [highlight]="sequence.hasPendingApproval(stage)"
-                               (click)="$event.stopPropagation();selectEvent(sequence, stage)"></ktb-stage-badge>
-            </ng-container>
+            <ktb-sequence-state-info [sequence]="sequence" (stageClicked)="stageClick($event)"></ktb-sequence-state-info>
+            <ktb-sequence-controls [sequence]="sequence" [smallButtons]="true"></ktb-sequence-controls>
           </div>
         </div>
       </ktb-selectable-tile-header>

--- a/bridge/client/app/_components/ktb-root-events-list/ktb-root-events-list.component.ts
+++ b/bridge/client/app/_components/ktb-root-events-list/ktb-root-events-list.component.ts
@@ -89,10 +89,6 @@ export class KtbRootEventsListComponent implements OnInit, OnDestroy {
     }
   }
 
-  stageClick($event: any): void {
-    console.log('event', $event);
-  }
-
   ngOnDestroy(): void {
     this.unsubscribe$.next();
     this.unsubscribe$.complete();

--- a/bridge/client/app/_components/ktb-root-events-list/ktb-root-events-list.component.ts
+++ b/bridge/client/app/_components/ktb-root-events-list/ktb-root-events-list.component.ts
@@ -89,6 +89,10 @@ export class KtbRootEventsListComponent implements OnInit, OnDestroy {
     }
   }
 
+  stageClick($event: any): void {
+    console.log('event', $event);
+  }
+
   ngOnDestroy(): void {
     this.unsubscribe$.next();
     this.unsubscribe$.complete();

--- a/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.html
+++ b/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.html
@@ -26,9 +26,9 @@
       <span [textContent]="sequence.getStatus()" uitestid="keptn-sequence-info-status"></span>
     </p>
   </div>
-  <div class="mt-2 stages-list" fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px"
+  <div *ngIf="showStages" class="mt-2 stages-list" fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px"
        uitestid="keptn-sequence-info-stageDetails">
-    <ng-container *ngFor="let stage of getStages()">
+    <ng-container *ngFor="let stage of sequence.getStages()">
       <ktb-stage-badge [stage]="stage" [evaluationResult]="sequence.getEvaluation(stage)"
                        [success]="sequence.isSuccessful(stage)"
                        [error]="sequence.isFaulty(stage)" [class.warning]="sequence.isWarning(stage)"

--- a/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.html
+++ b/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.html
@@ -1,3 +1,48 @@
-<ng-container *ngIf="currentSequence">
-
+<ng-container *ngIf="sequence">
+  <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px">
+    <dt-icon *ngIf="(!sequence.isLoading() && !sequence.isWaiting()) || sequence.hasPendingApproval(); else showLoading"
+             class="event-icon"
+             [name]="sequence.getIcon()"
+             [class.success]="sequence.isSuccessful()"
+             [class.error]="sequence.isFaulty()"
+             [class.highlight]="sequence.hasPendingApproval()"></dt-icon>
+    <ng-template #showLoading>
+      <button class="m-0 p-0" dt-button disabled variant="nested" *ngIf="sequence.isLoading() && !sequence.isWaiting()">
+        <dt-loading-spinner aria-label="Task is running..."></dt-loading-spinner>
+      </button>
+      <dt-icon *ngIf="sequence.isWaiting()" class="event-icon" name="idle"></dt-icon>
+    </ng-template>
+    <p class="m-0 small">
+      <a class="m-0 bold"
+         uitestid="keptn-sequence-info-sequenceName"
+         [routerLink]="getSequenceLink(sequence)"
+         [class.error]="sequence.isFaulty()"
+         [textContent]="sequence.name"></a>
+      of
+      <a *ngIf="sequence.getShortImageName(); else noImageName"
+         class="m-0 mr-1 bold nobreak"
+         uitestid="keptn-sequence-info-serviceName"
+         [routerLink]="getServiceLink(sequence)"
+         [textContent]="sequence.getShortImageName()"></a>
+      <ng-template #noImageName>
+        <a *ngIf="sequence.service"
+           class="m-0 mr-1 bold nobreak"
+           uitestid="keptn-sequence-info-serviceName"
+           [routerLink]="getServiceLink(sequence)"
+           [textContent]="sequence.service"></a>
+      </ng-template>
+      <span [textContent]="sequence.getStatus()" uitestid="keptn-sequence-info-status"></span>
+    </p>
+  </div>
+  <div class="mt-2" fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px" uitestid="keptn-sequence-info-stageDetails">
+    <ng-container *ngFor="let stage of getStages()">
+      <ng-container *ngIf="stage">
+        <ktb-stage-badge [stage]="stage" [evaluationResult]="sequence.getEvaluation(stage)"
+                         [success]="sequence.isSuccessful(stage)"
+                         [error]="sequence.isFaulty(stage)" [class.warning]="sequence.isWarning(stage)"
+                         [highlight]="sequence.hasPendingApproval(stage)"
+                         (click)="$event.stopPropagation();stageClick(sequence, stage)"></ktb-stage-badge>
+      </ng-container>
+    </ng-container>
+  </div>
 </ng-container>

--- a/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.html
+++ b/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.html
@@ -19,22 +19,17 @@
          [class.error]="sequence.isFaulty()"
          [textContent]="sequence.name"></a>
       of
-      <a *ngIf="sequence.getShortImageName(); else noImageName"
-         class="m-0 mr-1 bold nobreak"
+      <a class="m-0 mr-1 bold nobreak"
          uitestid="keptn-sequence-info-serviceName"
-         [routerLink]="getServiceLink(sequence)"
-         [textContent]="sequence.getShortImageName()"></a>
-      <ng-template #noImageName>
-        <a *ngIf="sequence.service"
-           class="m-0 mr-1 bold nobreak"
-           uitestid="keptn-sequence-info-serviceName"
-           [routerLink]="getServiceLink(sequence)"
-           [textContent]="sequence.service"></a>
-      </ng-template>
+         [routerLink]="getServiceLink(sequence)">
+        <span [textContent]="sequence.service"></span>
+        <ng-container *ngIf="sequence.getShortImageName()"> (<span [textContent]="sequence.getShortImageName()"></span>)</ng-container>
+      </a>
       <span [textContent]="sequence.getStatus()" uitestid="keptn-sequence-info-status"></span>
     </p>
   </div>
-  <div class="mt-2 stages-list" fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px" uitestid="keptn-sequence-info-stageDetails">
+  <div class="mt-2 stages-list" fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px"
+       uitestid="keptn-sequence-info-stageDetails">
     <ng-container *ngFor="let stage of getStages()">
       <ktb-stage-badge [stage]="stage" [evaluationResult]="sequence.getEvaluation(stage)"
                        [success]="sequence.isSuccessful(stage)"

--- a/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.html
+++ b/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.html
@@ -34,7 +34,7 @@
       <span [textContent]="sequence.getStatus()" uitestid="keptn-sequence-info-status"></span>
     </p>
   </div>
-  <div class="mt-2" fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px" uitestid="keptn-sequence-info-stageDetails">
+  <div class="mt-2 stages-list" fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px" uitestid="keptn-sequence-info-stageDetails">
     <ng-container *ngFor="let stage of getStages()">
       <ng-container *ngIf="stage">
         <ktb-stage-badge [stage]="stage" [evaluationResult]="sequence.getEvaluation(stage)"

--- a/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.html
+++ b/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.html
@@ -36,13 +36,11 @@
   </div>
   <div class="mt-2 stages-list" fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px" uitestid="keptn-sequence-info-stageDetails">
     <ng-container *ngFor="let stage of getStages()">
-      <ng-container *ngIf="stage">
-        <ktb-stage-badge [stage]="stage" [evaluationResult]="sequence.getEvaluation(stage)"
-                         [success]="sequence.isSuccessful(stage)"
-                         [error]="sequence.isFaulty(stage)" [class.warning]="sequence.isWarning(stage)"
-                         [highlight]="sequence.hasPendingApproval(stage)"
-                         (click)="$event.stopPropagation();stageClick(sequence, stage)"></ktb-stage-badge>
-      </ng-container>
+      <ktb-stage-badge [stage]="stage" [evaluationResult]="sequence.getEvaluation(stage)"
+                       [success]="sequence.isSuccessful(stage)"
+                       [error]="sequence.isFaulty(stage)" [class.warning]="sequence.isWarning(stage)"
+                       [highlight]="sequence.hasPendingApproval(stage)"
+                       (click)="$event.stopPropagation();stageClick(sequence, stage)"></ktb-stage-badge>
     </ng-container>
   </div>
 </ng-container>

--- a/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.html
+++ b/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.html
@@ -21,10 +21,8 @@
       of
       <a class="m-0 mr-1 bold nobreak"
          uitestid="keptn-sequence-info-serviceName"
-         [routerLink]="getServiceLink(sequence)">
-        <span [textContent]="sequence.service"></span>
-        <ng-container *ngIf="sequence.getShortImageName()"> (<span [textContent]="sequence.getShortImageName()"></span>)</ng-container>
-      </a>
+         [routerLink]="getServiceLink(sequence)"
+         [textContent]="sequence.service"></a>
       <span [textContent]="sequence.getStatus()" uitestid="keptn-sequence-info-status"></span>
     </p>
   </div>

--- a/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.html
+++ b/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.html
@@ -12,7 +12,7 @@
       </button>
       <dt-icon *ngIf="sequence.isWaiting()" class="event-icon" name="idle"></dt-icon>
     </ng-template>
-    <p class="m-0 small">
+    <p class="m-0 smaller">
       <a class="m-0 bold"
          uitestid="keptn-sequence-info-sequenceName"
          [routerLink]="getSequenceLink(sequence)"

--- a/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.html
+++ b/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.html
@@ -1,0 +1,3 @@
+<ng-container *ngIf="currentSequence">
+
+</ng-container>

--- a/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.scss
+++ b/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.scss
@@ -1,0 +1,2 @@
+@import '../../../variables';
+@import '~@dynatrace/barista-components/core/src/style/variables';

--- a/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.scss
+++ b/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.scss
@@ -1,2 +1,20 @@
 @import '../../../variables';
 @import '~@dynatrace/barista-components/core/src/style/variables';
+
+.ktb-sequence-state-info {
+  overflow: hidden;
+
+  .stages-list {
+    overflow: auto;
+
+    /* Hide scrollbar for IE, Edge and Firefox */
+    -ms-overflow-style: none;  /* IE and Edge */
+    scrollbar-width: none;  /* Firefox */
+  }
+
+  /* Hide scrollbar for Chrome, Safari and Opera */
+  .stages-list::-webkit-scrollbar {
+    display: none;
+  }
+
+}

--- a/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.spec.ts
+++ b/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.spec.ts
@@ -32,10 +32,13 @@ describe('KtbSequenceStateInfoComponent', () => {
     fixture = TestBed.createComponent(KtbSequenceStateInfoComponent);
     component = fixture.componentInstance;
     dataService = fixture.debugElement.injector.get(DataService);
-    dataService.loadProjects(); // reset project.sequences
-    project = await dataService.getProject(projectName).pipe(
-      filter((p: Project | undefined): p is Project => !!p)
-    ).toPromise();
+    dataService.getProject(projectName)
+      .pipe(
+        filter((p: Project | undefined): p is Project => !!p)
+      ).subscribe((pr: Project) => {
+      project = pr;
+      fixture.detectChanges();
+    });
   });
 
   it('should create', () => {
@@ -54,7 +57,7 @@ describe('KtbSequenceStateInfoComponent', () => {
     const status = fixture.nativeElement.querySelector('[uitestid=keptn-sequence-info-status]');
 
     expect(sequenceName.textContent).toEqual('delivery');
-    expect(serviceName.textContent).toEqual('carts:0.12.1');
+    expect(serviceName.textContent).toEqual('carts');
     expect(status.textContent).toEqual('succeeded');
   });
 

--- a/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.spec.ts
+++ b/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.spec.ts
@@ -5,7 +5,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { DataService } from '../../_services/data.service';
 import { DataServiceMock } from '../../_services/data.service.mock';
 import { Project } from '../../_models/project';
-import { filter } from 'rxjs/operators';
+import { filter, take } from 'rxjs/operators';
 
 describe('KtbSequenceStateInfoComponent', () => {
   let component: KtbSequenceStateInfoComponent;
@@ -14,8 +14,8 @@ describe('KtbSequenceStateInfoComponent', () => {
   const projectName = 'sockshop';
   let project: Project;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       declarations: [],
       imports: [
         AppModule,
@@ -32,14 +32,13 @@ describe('KtbSequenceStateInfoComponent', () => {
     fixture = TestBed.createComponent(KtbSequenceStateInfoComponent);
     component = fixture.componentInstance;
     dataService = fixture.debugElement.injector.get(DataService);
-    dataService.getProject(projectName)
-      .pipe(
-        filter((p: Project | undefined): p is Project => !!p)
-      ).subscribe((pr: Project) => {
-      project = pr;
-      fixture.detectChanges();
-    });
-  }));
+    project = await dataService.getProject(projectName).pipe(
+      filter((p: Project | undefined): p is Project => !!p),
+      take(1)
+    ).toPromise();
+
+    fixture.detectChanges();
+  });
 
   it('should create', () => {
     expect(component).toBeTruthy();

--- a/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.spec.ts
+++ b/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.spec.ts
@@ -32,11 +32,7 @@ describe('KtbSequenceStateInfoComponent', () => {
     component = fixture.componentInstance;
     dataService = fixture.debugElement.injector.get(DataService);
     dataService.loadProjects(); // reset project.sequences
-    // @ts-ignore
-    dataService.getProject(projectName).subscribe((pr: Project) => {
-      project = pr;
-      fixture.detectChanges();
-    });
+    project = await dataService.getProject(projectName).toPromise();
   });
 
   it('should create', () => {

--- a/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.spec.ts
+++ b/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { KtbSequenceStateInfoComponent } from './ktb-sequence-state-info.component';
 import { AppModule } from '../../app.module';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
@@ -14,8 +14,8 @@ describe('KtbSequenceStateInfoComponent', () => {
   const projectName = 'sockshop';
   let project: Project;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
       declarations: [],
       imports: [
         AppModule,
@@ -39,7 +39,7 @@ describe('KtbSequenceStateInfoComponent', () => {
       project = pr;
       fixture.detectChanges();
     });
-  });
+  }));
 
   it('should create', () => {
     expect(component).toBeTruthy();

--- a/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.spec.ts
+++ b/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.spec.ts
@@ -1,0 +1,27 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { KtbSequenceStateInfoComponent } from './ktb-sequence-state-info.component';
+import { AppModule } from '../../app.module';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+
+describe('KtbSequenceStateInfoComponent', () => {
+  let component: KtbSequenceStateInfoComponent;
+  let fixture: ComponentFixture<KtbSequenceStateInfoComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [],
+      imports: [
+        AppModule,
+        HttpClientTestingModule,
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(KtbSequenceStateInfoComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.spec.ts
+++ b/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.spec.ts
@@ -5,6 +5,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { DataService } from '../../_services/data.service';
 import { DataServiceMock } from '../../_services/data.service.mock';
 import { Project } from '../../_models/project';
+import { filter } from 'rxjs/operators';
 
 describe('KtbSequenceStateInfoComponent', () => {
   let component: KtbSequenceStateInfoComponent;
@@ -32,8 +33,9 @@ describe('KtbSequenceStateInfoComponent', () => {
     component = fixture.componentInstance;
     dataService = fixture.debugElement.injector.get(DataService);
     dataService.loadProjects(); // reset project.sequences
-    // @ts-ignore
-    project = await dataService.getProject(projectName).toPromise();
+    project = await dataService.getProject(projectName).pipe(
+      filter((p: Project | undefined): p is Project => !!p)
+    ).toPromise();
   });
 
   it('should create', () => {

--- a/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.spec.ts
+++ b/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.spec.ts
@@ -109,7 +109,6 @@ describe('KtbSequenceStateInfoComponent', () => {
     stageDetails[0].click();
 
     // then
-    expect(spy).toHaveBeenCalled();
     expect(spy).toHaveBeenCalledWith(sequence, sequence.getStages()[0]);
   });
 });

--- a/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.spec.ts
+++ b/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.spec.ts
@@ -74,19 +74,16 @@ describe('KtbSequenceStateInfoComponent', () => {
     expect(thirdStage.textContent).toEqual('production');
   });
 
-  it('should show sequence info with 1 stage if showOnlyLastStage is true', () => {
+  it('should show sequence info without stages if showStages is false', () => {
     // given
     dataService.loadSequences(project);
     component.sequence = project.sequences[11];
-    component.showOnlyLastStage = true;
+    component.showStages = false;
     fixture.detectChanges();
 
     // then
     const stageDetails = fixture.nativeElement.querySelectorAll('[uitestid=keptn-sequence-info-stageDetails] ktb-stage-badge');
-    expect(stageDetails.length).toEqual(1);
-
-    const firstStage = stageDetails[0].querySelector('dt-tag');
-    expect(firstStage.textContent).toEqual('production');
+    expect(stageDetails.length).toEqual(0);
   });
 
   it('should trigger click callback on stage', () => {

--- a/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.spec.ts
+++ b/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.spec.ts
@@ -4,11 +4,7 @@ import { AppModule } from '../../app.module';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { DataService } from '../../_services/data.service';
 import { DataServiceMock } from '../../_services/data.service.mock';
-import { ActivatedRoute } from '@angular/router';
-import { of } from 'rxjs';
-import { KtbRootEventsListComponent } from '../ktb-root-events-list/ktb-root-events-list.component';
 import { Project } from '../../_models/project';
-import { DeleteType } from '../../_interfaces/delete';
 
 describe('KtbSequenceStateInfoComponent', () => {
   let component: KtbSequenceStateInfoComponent;

--- a/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.spec.ts
+++ b/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.spec.ts
@@ -32,6 +32,7 @@ describe('KtbSequenceStateInfoComponent', () => {
     component = fixture.componentInstance;
     dataService = fixture.debugElement.injector.get(DataService);
     dataService.loadProjects(); // reset project.sequences
+    // @ts-ignore
     project = await dataService.getProject(projectName).toPromise();
   });
 

--- a/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.spec.ts
+++ b/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.spec.ts
@@ -2,10 +2,20 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { KtbSequenceStateInfoComponent } from './ktb-sequence-state-info.component';
 import { AppModule } from '../../app.module';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { DataService } from '../../_services/data.service';
+import { DataServiceMock } from '../../_services/data.service.mock';
+import { ActivatedRoute } from '@angular/router';
+import { of } from 'rxjs';
+import { KtbRootEventsListComponent } from '../ktb-root-events-list/ktb-root-events-list.component';
+import { Project } from '../../_models/project';
+import { DeleteType } from '../../_interfaces/delete';
 
 describe('KtbSequenceStateInfoComponent', () => {
   let component: KtbSequenceStateInfoComponent;
   let fixture: ComponentFixture<KtbSequenceStateInfoComponent>;
+  let dataService: DataService;
+  const projectName = 'sockshop';
+  let project: Project;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -14,14 +24,92 @@ describe('KtbSequenceStateInfoComponent', () => {
         AppModule,
         HttpClientTestingModule,
       ],
+      providers: [
+        {
+          provide: DataService,
+          useClass: DataServiceMock,
+        }
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(KtbSequenceStateInfoComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    dataService = fixture.debugElement.injector.get(DataService);
+    dataService.loadProjects(); // reset project.sequences
+    // @ts-ignore
+    dataService.getProject(projectName).subscribe((pr: Project) => {
+      project = pr;
+      fixture.detectChanges();
+    });
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should show sequence info', () => {
+    // given
+    dataService.loadSequences(project);
+    component.sequence = project.sequences[11];
+    fixture.detectChanges();
+
+    // then
+    const sequenceName = fixture.nativeElement.querySelector('[uitestid=keptn-sequence-info-sequenceName]');
+    const serviceName = fixture.nativeElement.querySelector('[uitestid=keptn-sequence-info-serviceName]');
+    const status = fixture.nativeElement.querySelector('[uitestid=keptn-sequence-info-status]');
+
+    expect(sequenceName.textContent).toEqual('delivery');
+    expect(serviceName.textContent).toEqual('carts:0.12.1');
+    expect(status.textContent).toEqual('succeeded');
+  });
+
+  it('should show sequence info with 3 stages', () => {
+    // given
+    dataService.loadSequences(project);
+    component.sequence = project.sequences[11];
+    fixture.detectChanges();
+
+    // then
+    const stageDetails = fixture.nativeElement.querySelectorAll('[uitestid=keptn-sequence-info-stageDetails] ktb-stage-badge');
+    expect(stageDetails.length).toEqual(3);
+
+    const firstStage = stageDetails[0].querySelector('dt-tag');
+    const secondStage = stageDetails[1].querySelector('dt-tag');
+    const thirdStage = stageDetails[2].querySelector('dt-tag');
+    expect(firstStage.textContent).toEqual('dev');
+    expect(secondStage.textContent).toEqual('staging');
+    expect(thirdStage.textContent).toEqual('production');
+  });
+
+  it('should show sequence info with 1 stage if showOnlyLastStage is true', () => {
+    // given
+    dataService.loadSequences(project);
+    component.sequence = project.sequences[11];
+    component.showOnlyLastStage = true;
+    fixture.detectChanges();
+
+    // then
+    const stageDetails = fixture.nativeElement.querySelectorAll('[uitestid=keptn-sequence-info-stageDetails] ktb-stage-badge');
+    expect(stageDetails.length).toEqual(1);
+
+    const firstStage = stageDetails[0].querySelector('dt-tag');
+    expect(firstStage.textContent).toEqual('production');
+  });
+
+  it('should trigger click callback on stage', () => {
+    // given
+    dataService.loadSequences(project);
+    const sequence = project.sequences[11]
+    component.sequence = sequence;
+    const spy = jest.spyOn(component, 'stageClick');
+    fixture.detectChanges();
+
+    // when
+    const stageDetails = fixture.nativeElement.querySelectorAll('[uitestid=keptn-sequence-info-stageDetails] ktb-stage-badge');
+    stageDetails[0].click();
+
+    // then
+    expect(spy).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledWith(sequence, sequence.getStages()[0]);
   });
 });

--- a/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.ts
+++ b/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.ts
@@ -1,10 +1,14 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output, ViewEncapsulation } from '@angular/core';
 import {Sequence} from '../../_models/sequence';
 
 @Component({
   selector: 'ktb-sequence-state-info',
   templateUrl: './ktb-sequence-state-info.component.html',
-  styleUrls: ['./ktb-sequence-state-info.component.scss']
+  styleUrls: ['./ktb-sequence-state-info.component.scss'],
+  host: {
+    class: 'ktb-sequence-state-info',
+  },
+  encapsulation: ViewEncapsulation.None,
 })
 export class KtbSequenceStateInfoComponent {
 

--- a/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.ts
+++ b/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.ts
@@ -1,0 +1,25 @@
+import {Component, Input} from '@angular/core';
+import {Sequence} from '../../_models/sequence';
+
+@Component({
+  selector: 'ktb-sequence-state-info',
+  templateUrl: './ktb-sequence-state-info.component.html',
+  styleUrls: ['./ktb-sequence-state-info.component.scss']
+})
+export class KtbSequenceStateInfoComponent {
+
+  private _sequence?: Sequence;
+
+  @Input()
+  get sequence(): Sequence | undefined {
+    return this._sequence;
+  }
+  set sequence(sequence: Sequence | undefined) {
+    if (this._sequence !== sequence) {
+      this._sequence = sequence;
+    }
+  }
+
+  constructor() {
+  }
+}

--- a/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.ts
+++ b/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.ts
@@ -37,9 +37,6 @@ export class KtbSequenceStateInfoComponent {
     }
   }
 
-  constructor() {
-  }
-
   getStages(): (string | undefined)[] | undefined {
     return this.showOnlyLastStage ? [this.sequence?.getLastStage()] : this.sequence?.getStages();
   }

--- a/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.ts
+++ b/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input} from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import {Sequence} from '../../_models/sequence';
 
 @Component({
@@ -9,6 +9,9 @@ import {Sequence} from '../../_models/sequence';
 export class KtbSequenceStateInfoComponent {
 
   private _sequence?: Sequence;
+  private _showOnlyLastStage = false;
+
+  @Output() readonly stageClicked = new EventEmitter<{ sequence: Sequence, stage?: string }>();
 
   @Input()
   get sequence(): Sequence | undefined {
@@ -20,6 +23,32 @@ export class KtbSequenceStateInfoComponent {
     }
   }
 
+  @Input()
+  get showOnlyLastStage(): boolean {
+    return this._showOnlyLastStage;
+  }
+  set showOnlyLastStage(showOnlyLastStage: boolean) {
+    if (this._showOnlyLastStage !== showOnlyLastStage) {
+      this._showOnlyLastStage = showOnlyLastStage;
+    }
+  }
+
   constructor() {
+  }
+
+  getStages(): (string | undefined)[] | undefined {
+    return this.showOnlyLastStage ? [this.sequence?.getLastStage()] : this.sequence?.getStages();
+  }
+
+  getServiceLink(sequence: Sequence): (string | undefined)[] {
+    return ['/project', sequence.project, 'service', sequence.service, 'context', sequence.shkeptncontext, 'stage', sequence.getLastStage()];
+  }
+
+  getSequenceLink(sequence: Sequence): (string | undefined)[] {
+    return ['/project', sequence.project, 'sequence', sequence.shkeptncontext, 'stage', sequence.getLastStage()];
+  }
+
+  stageClick(sequence: Sequence, stage: string): void {
+    this.stageClicked.emit({sequence, stage});
   }
 }

--- a/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.ts
+++ b/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.ts
@@ -13,7 +13,7 @@ import {Sequence} from '../../_models/sequence';
 export class KtbSequenceStateInfoComponent {
 
   private _sequence?: Sequence;
-  private _showOnlyLastStage = false;
+  private _showStages = true;
 
   @Output() readonly stageClicked = new EventEmitter<{ sequence: Sequence, stage?: string }>();
 
@@ -28,25 +28,13 @@ export class KtbSequenceStateInfoComponent {
   }
 
   @Input()
-  get showOnlyLastStage(): boolean {
-    return this._showOnlyLastStage;
+  get showStages(): boolean {
+    return this._showStages;
   }
-  set showOnlyLastStage(showOnlyLastStage: boolean) {
-    if (this._showOnlyLastStage !== showOnlyLastStage) {
-      this._showOnlyLastStage = showOnlyLastStage;
+  set showStages(showStages: boolean) {
+    if (this._showStages !== showStages) {
+      this._showStages = showStages;
     }
-  }
-
-  getStages(): string[] {
-    let stages: string[];
-    if (this.showOnlyLastStage) {
-      const stage = this.sequence?.getLastStage();
-      stages = stage ? [stage] : [];
-    }
-    else {
-      stages = this.sequence?.getStages() ?? [];
-    }
-    return stages;
   }
 
   getServiceLink(sequence: Sequence): (string | undefined)[] {

--- a/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.ts
+++ b/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.ts
@@ -37,8 +37,16 @@ export class KtbSequenceStateInfoComponent {
     }
   }
 
-  getStages(): (string | undefined)[] | undefined {
-    return this.showOnlyLastStage ? [this.sequence?.getLastStage()] : this.sequence?.getStages();
+  getStages(): string[] {
+    let stages: string[];
+    if (this.showOnlyLastStage) {
+      const stage = this.sequence?.getLastStage();
+      stages = stage ? [stage] : [];
+    }
+    else {
+      stages = this.sequence?.getStages() ?? [];
+    }
+    return stages;
   }
 
   getServiceLink(sequence: Sequence): (string | undefined)[] {

--- a/bridge/client/app/_components/ktb-sequence-state-list/ktb-sequence-state-list.component.html
+++ b/bridge/client/app/_components/ktb-sequence-state-list/ktb-sequence-state-list.component.html
@@ -1,42 +1,10 @@
 <div fxLayout="column" fxLayoutGap="5px">
   <ng-container *ngIf="sequenceStates && sequenceStates.length > 0; else noSequence">
     <dt-table [dataSource]="dataSource">
-      <ng-container dtColumnDef="serviceName" [dtColumnProportion]="3" uitestid="keptn-sequence-states-list-container">
-        <dt-cell *dtCellDef="let row">
-          <ng-container *ngIf="row | toType : SequenceClass as sequence">
-            <div class="mt-1 mb-1">
-              <p class="m-0 mb-1 small nobreak">
-                <a [routerLink]="getServiceLink(sequence)" [textContent]="sequence.service"></a> in
-              </p>
-              <ng-container *ngIf="sequence.getLastStage() as stage">
-                <ktb-stage-badge [stage]="stage" [evaluationResult]="sequence.getEvaluation(stage)"
-                                 [success]="sequence.isSuccessful(stage)"
-                                 [error]="sequence.isFaulty(stage)" [class.warning]="sequence.isWarning(stage)"
-                                 [highlight]="sequence.hasPendingApproval(stage)"></ktb-stage-badge>
-              </ng-container>
-            </div>
-          </ng-container>
-        </dt-cell>
-      </ng-container>
       <ng-container dtColumnDef="recentSequence" [dtColumnProportion]="4">
         <dt-cell *dtCellDef="let row">
           <ng-container *ngIf="row | toType : SequenceClass as sequence">
-            <div class="mt-1 mb-1" fxLayout="row" fxLayoutGap="5px" fxLayoutAlign="start center">
-              <dt-icon *ngIf="!sequence.isLoading() || sequence.hasPendingApproval(); else showLoading" class="event-icon"
-                       [name]="sequence.getIcon()"
-                       [class.success]="sequence.isSuccessful()"
-                       [class.error]="sequence.isFaulty()"
-                       [class.highlight]="sequence.hasPendingApproval()"></dt-icon>
-              <ng-template #showLoading>
-                <button class="m-0 p-0" dt-button disabled variant="nested">
-                  <dt-loading-spinner aria-label="Task is running..."></dt-loading-spinner>
-                </button>
-              </ng-template>
-              <a [routerLink]="getSequenceLink(sequence)" class="m-0 small" [class.error]="sequence.isFaulty()">
-                <span class="bold" [textContent]="sequence.name"></span>&nbsp;
-                <span [textContent]="sequence.getStatus()"></span>
-              </a>
-            </div>
+            <ktb-sequence-state-info [sequence]="sequence" [showOnlyLastStage]="true"></ktb-sequence-state-info>
           </ng-container>
         </dt-cell>
       </ng-container>
@@ -47,7 +15,7 @@
           </ng-container>
         </dt-cell>
       </ng-container>
-      <dt-row *dtRowDef="let row; columns: ['serviceName', 'recentSequence', 'recentEvaluation']"></dt-row>
+      <dt-row *dtRowDef="let row; columns: ['recentSequence', 'recentEvaluation']"></dt-row>
     </dt-table>
   </ng-container>
 </div>

--- a/bridge/client/app/_components/ktb-sequence-state-list/ktb-sequence-state-list.component.html
+++ b/bridge/client/app/_components/ktb-sequence-state-list/ktb-sequence-state-list.component.html
@@ -4,7 +4,7 @@
       <ng-container dtColumnDef="recentSequence" [dtColumnProportion]="4">
         <dt-cell *dtCellDef="let row">
           <ng-container *ngIf="row | toType : SequenceClass as sequence">
-            <ktb-sequence-state-info [sequence]="sequence" [showOnlyLastStage]="true"></ktb-sequence-state-info>
+            <ktb-sequence-state-info [sequence]="sequence" [showOnlyLastStage]="true" (stageClicked)="selectSequence($event)"></ktb-sequence-state-info>
           </ng-container>
         </dt-cell>
       </ng-container>

--- a/bridge/client/app/_components/ktb-sequence-state-list/ktb-sequence-state-list.component.html
+++ b/bridge/client/app/_components/ktb-sequence-state-list/ktb-sequence-state-list.component.html
@@ -4,7 +4,7 @@
       <ng-container dtColumnDef="recentSequence" [dtColumnProportion]="4">
         <dt-cell *dtCellDef="let row">
           <ng-container *ngIf="row | toType : SequenceClass as sequence">
-            <ktb-sequence-state-info [sequence]="sequence" [showOnlyLastStage]="true" (stageClicked)="selectSequence($event)"></ktb-sequence-state-info>
+            <ktb-sequence-state-info [sequence]="sequence" [showStages]="false" (stageClicked)="selectSequence($event)"></ktb-sequence-state-info>
           </ng-container>
         </dt-cell>
       </ng-container>

--- a/bridge/client/app/_components/ktb-sequence-state-list/ktb-sequence-state-list.component.ts
+++ b/bridge/client/app/_components/ktb-sequence-state-list/ktb-sequence-state-list.component.ts
@@ -68,14 +68,6 @@ export class KtbSequenceStateListComponent implements OnDestroy {
     this.dataSource = new DtTableDataSource(this.sequenceStates.slice(0, this.PAGE_SIZE) || []);
   }
 
-  getServiceLink(sequence: Sequence) {
-    return ['/project', sequence.project, 'service', sequence.service, 'context', sequence.shkeptncontext, 'stage', sequence.getLastStage()];
-  }
-
-  getSequenceLink(sequence: Sequence) {
-    return ['/project', sequence.project, 'sequence', sequence.shkeptncontext, 'stage', sequence.getLastStage()];
-  }
-
   ngOnDestroy(): void {
     this._timer.unsubscribe();
   }

--- a/bridge/client/app/_components/ktb-sequence-state-list/ktb-sequence-state-list.component.ts
+++ b/bridge/client/app/_components/ktb-sequence-state-list/ktb-sequence-state-list.component.ts
@@ -6,6 +6,8 @@ import { Sequence } from '../../_models/sequence';
 import { Subscription } from 'rxjs';
 import { Project } from '../../_models/project';
 import { AppUtils, POLLING_INTERVAL_MILLIS } from '../../_utils/app.utils';
+import { Router } from '@angular/router';
+import { Location } from '@angular/common';
 
 @Component({
   selector: 'ktb-sequence-state-list',
@@ -52,10 +54,10 @@ export class KtbSequenceStateListComponent implements OnDestroy {
     }
   }
 
-  constructor(public dataService: DataService, public dateUtil: DateUtil, private ngZone: NgZone, @Inject(POLLING_INTERVAL_MILLIS) private initialDelayMillis: number) {
+  constructor(public dataService: DataService, public dateUtil: DateUtil, private ngZone: NgZone, @Inject(POLLING_INTERVAL_MILLIS) private initialDelayMillis: number, private router: Router, private location: Location) {
   }
 
-  loadLatestSequences() {
+  loadLatestSequences(): void {
     if (this.project) {
       this.dataService.loadLatestSequences(this.project, this.PAGE_SIZE)
         .subscribe((sequences: Sequence[]) => {
@@ -64,8 +66,15 @@ export class KtbSequenceStateListComponent implements OnDestroy {
     }
   }
 
-  updateDataSource() {
+  updateDataSource(): void {
     this.dataSource = new DtTableDataSource(this.sequenceStates.slice(0, this.PAGE_SIZE) || []);
+  }
+
+  selectSequence(event: { sequence: Sequence, stage?: string }): void {
+    const stage = event.stage || event.sequence.getStages().pop();
+    const routeUrl = this.router.createUrlTree(['/project', event.sequence.project, 'sequence', event.sequence.shkeptncontext,
+      ...(stage ? ['stage', stage] : [])]);
+    this.location.go(routeUrl.toString());
   }
 
   ngOnDestroy(): void {

--- a/bridge/client/app/_components/ktb-sequence-state-list/ktb-sequence-state-list.component.ts
+++ b/bridge/client/app/_components/ktb-sequence-state-list/ktb-sequence-state-list.component.ts
@@ -54,7 +54,7 @@ export class KtbSequenceStateListComponent implements OnDestroy {
     }
   }
 
-  constructor(public dataService: DataService, public dateUtil: DateUtil, private ngZone: NgZone, @Inject(POLLING_INTERVAL_MILLIS) private initialDelayMillis: number, private router: Router, private location: Location) {
+  constructor(public dataService: DataService, public dateUtil: DateUtil, private ngZone: NgZone, @Inject(POLLING_INTERVAL_MILLIS) private initialDelayMillis: number, private router: Router) {
   }
 
   loadLatestSequences(): void {
@@ -72,9 +72,8 @@ export class KtbSequenceStateListComponent implements OnDestroy {
 
   selectSequence(event: { sequence: Sequence, stage?: string }): void {
     const stage = event.stage || event.sequence.getStages().pop();
-    const routeUrl = this.router.createUrlTree(['/project', event.sequence.project, 'sequence', event.sequence.shkeptncontext,
+    this.router.navigate(['/project', event.sequence.project, 'sequence', event.sequence.shkeptncontext,
       ...(stage ? ['stage', stage] : [])]);
-    this.location.go(routeUrl.toString());
   }
 
   ngOnDestroy(): void {

--- a/bridge/client/app/_components/ktb-sequence-state-list/ktb-sequence-state-list.component.ts
+++ b/bridge/client/app/_components/ktb-sequence-state-list/ktb-sequence-state-list.component.ts
@@ -7,7 +7,6 @@ import { Subscription } from 'rxjs';
 import { Project } from '../../_models/project';
 import { AppUtils, POLLING_INTERVAL_MILLIS } from '../../_utils/app.utils';
 import { Router } from '@angular/router';
-import { Location } from '@angular/common';
 
 @Component({
   selector: 'ktb-sequence-state-list',

--- a/bridge/client/app/_models/sequence.ts
+++ b/bridge/client/app/_models/sequence.ts
@@ -107,7 +107,7 @@ export class Sequence extends sq {
     if (lastStageName && this.state === SequenceState.STARTED) {
       const lastStage = this.getStage(lastStageName);
       return lastStage?.state === SequenceState.FINISHED || // last stages is finished, but sequence is still started, means it is waiting for next stage to be triggered
-        (lastStage?.state === SequenceState.TRIGGERED && this.getTraces(lastStageName).every(seq => !seq.isLoading())); // last stage is triggered, but has no running tasks
+        (lastStage?.state === SequenceState.TRIGGERED && !!lastStage?.latestEvent?.type.endsWith('.triggered')); // last stage is triggered, but has no running tasks
     } else {
       // no stages yet, sequence is triggered, so waiting
       return this.state === SequenceState.TRIGGERED;

--- a/bridge/client/app/app.module.ts
+++ b/bridge/client/app/app.module.ts
@@ -124,6 +124,7 @@ import { KtbEditServiceComponent } from './_components/ktb-edit-service/ktb-edit
 import { DtAlertModule } from '@dynatrace/barista-components/alert';
 import { KtbEditServiceFileListComponent } from './ktb-edit-service-file-list/ktb-edit-service-file-list.component';
 import { DtTreeTableModule } from '@dynatrace/barista-components/tree-table';
+import { KtbSequenceStateInfoComponent } from './_components/ktb-sequence-state-info/ktb-sequence-state-info.component';
 
 registerLocaleData(localeEn, 'en');
 
@@ -208,6 +209,7 @@ export function init_app(appLoadService: AppInitService): () => Promise<unknown>
     KtbServiceSettingsListComponent,
     KtbEditServiceComponent,
     KtbEditServiceFileListComponent,
+    KtbSequenceStateInfoComponent,
   ],
   imports: [
     BrowserModule,

--- a/bridge/client/styles.scss
+++ b/bridge/client/styles.scss
@@ -43,6 +43,14 @@ ktb-root {
   white-space: normal;
 }
 
+p.smaller,
+span.smaller {
+  font-family: BerninaSansWeb, OpenSans, sans-serif;
+  font-weight: 400;
+  font-size: 13px;
+  color: $gray-700;
+}
+
 p.small,
 span.small {
   font-family: BerninaSansWeb, OpenSans, sans-serif;


### PR DESCRIPTION
## This PR
- introduces a component that displays sequence state info the same way across multiple screens

### Related Issues
Fixes #5150 

Dashboard:
![image](https://user-images.githubusercontent.com/6098219/134362738-7e6e5177-b0c6-46e9-8afb-ffd5871fb259.png)

Sequence Screen:
![image](https://user-images.githubusercontent.com/6098219/134362856-558c3514-a910-438e-91e6-19e1f3713118.png)
