### PR TITLE
feat(bridge): Allow to create secret with scope selection #5269

### DIFF
--- a/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.html
+++ b/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.html
@@ -9,10 +9,16 @@
       <form [formGroup]="createSecretForm">
         <div class="mb-3" fxLayout="row" fxLayoutAlign="none end" fxLayoutGap="15px">
           <dt-form-field>
-            <dt-label>Name *</dt-label>
+            <dt-label class="required">Name</dt-label>
             <input formControlName="name" type="text" required dtInput placeholder="Secret name" />
             <dt-error *ngIf="getFormControl('name')?.errors?.required">Must not be empty</dt-error>
             <dt-error *ngIf="getFormControl('name')?.errors?.pattern">Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character</dt-error>
+          </dt-form-field>
+          <dt-form-field>
+            <dt-label class="required">Scope</dt-label>
+            <dt-select formControlName="scope" class="mr-2 item" placeholder="Choose scope" aria-label="Choose your task">
+              <dt-option *ngFor="let scope of scopes" [value]="scope" [textContent]="scope"></dt-option>
+            </dt-select>
           </dt-form-field>
         </div>
 
@@ -21,13 +27,13 @@
             <form [formGroup]="dataGroup">
               <div class="mb-1" fxLayout="row" fxLayoutAlign="none end" fxLayoutGap="15px">
                 <dt-form-field>
-                  <dt-label>Key *</dt-label>
+                  <dt-label class="required">Key</dt-label>
                   <input formControlName="key" type="text" required dtInput placeholder="Key" autocomplete="false" />
                   <dt-error *ngIf="dataGroup.get('key')?.errors?.required">Must not be empty</dt-error>
                   <dt-error *ngIf="dataGroup.get('key')?.errors?.pattern">Key must consist of alphanumeric characters, '-', '_' or '.'</dt-error>
                 </dt-form-field>
                 <dt-form-field>
-                  <dt-label>Value *</dt-label>
+                  <dt-label class="required">Value</dt-label>
                   <input formControlName="value" type="password" required dtInput placeholder="Value" autocomplete="false" />
                   <dt-error>Must not be empty</dt-error>
                 </dt-form-field>
@@ -52,8 +58,9 @@
             Cancel
           </button>
         </div>
-
-        <p class="small">* fields are required</p>
+        <div class="mt-2 required-info">
+          fields are required
+        </div>
       </form>
     </div>
   </div>

--- a/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.html
+++ b/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.html
@@ -7,28 +7,28 @@
       </p>
 
       <form [formGroup]="createSecretForm">
-        <div class="mb-3" fxLayout="row" fxLayoutAlign="none end" fxLayoutGap="15px">
-          <dt-form-field fxFlex>
-            <dt-label class="required">Name</dt-label>
-            <input formControlName="name" type="text" required dtInput placeholder="Secret name" uitestid="keptn-secret-name-input" />
-            <dt-error *ngIf="getFormControl('name')?.errors?.required">Must not be empty</dt-error>
-            <dt-error *ngIf="getFormControl('name')?.errors?.pattern">Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character</dt-error>
-          </dt-form-field>
-          <dt-form-field fxFlex>
-            <dt-label class="required">Scope</dt-label>
-            <dt-select formControlName="scope" class="mr-2 item" placeholder="Choose scope" aria-label="Choose your task" uitestid="keptn-secret-scope-input">
-              <dt-option *ngFor="let scope of scopes" [value]="scope" [textContent]="scope"></dt-option>
-            </dt-select>
-          </dt-form-field>
-        </div>
+        <dt-form-field>
+          <dt-label class="required">Name</dt-label>
+          <input formControlName="name" type="text" required dtInput placeholder="e.g. API" uitestid="keptn-secret-name-input" />
+          <dt-error *ngIf="getFormControl('name')?.errors?.required">Must not be empty</dt-error>
+          <dt-error *ngIf="getFormControl('name')?.errors?.pattern">Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character</dt-error>
+        </dt-form-field>
+
+        <dt-form-field>
+          <dt-label class="required">Scope</dt-label>
+          <dt-select formControlName="scope" class="mr-2 item" placeholder="Choose scope" aria-label="Choose your task" uitestid="keptn-secret-scope-input">
+            <dt-option *ngFor="let scope of scopes" [value]="scope" [textContent]="scope"></dt-option>
+          </dt-select>
+        </dt-form-field>
 
         <div formArrayName="data">
