### PR TITLE
fix(configuration-service): deprecate get default resources endpoints

### DIFF
--- a/configuration-service/cmd/configuration-service-server/main.go
+++ b/configuration-service/cmd/configuration-service-server/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-openapi/loads"
 	flags "github.com/jessevdk/go-flags"
+
 	"github.com/keptn/keptn/configuration-service/restapi"
 	"github.com/keptn/keptn/configuration-service/restapi/operations"
 )

--- a/configuration-service/models/error.go
+++ b/configuration-service/models/error.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -45,6 +47,11 @@ func (m *Error) validateMessage(formats strfmt.Registry) error {
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this error based on context it is used
+func (m *Error) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/configuration-service/models/project.go
+++ b/configuration-service/models/project.go
@@ -6,6 +6,7 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/go-openapi/errors"
@@ -49,7 +50,6 @@ func (m *Project) Validate(formats strfmt.Registry) error {
 }
 
 func (m *Project) validateStages(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.Stages) { // not required
 		return nil
 	}
@@ -61,6 +61,38 @@ func (m *Project) validateStages(formats strfmt.Registry) error {
 
 		if m.Stages[i] != nil {
 			if err := m.Stages[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("stages" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// ContextValidate validate this project based on the context it is used
+func (m *Project) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateStages(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *Project) contextValidateStages(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Stages); i++ {
+
+		if m.Stages[i] != nil {
+			if err := m.Stages[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("stages" + "." + strconv.Itoa(i))
 				}

--- a/configuration-service/models/resource.go
+++ b/configuration-service/models/resource.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -47,7 +49,6 @@ func (m *Resource) Validate(formats strfmt.Registry) error {
 }
 
 func (m *Resource) validateMetadata(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.Metadata) { // not required
 		return nil
 	}
@@ -68,6 +69,34 @@ func (m *Resource) validateResourceURI(formats strfmt.Registry) error {
 
 	if err := validate.Required("resourceURI", "body", m.ResourceURI); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validate this resource based on the context it is used
+func (m *Resource) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateMetadata(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *Resource) contextValidateMetadata(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.Metadata != nil {
+		if err := m.Metadata.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("metadata")
+			}
+			return err
+		}
 	}
 
 	return nil

--- a/configuration-service/models/resources.go
+++ b/configuration-service/models/resources.go
@@ -6,6 +6,7 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/go-openapi/errors"
@@ -46,7 +47,6 @@ func (m *Resources) Validate(formats strfmt.Registry) error {
 }
 
 func (m *Resources) validateResources(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.Resources) { // not required
 		return nil
 	}
@@ -58,6 +58,38 @@ func (m *Resources) validateResources(formats strfmt.Registry) error {
 
 		if m.Resources[i] != nil {
 			if err := m.Resources[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("resources" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// ContextValidate validate this resources based on the context it is used
+func (m *Resources) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateResources(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *Resources) contextValidateResources(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Resources); i++ {
+
+		if m.Resources[i] != nil {
+			if err := m.Resources[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("resources" + "." + strconv.Itoa(i))
 				}

--- a/configuration-service/models/service.go
+++ b/configuration-service/models/service.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 )
@@ -21,6 +23,11 @@ type Service struct {
 
 // Validate validates this service
 func (m *Service) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this service based on context it is used
+func (m *Service) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/configuration-service/models/stage.go
+++ b/configuration-service/models/stage.go
@@ -6,6 +6,7 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/go-openapi/errors"
@@ -40,7 +41,6 @@ func (m *Stage) Validate(formats strfmt.Registry) error {
 }
 
 func (m *Stage) validateServices(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.Services) { // not required
 		return nil
 	}
@@ -52,6 +52,38 @@ func (m *Stage) validateServices(formats strfmt.Registry) error {
 
 		if m.Services[i] != nil {
 			if err := m.Services[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("services" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// ContextValidate validate this stage based on the context it is used
+func (m *Stage) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateServices(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *Stage) contextValidateServices(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Services); i++ {
+
+		if m.Services[i] != nil {
+			if err := m.Services[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("services" + "." + strconv.Itoa(i))
 				}

--- a/configuration-service/models/version.go
+++ b/configuration-service/models/version.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 )
@@ -27,6 +29,11 @@ type Version struct {
 
 // Validate validates this version
 func (m *Version) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this version based on context it is used
+func (m *Version) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/configuration-service/restapi/embedded_spec.go
+++ b/configuration-service/restapi/embedded_spec.go
@@ -331,6 +331,7 @@ func init() {
           "Service Default Resource"
         ],
         "summary": "Get list of default resources for the service used in all stages",
+        "deprecated": true,
         "parameters": [
           {
             "$ref": "#/parameters/pageSize"
@@ -368,6 +369,7 @@ func init() {
           "Service Default Resource"
         ],
         "summary": "Update list of service default resources",
+        "deprecated": true,
         "parameters": [
           {
             "$ref": "#/parameters/resources"
@@ -440,6 +442,7 @@ func init() {
           "Service Default Resource"
         ],
         "summary": "Get the specified default resource for the service",
+        "deprecated": true,
         "parameters": [
           {
             "$ref": "#/parameters/disableUpstreamSync"
@@ -471,6 +474,7 @@ func init() {
           "Service Default Resource"
         ],
         "summary": "Update the specified default resource for the service",
+        "deprecated": true,
         "parameters": [
           {
             "$ref": "#/parameters/resource"
@@ -502,6 +506,7 @@ func init() {
           "Service Default Resource"
         ],
         "summary": "Delete the specified default resource for the service",
+        "deprecated": true,
         "responses": {
           "204": {
             "description": "Success. Service default resource has been deleted.",
@@ -1781,6 +1786,7 @@ func init() {
           "Service Default Resource"
         ],
         "summary": "Get list of default resources for the service used in all stages",
+        "deprecated": true,
         "parameters": [
           {
             "maximum": 50,
@@ -1831,6 +1837,7 @@ func init() {
           "Service Default Resource"
         ],
         "summary": "Update list of service default resources",
+        "deprecated": true,
         "parameters": [
           {
             "description": "List of resources",
@@ -1935,6 +1942,7 @@ func init() {
           "Service Default Resource"
         ],
         "summary": "Get the specified default resource for the service",
+        "deprecated": true,
         "parameters": [
           {
             "type": "boolean",
@@ -1970,6 +1978,7 @@ func init() {
           "Service Default Resource"
         ],
         "summary": "Update the specified default resource for the service",
+        "deprecated": true,
         "parameters": [
           {
             "description": "Resource",
@@ -2006,6 +2015,7 @@ func init() {
           "Service Default Resource"
         ],
         "summary": "Delete the specified default resource for the service",
+        "deprecated": true,
         "responses": {
           "204": {
             "description": "Success. Service default resource has been deleted.",

--- a/configuration-service/restapi/operations/configuration_service_api.go
+++ b/configuration-service/restapi/operations/configuration_service_api.go
@@ -40,6 +40,7 @@ func NewConfigurationServiceAPI(spec *loads.Document) *ConfigurationServiceAPI {
 		PreServerShutdown:   func() {},
 		ServerShutdown:      func() {},
 		spec:                spec,
+		useSwaggerUI:        false,
 		ServeError:          errors.ServeError,
 		BasicAuthenticator:  security.BasicAuth,
 		APIKeyAuthenticator: security.APIKeyAuth,
@@ -167,9 +168,11 @@ type ConfigurationServiceAPI struct {
 	// BasicAuthenticator generates a runtime.Authenticator from the supplied basic auth function.
 	// It has a default implementation in the security package, however you can replace it for your particular usage.
 	BasicAuthenticator func(security.UserPassAuthentication) runtime.Authenticator
+
 	// APIKeyAuthenticator generates a runtime.Authenticator from the supplied token auth function.
 	// It has a default implementation in the security package, however you can replace it for your particular usage.
 	APIKeyAuthenticator func(string, string, security.TokenAuthentication) runtime.Authenticator
+
 	// BearerAuthenticator generates a runtime.Authenticator from the supplied bearer token auth function.
 	// It has a default implementation in the security package, however you can replace it for your particular usage.
 	BearerAuthenticator func(string, security.ScopedTokenAuthentication) runtime.Authenticator
@@ -249,6 +252,7 @@ type ConfigurationServiceAPI struct {
 	ServiceResourcePutProjectProjectNameStageStageNameServiceServiceNameResourceHandler service_resource.PutProjectProjectNameStageStageNameServiceServiceNameResourceHandler
 	// ServiceResourcePutProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIHandler sets the operation handler for the put project project name stage stage name service service name resource resource URI operation
 	ServiceResourcePutProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIHandler service_resource.PutProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIHandler
+
 	// ServeError is called when an error is received, there is a default handler
 	// but you can set your own with this
 	ServeError func(http.ResponseWriter, *http.Request, error)
@@ -655,6 +659,9 @@ func (o *ConfigurationServiceAPI) Serve(builder middleware.Builder) http.Handler
 
 	if o.Middleware != nil {
 		return o.Middleware(builder)
+	}
+	if o.useSwaggerUI {
+		return o.context.APIHandlerSwaggerUI(builder)
 	}
 	return o.context.APIHandler(builder)
 }

--- a/configuration-service/restapi/operations/project/delete_project_project_name.go
+++ b/configuration-service/restapi/operations/project/delete_project_project_name.go
@@ -29,7 +29,7 @@ func NewDeleteProjectProjectName(ctx *middleware.Context, handler DeleteProjectP
 	return &DeleteProjectProjectName{Context: ctx, Handler: handler}
 }
 
-/*DeleteProjectProjectName swagger:route DELETE /project/{projectName} Project deleteProjectProjectName
+/* DeleteProjectProjectName swagger:route DELETE /project/{projectName} Project deleteProjectProjectName
 
 INTERNAL Endpoint: Delete the specified project
 
@@ -42,17 +42,15 @@ type DeleteProjectProjectName struct {
 func (o *DeleteProjectProjectName) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewDeleteProjectProjectNameParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/configuration-service/restapi/operations/project/delete_project_project_name_parameters.go
+++ b/configuration-service/restapi/operations/project/delete_project_project_name_parameters.go
@@ -14,7 +14,8 @@ import (
 )
 
 // NewDeleteProjectProjectNameParams creates a new DeleteProjectProjectNameParams object
-// no default values defined in spec.
+//
+// There are no default values defined in the spec.
 func NewDeleteProjectProjectNameParams() DeleteProjectProjectNameParams {
 
 	return DeleteProjectProjectNameParams{}
@@ -49,7 +50,6 @@ func (o *DeleteProjectProjectNameParams) BindRequest(r *http.Request, route *mid
 	if err := o.bindProjectName(rProjectName, rhkProjectName, route.Formats); err != nil {
 		res = append(res, err)
 	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -65,7 +65,6 @@ func (o *DeleteProjectProjectNameParams) bindProjectName(rawData []string, hasKe
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ProjectName = raw
 
 	return nil

--- a/configuration-service/restapi/operations/project/post_project.go
+++ b/configuration-service/restapi/operations/project/post_project.go
@@ -29,7 +29,7 @@ func NewPostProject(ctx *middleware.Context, handler PostProjectHandler) *PostPr
 	return &PostProject{Context: ctx, Handler: handler}
 }
 
-/*PostProject swagger:route POST /project Project postProject
+/* PostProject swagger:route POST /project Project postProject
 
 INTERNAL Endpoint: Create a new project by project name
 
@@ -42,17 +42,15 @@ type PostProject struct {
 func (o *PostProject) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewPostProjectParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/configuration-service/restapi/operations/project/post_project_parameters.go
+++ b/configuration-service/restapi/operations/project/post_project_parameters.go
@@ -6,17 +6,20 @@ package project
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/validate"
 
 	"github.com/keptn/keptn/configuration-service/models"
 )
 
 // NewPostProjectParams creates a new PostProjectParams object
-// no default values defined in spec.
+//
+// There are no default values defined in the spec.
 func NewPostProjectParams() PostProjectParams {
 
 	return PostProjectParams{}
@@ -54,6 +57,11 @@ func (o *PostProjectParams) BindRequest(r *http.Request, route *middleware.Match
 		} else {
 			// validate body object
 			if err := body.Validate(route.Formats); err != nil {
+				res = append(res, err)
+			}
+
+			ctx := validate.WithOperationRequest(context.Background())
+			if err := body.ContextValidate(ctx, route.Formats); err != nil {
 				res = append(res, err)
 			}
 

--- a/configuration-service/restapi/operations/project/put_project_project_name.go
+++ b/configuration-service/restapi/operations/project/put_project_project_name.go
@@ -29,7 +29,7 @@ func NewPutProjectProjectName(ctx *middleware.Context, handler PutProjectProject
 	return &PutProjectProjectName{Context: ctx, Handler: handler}
 }
 
-/*PutProjectProjectName swagger:route PUT /project/{projectName} Project putProjectProjectName
+/* PutProjectProjectName swagger:route PUT /project/{projectName} Project putProjectProjectName
 
 INTERNAL Endpoint: Update the specified project
 
@@ -42,17 +42,15 @@ type PutProjectProjectName struct {
 func (o *PutProjectProjectName) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewPutProjectProjectNameParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/configuration-service/restapi/operations/project/put_project_project_name_parameters.go
+++ b/configuration-service/restapi/operations/project/put_project_project_name_parameters.go
@@ -6,18 +6,21 @@ package project
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/validate"
 
 	"github.com/keptn/keptn/configuration-service/models"
 )
 
 // NewPutProjectProjectNameParams creates a new PutProjectProjectNameParams object
-// no default values defined in spec.
+//
+// There are no default values defined in the spec.
 func NewPutProjectProjectNameParams() PutProjectProjectNameParams {
 
 	return PutProjectProjectNameParams{}
@@ -63,16 +66,21 @@ func (o *PutProjectProjectNameParams) BindRequest(r *http.Request, route *middle
 				res = append(res, err)
 			}
 
+			ctx := validate.WithOperationRequest(context.Background())
+			if err := body.ContextValidate(ctx, route.Formats); err != nil {
+				res = append(res, err)
+			}
+
 			if len(res) == 0 {
 				o.Project = &body
 			}
 		}
 	}
+
 	rProjectName, rhkProjectName, _ := route.Params.GetOK("projectName")
 	if err := o.bindProjectName(rProjectName, rhkProjectName, route.Formats); err != nil {
 		res = append(res, err)
 	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -88,7 +96,6 @@ func (o *PutProjectProjectNameParams) bindProjectName(rawData []string, hasKey b
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ProjectName = raw
 
 	return nil

--- a/configuration-service/restapi/operations/project_resource/delete_project_project_name_resource_resource_uri.go
+++ b/configuration-service/restapi/operations/project_resource/delete_project_project_name_resource_resource_uri.go
@@ -29,7 +29,7 @@ func NewDeleteProjectProjectNameResourceResourceURI(ctx *middleware.Context, han
 	return &DeleteProjectProjectNameResourceResourceURI{Context: ctx, Handler: handler}
 }
 
-/*DeleteProjectProjectNameResourceResourceURI swagger:route DELETE /project/{projectName}/resource/{resourceURI} Project Resource deleteProjectProjectNameResourceResourceUri
+/* DeleteProjectProjectNameResourceResourceURI swagger:route DELETE /project/{projectName}/resource/{resourceURI} Project Resource deleteProjectProjectNameResourceResourceUri
 
 Delete the specified resource
 
@@ -42,17 +42,15 @@ type DeleteProjectProjectNameResourceResourceURI struct {
 func (o *DeleteProjectProjectNameResourceResourceURI) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewDeleteProjectProjectNameResourceResourceURIParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/configuration-service/restapi/operations/project_resource/delete_project_project_name_resource_resource_uri_parameters.go
+++ b/configuration-service/restapi/operations/project_resource/delete_project_project_name_resource_resource_uri_parameters.go
@@ -81,7 +81,6 @@ func (o *DeleteProjectProjectNameResourceResourceURIParams) BindRequest(r *http.
 	if err := o.bindResourceURI(rResourceURI, rhkResourceURI, route.Formats); err != nil {
 		res = append(res, err)
 	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -97,6 +96,7 @@ func (o *DeleteProjectProjectNameResourceResourceURIParams) bindDisableUpstreamS
 
 	// Required: false
 	// AllowEmptyValue: false
+
 	if raw == "" { // empty values pass all other validations
 		// Default values have been previously initialized by NewDeleteProjectProjectNameResourceResourceURIParams()
 		return nil
@@ -120,7 +120,6 @@ func (o *DeleteProjectProjectNameResourceResourceURIParams) bindProjectName(rawD
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ProjectName = raw
 
 	return nil
@@ -135,7 +134,6 @@ func (o *DeleteProjectProjectNameResourceResourceURIParams) bindResourceURI(rawD
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ResourceURI = raw
 
 	return nil

--- a/configuration-service/restapi/operations/project_resource/get_project_project_name_resource.go
+++ b/configuration-service/restapi/operations/project_resource/get_project_project_name_resource.go
@@ -29,7 +29,7 @@ func NewGetProjectProjectNameResource(ctx *middleware.Context, handler GetProjec
 	return &GetProjectProjectNameResource{Context: ctx, Handler: handler}
 }
 
-/*GetProjectProjectNameResource swagger:route GET /project/{projectName}/resource Project Resource getProjectProjectNameResource
+/* GetProjectProjectNameResource swagger:route GET /project/{projectName}/resource Project Resource getProjectProjectNameResource
 
 Get list of project resources
 
@@ -42,17 +42,15 @@ type GetProjectProjectNameResource struct {
 func (o *GetProjectProjectNameResource) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetProjectProjectNameResourceParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/configuration-service/restapi/operations/project_resource/get_project_project_name_resource_parameters.go
+++ b/configuration-service/restapi/operations/project_resource/get_project_project_name_resource_parameters.go
@@ -97,7 +97,6 @@ func (o *GetProjectProjectNameResourceParams) BindRequest(r *http.Request, route
 	if err := o.bindProjectName(rProjectName, rhkProjectName, route.Formats); err != nil {
 		res = append(res, err)
 	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -113,6 +112,7 @@ func (o *GetProjectProjectNameResourceParams) bindDisableUpstreamSync(rawData []
 
 	// Required: false
 	// AllowEmptyValue: false
+
 	if raw == "" { // empty values pass all other validations
 		// Default values have been previously initialized by NewGetProjectProjectNameResourceParams()
 		return nil
@@ -136,10 +136,10 @@ func (o *GetProjectProjectNameResourceParams) bindNextPageKey(rawData []string, 
 
 	// Required: false
 	// AllowEmptyValue: false
+
 	if raw == "" { // empty values pass all other validations
 		return nil
 	}
-
 	o.NextPageKey = &raw
 
 	return nil
@@ -154,6 +154,7 @@ func (o *GetProjectProjectNameResourceParams) bindPageSize(rawData []string, has
 
 	// Required: false
 	// AllowEmptyValue: false
+
 	if raw == "" { // empty values pass all other validations
 		// Default values have been previously initialized by NewGetProjectProjectNameResourceParams()
 		return nil
@@ -175,11 +176,11 @@ func (o *GetProjectProjectNameResourceParams) bindPageSize(rawData []string, has
 // validatePageSize carries on validations for parameter PageSize
 func (o *GetProjectProjectNameResourceParams) validatePageSize(formats strfmt.Registry) error {
 
-	if err := validate.MinimumInt("pageSize", "query", int64(*o.PageSize), 1, false); err != nil {
+	if err := validate.MinimumInt("pageSize", "query", *o.PageSize, 1, false); err != nil {
 		return err
 	}
 
-	if err := validate.MaximumInt("pageSize", "query", int64(*o.PageSize), 50, false); err != nil {
+	if err := validate.MaximumInt("pageSize", "query", *o.PageSize, 50, false); err != nil {
 		return err
 	}
 
@@ -195,7 +196,6 @@ func (o *GetProjectProjectNameResourceParams) bindProjectName(rawData []string, 
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ProjectName = raw
 
 	return nil

--- a/configuration-service/restapi/operations/project_resource/get_project_project_name_resource_resource_uri.go
+++ b/configuration-service/restapi/operations/project_resource/get_project_project_name_resource_resource_uri.go
@@ -29,7 +29,7 @@ func NewGetProjectProjectNameResourceResourceURI(ctx *middleware.Context, handle
 	return &GetProjectProjectNameResourceResourceURI{Context: ctx, Handler: handler}
 }
 
-/*GetProjectProjectNameResourceResourceURI swagger:route GET /project/{projectName}/resource/{resourceURI} Project Resource getProjectProjectNameResourceResourceUri
+/* GetProjectProjectNameResourceResourceURI swagger:route GET /project/{projectName}/resource/{resourceURI} Project Resource getProjectProjectNameResourceResourceUri
 
 Get the specified resource
 
@@ -42,17 +42,15 @@ type GetProjectProjectNameResourceResourceURI struct {
 func (o *GetProjectProjectNameResourceResourceURI) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetProjectProjectNameResourceResourceURIParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/configuration-service/restapi/operations/project_resource/get_project_project_name_resource_resource_uri_parameters.go
+++ b/configuration-service/restapi/operations/project_resource/get_project_project_name_resource_resource_uri_parameters.go
@@ -81,7 +81,6 @@ func (o *GetProjectProjectNameResourceResourceURIParams) BindRequest(r *http.Req
 	if err := o.bindResourceURI(rResourceURI, rhkResourceURI, route.Formats); err != nil {
 		res = append(res, err)
 	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -97,6 +96,7 @@ func (o *GetProjectProjectNameResourceResourceURIParams) bindDisableUpstreamSync
 
 	// Required: false
 	// AllowEmptyValue: false
+
 	if raw == "" { // empty values pass all other validations
 		// Default values have been previously initialized by NewGetProjectProjectNameResourceResourceURIParams()
 		return nil
@@ -120,7 +120,6 @@ func (o *GetProjectProjectNameResourceResourceURIParams) bindProjectName(rawData
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ProjectName = raw
 
 	return nil
@@ -135,7 +134,6 @@ func (o *GetProjectProjectNameResourceResourceURIParams) bindResourceURI(rawData
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ResourceURI = raw
 
 	return nil

--- a/configuration-service/restapi/operations/project_resource/post_project_project_name_resource.go
+++ b/configuration-service/restapi/operations/project_resource/post_project_project_name_resource.go
@@ -6,6 +6,7 @@ package project_resource
 // Editing this file might prove futile when you re-run the generate command
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 
@@ -35,7 +36,7 @@ func NewPostProjectProjectNameResource(ctx *middleware.Context, handler PostProj
 	return &PostProjectProjectNameResource{Context: ctx, Handler: handler}
 }
 
-/*PostProjectProjectNameResource swagger:route POST /project/{projectName}/resource Project Resource postProjectProjectNameResource
+/* PostProjectProjectNameResource swagger:route POST /project/{projectName}/resource Project Resource postProjectProjectNameResource
 
 Create list of new resources for the project
 
@@ -48,17 +49,15 @@ type PostProjectProjectNameResource struct {
 func (o *PostProjectProjectNameResource) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewPostProjectProjectNameResourceParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }
@@ -87,7 +86,6 @@ func (o *PostProjectProjectNameResourceBody) Validate(formats strfmt.Registry) e
 }
 
 func (o *PostProjectProjectNameResourceBody) validateResources(formats strfmt.Registry) error {
-
 	if swag.IsZero(o.Resources) { // not required
 		return nil
 	}
@@ -99,6 +97,38 @@ func (o *PostProjectProjectNameResourceBody) validateResources(formats strfmt.Re
 
 		if o.Resources[i] != nil {
 			if err := o.Resources[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("resources" + "." + "resources" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// ContextValidate validate this post project project name resource body based on the context it is used
+func (o *PostProjectProjectNameResourceBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.contextValidateResources(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *PostProjectProjectNameResourceBody) contextValidateResources(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(o.Resources); i++ {
+
+		if o.Resources[i] != nil {
+			if err := o.Resources[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("resources" + "." + "resources" + "." + strconv.Itoa(i))
 				}

--- a/configuration-service/restapi/operations/project_resource/post_project_project_name_resource_parameters.go
+++ b/configuration-service/restapi/operations/project_resource/post_project_project_name_resource_parameters.go
@@ -6,16 +6,19 @@ package project_resource
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/validate"
 )
 
 // NewPostProjectProjectNameResourceParams creates a new PostProjectProjectNameResourceParams object
-// no default values defined in spec.
+//
+// There are no default values defined in the spec.
 func NewPostProjectProjectNameResourceParams() PostProjectProjectNameResourceParams {
 
 	return PostProjectProjectNameResourceParams{}
@@ -66,6 +69,11 @@ func (o *PostProjectProjectNameResourceParams) BindRequest(r *http.Request, rout
 				res = append(res, err)
 			}
 
+			ctx := validate.WithOperationRequest(context.Background())
+			if err := body.ContextValidate(ctx, route.Formats); err != nil {
+				res = append(res, err)
+			}
+
 			if len(res) == 0 {
 				o.Resources = body
 			}
@@ -86,7 +94,6 @@ func (o *PostProjectProjectNameResourceParams) bindProjectName(rawData []string,
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ProjectName = raw
 
 	return nil

--- a/configuration-service/restapi/operations/project_resource/put_project_project_name_resource.go
+++ b/configuration-service/restapi/operations/project_resource/put_project_project_name_resource.go
@@ -6,6 +6,7 @@ package project_resource
 // Editing this file might prove futile when you re-run the generate command
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 
@@ -35,7 +36,7 @@ func NewPutProjectProjectNameResource(ctx *middleware.Context, handler PutProjec
 	return &PutProjectProjectNameResource{Context: ctx, Handler: handler}
 }
 
-/*PutProjectProjectNameResource swagger:route PUT /project/{projectName}/resource Project Resource putProjectProjectNameResource
+/* PutProjectProjectNameResource swagger:route PUT /project/{projectName}/resource Project Resource putProjectProjectNameResource
 
 Update list of project resources
 
@@ -48,17 +49,15 @@ type PutProjectProjectNameResource struct {
 func (o *PutProjectProjectNameResource) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewPutProjectProjectNameResourceParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }
@@ -87,7 +86,6 @@ func (o *PutProjectProjectNameResourceBody) Validate(formats strfmt.Registry) er
 }
 
 func (o *PutProjectProjectNameResourceBody) validateResources(formats strfmt.Registry) error {
-
 	if swag.IsZero(o.Resources) { // not required
 		return nil
 	}
@@ -99,6 +97,38 @@ func (o *PutProjectProjectNameResourceBody) validateResources(formats strfmt.Reg
 
 		if o.Resources[i] != nil {
 			if err := o.Resources[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("resources" + "." + "resources" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// ContextValidate validate this put project project name resource body based on the context it is used
+func (o *PutProjectProjectNameResourceBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.contextValidateResources(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *PutProjectProjectNameResourceBody) contextValidateResources(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(o.Resources); i++ {
+
+		if o.Resources[i] != nil {
+			if err := o.Resources[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("resources" + "." + "resources" + "." + strconv.Itoa(i))
 				}

--- a/configuration-service/restapi/operations/project_resource/put_project_project_name_resource_parameters.go
+++ b/configuration-service/restapi/operations/project_resource/put_project_project_name_resource_parameters.go
@@ -6,16 +6,19 @@ package project_resource
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/validate"
 )
 
 // NewPutProjectProjectNameResourceParams creates a new PutProjectProjectNameResourceParams object
-// no default values defined in spec.
+//
+// There are no default values defined in the spec.
 func NewPutProjectProjectNameResourceParams() PutProjectProjectNameResourceParams {
 
 	return PutProjectProjectNameResourceParams{}
@@ -66,6 +69,11 @@ func (o *PutProjectProjectNameResourceParams) BindRequest(r *http.Request, route
 				res = append(res, err)
 			}
 
+			ctx := validate.WithOperationRequest(context.Background())
+			if err := body.ContextValidate(ctx, route.Formats); err != nil {
+				res = append(res, err)
+			}
+
 			if len(res) == 0 {
 				o.Resources = body
 			}
@@ -86,7 +94,6 @@ func (o *PutProjectProjectNameResourceParams) bindProjectName(rawData []string, 
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ProjectName = raw
 
 	return nil

--- a/configuration-service/restapi/operations/project_resource/put_project_project_name_resource_resource_uri.go
+++ b/configuration-service/restapi/operations/project_resource/put_project_project_name_resource_resource_uri.go
@@ -29,7 +29,7 @@ func NewPutProjectProjectNameResourceResourceURI(ctx *middleware.Context, handle
 	return &PutProjectProjectNameResourceResourceURI{Context: ctx, Handler: handler}
 }
 
-/*PutProjectProjectNameResourceResourceURI swagger:route PUT /project/{projectName}/resource/{resourceURI} Project Resource putProjectProjectNameResourceResourceUri
+/* PutProjectProjectNameResourceResourceURI swagger:route PUT /project/{projectName}/resource/{resourceURI} Project Resource putProjectProjectNameResourceResourceUri
 
 Update the specified resource
 
@@ -42,17 +42,15 @@ type PutProjectProjectNameResourceResourceURI struct {
 func (o *PutProjectProjectNameResourceResourceURI) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewPutProjectProjectNameResourceResourceURIParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/configuration-service/restapi/operations/project_resource/put_project_project_name_resource_resource_uri_parameters.go
+++ b/configuration-service/restapi/operations/project_resource/put_project_project_name_resource_resource_uri_parameters.go
@@ -6,6 +6,7 @@ package project_resource
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
@@ -13,6 +14,7 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 
 	"github.com/keptn/keptn/configuration-service/models"
 )
@@ -94,16 +96,21 @@ func (o *PutProjectProjectNameResourceResourceURIParams) BindRequest(r *http.Req
 				res = append(res, err)
 			}
 
+			ctx := validate.WithOperationRequest(context.Background())
+			if err := body.ContextValidate(ctx, route.Formats); err != nil {
+				res = append(res, err)
+			}
+
 			if len(res) == 0 {
 				o.Resource = &body
 			}
 		}
 	}
+
 	rResourceURI, rhkResourceURI, _ := route.Params.GetOK("resourceURI")
 	if err := o.bindResourceURI(rResourceURI, rhkResourceURI, route.Formats); err != nil {
 		res = append(res, err)
 	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -119,6 +126,7 @@ func (o *PutProjectProjectNameResourceResourceURIParams) bindDisableUpstreamSync
 
 	// Required: false
 	// AllowEmptyValue: false
+
 	if raw == "" { // empty values pass all other validations
 		// Default values have been previously initialized by NewPutProjectProjectNameResourceResourceURIParams()
 		return nil
@@ -142,7 +150,6 @@ func (o *PutProjectProjectNameResourceResourceURIParams) bindProjectName(rawData
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ProjectName = raw
 
 	return nil
@@ -157,7 +164,6 @@ func (o *PutProjectProjectNameResourceResourceURIParams) bindResourceURI(rawData
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ResourceURI = raw
 
 	return nil

--- a/configuration-service/restapi/operations/service/delete_project_project_name_stage_stage_name_service_service_name.go
+++ b/configuration-service/restapi/operations/service/delete_project_project_name_stage_stage_name_service_service_name.go
@@ -29,7 +29,7 @@ func NewDeleteProjectProjectNameStageStageNameServiceServiceName(ctx *middleware
 	return &DeleteProjectProjectNameStageStageNameServiceServiceName{Context: ctx, Handler: handler}
 }
 
-/*DeleteProjectProjectNameStageStageNameServiceServiceName swagger:route DELETE /project/{projectName}/stage/{stageName}/service/{serviceName} Service deleteProjectProjectNameStageStageNameServiceServiceName
+/* DeleteProjectProjectNameStageStageNameServiceServiceName swagger:route DELETE /project/{projectName}/stage/{stageName}/service/{serviceName} Service deleteProjectProjectNameStageStageNameServiceServiceName
 
 INTERNAL Endpoint: Delete the specified service
 
@@ -42,17 +42,15 @@ type DeleteProjectProjectNameStageStageNameServiceServiceName struct {
 func (o *DeleteProjectProjectNameStageStageNameServiceServiceName) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewDeleteProjectProjectNameStageStageNameServiceServiceNameParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/configuration-service/restapi/operations/service/delete_project_project_name_stage_stage_name_service_service_name_parameters.go
+++ b/configuration-service/restapi/operations/service/delete_project_project_name_stage_stage_name_service_service_name_parameters.go
@@ -14,7 +14,8 @@ import (
 )
 
 // NewDeleteProjectProjectNameStageStageNameServiceServiceNameParams creates a new DeleteProjectProjectNameStageStageNameServiceServiceNameParams object
-// no default values defined in spec.
+//
+// There are no default values defined in the spec.
 func NewDeleteProjectProjectNameStageStageNameServiceServiceNameParams() DeleteProjectProjectNameStageStageNameServiceServiceNameParams {
 
 	return DeleteProjectProjectNameStageStageNameServiceServiceNameParams{}
@@ -69,7 +70,6 @@ func (o *DeleteProjectProjectNameStageStageNameServiceServiceNameParams) BindReq
 	if err := o.bindStageName(rStageName, rhkStageName, route.Formats); err != nil {
 		res = append(res, err)
 	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -85,7 +85,6 @@ func (o *DeleteProjectProjectNameStageStageNameServiceServiceNameParams) bindPro
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ProjectName = raw
 
 	return nil
@@ -100,7 +99,6 @@ func (o *DeleteProjectProjectNameStageStageNameServiceServiceNameParams) bindSer
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ServiceName = raw
 
 	return nil
@@ -115,7 +113,6 @@ func (o *DeleteProjectProjectNameStageStageNameServiceServiceNameParams) bindSta
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.StageName = raw
 
 	return nil

--- a/configuration-service/restapi/operations/service/post_project_project_name_stage_stage_name_service.go
+++ b/configuration-service/restapi/operations/service/post_project_project_name_stage_stage_name_service.go
@@ -29,7 +29,7 @@ func NewPostProjectProjectNameStageStageNameService(ctx *middleware.Context, han
 	return &PostProjectProjectNameStageStageNameService{Context: ctx, Handler: handler}
 }
 
-/*PostProjectProjectNameStageStageNameService swagger:route POST /project/{projectName}/stage/{stageName}/service Service postProjectProjectNameStageStageNameService
+/* PostProjectProjectNameStageStageNameService swagger:route POST /project/{projectName}/stage/{stageName}/service Service postProjectProjectNameStageStageNameService
 
 INTERNAL Endpoint: Create a new service by service name
 
@@ -42,17 +42,15 @@ type PostProjectProjectNameStageStageNameService struct {
 func (o *PostProjectProjectNameStageStageNameService) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewPostProjectProjectNameStageStageNameServiceParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/configuration-service/restapi/operations/service/post_project_project_name_stage_stage_name_service_parameters.go
+++ b/configuration-service/restapi/operations/service/post_project_project_name_stage_stage_name_service_parameters.go
@@ -6,18 +6,21 @@ package service
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/validate"
 
 	"github.com/keptn/keptn/configuration-service/models"
 )
 
 // NewPostProjectProjectNameStageStageNameServiceParams creates a new PostProjectProjectNameStageStageNameServiceParams object
-// no default values defined in spec.
+//
+// There are no default values defined in the spec.
 func NewPostProjectProjectNameStageStageNameServiceParams() PostProjectProjectNameStageStageNameServiceParams {
 
 	return PostProjectProjectNameStageStageNameServiceParams{}
@@ -73,16 +76,21 @@ func (o *PostProjectProjectNameStageStageNameServiceParams) BindRequest(r *http.
 				res = append(res, err)
 			}
 
+			ctx := validate.WithOperationRequest(context.Background())
+			if err := body.ContextValidate(ctx, route.Formats); err != nil {
+				res = append(res, err)
+			}
+
 			if len(res) == 0 {
 				o.Service = &body
 			}
 		}
 	}
+
 	rStageName, rhkStageName, _ := route.Params.GetOK("stageName")
 	if err := o.bindStageName(rStageName, rhkStageName, route.Formats); err != nil {
 		res = append(res, err)
 	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -98,7 +106,6 @@ func (o *PostProjectProjectNameStageStageNameServiceParams) bindProjectName(rawD
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ProjectName = raw
 
 	return nil
@@ -113,7 +120,6 @@ func (o *PostProjectProjectNameStageStageNameServiceParams) bindStageName(rawDat
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.StageName = raw
 
 	return nil

--- a/configuration-service/restapi/operations/service/put_project_project_name_stage_stage_name_service_service_name.go
+++ b/configuration-service/restapi/operations/service/put_project_project_name_stage_stage_name_service_service_name.go
@@ -29,7 +29,7 @@ func NewPutProjectProjectNameStageStageNameServiceServiceName(ctx *middleware.Co
 	return &PutProjectProjectNameStageStageNameServiceServiceName{Context: ctx, Handler: handler}
 }
 
-/*PutProjectProjectNameStageStageNameServiceServiceName swagger:route PUT /project/{projectName}/stage/{stageName}/service/{serviceName} Service putProjectProjectNameStageStageNameServiceServiceName
+/* PutProjectProjectNameStageStageNameServiceServiceName swagger:route PUT /project/{projectName}/stage/{stageName}/service/{serviceName} Service putProjectProjectNameStageStageNameServiceServiceName
 
 INTERNAL Endpoint: Update the specified service
 
@@ -42,17 +42,15 @@ type PutProjectProjectNameStageStageNameServiceServiceName struct {
 func (o *PutProjectProjectNameStageStageNameServiceServiceName) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewPutProjectProjectNameStageStageNameServiceServiceNameParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/configuration-service/restapi/operations/service/put_project_project_name_stage_stage_name_service_service_name_parameters.go
+++ b/configuration-service/restapi/operations/service/put_project_project_name_stage_stage_name_service_service_name_parameters.go
@@ -6,18 +6,21 @@ package service
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/validate"
 
 	"github.com/keptn/keptn/configuration-service/models"
 )
 
 // NewPutProjectProjectNameStageStageNameServiceServiceNameParams creates a new PutProjectProjectNameStageStageNameServiceServiceNameParams object
-// no default values defined in spec.
+//
+// There are no default values defined in the spec.
 func NewPutProjectProjectNameStageStageNameServiceServiceNameParams() PutProjectProjectNameStageStageNameServiceServiceNameParams {
 
 	return PutProjectProjectNameStageStageNameServiceServiceNameParams{}
@@ -78,11 +81,17 @@ func (o *PutProjectProjectNameStageStageNameServiceServiceNameParams) BindReques
 				res = append(res, err)
 			}
 
+			ctx := validate.WithOperationRequest(context.Background())
+			if err := body.ContextValidate(ctx, route.Formats); err != nil {
+				res = append(res, err)
+			}
+
 			if len(res) == 0 {
 				o.Service = &body
 			}
 		}
 	}
+
 	rServiceName, rhkServiceName, _ := route.Params.GetOK("serviceName")
 	if err := o.bindServiceName(rServiceName, rhkServiceName, route.Formats); err != nil {
 		res = append(res, err)
@@ -92,7 +101,6 @@ func (o *PutProjectProjectNameStageStageNameServiceServiceNameParams) BindReques
 	if err := o.bindStageName(rStageName, rhkStageName, route.Formats); err != nil {
 		res = append(res, err)
 	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -108,7 +116,6 @@ func (o *PutProjectProjectNameStageStageNameServiceServiceNameParams) bindProjec
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ProjectName = raw
 
 	return nil
@@ -123,7 +130,6 @@ func (o *PutProjectProjectNameStageStageNameServiceServiceNameParams) bindServic
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ServiceName = raw
 
 	return nil
@@ -138,7 +144,6 @@ func (o *PutProjectProjectNameStageStageNameServiceServiceNameParams) bindStageN
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.StageName = raw
 
 	return nil

--- a/configuration-service/restapi/operations/service_default_resource/delete_project_project_name_service_service_name_resource_resource_uri.go
+++ b/configuration-service/restapi/operations/service_default_resource/delete_project_project_name_service_service_name_resource_resource_uri.go
@@ -29,7 +29,7 @@ func NewDeleteProjectProjectNameServiceServiceNameResourceResourceURI(ctx *middl
 	return &DeleteProjectProjectNameServiceServiceNameResourceResourceURI{Context: ctx, Handler: handler}
 }
 
-/*DeleteProjectProjectNameServiceServiceNameResourceResourceURI swagger:route DELETE /project/{projectName}/service/{serviceName}/resource/{resourceURI} Service Default Resource deleteProjectProjectNameServiceServiceNameResourceResourceUri
+/* DeleteProjectProjectNameServiceServiceNameResourceResourceURI swagger:route DELETE /project/{projectName}/service/{serviceName}/resource/{resourceURI} Service Default Resource deleteProjectProjectNameServiceServiceNameResourceResourceUri
 
 Delete the specified default resource for the service
 
@@ -42,17 +42,15 @@ type DeleteProjectProjectNameServiceServiceNameResourceResourceURI struct {
 func (o *DeleteProjectProjectNameServiceServiceNameResourceResourceURI) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewDeleteProjectProjectNameServiceServiceNameResourceResourceURIParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/configuration-service/restapi/operations/service_default_resource/delete_project_project_name_service_service_name_resource_resource_uri_parameters.go
+++ b/configuration-service/restapi/operations/service_default_resource/delete_project_project_name_service_service_name_resource_resource_uri_parameters.go
@@ -14,7 +14,8 @@ import (
 )
 
 // NewDeleteProjectProjectNameServiceServiceNameResourceResourceURIParams creates a new DeleteProjectProjectNameServiceServiceNameResourceResourceURIParams object
-// no default values defined in spec.
+//
+// There are no default values defined in the spec.
 func NewDeleteProjectProjectNameServiceServiceNameResourceResourceURIParams() DeleteProjectProjectNameServiceServiceNameResourceResourceURIParams {
 
 	return DeleteProjectProjectNameServiceServiceNameResourceResourceURIParams{}
@@ -69,7 +70,6 @@ func (o *DeleteProjectProjectNameServiceServiceNameResourceResourceURIParams) Bi
 	if err := o.bindServiceName(rServiceName, rhkServiceName, route.Formats); err != nil {
 		res = append(res, err)
 	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -85,7 +85,6 @@ func (o *DeleteProjectProjectNameServiceServiceNameResourceResourceURIParams) bi
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ProjectName = raw
 
 	return nil
@@ -100,7 +99,6 @@ func (o *DeleteProjectProjectNameServiceServiceNameResourceResourceURIParams) bi
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ResourceURI = raw
 
 	return nil
@@ -115,7 +113,6 @@ func (o *DeleteProjectProjectNameServiceServiceNameResourceResourceURIParams) bi
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ServiceName = raw
 
 	return nil

--- a/configuration-service/restapi/operations/service_default_resource/get_project_project_name_service_service_name_resource.go
+++ b/configuration-service/restapi/operations/service_default_resource/get_project_project_name_service_service_name_resource.go
@@ -29,7 +29,7 @@ func NewGetProjectProjectNameServiceServiceNameResource(ctx *middleware.Context,
 	return &GetProjectProjectNameServiceServiceNameResource{Context: ctx, Handler: handler}
 }
 
-/*GetProjectProjectNameServiceServiceNameResource swagger:route GET /project/{projectName}/service/{serviceName}/resource Service Default Resource getProjectProjectNameServiceServiceNameResource
+/* GetProjectProjectNameServiceServiceNameResource swagger:route GET /project/{projectName}/service/{serviceName}/resource Service Default Resource getProjectProjectNameServiceServiceNameResource
 
 Get list of default resources for the service used in all stages
 
@@ -42,17 +42,15 @@ type GetProjectProjectNameServiceServiceNameResource struct {
 func (o *GetProjectProjectNameServiceServiceNameResource) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetProjectProjectNameServiceServiceNameResourceParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/configuration-service/restapi/operations/service_default_resource/get_project_project_name_service_service_name_resource_parameters.go
+++ b/configuration-service/restapi/operations/service_default_resource/get_project_project_name_service_service_name_resource_parameters.go
@@ -107,7 +107,6 @@ func (o *GetProjectProjectNameServiceServiceNameResourceParams) BindRequest(r *h
 	if err := o.bindServiceName(rServiceName, rhkServiceName, route.Formats); err != nil {
 		res = append(res, err)
 	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -123,6 +122,7 @@ func (o *GetProjectProjectNameServiceServiceNameResourceParams) bindDisableUpstr
 
 	// Required: false
 	// AllowEmptyValue: false
+
 	if raw == "" { // empty values pass all other validations
 		// Default values have been previously initialized by NewGetProjectProjectNameServiceServiceNameResourceParams()
 		return nil
@@ -146,10 +146,10 @@ func (o *GetProjectProjectNameServiceServiceNameResourceParams) bindNextPageKey(
 
 	// Required: false
 	// AllowEmptyValue: false
+
 	if raw == "" { // empty values pass all other validations
 		return nil
 	}
-
 	o.NextPageKey = &raw
 
 	return nil
@@ -164,6 +164,7 @@ func (o *GetProjectProjectNameServiceServiceNameResourceParams) bindPageSize(raw
 
 	// Required: false
 	// AllowEmptyValue: false
+
 	if raw == "" { // empty values pass all other validations
 		// Default values have been previously initialized by NewGetProjectProjectNameServiceServiceNameResourceParams()
 		return nil
@@ -185,11 +186,11 @@ func (o *GetProjectProjectNameServiceServiceNameResourceParams) bindPageSize(raw
 // validatePageSize carries on validations for parameter PageSize
 func (o *GetProjectProjectNameServiceServiceNameResourceParams) validatePageSize(formats strfmt.Registry) error {
 
-	if err := validate.MinimumInt("pageSize", "query", int64(*o.PageSize), 1, false); err != nil {
+	if err := validate.MinimumInt("pageSize", "query", *o.PageSize, 1, false); err != nil {
 		return err
 	}
 
-	if err := validate.MaximumInt("pageSize", "query", int64(*o.PageSize), 50, false); err != nil {
+	if err := validate.MaximumInt("pageSize", "query", *o.PageSize, 50, false); err != nil {
 		return err
 	}
 
@@ -205,7 +206,6 @@ func (o *GetProjectProjectNameServiceServiceNameResourceParams) bindProjectName(
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ProjectName = raw
 
 	return nil
@@ -220,7 +220,6 @@ func (o *GetProjectProjectNameServiceServiceNameResourceParams) bindServiceName(
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ServiceName = raw
 
 	return nil

--- a/configuration-service/restapi/operations/service_default_resource/get_project_project_name_service_service_name_resource_resource_uri.go
+++ b/configuration-service/restapi/operations/service_default_resource/get_project_project_name_service_service_name_resource_resource_uri.go
@@ -29,7 +29,7 @@ func NewGetProjectProjectNameServiceServiceNameResourceResourceURI(ctx *middlewa
 	return &GetProjectProjectNameServiceServiceNameResourceResourceURI{Context: ctx, Handler: handler}
 }
 
-/*GetProjectProjectNameServiceServiceNameResourceResourceURI swagger:route GET /project/{projectName}/service/{serviceName}/resource/{resourceURI} Service Default Resource getProjectProjectNameServiceServiceNameResourceResourceUri
+/* GetProjectProjectNameServiceServiceNameResourceResourceURI swagger:route GET /project/{projectName}/service/{serviceName}/resource/{resourceURI} Service Default Resource getProjectProjectNameServiceServiceNameResourceResourceUri
 
 Get the specified default resource for the service
 
@@ -42,17 +42,15 @@ type GetProjectProjectNameServiceServiceNameResourceResourceURI struct {
 func (o *GetProjectProjectNameServiceServiceNameResourceResourceURI) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetProjectProjectNameServiceServiceNameResourceResourceURIParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/configuration-service/restapi/operations/service_default_resource/get_project_project_name_service_service_name_resource_resource_uri_parameters.go
+++ b/configuration-service/restapi/operations/service_default_resource/get_project_project_name_service_service_name_resource_resource_uri_parameters.go
@@ -91,7 +91,6 @@ func (o *GetProjectProjectNameServiceServiceNameResourceResourceURIParams) BindR
 	if err := o.bindServiceName(rServiceName, rhkServiceName, route.Formats); err != nil {
 		res = append(res, err)
 	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -107,6 +106,7 @@ func (o *GetProjectProjectNameServiceServiceNameResourceResourceURIParams) bindD
 
 	// Required: false
 	// AllowEmptyValue: false
+
 	if raw == "" { // empty values pass all other validations
 		// Default values have been previously initialized by NewGetProjectProjectNameServiceServiceNameResourceResourceURIParams()
 		return nil
@@ -130,7 +130,6 @@ func (o *GetProjectProjectNameServiceServiceNameResourceResourceURIParams) bindP
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ProjectName = raw
 
 	return nil
@@ -145,7 +144,6 @@ func (o *GetProjectProjectNameServiceServiceNameResourceResourceURIParams) bindR
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ResourceURI = raw
 
 	return nil
@@ -160,7 +158,6 @@ func (o *GetProjectProjectNameServiceServiceNameResourceResourceURIParams) bindS
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ServiceName = raw
 
 	return nil

--- a/configuration-service/restapi/operations/service_default_resource/post_project_project_name_service_service_name_resource.go
+++ b/configuration-service/restapi/operations/service_default_resource/post_project_project_name_service_service_name_resource.go
@@ -6,6 +6,7 @@ package service_default_resource
 // Editing this file might prove futile when you re-run the generate command
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 
@@ -35,7 +36,7 @@ func NewPostProjectProjectNameServiceServiceNameResource(ctx *middleware.Context
 	return &PostProjectProjectNameServiceServiceNameResource{Context: ctx, Handler: handler}
 }
 
-/*PostProjectProjectNameServiceServiceNameResource swagger:route POST /project/{projectName}/service/{serviceName}/resource Service Default Resource postProjectProjectNameServiceServiceNameResource
+/* PostProjectProjectNameServiceServiceNameResource swagger:route POST /project/{projectName}/service/{serviceName}/resource Service Default Resource postProjectProjectNameServiceServiceNameResource
 
 Create list of default resources for the service used in all stages
 
@@ -48,17 +49,15 @@ type PostProjectProjectNameServiceServiceNameResource struct {
 func (o *PostProjectProjectNameServiceServiceNameResource) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewPostProjectProjectNameServiceServiceNameResourceParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }
@@ -87,7 +86,6 @@ func (o *PostProjectProjectNameServiceServiceNameResourceBody) Validate(formats 
 }
 
 func (o *PostProjectProjectNameServiceServiceNameResourceBody) validateResources(formats strfmt.Registry) error {
-
 	if swag.IsZero(o.Resources) { // not required
 		return nil
 	}
@@ -99,6 +97,38 @@ func (o *PostProjectProjectNameServiceServiceNameResourceBody) validateResources
 
 		if o.Resources[i] != nil {
 			if err := o.Resources[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("resources" + "." + "resources" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// ContextValidate validate this post project project name service service name resource body based on the context it is used
+func (o *PostProjectProjectNameServiceServiceNameResourceBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.contextValidateResources(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *PostProjectProjectNameServiceServiceNameResourceBody) contextValidateResources(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(o.Resources); i++ {
+
+		if o.Resources[i] != nil {
+			if err := o.Resources[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("resources" + "." + "resources" + "." + strconv.Itoa(i))
 				}

--- a/configuration-service/restapi/operations/service_default_resource/post_project_project_name_service_service_name_resource_parameters.go
+++ b/configuration-service/restapi/operations/service_default_resource/post_project_project_name_service_service_name_resource_parameters.go
@@ -6,16 +6,19 @@ package service_default_resource
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/validate"
 )
 
 // NewPostProjectProjectNameServiceServiceNameResourceParams creates a new PostProjectProjectNameServiceServiceNameResourceParams object
-// no default values defined in spec.
+//
+// There are no default values defined in the spec.
 func NewPostProjectProjectNameServiceServiceNameResourceParams() PostProjectProjectNameServiceServiceNameResourceParams {
 
 	return PostProjectProjectNameServiceServiceNameResourceParams{}
@@ -71,16 +74,21 @@ func (o *PostProjectProjectNameServiceServiceNameResourceParams) BindRequest(r *
 				res = append(res, err)
 			}
 
+			ctx := validate.WithOperationRequest(context.Background())
+			if err := body.ContextValidate(ctx, route.Formats); err != nil {
+				res = append(res, err)
+			}
+
 			if len(res) == 0 {
 				o.Resources = body
 			}
 		}
 	}
+
 	rServiceName, rhkServiceName, _ := route.Params.GetOK("serviceName")
 	if err := o.bindServiceName(rServiceName, rhkServiceName, route.Formats); err != nil {
 		res = append(res, err)
 	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -96,7 +104,6 @@ func (o *PostProjectProjectNameServiceServiceNameResourceParams) bindProjectName
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ProjectName = raw
 
 	return nil
@@ -111,7 +118,6 @@ func (o *PostProjectProjectNameServiceServiceNameResourceParams) bindServiceName
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ServiceName = raw
 
 	return nil

--- a/configuration-service/restapi/operations/service_default_resource/put_project_project_name_service_service_name_resource.go
+++ b/configuration-service/restapi/operations/service_default_resource/put_project_project_name_service_service_name_resource.go
@@ -6,6 +6,7 @@ package service_default_resource
 // Editing this file might prove futile when you re-run the generate command
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 
@@ -35,7 +36,7 @@ func NewPutProjectProjectNameServiceServiceNameResource(ctx *middleware.Context,
 	return &PutProjectProjectNameServiceServiceNameResource{Context: ctx, Handler: handler}
 }
 
-/*PutProjectProjectNameServiceServiceNameResource swagger:route PUT /project/{projectName}/service/{serviceName}/resource Service Default Resource putProjectProjectNameServiceServiceNameResource
+/* PutProjectProjectNameServiceServiceNameResource swagger:route PUT /project/{projectName}/service/{serviceName}/resource Service Default Resource putProjectProjectNameServiceServiceNameResource
 
 Update list of service default resources
 
@@ -48,17 +49,15 @@ type PutProjectProjectNameServiceServiceNameResource struct {
 func (o *PutProjectProjectNameServiceServiceNameResource) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewPutProjectProjectNameServiceServiceNameResourceParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }
@@ -87,7 +86,6 @@ func (o *PutProjectProjectNameServiceServiceNameResourceBody) Validate(formats s
 }
 
 func (o *PutProjectProjectNameServiceServiceNameResourceBody) validateResources(formats strfmt.Registry) error {
-
 	if swag.IsZero(o.Resources) { // not required
 		return nil
 	}
@@ -99,6 +97,38 @@ func (o *PutProjectProjectNameServiceServiceNameResourceBody) validateResources(
 
 		if o.Resources[i] != nil {
 			if err := o.Resources[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("resources" + "." + "resources" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// ContextValidate validate this put project project name service service name resource body based on the context it is used
+func (o *PutProjectProjectNameServiceServiceNameResourceBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.contextValidateResources(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *PutProjectProjectNameServiceServiceNameResourceBody) contextValidateResources(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(o.Resources); i++ {
+
+		if o.Resources[i] != nil {
+			if err := o.Resources[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("resources" + "." + "resources" + "." + strconv.Itoa(i))
 				}

--- a/configuration-service/restapi/operations/service_default_resource/put_project_project_name_service_service_name_resource_parameters.go
+++ b/configuration-service/restapi/operations/service_default_resource/put_project_project_name_service_service_name_resource_parameters.go
@@ -6,16 +6,19 @@ package service_default_resource
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/validate"
 )
 
 // NewPutProjectProjectNameServiceServiceNameResourceParams creates a new PutProjectProjectNameServiceServiceNameResourceParams object
-// no default values defined in spec.
+//
+// There are no default values defined in the spec.
 func NewPutProjectProjectNameServiceServiceNameResourceParams() PutProjectProjectNameServiceServiceNameResourceParams {
 
 	return PutProjectProjectNameServiceServiceNameResourceParams{}
@@ -71,16 +74,21 @@ func (o *PutProjectProjectNameServiceServiceNameResourceParams) BindRequest(r *h
 				res = append(res, err)
 			}
 
+			ctx := validate.WithOperationRequest(context.Background())
+			if err := body.ContextValidate(ctx, route.Formats); err != nil {
+				res = append(res, err)
+			}
+
 			if len(res) == 0 {
 				o.Resources = body
 			}
 		}
 	}
+
 	rServiceName, rhkServiceName, _ := route.Params.GetOK("serviceName")
 	if err := o.bindServiceName(rServiceName, rhkServiceName, route.Formats); err != nil {
 		res = append(res, err)
 	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -96,7 +104,6 @@ func (o *PutProjectProjectNameServiceServiceNameResourceParams) bindProjectName(
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ProjectName = raw
 
 	return nil
@@ -111,7 +118,6 @@ func (o *PutProjectProjectNameServiceServiceNameResourceParams) bindServiceName(
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ServiceName = raw
 
 	return nil

--- a/configuration-service/restapi/operations/service_default_resource/put_project_project_name_service_service_name_resource_resource_uri.go
+++ b/configuration-service/restapi/operations/service_default_resource/put_project_project_name_service_service_name_resource_resource_uri.go
@@ -29,7 +29,7 @@ func NewPutProjectProjectNameServiceServiceNameResourceResourceURI(ctx *middlewa
 	return &PutProjectProjectNameServiceServiceNameResourceResourceURI{Context: ctx, Handler: handler}
 }
 
-/*PutProjectProjectNameServiceServiceNameResourceResourceURI swagger:route PUT /project/{projectName}/service/{serviceName}/resource/{resourceURI} Service Default Resource putProjectProjectNameServiceServiceNameResourceResourceUri
+/* PutProjectProjectNameServiceServiceNameResourceResourceURI swagger:route PUT /project/{projectName}/service/{serviceName}/resource/{resourceURI} Service Default Resource putProjectProjectNameServiceServiceNameResourceResourceUri
 
 Update the specified default resource for the service
 
@@ -42,17 +42,15 @@ type PutProjectProjectNameServiceServiceNameResourceResourceURI struct {
 func (o *PutProjectProjectNameServiceServiceNameResourceResourceURI) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewPutProjectProjectNameServiceServiceNameResourceResourceURIParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/configuration-service/restapi/operations/service_default_resource/put_project_project_name_service_service_name_resource_resource_uri_parameters.go
+++ b/configuration-service/restapi/operations/service_default_resource/put_project_project_name_service_service_name_resource_resource_uri_parameters.go
@@ -6,18 +6,21 @@ package service_default_resource
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/validate"
 
 	"github.com/keptn/keptn/configuration-service/models"
 )
 
 // NewPutProjectProjectNameServiceServiceNameResourceResourceURIParams creates a new PutProjectProjectNameServiceServiceNameResourceResourceURIParams object
-// no default values defined in spec.
+//
+// There are no default values defined in the spec.
 func NewPutProjectProjectNameServiceServiceNameResourceResourceURIParams() PutProjectProjectNameServiceServiceNameResourceResourceURIParams {
 
 	return PutProjectProjectNameServiceServiceNameResourceResourceURIParams{}
@@ -78,11 +81,17 @@ func (o *PutProjectProjectNameServiceServiceNameResourceResourceURIParams) BindR
 				res = append(res, err)
 			}
 
+			ctx := validate.WithOperationRequest(context.Background())
+			if err := body.ContextValidate(ctx, route.Formats); err != nil {
+				res = append(res, err)
+			}
+
 			if len(res) == 0 {
 				o.Resource = &body
 			}
 		}
 	}
+
 	rResourceURI, rhkResourceURI, _ := route.Params.GetOK("resourceURI")
 	if err := o.bindResourceURI(rResourceURI, rhkResourceURI, route.Formats); err != nil {
 		res = append(res, err)
@@ -92,7 +101,6 @@ func (o *PutProjectProjectNameServiceServiceNameResourceResourceURIParams) BindR
 	if err := o.bindServiceName(rServiceName, rhkServiceName, route.Formats); err != nil {
 		res = append(res, err)
 	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -108,7 +116,6 @@ func (o *PutProjectProjectNameServiceServiceNameResourceResourceURIParams) bindP
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ProjectName = raw
 
 	return nil
@@ -123,7 +130,6 @@ func (o *PutProjectProjectNameServiceServiceNameResourceResourceURIParams) bindR
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ResourceURI = raw
 
 	return nil
@@ -138,7 +144,6 @@ func (o *PutProjectProjectNameServiceServiceNameResourceResourceURIParams) bindS
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ServiceName = raw
 
 	return nil

--- a/configuration-service/restapi/operations/service_resource/delete_project_project_name_stage_stage_name_service_service_name_resource_resource_uri.go
+++ b/configuration-service/restapi/operations/service_resource/delete_project_project_name_stage_stage_name_service_service_name_resource_resource_uri.go
@@ -29,7 +29,7 @@ func NewDeleteProjectProjectNameStageStageNameServiceServiceNameResourceResource
 	return &DeleteProjectProjectNameStageStageNameServiceServiceNameResourceResourceURI{Context: ctx, Handler: handler}
 }
 
-/*DeleteProjectProjectNameStageStageNameServiceServiceNameResourceResourceURI swagger:route DELETE /project/{projectName}/stage/{stageName}/service/{serviceName}/resource/{resourceURI} Service Resource deleteProjectProjectNameStageStageNameServiceServiceNameResourceResourceUri
+/* DeleteProjectProjectNameStageStageNameServiceServiceNameResourceResourceURI swagger:route DELETE /project/{projectName}/stage/{stageName}/service/{serviceName}/resource/{resourceURI} Service Resource deleteProjectProjectNameStageStageNameServiceServiceNameResourceResourceUri
 
 Delete the specified resource
 
@@ -42,17 +42,15 @@ type DeleteProjectProjectNameStageStageNameServiceServiceNameResourceResourceURI
 func (o *DeleteProjectProjectNameStageStageNameServiceServiceNameResourceResourceURI) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewDeleteProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/configuration-service/restapi/operations/service_resource/delete_project_project_name_stage_stage_name_service_service_name_resource_resource_uri_parameters.go
+++ b/configuration-service/restapi/operations/service_resource/delete_project_project_name_stage_stage_name_service_service_name_resource_resource_uri_parameters.go
@@ -14,7 +14,8 @@ import (
 )
 
 // NewDeleteProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIParams creates a new DeleteProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIParams object
-// no default values defined in spec.
+//
+// There are no default values defined in the spec.
 func NewDeleteProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIParams() DeleteProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIParams {
 
 	return DeleteProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIParams{}
@@ -79,7 +80,6 @@ func (o *DeleteProjectProjectNameStageStageNameServiceServiceNameResourceResourc
 	if err := o.bindStageName(rStageName, rhkStageName, route.Formats); err != nil {
 		res = append(res, err)
 	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -95,7 +95,6 @@ func (o *DeleteProjectProjectNameStageStageNameServiceServiceNameResourceResourc
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ProjectName = raw
 
 	return nil
@@ -110,7 +109,6 @@ func (o *DeleteProjectProjectNameStageStageNameServiceServiceNameResourceResourc
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ResourceURI = raw
 
 	return nil
@@ -125,7 +123,6 @@ func (o *DeleteProjectProjectNameStageStageNameServiceServiceNameResourceResourc
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ServiceName = raw
 
 	return nil
@@ -140,7 +137,6 @@ func (o *DeleteProjectProjectNameStageStageNameServiceServiceNameResourceResourc
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.StageName = raw
 
 	return nil

--- a/configuration-service/restapi/operations/service_resource/get_project_project_name_stage_stage_name_service_service_name_resource.go
+++ b/configuration-service/restapi/operations/service_resource/get_project_project_name_stage_stage_name_service_service_name_resource.go
@@ -29,7 +29,7 @@ func NewGetProjectProjectNameStageStageNameServiceServiceNameResource(ctx *middl
 	return &GetProjectProjectNameStageStageNameServiceServiceNameResource{Context: ctx, Handler: handler}
 }
 
-/*GetProjectProjectNameStageStageNameServiceServiceNameResource swagger:route GET /project/{projectName}/stage/{stageName}/service/{serviceName}/resource Service Resource getProjectProjectNameStageStageNameServiceServiceNameResource
+/* GetProjectProjectNameStageStageNameServiceServiceNameResource swagger:route GET /project/{projectName}/stage/{stageName}/service/{serviceName}/resource Service Resource getProjectProjectNameStageStageNameServiceServiceNameResource
 
 Get list of service resources
 
@@ -42,17 +42,15 @@ type GetProjectProjectNameStageStageNameServiceServiceNameResource struct {
 func (o *GetProjectProjectNameStageStageNameServiceServiceNameResource) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetProjectProjectNameStageStageNameServiceServiceNameResourceParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/configuration-service/restapi/operations/service_resource/get_project_project_name_stage_stage_name_service_service_name_resource_parameters.go
+++ b/configuration-service/restapi/operations/service_resource/get_project_project_name_stage_stage_name_service_service_name_resource_parameters.go
@@ -117,7 +117,6 @@ func (o *GetProjectProjectNameStageStageNameServiceServiceNameResourceParams) Bi
 	if err := o.bindStageName(rStageName, rhkStageName, route.Formats); err != nil {
 		res = append(res, err)
 	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -133,6 +132,7 @@ func (o *GetProjectProjectNameStageStageNameServiceServiceNameResourceParams) bi
 
 	// Required: false
 	// AllowEmptyValue: false
+
 	if raw == "" { // empty values pass all other validations
 		// Default values have been previously initialized by NewGetProjectProjectNameStageStageNameServiceServiceNameResourceParams()
 		return nil
@@ -156,10 +156,10 @@ func (o *GetProjectProjectNameStageStageNameServiceServiceNameResourceParams) bi
 
 	// Required: false
 	// AllowEmptyValue: false
+
 	if raw == "" { // empty values pass all other validations
 		return nil
 	}
-
 	o.NextPageKey = &raw
 
 	return nil
@@ -174,6 +174,7 @@ func (o *GetProjectProjectNameStageStageNameServiceServiceNameResourceParams) bi
 
 	// Required: false
 	// AllowEmptyValue: false
+
 	if raw == "" { // empty values pass all other validations
 		// Default values have been previously initialized by NewGetProjectProjectNameStageStageNameServiceServiceNameResourceParams()
 		return nil
@@ -195,11 +196,11 @@ func (o *GetProjectProjectNameStageStageNameServiceServiceNameResourceParams) bi
 // validatePageSize carries on validations for parameter PageSize
 func (o *GetProjectProjectNameStageStageNameServiceServiceNameResourceParams) validatePageSize(formats strfmt.Registry) error {
 
-	if err := validate.MinimumInt("pageSize", "query", int64(*o.PageSize), 1, false); err != nil {
+	if err := validate.MinimumInt("pageSize", "query", *o.PageSize, 1, false); err != nil {
 		return err
 	}
 
-	if err := validate.MaximumInt("pageSize", "query", int64(*o.PageSize), 50, false); err != nil {
+	if err := validate.MaximumInt("pageSize", "query", *o.PageSize, 50, false); err != nil {
 		return err
 	}
 
@@ -215,7 +216,6 @@ func (o *GetProjectProjectNameStageStageNameServiceServiceNameResourceParams) bi
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ProjectName = raw
 
 	return nil
@@ -230,7 +230,6 @@ func (o *GetProjectProjectNameStageStageNameServiceServiceNameResourceParams) bi
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ServiceName = raw
 
 	return nil
@@ -245,7 +244,6 @@ func (o *GetProjectProjectNameStageStageNameServiceServiceNameResourceParams) bi
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.StageName = raw
 
 	return nil

--- a/configuration-service/restapi/operations/service_resource/get_project_project_name_stage_stage_name_service_service_name_resource_resource_uri.go
+++ b/configuration-service/restapi/operations/service_resource/get_project_project_name_stage_stage_name_service_service_name_resource_resource_uri.go
@@ -29,7 +29,7 @@ func NewGetProjectProjectNameStageStageNameServiceServiceNameResourceResourceURI
 	return &GetProjectProjectNameStageStageNameServiceServiceNameResourceResourceURI{Context: ctx, Handler: handler}
 }
 
-/*GetProjectProjectNameStageStageNameServiceServiceNameResourceResourceURI swagger:route GET /project/{projectName}/stage/{stageName}/service/{serviceName}/resource/{resourceURI} Service Resource getProjectProjectNameStageStageNameServiceServiceNameResourceResourceUri
+/* GetProjectProjectNameStageStageNameServiceServiceNameResourceResourceURI swagger:route GET /project/{projectName}/stage/{stageName}/service/{serviceName}/resource/{resourceURI} Service Resource getProjectProjectNameStageStageNameServiceServiceNameResourceResourceUri
 
 Get the specified resource
 
@@ -42,17 +42,15 @@ type GetProjectProjectNameStageStageNameServiceServiceNameResourceResourceURI st
 func (o *GetProjectProjectNameStageStageNameServiceServiceNameResourceResourceURI) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/configuration-service/restapi/operations/service_resource/get_project_project_name_stage_stage_name_service_service_name_resource_resource_uri_parameters.go
+++ b/configuration-service/restapi/operations/service_resource/get_project_project_name_stage_stage_name_service_service_name_resource_resource_uri_parameters.go
@@ -101,7 +101,6 @@ func (o *GetProjectProjectNameStageStageNameServiceServiceNameResourceResourceUR
 	if err := o.bindStageName(rStageName, rhkStageName, route.Formats); err != nil {
 		res = append(res, err)
 	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -117,6 +116,7 @@ func (o *GetProjectProjectNameStageStageNameServiceServiceNameResourceResourceUR
 
 	// Required: false
 	// AllowEmptyValue: false
+
 	if raw == "" { // empty values pass all other validations
 		// Default values have been previously initialized by NewGetProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIParams()
 		return nil
@@ -140,7 +140,6 @@ func (o *GetProjectProjectNameStageStageNameServiceServiceNameResourceResourceUR
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ProjectName = raw
 
 	return nil
@@ -155,7 +154,6 @@ func (o *GetProjectProjectNameStageStageNameServiceServiceNameResourceResourceUR
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ResourceURI = raw
 
 	return nil
@@ -170,7 +168,6 @@ func (o *GetProjectProjectNameStageStageNameServiceServiceNameResourceResourceUR
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ServiceName = raw
 
 	return nil
@@ -185,7 +182,6 @@ func (o *GetProjectProjectNameStageStageNameServiceServiceNameResourceResourceUR
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.StageName = raw
 
 	return nil

--- a/configuration-service/restapi/operations/service_resource/post_project_project_name_stage_stage_name_service_service_name_resource.go
+++ b/configuration-service/restapi/operations/service_resource/post_project_project_name_stage_stage_name_service_service_name_resource.go
@@ -6,6 +6,7 @@ package service_resource
 // Editing this file might prove futile when you re-run the generate command
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 
@@ -35,7 +36,7 @@ func NewPostProjectProjectNameStageStageNameServiceServiceNameResource(ctx *midd
 	return &PostProjectProjectNameStageStageNameServiceServiceNameResource{Context: ctx, Handler: handler}
 }
 
-/*PostProjectProjectNameStageStageNameServiceServiceNameResource swagger:route POST /project/{projectName}/stage/{stageName}/service/{serviceName}/resource Service Resource postProjectProjectNameStageStageNameServiceServiceNameResource
+/* PostProjectProjectNameStageStageNameServiceServiceNameResource swagger:route POST /project/{projectName}/stage/{stageName}/service/{serviceName}/resource Service Resource postProjectProjectNameStageStageNameServiceServiceNameResource
 
 Create list of new resources for the service
 
@@ -48,17 +49,15 @@ type PostProjectProjectNameStageStageNameServiceServiceNameResource struct {
 func (o *PostProjectProjectNameStageStageNameServiceServiceNameResource) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewPostProjectProjectNameStageStageNameServiceServiceNameResourceParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }
@@ -87,7 +86,6 @@ func (o *PostProjectProjectNameStageStageNameServiceServiceNameResourceBody) Val
 }
 
 func (o *PostProjectProjectNameStageStageNameServiceServiceNameResourceBody) validateResources(formats strfmt.Registry) error {
-
 	if swag.IsZero(o.Resources) { // not required
 		return nil
 	}
@@ -99,6 +97,38 @@ func (o *PostProjectProjectNameStageStageNameServiceServiceNameResourceBody) val
 
 		if o.Resources[i] != nil {
 			if err := o.Resources[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("resources" + "." + "resources" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// ContextValidate validate this post project project name stage stage name service service name resource body based on the context it is used
+func (o *PostProjectProjectNameStageStageNameServiceServiceNameResourceBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.contextValidateResources(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *PostProjectProjectNameStageStageNameServiceServiceNameResourceBody) contextValidateResources(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(o.Resources); i++ {
+
+		if o.Resources[i] != nil {
+			if err := o.Resources[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("resources" + "." + "resources" + "." + strconv.Itoa(i))
 				}

--- a/configuration-service/restapi/operations/service_resource/post_project_project_name_stage_stage_name_service_service_name_resource_parameters.go
+++ b/configuration-service/restapi/operations/service_resource/post_project_project_name_stage_stage_name_service_service_name_resource_parameters.go
@@ -6,16 +6,19 @@ package service_resource
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/validate"
 )
 
 // NewPostProjectProjectNameStageStageNameServiceServiceNameResourceParams creates a new PostProjectProjectNameStageStageNameServiceServiceNameResourceParams object
-// no default values defined in spec.
+//
+// There are no default values defined in the spec.
 func NewPostProjectProjectNameStageStageNameServiceServiceNameResourceParams() PostProjectProjectNameStageStageNameServiceServiceNameResourceParams {
 
 	return PostProjectProjectNameStageStageNameServiceServiceNameResourceParams{}
@@ -76,11 +79,17 @@ func (o *PostProjectProjectNameStageStageNameServiceServiceNameResourceParams) B
 				res = append(res, err)
 			}
 
+			ctx := validate.WithOperationRequest(context.Background())
+			if err := body.ContextValidate(ctx, route.Formats); err != nil {
+				res = append(res, err)
+			}
+
 			if len(res) == 0 {
 				o.Resources = body
 			}
 		}
 	}
+
 	rServiceName, rhkServiceName, _ := route.Params.GetOK("serviceName")
 	if err := o.bindServiceName(rServiceName, rhkServiceName, route.Formats); err != nil {
 		res = append(res, err)
@@ -90,7 +99,6 @@ func (o *PostProjectProjectNameStageStageNameServiceServiceNameResourceParams) B
 	if err := o.bindStageName(rStageName, rhkStageName, route.Formats); err != nil {
 		res = append(res, err)
 	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -106,7 +114,6 @@ func (o *PostProjectProjectNameStageStageNameServiceServiceNameResourceParams) b
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ProjectName = raw
 
 	return nil
@@ -121,7 +128,6 @@ func (o *PostProjectProjectNameStageStageNameServiceServiceNameResourceParams) b
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ServiceName = raw
 
 	return nil
@@ -136,7 +142,6 @@ func (o *PostProjectProjectNameStageStageNameServiceServiceNameResourceParams) b
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.StageName = raw
 
 	return nil

--- a/configuration-service/restapi/operations/service_resource/put_project_project_name_stage_stage_name_service_service_name_resource.go
+++ b/configuration-service/restapi/operations/service_resource/put_project_project_name_stage_stage_name_service_service_name_resource.go
@@ -6,6 +6,7 @@ package service_resource
 // Editing this file might prove futile when you re-run the generate command
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 
@@ -35,7 +36,7 @@ func NewPutProjectProjectNameStageStageNameServiceServiceNameResource(ctx *middl
 	return &PutProjectProjectNameStageStageNameServiceServiceNameResource{Context: ctx, Handler: handler}
 }
 
-/*PutProjectProjectNameStageStageNameServiceServiceNameResource swagger:route PUT /project/{projectName}/stage/{stageName}/service/{serviceName}/resource Service Resource putProjectProjectNameStageStageNameServiceServiceNameResource
+/* PutProjectProjectNameStageStageNameServiceServiceNameResource swagger:route PUT /project/{projectName}/stage/{stageName}/service/{serviceName}/resource Service Resource putProjectProjectNameStageStageNameServiceServiceNameResource
 
 Update list of service resources
 
@@ -48,17 +49,15 @@ type PutProjectProjectNameStageStageNameServiceServiceNameResource struct {
 func (o *PutProjectProjectNameStageStageNameServiceServiceNameResource) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewPutProjectProjectNameStageStageNameServiceServiceNameResourceParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }
@@ -87,7 +86,6 @@ func (o *PutProjectProjectNameStageStageNameServiceServiceNameResourceBody) Vali
 }
 
 func (o *PutProjectProjectNameStageStageNameServiceServiceNameResourceBody) validateResources(formats strfmt.Registry) error {
-
 	if swag.IsZero(o.Resources) { // not required
 		return nil
 	}
@@ -99,6 +97,38 @@ func (o *PutProjectProjectNameStageStageNameServiceServiceNameResourceBody) vali
 
 		if o.Resources[i] != nil {
 			if err := o.Resources[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("resources" + "." + "resources" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// ContextValidate validate this put project project name stage stage name service service name resource body based on the context it is used
+func (o *PutProjectProjectNameStageStageNameServiceServiceNameResourceBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.contextValidateResources(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *PutProjectProjectNameStageStageNameServiceServiceNameResourceBody) contextValidateResources(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(o.Resources); i++ {
+
+		if o.Resources[i] != nil {
+			if err := o.Resources[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("resources" + "." + "resources" + "." + strconv.Itoa(i))
 				}

--- a/configuration-service/restapi/operations/service_resource/put_project_project_name_stage_stage_name_service_service_name_resource_parameters.go
+++ b/configuration-service/restapi/operations/service_resource/put_project_project_name_stage_stage_name_service_service_name_resource_parameters.go
@@ -6,16 +6,19 @@ package service_resource
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/validate"
 )
 
 // NewPutProjectProjectNameStageStageNameServiceServiceNameResourceParams creates a new PutProjectProjectNameStageStageNameServiceServiceNameResourceParams object
-// no default values defined in spec.
+//
+// There are no default values defined in the spec.
 func NewPutProjectProjectNameStageStageNameServiceServiceNameResourceParams() PutProjectProjectNameStageStageNameServiceServiceNameResourceParams {
 
 	return PutProjectProjectNameStageStageNameServiceServiceNameResourceParams{}
@@ -76,11 +79,17 @@ func (o *PutProjectProjectNameStageStageNameServiceServiceNameResourceParams) Bi
 				res = append(res, err)
 			}
 
+			ctx := validate.WithOperationRequest(context.Background())
+			if err := body.ContextValidate(ctx, route.Formats); err != nil {
+				res = append(res, err)
+			}
+
 			if len(res) == 0 {
 				o.Resources = body
 			}
 		}
 	}
+
 	rServiceName, rhkServiceName, _ := route.Params.GetOK("serviceName")
 	if err := o.bindServiceName(rServiceName, rhkServiceName, route.Formats); err != nil {
 		res = append(res, err)
@@ -90,7 +99,6 @@ func (o *PutProjectProjectNameStageStageNameServiceServiceNameResourceParams) Bi
 	if err := o.bindStageName(rStageName, rhkStageName, route.Formats); err != nil {
 		res = append(res, err)
 	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -106,7 +114,6 @@ func (o *PutProjectProjectNameStageStageNameServiceServiceNameResourceParams) bi
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ProjectName = raw
 
 	return nil
@@ -121,7 +128,6 @@ func (o *PutProjectProjectNameStageStageNameServiceServiceNameResourceParams) bi
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ServiceName = raw
 
 	return nil
@@ -136,7 +142,6 @@ func (o *PutProjectProjectNameStageStageNameServiceServiceNameResourceParams) bi
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.StageName = raw
 
 	return nil

--- a/configuration-service/restapi/operations/service_resource/put_project_project_name_stage_stage_name_service_service_name_resource_resource_uri.go
+++ b/configuration-service/restapi/operations/service_resource/put_project_project_name_stage_stage_name_service_service_name_resource_resource_uri.go
@@ -29,7 +29,7 @@ func NewPutProjectProjectNameStageStageNameServiceServiceNameResourceResourceURI
 	return &PutProjectProjectNameStageStageNameServiceServiceNameResourceResourceURI{Context: ctx, Handler: handler}
 }
 
-/*PutProjectProjectNameStageStageNameServiceServiceNameResourceResourceURI swagger:route PUT /project/{projectName}/stage/{stageName}/service/{serviceName}/resource/{resourceURI} Service Resource putProjectProjectNameStageStageNameServiceServiceNameResourceResourceUri
+/* PutProjectProjectNameStageStageNameServiceServiceNameResourceResourceURI swagger:route PUT /project/{projectName}/stage/{stageName}/service/{serviceName}/resource/{resourceURI} Service Resource putProjectProjectNameStageStageNameServiceServiceNameResourceResourceUri
 
 Update the specified resource
 
@@ -42,17 +42,15 @@ type PutProjectProjectNameStageStageNameServiceServiceNameResourceResourceURI st
 func (o *PutProjectProjectNameStageStageNameServiceServiceNameResourceResourceURI) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewPutProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/configuration-service/restapi/operations/service_resource/put_project_project_name_stage_stage_name_service_service_name_resource_resource_uri_parameters.go
+++ b/configuration-service/restapi/operations/service_resource/put_project_project_name_stage_stage_name_service_service_name_resource_resource_uri_parameters.go
@@ -6,18 +6,21 @@ package service_resource
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/validate"
 
 	"github.com/keptn/keptn/configuration-service/models"
 )
 
 // NewPutProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIParams creates a new PutProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIParams object
-// no default values defined in spec.
+//
+// There are no default values defined in the spec.
 func NewPutProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIParams() PutProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIParams {
 
 	return PutProjectProjectNameStageStageNameServiceServiceNameResourceResourceURIParams{}
@@ -83,11 +86,17 @@ func (o *PutProjectProjectNameStageStageNameServiceServiceNameResourceResourceUR
 				res = append(res, err)
 			}
 
+			ctx := validate.WithOperationRequest(context.Background())
+			if err := body.ContextValidate(ctx, route.Formats); err != nil {
+				res = append(res, err)
+			}
+
 			if len(res) == 0 {
 				o.Resource = &body
 			}
 		}
 	}
+
 	rResourceURI, rhkResourceURI, _ := route.Params.GetOK("resourceURI")
 	if err := o.bindResourceURI(rResourceURI, rhkResourceURI, route.Formats); err != nil {
 		res = append(res, err)
@@ -102,7 +111,6 @@ func (o *PutProjectProjectNameStageStageNameServiceServiceNameResourceResourceUR
 	if err := o.bindStageName(rStageName, rhkStageName, route.Formats); err != nil {
 		res = append(res, err)
 	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -118,7 +126,6 @@ func (o *PutProjectProjectNameStageStageNameServiceServiceNameResourceResourceUR
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ProjectName = raw
 
 	return nil
@@ -133,7 +140,6 @@ func (o *PutProjectProjectNameStageStageNameServiceServiceNameResourceResourceUR
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ResourceURI = raw
 
 	return nil
@@ -148,7 +154,6 @@ func (o *PutProjectProjectNameStageStageNameServiceServiceNameResourceResourceUR
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ServiceName = raw
 
 	return nil
@@ -163,7 +168,6 @@ func (o *PutProjectProjectNameStageStageNameServiceServiceNameResourceResourceUR
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.StageName = raw
 
 	return nil

--- a/configuration-service/restapi/operations/stage/delete_project_project_name_stage_stage_name.go
+++ b/configuration-service/restapi/operations/stage/delete_project_project_name_stage_stage_name.go
@@ -29,7 +29,7 @@ func NewDeleteProjectProjectNameStageStageName(ctx *middleware.Context, handler 
 	return &DeleteProjectProjectNameStageStageName{Context: ctx, Handler: handler}
 }
 
-/*DeleteProjectProjectNameStageStageName swagger:route DELETE /project/{projectName}/stage/{stageName} Stage deleteProjectProjectNameStageStageName
+/* DeleteProjectProjectNameStageStageName swagger:route DELETE /project/{projectName}/stage/{stageName} Stage deleteProjectProjectNameStageStageName
 
 INTERNAL Endpoint: Delete the specified stage
 
@@ -42,17 +42,15 @@ type DeleteProjectProjectNameStageStageName struct {
 func (o *DeleteProjectProjectNameStageStageName) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewDeleteProjectProjectNameStageStageNameParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/configuration-service/restapi/operations/stage/delete_project_project_name_stage_stage_name_parameters.go
+++ b/configuration-service/restapi/operations/stage/delete_project_project_name_stage_stage_name_parameters.go
@@ -14,7 +14,8 @@ import (
 )
 
 // NewDeleteProjectProjectNameStageStageNameParams creates a new DeleteProjectProjectNameStageStageNameParams object
-// no default values defined in spec.
+//
+// There are no default values defined in the spec.
 func NewDeleteProjectProjectNameStageStageNameParams() DeleteProjectProjectNameStageStageNameParams {
 
 	return DeleteProjectProjectNameStageStageNameParams{}
@@ -59,7 +60,6 @@ func (o *DeleteProjectProjectNameStageStageNameParams) BindRequest(r *http.Reque
 	if err := o.bindStageName(rStageName, rhkStageName, route.Formats); err != nil {
 		res = append(res, err)
 	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -75,7 +75,6 @@ func (o *DeleteProjectProjectNameStageStageNameParams) bindProjectName(rawData [
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ProjectName = raw
 
 	return nil
@@ -90,7 +89,6 @@ func (o *DeleteProjectProjectNameStageStageNameParams) bindStageName(rawData []s
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.StageName = raw
 
 	return nil

--- a/configuration-service/restapi/operations/stage/post_project_project_name_stage.go
+++ b/configuration-service/restapi/operations/stage/post_project_project_name_stage.go
@@ -29,7 +29,7 @@ func NewPostProjectProjectNameStage(ctx *middleware.Context, handler PostProject
 	return &PostProjectProjectNameStage{Context: ctx, Handler: handler}
 }
 
-/*PostProjectProjectNameStage swagger:route POST /project/{projectName}/stage Stage postProjectProjectNameStage
+/* PostProjectProjectNameStage swagger:route POST /project/{projectName}/stage Stage postProjectProjectNameStage
 
 INTERNAL Endpoint: Create a new stage by stage name
 
@@ -42,17 +42,15 @@ type PostProjectProjectNameStage struct {
 func (o *PostProjectProjectNameStage) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewPostProjectProjectNameStageParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/configuration-service/restapi/operations/stage/post_project_project_name_stage_parameters.go
+++ b/configuration-service/restapi/operations/stage/post_project_project_name_stage_parameters.go
@@ -6,18 +6,21 @@ package stage
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/validate"
 
 	"github.com/keptn/keptn/configuration-service/models"
 )
 
 // NewPostProjectProjectNameStageParams creates a new PostProjectProjectNameStageParams object
-// no default values defined in spec.
+//
+// There are no default values defined in the spec.
 func NewPostProjectProjectNameStageParams() PostProjectProjectNameStageParams {
 
 	return PostProjectProjectNameStageParams{}
@@ -68,6 +71,11 @@ func (o *PostProjectProjectNameStageParams) BindRequest(r *http.Request, route *
 				res = append(res, err)
 			}
 
+			ctx := validate.WithOperationRequest(context.Background())
+			if err := body.ContextValidate(ctx, route.Formats); err != nil {
+				res = append(res, err)
+			}
+
 			if len(res) == 0 {
 				o.Stage = &body
 			}
@@ -88,7 +96,6 @@ func (o *PostProjectProjectNameStageParams) bindProjectName(rawData []string, ha
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ProjectName = raw
 
 	return nil

--- a/configuration-service/restapi/operations/stage/put_project_project_name_stage_stage_name.go
+++ b/configuration-service/restapi/operations/stage/put_project_project_name_stage_stage_name.go
@@ -29,7 +29,7 @@ func NewPutProjectProjectNameStageStageName(ctx *middleware.Context, handler Put
 	return &PutProjectProjectNameStageStageName{Context: ctx, Handler: handler}
 }
 
-/*PutProjectProjectNameStageStageName swagger:route PUT /project/{projectName}/stage/{stageName} Stage putProjectProjectNameStageStageName
+/* PutProjectProjectNameStageStageName swagger:route PUT /project/{projectName}/stage/{stageName} Stage putProjectProjectNameStageStageName
 
 INTERNAL Endpoint: Update the specified stage
 
@@ -42,17 +42,15 @@ type PutProjectProjectNameStageStageName struct {
 func (o *PutProjectProjectNameStageStageName) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewPutProjectProjectNameStageStageNameParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/configuration-service/restapi/operations/stage/put_project_project_name_stage_stage_name_parameters.go
+++ b/configuration-service/restapi/operations/stage/put_project_project_name_stage_stage_name_parameters.go
@@ -6,18 +6,21 @@ package stage
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/validate"
 
 	"github.com/keptn/keptn/configuration-service/models"
 )
 
 // NewPutProjectProjectNameStageStageNameParams creates a new PutProjectProjectNameStageStageNameParams object
-// no default values defined in spec.
+//
+// There are no default values defined in the spec.
 func NewPutProjectProjectNameStageStageNameParams() PutProjectProjectNameStageStageNameParams {
 
 	return PutProjectProjectNameStageStageNameParams{}
@@ -73,16 +76,21 @@ func (o *PutProjectProjectNameStageStageNameParams) BindRequest(r *http.Request,
 				res = append(res, err)
 			}
 
+			ctx := validate.WithOperationRequest(context.Background())
+			if err := body.ContextValidate(ctx, route.Formats); err != nil {
+				res = append(res, err)
+			}
+
 			if len(res) == 0 {
 				o.Stage = &body
 			}
 		}
 	}
+
 	rStageName, rhkStageName, _ := route.Params.GetOK("stageName")
 	if err := o.bindStageName(rStageName, rhkStageName, route.Formats); err != nil {
 		res = append(res, err)
 	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -98,7 +106,6 @@ func (o *PutProjectProjectNameStageStageNameParams) bindProjectName(rawData []st
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ProjectName = raw
 
 	return nil
@@ -113,7 +120,6 @@ func (o *PutProjectProjectNameStageStageNameParams) bindStageName(rawData []stri
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.StageName = raw
 
 	return nil

--- a/configuration-service/restapi/operations/stage_resource/delete_project_project_name_stage_stage_name_resource_resource_uri.go
+++ b/configuration-service/restapi/operations/stage_resource/delete_project_project_name_stage_stage_name_resource_resource_uri.go
@@ -29,7 +29,7 @@ func NewDeleteProjectProjectNameStageStageNameResourceResourceURI(ctx *middlewar
 	return &DeleteProjectProjectNameStageStageNameResourceResourceURI{Context: ctx, Handler: handler}
 }
 
-/*DeleteProjectProjectNameStageStageNameResourceResourceURI swagger:route DELETE /project/{projectName}/stage/{stageName}/resource/{resourceURI} Stage Resource deleteProjectProjectNameStageStageNameResourceResourceUri
+/* DeleteProjectProjectNameStageStageNameResourceResourceURI swagger:route DELETE /project/{projectName}/stage/{stageName}/resource/{resourceURI} Stage Resource deleteProjectProjectNameStageStageNameResourceResourceUri
 
 Delete the specified resource
 
@@ -42,17 +42,15 @@ type DeleteProjectProjectNameStageStageNameResourceResourceURI struct {
 func (o *DeleteProjectProjectNameStageStageNameResourceResourceURI) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewDeleteProjectProjectNameStageStageNameResourceResourceURIParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/configuration-service/restapi/operations/stage_resource/delete_project_project_name_stage_stage_name_resource_resource_uri_parameters.go
+++ b/configuration-service/restapi/operations/stage_resource/delete_project_project_name_stage_stage_name_resource_resource_uri_parameters.go
@@ -14,7 +14,8 @@ import (
 )
 
 // NewDeleteProjectProjectNameStageStageNameResourceResourceURIParams creates a new DeleteProjectProjectNameStageStageNameResourceResourceURIParams object
-// no default values defined in spec.
+//
+// There are no default values defined in the spec.
 func NewDeleteProjectProjectNameStageStageNameResourceResourceURIParams() DeleteProjectProjectNameStageStageNameResourceResourceURIParams {
 
 	return DeleteProjectProjectNameStageStageNameResourceResourceURIParams{}
@@ -69,7 +70,6 @@ func (o *DeleteProjectProjectNameStageStageNameResourceResourceURIParams) BindRe
 	if err := o.bindStageName(rStageName, rhkStageName, route.Formats); err != nil {
 		res = append(res, err)
 	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -85,7 +85,6 @@ func (o *DeleteProjectProjectNameStageStageNameResourceResourceURIParams) bindPr
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ProjectName = raw
 
 	return nil
@@ -100,7 +99,6 @@ func (o *DeleteProjectProjectNameStageStageNameResourceResourceURIParams) bindRe
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ResourceURI = raw
 
 	return nil
@@ -115,7 +113,6 @@ func (o *DeleteProjectProjectNameStageStageNameResourceResourceURIParams) bindSt
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.StageName = raw
 
 	return nil

--- a/configuration-service/restapi/operations/stage_resource/get_project_project_name_stage_stage_name_resource.go
+++ b/configuration-service/restapi/operations/stage_resource/get_project_project_name_stage_stage_name_resource.go
@@ -29,7 +29,7 @@ func NewGetProjectProjectNameStageStageNameResource(ctx *middleware.Context, han
 	return &GetProjectProjectNameStageStageNameResource{Context: ctx, Handler: handler}
 }
 
-/*GetProjectProjectNameStageStageNameResource swagger:route GET /project/{projectName}/stage/{stageName}/resource Stage Resource getProjectProjectNameStageStageNameResource
+/* GetProjectProjectNameStageStageNameResource swagger:route GET /project/{projectName}/stage/{stageName}/resource Stage Resource getProjectProjectNameStageStageNameResource
 
 Get list of stage resources
 
@@ -42,17 +42,15 @@ type GetProjectProjectNameStageStageNameResource struct {
 func (o *GetProjectProjectNameStageStageNameResource) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetProjectProjectNameStageStageNameResourceParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/configuration-service/restapi/operations/stage_resource/get_project_project_name_stage_stage_name_resource_parameters.go
+++ b/configuration-service/restapi/operations/stage_resource/get_project_project_name_stage_stage_name_resource_parameters.go
@@ -107,7 +107,6 @@ func (o *GetProjectProjectNameStageStageNameResourceParams) BindRequest(r *http.
 	if err := o.bindStageName(rStageName, rhkStageName, route.Formats); err != nil {
 		res = append(res, err)
 	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -123,6 +122,7 @@ func (o *GetProjectProjectNameStageStageNameResourceParams) bindDisableUpstreamS
 
 	// Required: false
 	// AllowEmptyValue: false
+
 	if raw == "" { // empty values pass all other validations
 		// Default values have been previously initialized by NewGetProjectProjectNameStageStageNameResourceParams()
 		return nil
@@ -146,10 +146,10 @@ func (o *GetProjectProjectNameStageStageNameResourceParams) bindNextPageKey(rawD
 
 	// Required: false
 	// AllowEmptyValue: false
+
 	if raw == "" { // empty values pass all other validations
 		return nil
 	}
-
 	o.NextPageKey = &raw
 
 	return nil
@@ -164,6 +164,7 @@ func (o *GetProjectProjectNameStageStageNameResourceParams) bindPageSize(rawData
 
 	// Required: false
 	// AllowEmptyValue: false
+
 	if raw == "" { // empty values pass all other validations
 		// Default values have been previously initialized by NewGetProjectProjectNameStageStageNameResourceParams()
 		return nil
@@ -185,11 +186,11 @@ func (o *GetProjectProjectNameStageStageNameResourceParams) bindPageSize(rawData
 // validatePageSize carries on validations for parameter PageSize
 func (o *GetProjectProjectNameStageStageNameResourceParams) validatePageSize(formats strfmt.Registry) error {
 
-	if err := validate.MinimumInt("pageSize", "query", int64(*o.PageSize), 1, false); err != nil {
+	if err := validate.MinimumInt("pageSize", "query", *o.PageSize, 1, false); err != nil {
 		return err
 	}
 
-	if err := validate.MaximumInt("pageSize", "query", int64(*o.PageSize), 50, false); err != nil {
+	if err := validate.MaximumInt("pageSize", "query", *o.PageSize, 50, false); err != nil {
 		return err
 	}
 
@@ -205,7 +206,6 @@ func (o *GetProjectProjectNameStageStageNameResourceParams) bindProjectName(rawD
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ProjectName = raw
 
 	return nil
@@ -220,7 +220,6 @@ func (o *GetProjectProjectNameStageStageNameResourceParams) bindStageName(rawDat
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.StageName = raw
 
 	return nil

--- a/configuration-service/restapi/operations/stage_resource/get_project_project_name_stage_stage_name_resource_resource_uri.go
+++ b/configuration-service/restapi/operations/stage_resource/get_project_project_name_stage_stage_name_resource_resource_uri.go
@@ -29,7 +29,7 @@ func NewGetProjectProjectNameStageStageNameResourceResourceURI(ctx *middleware.C
 	return &GetProjectProjectNameStageStageNameResourceResourceURI{Context: ctx, Handler: handler}
 }
 
-/*GetProjectProjectNameStageStageNameResourceResourceURI swagger:route GET /project/{projectName}/stage/{stageName}/resource/{resourceURI} Stage Resource getProjectProjectNameStageStageNameResourceResourceUri
+/* GetProjectProjectNameStageStageNameResourceResourceURI swagger:route GET /project/{projectName}/stage/{stageName}/resource/{resourceURI} Stage Resource getProjectProjectNameStageStageNameResourceResourceUri
 
 Get the specified resource
 
@@ -42,17 +42,15 @@ type GetProjectProjectNameStageStageNameResourceResourceURI struct {
 func (o *GetProjectProjectNameStageStageNameResourceResourceURI) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetProjectProjectNameStageStageNameResourceResourceURIParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/configuration-service/restapi/operations/stage_resource/get_project_project_name_stage_stage_name_resource_resource_uri_parameters.go
+++ b/configuration-service/restapi/operations/stage_resource/get_project_project_name_stage_stage_name_resource_resource_uri_parameters.go
@@ -91,7 +91,6 @@ func (o *GetProjectProjectNameStageStageNameResourceResourceURIParams) BindReque
 	if err := o.bindStageName(rStageName, rhkStageName, route.Formats); err != nil {
 		res = append(res, err)
 	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -107,6 +106,7 @@ func (o *GetProjectProjectNameStageStageNameResourceResourceURIParams) bindDisab
 
 	// Required: false
 	// AllowEmptyValue: false
+
 	if raw == "" { // empty values pass all other validations
 		// Default values have been previously initialized by NewGetProjectProjectNameStageStageNameResourceResourceURIParams()
 		return nil
@@ -130,7 +130,6 @@ func (o *GetProjectProjectNameStageStageNameResourceResourceURIParams) bindProje
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ProjectName = raw
 
 	return nil
@@ -145,7 +144,6 @@ func (o *GetProjectProjectNameStageStageNameResourceResourceURIParams) bindResou
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ResourceURI = raw
 
 	return nil
@@ -160,7 +158,6 @@ func (o *GetProjectProjectNameStageStageNameResourceResourceURIParams) bindStage
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.StageName = raw
 
 	return nil

--- a/configuration-service/restapi/operations/stage_resource/post_project_project_name_stage_stage_name_resource.go
+++ b/configuration-service/restapi/operations/stage_resource/post_project_project_name_stage_stage_name_resource.go
@@ -6,6 +6,7 @@ package stage_resource
 // Editing this file might prove futile when you re-run the generate command
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 
@@ -35,7 +36,7 @@ func NewPostProjectProjectNameStageStageNameResource(ctx *middleware.Context, ha
 	return &PostProjectProjectNameStageStageNameResource{Context: ctx, Handler: handler}
 }
 
-/*PostProjectProjectNameStageStageNameResource swagger:route POST /project/{projectName}/stage/{stageName}/resource Stage Resource postProjectProjectNameStageStageNameResource
+/* PostProjectProjectNameStageStageNameResource swagger:route POST /project/{projectName}/stage/{stageName}/resource Stage Resource postProjectProjectNameStageStageNameResource
 
 Create list of new resources for the stage
 
@@ -48,17 +49,15 @@ type PostProjectProjectNameStageStageNameResource struct {
 func (o *PostProjectProjectNameStageStageNameResource) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewPostProjectProjectNameStageStageNameResourceParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }
@@ -87,7 +86,6 @@ func (o *PostProjectProjectNameStageStageNameResourceBody) Validate(formats strf
 }
 
 func (o *PostProjectProjectNameStageStageNameResourceBody) validateResources(formats strfmt.Registry) error {
-
 	if swag.IsZero(o.Resources) { // not required
 		return nil
 	}
@@ -99,6 +97,38 @@ func (o *PostProjectProjectNameStageStageNameResourceBody) validateResources(for
 
 		if o.Resources[i] != nil {
 			if err := o.Resources[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("resources" + "." + "resources" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// ContextValidate validate this post project project name stage stage name resource body based on the context it is used
+func (o *PostProjectProjectNameStageStageNameResourceBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.contextValidateResources(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *PostProjectProjectNameStageStageNameResourceBody) contextValidateResources(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(o.Resources); i++ {
+
+		if o.Resources[i] != nil {
+			if err := o.Resources[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("resources" + "." + "resources" + "." + strconv.Itoa(i))
 				}

--- a/configuration-service/restapi/operations/stage_resource/post_project_project_name_stage_stage_name_resource_parameters.go
+++ b/configuration-service/restapi/operations/stage_resource/post_project_project_name_stage_stage_name_resource_parameters.go
@@ -6,16 +6,19 @@ package stage_resource
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/validate"
 )
 
 // NewPostProjectProjectNameStageStageNameResourceParams creates a new PostProjectProjectNameStageStageNameResourceParams object
-// no default values defined in spec.
+//
+// There are no default values defined in the spec.
 func NewPostProjectProjectNameStageStageNameResourceParams() PostProjectProjectNameStageStageNameResourceParams {
 
 	return PostProjectProjectNameStageStageNameResourceParams{}
@@ -71,16 +74,21 @@ func (o *PostProjectProjectNameStageStageNameResourceParams) BindRequest(r *http
 				res = append(res, err)
 			}
 
+			ctx := validate.WithOperationRequest(context.Background())
+			if err := body.ContextValidate(ctx, route.Formats); err != nil {
+				res = append(res, err)
+			}
+
 			if len(res) == 0 {
 				o.Resources = body
 			}
 		}
 	}
+
 	rStageName, rhkStageName, _ := route.Params.GetOK("stageName")
 	if err := o.bindStageName(rStageName, rhkStageName, route.Formats); err != nil {
 		res = append(res, err)
 	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -96,7 +104,6 @@ func (o *PostProjectProjectNameStageStageNameResourceParams) bindProjectName(raw
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ProjectName = raw
 
 	return nil
@@ -111,7 +118,6 @@ func (o *PostProjectProjectNameStageStageNameResourceParams) bindStageName(rawDa
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.StageName = raw
 
 	return nil

--- a/configuration-service/restapi/operations/stage_resource/put_project_project_name_stage_stage_name_resource.go
+++ b/configuration-service/restapi/operations/stage_resource/put_project_project_name_stage_stage_name_resource.go
@@ -6,6 +6,7 @@ package stage_resource
 // Editing this file might prove futile when you re-run the generate command
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 
@@ -35,7 +36,7 @@ func NewPutProjectProjectNameStageStageNameResource(ctx *middleware.Context, han
 	return &PutProjectProjectNameStageStageNameResource{Context: ctx, Handler: handler}
 }
 
-/*PutProjectProjectNameStageStageNameResource swagger:route PUT /project/{projectName}/stage/{stageName}/resource Stage Resource putProjectProjectNameStageStageNameResource
+/* PutProjectProjectNameStageStageNameResource swagger:route PUT /project/{projectName}/stage/{stageName}/resource Stage Resource putProjectProjectNameStageStageNameResource
 
 Update list of stage resources
 
@@ -48,17 +49,15 @@ type PutProjectProjectNameStageStageNameResource struct {
 func (o *PutProjectProjectNameStageStageNameResource) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewPutProjectProjectNameStageStageNameResourceParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }
@@ -87,7 +86,6 @@ func (o *PutProjectProjectNameStageStageNameResourceBody) Validate(formats strfm
 }
 
 func (o *PutProjectProjectNameStageStageNameResourceBody) validateResources(formats strfmt.Registry) error {
-
 	if swag.IsZero(o.Resources) { // not required
 		return nil
 	}
@@ -99,6 +97,38 @@ func (o *PutProjectProjectNameStageStageNameResourceBody) validateResources(form
 
 		if o.Resources[i] != nil {
 			if err := o.Resources[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("resources" + "." + "resources" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// ContextValidate validate this put project project name stage stage name resource body based on the context it is used
+func (o *PutProjectProjectNameStageStageNameResourceBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.contextValidateResources(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *PutProjectProjectNameStageStageNameResourceBody) contextValidateResources(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(o.Resources); i++ {
+
+		if o.Resources[i] != nil {
+			if err := o.Resources[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("resources" + "." + "resources" + "." + strconv.Itoa(i))
 				}

--- a/configuration-service/restapi/operations/stage_resource/put_project_project_name_stage_stage_name_resource_parameters.go
+++ b/configuration-service/restapi/operations/stage_resource/put_project_project_name_stage_stage_name_resource_parameters.go
@@ -6,16 +6,19 @@ package stage_resource
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/validate"
 )
 
 // NewPutProjectProjectNameStageStageNameResourceParams creates a new PutProjectProjectNameStageStageNameResourceParams object
-// no default values defined in spec.
+//
+// There are no default values defined in the spec.
 func NewPutProjectProjectNameStageStageNameResourceParams() PutProjectProjectNameStageStageNameResourceParams {
 
 	return PutProjectProjectNameStageStageNameResourceParams{}
@@ -71,16 +74,21 @@ func (o *PutProjectProjectNameStageStageNameResourceParams) BindRequest(r *http.
 				res = append(res, err)
 			}
 
+			ctx := validate.WithOperationRequest(context.Background())
+			if err := body.ContextValidate(ctx, route.Formats); err != nil {
+				res = append(res, err)
+			}
+
 			if len(res) == 0 {
 				o.Resources = body
 			}
 		}
 	}
+
 	rStageName, rhkStageName, _ := route.Params.GetOK("stageName")
 	if err := o.bindStageName(rStageName, rhkStageName, route.Formats); err != nil {
 		res = append(res, err)
 	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -96,7 +104,6 @@ func (o *PutProjectProjectNameStageStageNameResourceParams) bindProjectName(rawD
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ProjectName = raw
 
 	return nil
@@ -111,7 +118,6 @@ func (o *PutProjectProjectNameStageStageNameResourceParams) bindStageName(rawDat
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.StageName = raw
 
 	return nil

--- a/configuration-service/restapi/operations/stage_resource/put_project_project_name_stage_stage_name_resource_resource_uri.go
+++ b/configuration-service/restapi/operations/stage_resource/put_project_project_name_stage_stage_name_resource_resource_uri.go
@@ -29,7 +29,7 @@ func NewPutProjectProjectNameStageStageNameResourceResourceURI(ctx *middleware.C
 	return &PutProjectProjectNameStageStageNameResourceResourceURI{Context: ctx, Handler: handler}
 }
 
-/*PutProjectProjectNameStageStageNameResourceResourceURI swagger:route PUT /project/{projectName}/stage/{stageName}/resource/{resourceURI} Stage Resource putProjectProjectNameStageStageNameResourceResourceUri
+/* PutProjectProjectNameStageStageNameResourceResourceURI swagger:route PUT /project/{projectName}/stage/{stageName}/resource/{resourceURI} Stage Resource putProjectProjectNameStageStageNameResourceResourceUri
 
 Update the specified resource
 
@@ -42,17 +42,15 @@ type PutProjectProjectNameStageStageNameResourceResourceURI struct {
 func (o *PutProjectProjectNameStageStageNameResourceResourceURI) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewPutProjectProjectNameStageStageNameResourceResourceURIParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/configuration-service/restapi/operations/stage_resource/put_project_project_name_stage_stage_name_resource_resource_uri_parameters.go
+++ b/configuration-service/restapi/operations/stage_resource/put_project_project_name_stage_stage_name_resource_resource_uri_parameters.go
@@ -6,18 +6,21 @@ package stage_resource
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/validate"
 
 	"github.com/keptn/keptn/configuration-service/models"
 )
 
 // NewPutProjectProjectNameStageStageNameResourceResourceURIParams creates a new PutProjectProjectNameStageStageNameResourceResourceURIParams object
-// no default values defined in spec.
+//
+// There are no default values defined in the spec.
 func NewPutProjectProjectNameStageStageNameResourceResourceURIParams() PutProjectProjectNameStageStageNameResourceResourceURIParams {
 
 	return PutProjectProjectNameStageStageNameResourceResourceURIParams{}
@@ -78,11 +81,17 @@ func (o *PutProjectProjectNameStageStageNameResourceResourceURIParams) BindReque
 				res = append(res, err)
 			}
 
+			ctx := validate.WithOperationRequest(context.Background())
+			if err := body.ContextValidate(ctx, route.Formats); err != nil {
+				res = append(res, err)
+			}
+
 			if len(res) == 0 {
 				o.Resource = &body
 			}
 		}
 	}
+
 	rResourceURI, rhkResourceURI, _ := route.Params.GetOK("resourceURI")
 	if err := o.bindResourceURI(rResourceURI, rhkResourceURI, route.Formats); err != nil {
 		res = append(res, err)
@@ -92,7 +101,6 @@ func (o *PutProjectProjectNameStageStageNameResourceResourceURIParams) BindReque
 	if err := o.bindStageName(rStageName, rhkStageName, route.Formats); err != nil {
 		res = append(res, err)
 	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -108,7 +116,6 @@ func (o *PutProjectProjectNameStageStageNameResourceResourceURIParams) bindProje
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ProjectName = raw
 
 	return nil
@@ -123,7 +130,6 @@ func (o *PutProjectProjectNameStageStageNameResourceResourceURIParams) bindResou
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.ResourceURI = raw
 
 	return nil
@@ -138,7 +144,6 @@ func (o *PutProjectProjectNameStageStageNameResourceResourceURIParams) bindStage
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.StageName = raw
 
 	return nil

--- a/configuration-service/swagger.yaml
+++ b/configuration-service/swagger.yaml
@@ -773,7 +773,6 @@ paths:
       tags:
         - Service Default Resource 
       summary: Create list of default resources for the service used in all stages
-      deprecated: true
       parameters:
         - $ref: '#/parameters/resources' 
       responses:
@@ -797,6 +796,7 @@ paths:
         - $ref: '#/parameters/nextPageKey'
         - $ref: '#/parameters/disableUpstreamSync'
       summary: Get list of default resources for the service used in all stages
+      deprecated: true
       responses:
         '200':
           description: Success
@@ -816,6 +816,7 @@ paths:
       parameters:
         - $ref: '#/parameters/resources'
       summary: Update list of service default resources
+      deprecated: true
       responses:
         '201':
           description: Success. Service default resources have been updated. The version of the new configuration is returned.
@@ -859,6 +860,7 @@ paths:
       tags:
         - Service Default Resource
       summary: Update the specified default resource for the service
+      deprecated: true
       parameters:
         - $ref: '#/parameters/resource'
       responses:
@@ -878,6 +880,7 @@ paths:
       tags:
         - Service Default Resource
       summary: Delete the specified default resource for the service
+      deprecated: true
       responses:
         '204':
           description: Success. Service default resource has been deleted.

--- a/configuration-service/swagger.yaml
+++ b/configuration-service/swagger.yaml
@@ -773,6 +773,7 @@ paths:
       tags:
         - Service Default Resource 
       summary: Create list of default resources for the service used in all stages
+      deprecated: true
       parameters:
         - $ref: '#/parameters/resources' 
       responses:
@@ -838,6 +839,7 @@ paths:
       tags:
         - Service Default Resource
       summary: Get the specified default resource for the service
+      deprecated: true
       parameters:
         - $ref: '#/parameters/disableUpstreamSync'
       responses:


### PR DESCRIPTION
closes #5210 

I marked **all** endpoints dealing with default resources as deprecated.
Pls double check if this is OK.

Note: the only relevant file for this PR is `swagger.yaml`, as the rest is generated from it.