### PR TITLE
feat(bridge): Make session cookie timeout configurable and set default value to 60 minutes

### DIFF
--- a/bridge/package-lock.json
+++ b/bridge/package-lock.json
@@ -21513,12 +21513,12 @@
               },
               "dependencies": {
                 "is-glob": {
-                  "version": "3.1.0",
-                  "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-                  "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                  "version": "4.0.3",
+                  "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+                  "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
                   "dev": true,
                   "requires": {
-                    "is-extglob": "^2.1.0"
+                    "is-extglob": "^2.1.1"
                   }
                 }
               }

--- a/bridge/server/user/session.ts
+++ b/bridge/server/user/session.ts
@@ -13,7 +13,7 @@ declare module 'express-session' {
 const memoryStore = mS(expressSession);
 const router = Router();
 const CHECK_PERIOD = 600_000; // check every 10 minutes
-const SESSION_TIME = 1_200_000; // max age is 20 minutes
+const SESSION_TIME = getOrDefaultSessionTimeout(3_600_000); // session timeout, default to 60 minutes
 const COOKIE_LENGTH = 10;
 const COOKIE_NAME = 'KTSESSION';
 const DEFAULT_TRUST_PROXY = 1;
@@ -104,7 +104,7 @@ function removeSession(req: Request): void {
 }
 
 function sessionRouter(app: Express): Router {
-  console.log('Enabling sessions for bridge.');
+  console.log(`Enabling sessions for bridge with session timeout ${SESSION_TIME}ms.`);
 
   if (process.env.SECURE_COOKIE === 'true') {
     console.log('Setting secure cookies. Make sure SSL is enabled for deployment & correct trust proxy value is used.');
@@ -125,6 +125,22 @@ function sessionRouter(app: Express): Router {
   router.use(expressSession(sessionConfig));
 
   return router;
+}
+
+/**
+ * Function to determine session timeout. Value must be in milliseconds and can be configurable through environment
+ * variable SESSION_TIMEOUT_MS. If the configuration is invalid, fallback to provided default value.
+ */
+function getOrDefaultSessionTimeout(def: number): number {
+  if (process.env.SESSION_TIMEOUT_MS) {
+    const sTimeout = parseInt(process.env.SESSION_TIMEOUT_MS, 10);
+
+    if (!isNaN(sTimeout) && sTimeout > 0) {
+      return sTimeout;
+    }
+  }
+
+  return def;
 }
 
 export { sessionRouter };

--- a/bridge/server/user/session.ts
+++ b/bridge/server/user/session.ts
@@ -13,11 +13,11 @@ declare module 'express-session' {
 const memoryStore = mS(expressSession);
 const router = Router();
 const CHECK_PERIOD = 600_000; // check every 10 minutes
-const SESSION_TIME = getOrDefaultSessionTimeout(3_600_000); // session timeout, default to 60 minutes
+const SESSION_TIME = getOrDefaultSessionTimeout(60); // session timeout, default to 60 minutes
 const COOKIE_LENGTH = 10;
 const COOKIE_NAME = 'KTSESSION';
 const DEFAULT_TRUST_PROXY = 1;
-const SESSION_SECRET = random({ length: 200 });
+const SESSION_SECRET = random({length: 200});
 
 /**
  * Uses a session cookie backed by in-memory cookies store.
@@ -35,7 +35,7 @@ const sessionConfig = {
   secret: SESSION_SECRET,
   resave: false,
   saveUninitialized: false,
-  genid: (): string => random({ length: COOKIE_LENGTH, type: 'url-safe' }),
+  genid: (): string => random({length: COOKIE_LENGTH, type: 'url-safe'}),
   store: new memoryStore({
     checkPeriod: CHECK_PERIOD,
     ttl: SESSION_TIME,
@@ -128,19 +128,20 @@ function sessionRouter(app: Express): Router {
 }
 
 /**
- * Function to determine session timeout. Value must be in milliseconds and can be configurable through environment
- * variable SESSION_TIMEOUT_MS. If the configuration is invalid, fallback to provided default value.
+ * Function to determine session timeout. Input value is in minutes and return value is in millisecond. Value can be
+ * configurable through environment variable SESSION_TIMEOUT_MIN. If the configuration is invalid, fallback to
+ * provided default value.
  */
-function getOrDefaultSessionTimeout(def: number): number {
-  if (process.env.SESSION_TIMEOUT_MS) {
-    const sTimeout = parseInt(process.env.SESSION_TIMEOUT_MS, 10);
+function getOrDefaultSessionTimeout(defMinutes: number): number {
+  if (process.env.SESSION_TIMEOUT_MIN) {
+    const sTimeout = parseInt(process.env.SESSION_TIMEOUT_MIN, 10);
 
     if (!isNaN(sTimeout) && sTimeout > 0) {
-      return sTimeout;
+      return sTimeout * 60 * 1000;
     }
   }
 
-  return def;
+  return defMinutes * 60 * 1000;
 }
 
 export { sessionRouter };

--- a/bridge/server/user/session.ts
+++ b/bridge/server/user/session.ts
@@ -17,7 +17,7 @@ const SESSION_TIME = getOrDefaultSessionTimeout(60); // session timeout, default
 const COOKIE_LENGTH = 10;
 const COOKIE_NAME = 'KTSESSION';
 const DEFAULT_TRUST_PROXY = 1;
-const SESSION_SECRET = random({length: 200});
+const SESSION_SECRET = random({ length: 200 });
 
 /**
  * Uses a session cookie backed by in-memory cookies store.
@@ -35,7 +35,7 @@ const sessionConfig = {
   secret: SESSION_SECRET,
   resave: false,
   saveUninitialized: false,
-  genid: (): string => random({length: COOKIE_LENGTH, type: 'url-safe'}),
+  genid: (): string => random({ length: COOKIE_LENGTH, type: 'url-safe' }),
   store: new memoryStore({
     checkPeriod: CHECK_PERIOD,
     ttl: SESSION_TIME,

--- a/installer/manifests/keptn/charts/control-plane/templates/core.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/core.yaml
@@ -230,9 +230,9 @@ spec:
               value: "{{ .Values.bridge.oauth.discovery }}"
             - name: SECURE_COOKIE
               value: "{{ .Values.bridge.oauth.secureCookie }}"
-            # Session cookie timeout in milliseconds
-            - name: SESSION_TIMEOUT_MS
-              value: "{{ .Values.bridge.oauth.sessionTimeoutMS}}"
+            # Session cookie timeout in minutes
+            - name: SESSION_TIMEOUT_MIN
+              value: "{{ .Values.bridge.oauth.sessionTimeoutMin}}"
             # Correlates to trust proxy number of hops as defined at http://expressjs.com/en/guide/behind-proxies.html
             - name: TRUST_PROXY
               value: "{{ .Values.bridge.oauth.trustProxy }}"

--- a/installer/manifests/keptn/charts/control-plane/templates/core.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/core.yaml
@@ -230,6 +230,9 @@ spec:
               value: "{{ .Values.bridge.oauth.discovery }}"
             - name: SECURE_COOKIE
               value: "{{ .Values.bridge.oauth.secureCookie }}"
+            # Session cookie timeout in milliseconds
+            - name: SESSION_TIMEOUT_MS
+              value: "{{ .Values.bridge.oauth.sessionTimeoutMS}}"
             # Correlates to trust proxy number of hops as defined at http://expressjs.com/en/guide/behind-proxies.html
             - name: TRUST_PROXY
               value: "{{ .Values.bridge.oauth.trustProxy }}"

--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -59,7 +59,7 @@ bridge:
     discovery: ""
     secureCookie: false
     trustProxy: ""
-    sessionTimeoutMS: ""
+    sessionTimeoutMin: ""
 
 distributor:
   metadata:

--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -59,6 +59,7 @@ bridge:
     discovery: ""
     secureCookie: false
     trustProxy: ""
+    sessionTimeoutMS: ""
 
 distributor:
   metadata:


### PR DESCRIPTION
## This PR
Fixes #5449

PR improves the configurability of OAuth session cookie timeout. Further, it increases the default timeout to 60mnts in code level.

Installer argument `SESSION_TIMEOUT_MS` is set in Helm template.

### Related Issues
 #3448

### How to test
If #3448 fulfilling OAuth provider is present for Bridge, this can be tested easily.  Timeout can be configured by using env. variable `SESSION_TIMEOUT_MS`, then validate the console output for correct value extraction and verify session timeouts in Bridge. 

Note - refactored method signatures in `session.ts` to improve code quality. 