+          <h3>Key-value pairs</h3>
           <ng-container *ngFor="let dataGroup of dataControls; let i = index;">
             <form [formGroup]="dataGroup">
               <div class="mb-1" fxLayout="row" fxLayoutAlign="none end" fxLayoutGap="15px">
                 <dt-form-field fxFlex>
                   <dt-label class="required">Key</dt-label>
-                  <input formControlName="key" type="text" required dtInput placeholder="Key" autocomplete="false" uitestid="keptn-secret-key-input" />
+                  <input formControlName="key" type="text" required dtInput placeholder="e.g. Token" autocomplete="false" uitestid="keptn-secret-key-input" />
                   <dt-error *ngIf="dataGroup.get('key')?.errors?.required">Must not be empty</dt-error>
                   <dt-error *ngIf="dataGroup.get('key')?.errors?.pattern">Key must consist of alphanumeric characters, '-', '_' or '.'</dt-error>
                 </dt-form-field>
@@ -45,8 +45,8 @@
           </ng-container>
         </div>
 
-        <button type="button" dt-icon-button variant="nested" aria-label="Add key-value pair" title="Add key-value pair" (click)="addPair()" uitestid="keptn-secret-add-pair-button">
-          <dt-icon name="addrowonbottom"></dt-icon>
+        <button type="button" dt-button variant="nested" aria-label="Add key-value pair" title="Add key-value pair" (click)="addPair()" uitestid="keptn-secret-add-pair-button">
+          <dt-icon name="addrowonbottom"></dt-icon> Add key-value pair
         </button>
 
         <div fxLayout="row" fxLayoutAlign="none end" fxLayoutGap="15px" class="mt-3">

--- a/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.html
+++ b/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.html
@@ -8,13 +8,13 @@
 
       <form [formGroup]="createSecretForm">
         <div class="mb-3" fxLayout="row" fxLayoutAlign="none end" fxLayoutGap="15px">
-          <dt-form-field>
+          <dt-form-field fxFlex>
             <dt-label class="required">Name</dt-label>
             <input formControlName="name" type="text" required dtInput placeholder="Secret name" uitestid="keptn-secret-name-input" />
             <dt-error *ngIf="getFormControl('name')?.errors?.required">Must not be empty</dt-error>
             <dt-error *ngIf="getFormControl('name')?.errors?.pattern">Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character</dt-error>
           </dt-form-field>
-          <dt-form-field fxFlex="220px">
+          <dt-form-field fxFlex>
             <dt-label class="required">Scope</dt-label>
             <dt-select formControlName="scope" class="mr-2 item" placeholder="Choose scope" aria-label="Choose your task" uitestid="keptn-secret-scope-input">
               <dt-option *ngFor="let scope of scopes" [value]="scope" [textContent]="scope"></dt-option>
@@ -26,13 +26,13 @@
           <ng-container *ngFor="let dataGroup of dataControls; let i = index;">
             <form [formGroup]="dataGroup">
               <div class="mb-1" fxLayout="row" fxLayoutAlign="none end" fxLayoutGap="15px">
-                <dt-form-field>
+                <dt-form-field fxFlex>
                   <dt-label class="required">Key</dt-label>
                   <input formControlName="key" type="text" required dtInput placeholder="Key" autocomplete="false" uitestid="keptn-secret-key-input" />
                   <dt-error *ngIf="dataGroup.get('key')?.errors?.required">Must not be empty</dt-error>
                   <dt-error *ngIf="dataGroup.get('key')?.errors?.pattern">Key must consist of alphanumeric characters, '-', '_' or '.'</dt-error>
                 </dt-form-field>
