### PR TITLE
fix(distributor): Fixed leaking go routines in `distributor::forwarder.go`

### DIFF
--- a/distributor/pkg/lib/events/forwarder.go
+++ b/distributor/pkg/lib/events/forwarder.go
@@ -86,10 +86,13 @@ func (f *Forwarder) handleEvent(rw http.ResponseWriter, req *http.Request) {
 }
 
 func (f *Forwarder) forwardEvent(event cloudevents.Event) error {
-	logger.Infof("Received CloudEvent with ID %s - Forwarding to Keptn API\n", event.ID())
-	go func() {
-		f.EventChannel <- event
-	}()
+	logger.Infof("Received CloudEvent with ID %s - Forwarding to Keptn\n", event.ID())
+	select {
+	case f.EventChannel <- event:
+		// no-op
+	default:
+		// no-op
+	}
 
 	if event.Context.GetType() == v0_2_0.ErrorLogEventName {
 		return nil

--- a/distributor/pkg/lib/events/forwarder_test.go
+++ b/distributor/pkg/lib/events/forwarder_test.go
@@ -63,13 +63,14 @@ func Test_ForwardEventsToNATS(t *testing.T) {
 	executionContext := NewExecutionContext(ctx, 1)
 	go f.Start(executionContext)
 
-	//TODO: remove waiting
 	time.Sleep(2 * time.Second)
-	eventFromService(taskStartedEvent)
-	eventFromService(taskFinishedEvent)
+	numEvents := 1000
+	for i := 0; i < numEvents; i++ {
+		eventFromService(taskFinishedEvent)
+	}
 
 	assert.Eventually(t, func() bool {
-		return expectedReceivedMessageCount == 2
+		return expectedReceivedMessageCount == numEvents
 	}, time.Second*time.Duration(10), time.Second)
 
 	cancel()


### PR DESCRIPTION
Closes #5402 
This PR fixes a go routine leak in `forwarder.go`