-                <dt-form-field>
+                <dt-form-field fxFlex>
                   <dt-label class="required">Value</dt-label>
                   <input formControlName="value" type="password" required dtInput placeholder="Value" autocomplete="false" uitestid="keptn-secret-value-input" />
                   <dt-error>Must not be empty</dt-error>

--- a/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.html
+++ b/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.html
@@ -14,7 +14,7 @@
             <dt-error *ngIf="getFormControl('name')?.errors?.required">Must not be empty</dt-error>
             <dt-error *ngIf="getFormControl('name')?.errors?.pattern">Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character</dt-error>
           </dt-form-field>
-          <dt-form-field>
+          <dt-form-field fxFlex="220px">
             <dt-label class="required">Scope</dt-label>
             <dt-select formControlName="scope" class="mr-2 item" placeholder="Choose scope" aria-label="Choose your task" uitestid="keptn-secret-scope-input">
               <dt-option *ngFor="let scope of scopes" [value]="scope" [textContent]="scope"></dt-option>

--- a/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.html
+++ b/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.html
@@ -37,7 +37,7 @@
                   <input formControlName="value" type="password" required dtInput placeholder="Value" autocomplete="false" uitestid="keptn-secret-value-input" />
                   <dt-error>Must not be empty</dt-error>
                 </dt-form-field>
-                <button type="button" dt-icon-button variant="nested" aria-label="Remove key-value pair" title="Remove key-value pair" (click)="removePair(i)" [disabled]="(data?.controls?.length || 0) <= 1">
+                <button type="button" dt-icon-button variant="nested" aria-label="Remove key-value pair" title="Remove key-value pair" (click)="removePair(i)" [disabled]="(data?.controls?.length || 0) <= 1" uitestid="keptn-secret-remove-pair-button">
                   <dt-icon name="removerow"></dt-icon>
                 </button>
               </div>

--- a/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.html
+++ b/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.html
@@ -10,13 +10,13 @@
         <div class="mb-3" fxLayout="row" fxLayoutAlign="none end" fxLayoutGap="15px">
           <dt-form-field>
             <dt-label class="required">Name</dt-label>
-            <input formControlName="name" type="text" required dtInput placeholder="Secret name" />
+            <input formControlName="name" type="text" required dtInput placeholder="Secret name" uitestid="keptn-secret-name-input" />
             <dt-error *ngIf="getFormControl('name')?.errors?.required">Must not be empty</dt-error>
             <dt-error *ngIf="getFormControl('name')?.errors?.pattern">Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character</dt-error>
           </dt-form-field>
           <dt-form-field>
             <dt-label class="required">Scope</dt-label>
-            <dt-select formControlName="scope" class="mr-2 item" placeholder="Choose scope" aria-label="Choose your task">
+            <dt-select formControlName="scope" class="mr-2 item" placeholder="Choose scope" aria-label="Choose your task" uitestid="keptn-secret-scope-input">
               <dt-option *ngFor="let scope of scopes" [value]="scope" [textContent]="scope"></dt-option>
             </dt-select>
           </dt-form-field>
@@ -28,13 +28,13 @@
               <div class="mb-1" fxLayout="row" fxLayoutAlign="none end" fxLayoutGap="15px">
                 <dt-form-field>
                   <dt-label class="required">Key</dt-label>
-                  <input formControlName="key" type="text" required dtInput placeholder="Key" autocomplete="false" />
+                  <input formControlName="key" type="text" required dtInput placeholder="Key" autocomplete="false" uitestid="keptn-secret-key-input" />
                   <dt-error *ngIf="dataGroup.get('key')?.errors?.required">Must not be empty</dt-error>
                   <dt-error *ngIf="dataGroup.get('key')?.errors?.pattern">Key must consist of alphanumeric characters, '-', '_' or '.'</dt-error>
                 </dt-form-field>
                 <dt-form-field>
                   <dt-label class="required">Value</dt-label>
-                  <input formControlName="value" type="password" required dtInput placeholder="Value" autocomplete="false" />
+                  <input formControlName="value" type="password" required dtInput placeholder="Value" autocomplete="false" uitestid="keptn-secret-value-input" />
                   <dt-error>Must not be empty</dt-error>
                 </dt-form-field>
                 <button type="button" dt-icon-button variant="nested" aria-label="Remove key-value pair" title="Remove key-value pair" (click)="removePair(i)" [disabled]="(data?.controls?.length || 0) <= 1">
@@ -45,12 +45,12 @@
           </ng-container>
         </div>
 
-        <button type="button" dt-icon-button variant="nested" aria-label="Add key-value pair" title="Add key-value pair" (click)="addPair()">
+        <button type="button" dt-icon-button variant="nested" aria-label="Add key-value pair" title="Add key-value pair" (click)="addPair()" uitestid="keptn-secret-add-pair-button">
           <dt-icon name="addrowonbottom"></dt-icon>
         </button>
 
         <div fxLayout="row" fxLayoutAlign="none end" fxLayoutGap="15px" class="mt-3">
-          <button (click)="createSecret()" [disabled]="createSecretForm.invalid || isLoading" dt-button>
+          <button (click)="createSecret()" [disabled]="createSecretForm.invalid || isLoading" dt-button uitestid="keptn-secret-create-button">
             <dt-loading-spinner *ngIf="isLoading" aria-label="Create secret"></dt-loading-spinner>
             Add secret
           </button>

--- a/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.scss
+++ b/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.scss
@@ -1,2 +1,6 @@
 @import '../../../variables';
 @import '../../../../node_modules/@dynatrace/barista-components/core/src/style/variables';
+
+.settings-section {
+  width: 50%;
+}

--- a/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.scss
+++ b/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.scss
@@ -1,6 +1,0 @@
-@import '../../../variables';
-@import '../../../../node_modules/@dynatrace/barista-components/core/src/style/variables';
-
-.settings-section {
-  width: 50%;
-}

--- a/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.spec.ts
+++ b/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.spec.ts
@@ -4,6 +4,7 @@ import { KtbCreateSecretFormComponent } from './ktb-create-secret-form.component
 import { AppModule } from '../../app.module';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { DataService } from '../../_services/data.service';
+import { Secret } from '../../_models/secret';
 
 describe('KtbCreateSecretFormComponent', () => {
   let component: KtbCreateSecretFormComponent;
@@ -32,40 +33,38 @@ describe('KtbCreateSecretFormComponent', () => {
     // given
     const createButton = fixture.nativeElement.querySelector('[uitestid=keptn-secret-create-button]');
     const spy = jest.spyOn(dataService, 'addSecret');
+    const secret: Secret = new Secret();
+    secret.name = 'test';
+    secret.scope = component.scopes[0];
+    secret.data.push({key: 'testKey', value: 'testValue'});
 
     // when
-    component.getFormControl('name')?.setValue('test');
-    component.data?.controls[0].get('key')?.setValue('testKey');
-    component.data?.controls[0].get('value')?.setValue('testValue');
+    component.getFormControl('name')?.setValue(secret.name);
+    component.data?.controls[0].get('key')?.setValue(secret.data[0].key);
+    component.data?.controls[0].get('value')?.setValue(secret.data[0].value);
     createButton.click();
 
     // then
-    expect(spy).toHaveBeenCalled();
-    const argument = spy.mock.calls[0][0];
-    expect(argument.name).toEqual('test');
-    expect(argument.scope).toEqual(component.scopes[0]);
-    expect(argument.data[0].key).toEqual('testKey');
-    expect(argument.data[0].value).toEqual('testValue');
+    expect(spy).toHaveBeenCalledWith(secret);
   });
 
   it('should create secret with selected scope', () => {
     // given
     const createButton = fixture.nativeElement.querySelector('[uitestid=keptn-secret-create-button]');
     const spy = jest.spyOn(dataService, 'addSecret');
+    const secret: Secret = new Secret();
+    secret.name = 'test';
+    secret.scope = component.scopes[1];
+    secret.data.push({key: 'testKey', value: 'testValue'});
 
     // when
-    component.getFormControl('name')?.setValue('test');
-    component.getFormControl('scope')?.setValue(component.scopes[1]);
-    component.data?.controls[0].get('key')?.setValue('testKey');
-    component.data?.controls[0].get('value')?.setValue('testValue');
+    component.getFormControl('name')?.setValue(secret.name);
+    component.getFormControl('scope')?.setValue(secret.scope);
+    component.data?.controls[0].get('key')?.setValue(secret.data[0].key);
+    component.data?.controls[0].get('value')?.setValue(secret.data[0].value);
     createButton.click();
 
     // then
-    expect(spy).toHaveBeenCalled();
-    const argument = spy.mock.calls[0][0];
-    expect(argument.name).toEqual('test');
-    expect(argument.scope).toEqual(component.scopes[1]);
-    expect(argument.data[0].key).toEqual('testKey');
-    expect(argument.data[0].value).toEqual('testValue');
+    expect(spy).toHaveBeenCalledWith(secret);
   });
 });

--- a/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.spec.ts
+++ b/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.spec.ts
@@ -3,13 +3,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { KtbCreateSecretFormComponent } from './ktb-create-secret-form.component';
 import { AppModule } from '../../app.module';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { DataService } from '../../_services/data.service';
 
 describe('KtbCreateSecretFormComponent', () => {
   let component: KtbCreateSecretFormComponent;
   let fixture: ComponentFixture<KtbCreateSecretFormComponent>;
+  let dataService: DataService;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      declarations: [],
       imports: [
         AppModule,
         HttpClientTestingModule,
@@ -18,10 +21,51 @@ describe('KtbCreateSecretFormComponent', () => {
 
     fixture = TestBed.createComponent(KtbCreateSecretFormComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    dataService = fixture.debugElement.injector.get(DataService);
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should create secret with keptn-default scope', () => {
+    // given
+    const createButton = fixture.nativeElement.querySelector('[uitestid=keptn-secret-create-button]');
+    const spy = jest.spyOn(dataService, 'addSecret');
+
+    // when
+    component.getFormControl('name')?.setValue('test');
+    component.data?.controls[0].get('key')?.setValue('testKey');
+    component.data?.controls[0].get('value')?.setValue('testValue');
+    createButton.click();
+
+    // then
+    expect(spy).toHaveBeenCalled();
+    const argument = spy.mock.calls[0][0];
+    expect(argument.name).toEqual('test');
+    expect(argument.scope).toEqual(component.scopes[0]);
+    expect(argument.data[0].key).toEqual('testKey');
+    expect(argument.data[0].value).toEqual('testValue');
+  });
+
+  it('should create secret with selected scope', () => {
+    // given
+    const createButton = fixture.nativeElement.querySelector('[uitestid=keptn-secret-create-button]');
+    const spy = jest.spyOn(dataService, 'addSecret');
+
+    // when
+    component.getFormControl('name')?.setValue('test');
+    component.getFormControl('scope')?.setValue(component.scopes[1]);
+    component.data?.controls[0].get('key')?.setValue('testKey');
+    component.data?.controls[0].get('value')?.setValue('testValue');
+    createButton.click();
+
+    // then
+    expect(spy).toHaveBeenCalled();
+    const argument = spy.mock.calls[0][0];
+    expect(argument.name).toEqual('test');
+    expect(argument.scope).toEqual(component.scopes[1]);
+    expect(argument.data[0].key).toEqual('testKey');
+    expect(argument.data[0].value).toEqual('testValue');
   });
 });

--- a/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.spec.ts
+++ b/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.spec.ts
@@ -42,6 +42,11 @@ describe('KtbCreateSecretFormComponent', () => {
     component.getFormControl('name')?.setValue(secret.name);
     component.data?.controls[0].get('key')?.setValue(secret.data[0].key);
     component.data?.controls[0].get('value')?.setValue(secret.data[0].value);
+    component.createSecretForm.updateValueAndValidity();
+    fixture.detectChanges();
+
+    expect(component.createSecretForm.errors).toBeNull();
+    expect(createButton.disabled).toBe(false);
     createButton.click();
 
     // then
@@ -62,6 +67,11 @@ describe('KtbCreateSecretFormComponent', () => {
     component.getFormControl('scope')?.setValue(secret.scope);
     component.data?.controls[0].get('key')?.setValue(secret.data[0].key);
     component.data?.controls[0].get('value')?.setValue(secret.data[0].value);
+    component.createSecretForm.updateValueAndValidity();
+    fixture.detectChanges();
+
+    expect(component.createSecretForm.errors).toBeNull();
+    expect(createButton.disabled).toBe(false);
     createButton.click();
 
     // then

--- a/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.spec.ts
+++ b/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.spec.ts
@@ -67,4 +67,38 @@ describe('KtbCreateSecretFormComponent', () => {
     // then
     expect(spy).toHaveBeenCalledWith(secret);
   });
+
+  it('remove key/value pair should be disabled', () => {
+    // given
+    fixture.detectChanges();
+    const removePairButton = fixture.nativeElement.querySelector('[uitestid=keptn-secret-remove-pair-button]');
+
+    // then
+    expect(removePairButton.disabled).toBe(true);
+  });
+
+  it('should add key/value pair', () => {
+    // given
+    const addPairButton = fixture.nativeElement.querySelector('[uitestid=keptn-secret-add-pair-button]');
+
+    // when
+    addPairButton.click();
+
+    // then
+    expect(component.dataControls.length).toBe(2);
+  });
+
+  it('should remove key/value pair', () => {
+    // given
+    const addPairButton = fixture.nativeElement.querySelector('[uitestid=keptn-secret-add-pair-button]');
+
+    // when
+    addPairButton.click();
+    fixture.detectChanges();
+    const removePairButtons: HTMLElement[] = Array.from(fixture.nativeElement.querySelectorAll('[uitestid=keptn-secret-remove-pair-button]'));
+    removePairButtons[0].click();
+
+    // then
+    expect(component.dataControls.length).toBe(1);
+  });
 });

--- a/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.ts
+++ b/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.ts
@@ -16,8 +16,11 @@ export class KtbCreateSecretFormComponent {
   private secretNamePattern = '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*';
   private secretKeyPattern = '[-._a-zA-Z0-9]+';
 
+  public scopes = ['keptn-default', 'keptn-webhook-service', 'dynatrace-service'];
+
   public createSecretForm = this.fb.group({
     name: ['', [Validators.required, Validators.pattern(this.secretNamePattern)]],
+    scope: [this.scopes[0], [Validators.required]],
     data: this.fb.array([
       this.fb.group({
         key: ['', [Validators.required, Validators.pattern(this.secretKeyPattern)]],
@@ -43,6 +46,7 @@ export class KtbCreateSecretFormComponent {
 
       const secret: Secret = new Secret();
       secret.setName(this.createSecretForm.get('name')?.value);
+      secret.setScope(this.createSecretForm.get('scope')?.value);
       for (const dataGroup of this.data?.controls || []) {
         secret.addData(dataGroup.get('key')?.value, dataGroup.get('value')?.value);
       }

--- a/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.ts
+++ b/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { DataService } from '../../_services/data.service';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AbstractControl, FormArray, FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { Secret } from '../../_models/secret';
+import { Scopes, Secret } from '../../_models/secret';
 
 @Component({
   selector: 'ktb-secrets-view',
@@ -16,7 +16,7 @@ export class KtbCreateSecretFormComponent {
   private secretNamePattern = '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*';
   private secretKeyPattern = '[-._a-zA-Z0-9]+';
 
-  public scopes = ['keptn-default', 'keptn-webhook-service', 'dynatrace-service'];
+  public scopes = Object.values(Scopes);
 
   public createSecretForm = this.fb.group({
     name: ['', [Validators.required, Validators.pattern(this.secretNamePattern)]],

--- a/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.ts
+++ b/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.ts
@@ -7,7 +7,7 @@ import { Scopes, Secret } from '../../_models/secret';
 @Component({
   selector: 'ktb-secrets-view',
   templateUrl: './ktb-create-secret-form.component.html',
-  styleUrls: ['./ktb-create-secret-form.component.scss']
+  styleUrls: []
 })
 export class KtbCreateSecretFormComponent {
 

--- a/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.ts
+++ b/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.ts
@@ -16,7 +16,7 @@ export class KtbCreateSecretFormComponent {
   private secretNamePattern = '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*';
   private secretKeyPattern = '[-._a-zA-Z0-9]+';
 
-  public scopes = Object.values(Scopes);
+  public scopes: string[] = Object.values(Scopes);
 
   public createSecretForm = this.fb.group({
     name: ['', [Validators.required, Validators.pattern(this.secretNamePattern)]],

--- a/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.ts
+++ b/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.ts
@@ -2,7 +2,8 @@ import { Component } from '@angular/core';
 import { DataService } from '../../_services/data.service';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AbstractControl, FormArray, FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { Scopes, Secret } from '../../_models/secret';
+import { Secret } from '../../_models/secret';
+import { SecretScope } from '../../../../shared/interfaces/secret-scope';
 
 @Component({
   selector: 'ktb-secrets-view',
@@ -16,7 +17,7 @@ export class KtbCreateSecretFormComponent {
   private secretNamePattern = '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*';
   private secretKeyPattern = '[-._a-zA-Z0-9]+';
 
-  public scopes: string[] = Object.values(Scopes);
+  public scopes: string[] = Object.values(SecretScope);
 
   public createSecretForm = this.fb.group({
     name: ['', [Validators.required, Validators.pattern(this.secretNamePattern)]],

--- a/bridge/client/app/_models/secret.ts
+++ b/bridge/client/app/_models/secret.ts
@@ -1,3 +1,9 @@
+export enum Scopes {
+  KeptnDefault = 'keptn-default',
+  KeptnWebhookService = 'keptn-webhook-service',
+  KeptnDynatraceService = 'dynatrace-service'
+}
+
 class KeyValuePair {
   key!: string;
   value!: string;
@@ -9,6 +15,7 @@ export class Secret {
   data: KeyValuePair[];
 
   constructor() {
+    this.scope = Scopes.KeptnDefault;
     this.data = [];
   }
 

--- a/bridge/client/app/_models/secret.ts
+++ b/bridge/client/app/_models/secret.ts
@@ -9,16 +9,19 @@ export class Secret {
   data: KeyValuePair[];
 
   constructor() {
-    this.scope = 'keptn-default';
     this.data = [];
   }
 
-  static fromJSON(data: unknown) {
+  static fromJSON(data: unknown): Secret {
     return Object.assign(new this(), data);
   }
 
   setName(name: string): void {
     this.name = name;
+  }
+
+  setScope(scope: string): void {
+    this.scope = scope;
   }
 
   addData(key: string, value: string): void {

--- a/bridge/client/app/_models/secret.ts
+++ b/bridge/client/app/_models/secret.ts
@@ -1,8 +1,4 @@
-export enum Scopes {
-  KeptnDefault = 'keptn-default',
-  KeptnWebhookService = 'keptn-webhook-service',
-  KeptnDynatraceService = 'dynatrace-service'
-}
+import { SecretScope } from '../../../shared/interfaces/secret-scope';
 
 class KeyValuePair {
   key!: string;
@@ -15,7 +11,7 @@ export class Secret {
   data: KeyValuePair[];
 
   constructor() {
-    this.scope = Scopes.KeptnDefault;
+    this.scope = SecretScope.DEFAULT;
     this.data = [];
   }
 

--- a/bridge/shared/interfaces/secret-scope.ts
+++ b/bridge/shared/interfaces/secret-scope.ts
@@ -1,0 +1,5 @@
+export enum SecretScope {
+  DEFAULT = 'keptn-default',
+  WEBHOOK = 'keptn-webhook-service',
+  DYNATRACE = 'dynatrace-service',
+}


### PR DESCRIPTION
## This PR
- adds a dropdown to select a scope while creating a secret

### Related Issues
Fixes #5269 

Signed-off-by: ermin.muratovic <ermin.muratovic@gmail.com>

![image](https://user-images.githubusercontent.com/6098219/134505081-6e0450d2-59f5-4a66-be31-740bd9a5a927.png)