### PR TITLE
feat: customize image registry

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -75,3 +75,4 @@ For a realtime overview of current contributors to the Keptn project, we refer t
 * [Kolla](https://github.com/krkolla)
 * [Alasdair Patton](https://github.com/alipatton10)
 * [Brad McCoy](https://github.com/bradmccoydev)
+* [Luis Marsano](https://github.com/lmmarsano)

--- a/helm-service/chart/README.md
+++ b/helm-service/chart/README.md
@@ -11,14 +11,18 @@ The following table lists the configurable parameters of the Helm-service chart 
 
 | Parameter                | Description             | Default        |
 | ------------------------ | ----------------------- | -------------- |
-| `helmservice.image.repository` | Container image name | `"docker.io/keptn/helm-service"` |
+| `global.imagePullSecrets` | An array of image registry secrets | `[]` |
+| `global.imageRegistry` | Registry where all images are located |  |
+| `helmservice.image.registry` | Registry where the image is located |  |
+| `helmservice.image.repository` | Container image name | `"keptn/helm-service"` |
 | `helmservice.image.pullPolicy` | Kubernetes image pull policy | `"IfNotPresent"` |
 | `helmservice.image.tag` | Container tag | `""` |
 | `helmservice.service.enabled` | Creates a kubernetes service for the helm-service | `true` |
 | `distributor.stageFilter` | Sets the stage this helm service belongs to | `""` |
 | `distributor.serviceFilter` | Sets the service this helm service belongs to | `""` |
 | `distributor.projectFilter` | Sets the project this helm service belongs to | `""` |
-| `distributor.image.repository` | Container image name | `"docker.io/keptn/distributor"` |
+| `distributor.image.registry` | Registry where the image is located |  |
+| `distributor.image.repository` | Container image name | `"keptn/distributor"` |
 | `distributor.image.pullPolicy` | Kubernetes image pull policy | `"IfNotPresent"` |
 | `distributor.image.tag` | Container tag | `""` |
 | `remoteControlPlane.enabled` | Enables remote execution plane mode | `false` |

--- a/helm-service/chart/templates/_helpers.tpl
+++ b/helm-service/chart/templates/_helpers.tpl
@@ -61,3 +61,90 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Return the proper image name
+{{ dict "imageRoot" .Values.path.to.the.image "context" $ | include "helm-service.images.image" }}
+*/}}
+{{- define "helm-service.images.image" -}}
+  {{- $global := .context.Values.global -}}
+  {{- $registryName := .imageRoot.registry -}}
+  {{- $repositoryName := .imageRoot.repository -}}
+  {{- $tag := default .context.Chart.AppVersion .imageRoot.tag | toString -}}
+  {{- if and (not $registryName) $global }}
+    {{- if $global.imageRegistry }}
+       {{- $registryName = $global.imageRegistry -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if $registryName }}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+  {{- else -}}
+    {{- printf "%s:%s" $repositoryName $tag -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names evaluating values as templates
+{{ list .Values.path.to.the.image1 .Values.path.to.the.image2 | dict "context" $ "images" | include "helm-service.images.renderPullSecrets" }}
+*/}}
+{{- define "helm-service.images.renderPullSecrets" -}}
+  {{- $pullSecrets := list }}
+  {{- $context := .context }}
+
+  {{- if $context.Values.global }}
+    {{- range $context.Values.global.imagePullSecrets -}}
+      {{- $pullSecrets = dict "value" . "context" $context | include "helm-service.tplvalues.render" | append $pullSecrets -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- range .images -}}
+    {{- range .pullSecrets -}}
+      {{- $pullSecrets = dict "value" . "context" $context | include "helm-service.tplvalues.render" | append $pullSecrets -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if empty $pullSecrets | not -}}
+imagePullSecrets:
+    {{- range $pullSecrets }}
+- name: {{ . }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{/*
+Renders a value that contains template.
+Usage:
+{{ dict "value" .Values.path.to.the.Value "context" $ | include "helm-service.tplvalues.render" }}
+*/}}
+{{- define "helm-service.tplvalues.render" -}}
+  {{- if typeIs "string" .value }}
+    {{- tpl .value .context }}
+  {{- else }}
+    {{- tpl (toYaml .value) .context }}
+  {{- end }}
+{{- end }}
+
+{{/*
+Return the image name.
+Usage:
+{{ dict "space" .Values.imageNameSpace "context" $ | include "helm-service.image.name" }}
+*/}}
+{{- define "helm-service.image.name" }}
+{{- dict "imageRoot" .space.image "context" .context | include "helm-service.images.image" }}
+{{- end }}
+
+{{/*
+Return the proper Docker Image Registry Secret Names.
+Usage:
+{{ list .Values.imageNameSpace0 .Values.imageNameSpace1 | dict "context" $ "indent" $number "bases" | include "helm-service.image.pullSecrets" }}
+*/}}
+{{- define "helm-service.image.pullSecrets" }}
+{{- $images := list }}
+{{- range .bases }}
+  {{- $images = append $images .image }}
+{{- end }}
+{{- $content := dict "images" $images "context" .context | include "helm-service.images.renderPullSecrets" }}
+{{- if $content }}
+  {{- nindent .indent $content }}
+{{- end }}
+{{- end }}

--- a/helm-service/chart/templates/deployment.yaml
+++ b/helm-service/chart/templates/deployment.yaml
@@ -19,10 +19,7 @@ spec:
       labels:
         {{- include "helm-service.labels" . | nindent 8 }}
     spec:
-      {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- list .Values.helmservice .Values.distributor | dict "context" . "indent" 6 "bases" | include "helm-service.image.pullSecrets" }}
       serviceAccountName: {{ include "helm-service.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
@@ -33,8 +30,8 @@ spec:
           {{- if .Values.image }}
           image: {{ .Values.image }} # use image from .Values.image (e.g., when starting via skaffold)
           {{- else }}
-          image: "{{ .Values.helmservice.image.repository }}:{{ .Values.helmservice.image.tag | default .Chart.AppVersion }}"
-          {{ end }}
+          image: {{ dict "space" .Values.helmservice "context" . | include "helm-service.image.name" }}
+          {{- end }}
           imagePullPolicy: {{ .Values.helmservice.image.pullPolicy }}
           ports:
             - containerPort: 80
@@ -92,7 +89,7 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
         - name: distributor
-          image: "{{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}"
+          image: {{ dict "space" .Values.distributor "context" . | include "helm-service.image.name" }}
           livenessProbe:
             httpGet:
               path: /health

--- a/helm-service/chart/values.schema.json
+++ b/helm-service/chart/values.schema.json
@@ -1,6 +1,50 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
+  "definitions": {
+    "dnsSubdomainName": {
+      "pattern": "^([a-z0-9]|[a-z0-9][a-z0-9-.]{0,251}[a-z0-9])$"
+    },
+    "hostname": {
+      "pattern": "^(([a-z0-9]|[a-z0-9][a-z0-9-.]{0,251}[a-z0-9])(:[0-9]+)?)$"
+    },
+    "image": {
+      "properties": {
+        "registry": {
+          "$ref": "#/definitions/hostname"
+        },
+        "repository": {
+          "pattern": "^([a-z0-9][a-z0-9-.]{2,63})(:[0-9]+)?([a-z0-9-./]{1,128})$"
+        },
+        "pullPolicy": {
+          "enum": [
+            "IfNotPresent",
+            "Always"
+          ]
+        },
+        "pullSecrets": {
+          "$ref": "#/definitions/pullSecrets"
+        }
+      }
+    },
+    "pullSecrets": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/dnsSubdomainName"
+      }
+    }
+  },
   "properties": {
+    "global": {
+      "type": "object",
+      "properties": {
+        "imagePullSecrets": {
+          "$ref": "#/definitions/pullSecrets"
+        },
+        "registry": {
+          "$ref": "#/definitions/hostname"
+        }
+      }
+    },
     "remoteControlPlane": {
       "type": "object",
       "required": [
@@ -29,7 +73,7 @@
             ],
             "properties": {
               "hostname": {
-                "pattern": "^([a-z0-9][a-z0-9-.]{2,63})(:[0-9]+)?$"
+                "$ref": "#/definitions/hostname"
               },
               "protocol": {
                 "enum": [
@@ -55,17 +99,7 @@
       ],
       "properties": {
         "image": {
-          "properties": {
-            "repository": {
-              "pattern": "^([a-z0-9][a-z0-9-.]{2,63})(:[0-9]+)?([a-z0-9-./]{1,128})$"
-            },
-            "pullPolicy": {
-              "enum": [
-                "IfNotPresent",
-                "Always"
-              ]
-            }
-          }
+          "$ref": "#/definitions/image"
         },
         "service": {
           "properties": {
@@ -83,17 +117,7 @@
       ],
       "properties": {
         "image": {
-          "properties": {
-            "repository": {
-              "pattern": "^([a-z0-9][a-z0-9-.]{2,63})(:[0-9]+)?([a-z0-9-./]{1,128})$"
-            },
-            "pullPolicy": {
-              "enum": [
-                "IfNotPresent",
-                "Always"
-              ]
-            }
-          }
+          "$ref": "#/definitions/image"
         },
         "stageFilter": {
           "pattern": "^$|[A-Za-z0-9-.]{2,63}$"

--- a/helm-service/chart/values.schema.json
+++ b/helm-service/chart/values.schema.json
@@ -40,7 +40,7 @@
         "imagePullSecrets": {
           "$ref": "#/definitions/pullSecrets"
         },
-        "registry": {
+        "imageRegistry": {
           "$ref": "#/definitions/hostname"
         }
       }

--- a/helm-service/chart/values.yaml
+++ b/helm-service/chart/values.yaml
@@ -1,6 +1,10 @@
+global:
+  imagePullSecrets: []                         # Secrets to use for container registry credentials
+
 helmservice:
   image:
-    repository: docker.io/keptn/helm-service # Container Image Name
+    registry: docker.io
+    repository: keptn/helm-service # Container Image Name
     pullPolicy: IfNotPresent                 # Kubernetes Image Pull Policy
     tag: ""                                  # Container Tag
   service:
@@ -11,7 +15,8 @@ distributor:
   serviceFilter: ""                          # Sets the service this helm service belongs to
   projectFilter: ""                          # Sets the project this helm service belongs to
   image:
-    repository: docker.io/keptn/distributor  # Container Image Name
+    registry: docker.io
+    repository: keptn/distributor  # Container Image Name
     pullPolicy: IfNotPresent                 # Kubernetes Image Pull Policy
     tag: ""                                  # Container Tag
 
@@ -22,8 +27,6 @@ remoteControlPlane:
     hostname: ""                             # Hostname of the control plane cluster (and Port)
     apiValidateTls: true                     # Defines if the control plane certificate should be validated
     token: ""                                # Keptn API Token
-
-imagePullSecrets: []                         # Secrets to use for container registry credentials
 
 serviceAccount:
   create: true                               # Enables the service account creation

--- a/helm-service/chart/values.yaml
+++ b/helm-service/chart/values.yaml
@@ -3,7 +3,6 @@ global:
 
 helmservice:
   image:
-    registry: docker.io
     repository: keptn/helm-service # Container Image Name
     pullPolicy: IfNotPresent                 # Kubernetes Image Pull Policy
     tag: ""                                  # Container Tag
@@ -15,7 +14,6 @@ distributor:
   serviceFilter: ""                          # Sets the service this helm service belongs to
   projectFilter: ""                          # Sets the project this helm service belongs to
   image:
-    registry: docker.io
     repository: keptn/distributor  # Container Image Name
     pullPolicy: IfNotPresent                 # Kubernetes Image Pull Policy
     tag: ""                                  # Container Tag

--- a/installer/airgapped/install_keptn.sh
+++ b/installer/airgapped/install_keptn.sh
@@ -11,6 +11,10 @@ KEPTN_HELM_CHART=${2}
 KEPTN_HELM_SERVICE_HELM_CHART=${3}
 KEPTN_JMETER_SERVICE_HELM_CHART=${4}
 
+if [[ $TARGET_INTERNAL_DOCKER_REGISTRY ]]
+then GLOBAL_IMAGE_REGISTRY="global.imageRegistry=${TARGET_INTERNAL_DOCKER_REGISTRY%/},"
+else GLOBAL_IMAGE_REGISTRY=
+fi
 KEPTN_NAMESPACE=${KEPTN_NAMESPACE:-"keptn"}
 KEPTN_SERVICE_TYPE=${KEPTN_SERVICE_TYPE:-"ClusterIP"}
 
@@ -22,25 +26,25 @@ kubectl create namespace "${KEPTN_NAMESPACE}"
 
 helm upgrade keptn "${KEPTN_HELM_CHART}" --install --create-namespace -n "${KEPTN_NAMESPACE}" --wait \
 --set="control-plane.apiGatewayNginx.type=${KEPTN_SERVICE_TYPE},continuous-delivery.enabled=true,\
-control-plane.mongo.image.registry=${TARGET_INTERNAL_DOCKER_REGISTRY%/},\
+${GLOBAL_IMAGE_REGISTRY}\
 control-plane.nats.nats.image=${TARGET_INTERNAL_DOCKER_REGISTRY}nats:2.1.9-alpine3.12,\
 control-plane.nats.reloader.image=${TARGET_INTERNAL_DOCKER_REGISTRY}connecteverything/nats-server-config-reloader:0.6.0,\
 control-plane.nats.exporter.image=${TARGET_INTERNAL_DOCKER_REGISTRY}synadia/prometheus-nats-exporter:0.5.0,\
-control-plane.apiGatewayNginx.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}nginxinc/nginx-unprivileged,\
+control-plane.apiGatewayNginx.image.repository=nginxinc/nginx-unprivileged,\
 control-plane.apiGatewayNginx.image.tag=1.21.3-alpine,\
-control-plane.remediationService.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/remediation-service,\
-control-plane.apiService.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/api,\
-control-plane.bridge.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/bridge2,\
-control-plane.distributor.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/distributor,\
-control-plane.shipyardController.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/shipyard-controller,\
-control-plane.configurationService.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/configuration-service,\
-control-plane.mongodbDatastore.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/mongodb-datastore,\
-control-plane.statisticsService.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/statistics-service,\
-control-plane.lighthouseService.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/lighthouse-service,\
-control-plane.secretService.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/secret-service,\
-control-plane.approvalService.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/approval-service,\
-control-plane.webhookService.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/webhook-service,\
-continuous-delivery.distributor.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/distributor"
+control-plane.remediationService.image.repository=keptn/remediation-service,\
+control-plane.apiService.image.repository=keptn/api,\
+control-plane.bridge.image.repository=keptn/bridge2,\
+control-plane.distributor.image.repository=keptn/distributor,\
+control-plane.shipyardController.image.repository=keptn/shipyard-controller,\
+control-plane.configurationService.image.repository=keptn/configuration-service,\
+control-plane.mongodbDatastore.image.repository=keptn/mongodb-datastore,\
+control-plane.statisticsService.image.repository=keptn/statistics-service,\
+control-plane.lighthouseService.image.repository=keptn/lighthouse-service,\
+control-plane.secretService.image.repository=keptn/secret-service,\
+control-plane.approvalService.image.repository=keptn/approval-service,\
+control-plane.webhookService.image.repository=keptn/webhook-service,\
+continuous-delivery.distributor.image.repository=keptn/distributor"
 
 if [[ $? -ne 0 ]]; then
   echo "Installing Keptn failed."
@@ -54,8 +58,9 @@ echo "Installing Keptn Helm-Service Helm Chart in Namespace ${KEPTN_NAMESPACE}"
 echo "-----------------------------------------------------------------------"
 
 helm upgrade helm-service "${KEPTN_HELM_SERVICE_HELM_CHART}" --install -n "${KEPTN_NAMESPACE}" \
---set="helmservice.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/helm-service,\
-distributor.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/distributor"
+--set="${GLOBAL_IMAGE_REGISTRY}\
+helmservice.image.repository=keptn/helm-service,\
+distributor.image.repository=keptn/distributor"
 
 if [[ $? -ne 0 ]]; then
   echo "Installing helm-service failed."
@@ -69,8 +74,9 @@ echo "Installing Keptn JMeter-Service Helm Chart in Namespace ${KEPTN_NAMESPACE}
 echo "-----------------------------------------------------------------------"
 
 helm upgrade jmeter-service "${KEPTN_JMETER_SERVICE_HELM_CHART}" --install -n "${KEPTN_NAMESPACE}" \
---set="jmeterservice.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/jmeter-service,\
-distributor.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/distributor"
+--set="${GLOBAL_IMAGE_REGISTRY}\
+jmeterservice.image.repository=keptn/jmeter-service,\
+distributor.image.repository=keptn/distributor"
 
 if [[ $? -ne 0 ]]; then
   echo "Installing jmeter-service failed."

--- a/installer/manifests/keptn/charts/continuous-delivery/charts/openshift/templates/route-service-openshift.yaml
+++ b/installer/manifests/keptn/charts/continuous-delivery/charts/openshift/templates/route-service-openshift.yaml
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "openshift.name" . }}
-    helm.sh/chart: {{ include "openshift.chart" . }}   
+    helm.sh/chart: {{ include "openshift.chart" . }}
 rules:
   - apiGroups:
       - ""
@@ -45,7 +45,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "openshift.name" . }}
-    helm.sh/chart: {{ include "openshift.chart" . }}   
+    helm.sh/chart: {{ include "openshift.chart" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -66,7 +66,7 @@ metadata:
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "openshift.name" . }}
     app.kubernetes.io/version: {{ .Values.openshiftRouteService.image.tag | default .Chart.AppVersion }}
-    helm.sh/chart: {{ include "openshift.chart" . }}     
+    helm.sh/chart: {{ include "openshift.chart" . }}
 spec:
   selector:
     matchLabels:
@@ -82,11 +82,12 @@ spec:
         app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
         app.kubernetes.io/component: {{ include "openshift.name" . }}
         app.kubernetes.io/version: {{ .Values.openshiftRouteService.image.tag | default .Chart.AppVersion }}
-        helm.sh/chart: {{ include "openshift.chart" . }}        
+        helm.sh/chart: {{ include "openshift.chart" . }}
     spec:
+      {{- list .Values.openshiftRouteService .Values.distributor | dict "context" . "indent" 6 "bases" | include "keptn.image.pullSecrets" }}
       containers:
       - name: openshift-route-service
-        image: {{ .Values.openshiftRouteService.image.repository }}:{{ .Values.openshiftRouteService.image.tag | default .Chart.AppVersion }}
+        image: {{ dict "space" .Values.openshiftRouteService "context" . | include "keptn.image.name" }}
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -98,7 +99,7 @@ spec:
             memory: "128Mi"
             cpu: "200m"
       - name: distributor
-        image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
+        image: {{ include "keptn.distributor.imageName" . }}
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 8080
@@ -123,7 +124,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "openshift.name" . }}
-    helm.sh/chart: {{ include "openshift.chart" . }}       
+    helm.sh/chart: {{ include "openshift.chart" . }}
 spec:
   ports:
   - port: 8080

--- a/installer/manifests/keptn/charts/continuous-delivery/charts/openshift/values.yaml
+++ b/installer/manifests/keptn/charts/continuous-delivery/charts/openshift/values.yaml
@@ -1,9 +1,11 @@
 distributor:
   image:
-    repository: docker.io/keptn/distributor
-    tag: ""
+    registry: docker.io
+    repository: keptn/distributor
+    tag: ''
 
 openshiftRouteService:
   image:
-    repository: docker.io/keptn/openshift-route-service
-    tag: ""
+    registry: docker.io
+    repository: keptn/openshift-route-service
+    tag: ''

--- a/installer/manifests/keptn/charts/continuous-delivery/charts/openshift/values.yaml
+++ b/installer/manifests/keptn/charts/continuous-delivery/charts/openshift/values.yaml
@@ -1,11 +1,9 @@
 distributor:
   image:
-    registry: docker.io
     repository: keptn/distributor
     tag: ''
 
 openshiftRouteService:
   image:
-    registry: docker.io
     repository: keptn/openshift-route-service
     tag: ''

--- a/installer/manifests/keptn/charts/control-plane/templates/api-gateway-nginx.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/api-gateway-nginx.yaml
@@ -300,11 +300,12 @@ spec:
       annotations: # add randomizer to restart the deployment if anything changes - see https://github.com/keptn/keptn/issues/3320
         rollme: {{ randAlphaNum 5 | quote }}
     spec:
+      {{- list .Values.apiGatewayNginx | dict "context" . "indent" 6 "bases" | include "keptn.image.pullSecrets" }}
       securityContext:
         fsGroup: 101
       containers:
         - name: api-gateway-nginx
-          image: {{ .Values.apiGatewayNginx.image.repository }}:{{ .Values.apiGatewayNginx.image.tag }}
+          image: {{ dict "space" .Values.apiGatewayNginx "context" . | include "keptn.image.name" }}
           ports:
             - containerPort: 8080
           livenessProbe:
@@ -365,7 +366,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "control-plane.name" . }}
-    helm.sh/chart: {{ include "control-plane.chart" . }}       
+    helm.sh/chart: {{ include "control-plane.chart" . }}
 spec:
   type: {{ .Values.apiGatewayNginx.type }}
   ports:

--- a/installer/manifests/keptn/charts/control-plane/templates/continuous-operations.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/continuous-operations.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "control-plane.name" . }}
     app.kubernetes.io/version: {{ .Values.remediationService.image.tag | default .Chart.AppVersion }}
-    helm.sh/chart: {{ include "control-plane.chart" . }}           
+    helm.sh/chart: {{ include "control-plane.chart" . }}
 spec:
   selector:
     matchLabels:
@@ -27,13 +27,14 @@ spec:
         app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
         app.kubernetes.io/component: {{ include "control-plane.name" . }}
         app.kubernetes.io/version: {{ .Values.remediationService.image.tag | default .Chart.AppVersion }}
-        helm.sh/chart: {{ include "control-plane.chart" . }}                   
+        helm.sh/chart: {{ include "control-plane.chart" . }}
     spec:
+      {{- list .Values.remediationService .Values.distributor | dict "context" . "indent" 6 "bases" | include "keptn.image.pullSecrets" }}
       securityContext:
         fsGroup: 65532
       containers:
       - name: remediation-service
-        image: {{ .Values.remediationService.image.repository }}:{{ .Values.remediationService.image.tag | default .Chart.AppVersion }}
+        image: {{ dict "space" .Values.remediationService "context" . | include "keptn.image.name" }}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -69,7 +70,7 @@ spec:
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
       - name: distributor
-        image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
+        image: {{ include "keptn.distributor.imageName" . }}
         imagePullPolicy: IfNotPresent
         {{- include "control-plane.dist.livenessProbe" . | nindent 8 }}
         {{- include "control-plane.dist.readinessProbe" . | nindent 8 }}
@@ -101,7 +102,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "control-plane.name" . }}
-    helm.sh/chart: {{ include "control-plane.chart" . }}               
+    helm.sh/chart: {{ include "control-plane.chart" . }}
 spec:
   ports:
   - port: 8080
@@ -110,4 +111,3 @@ spec:
   selector:
     app.kubernetes.io/name: remediation-service
     app.kubernetes.io/instance: {{ .Release.Name }}
-

--- a/installer/manifests/keptn/charts/control-plane/templates/core.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/core.yaml
@@ -73,11 +73,12 @@ spec:
         app.kubernetes.io/version: {{ .Values.apiService.image.tag | default .Chart.AppVersion }}
         helm.sh/chart: {{ include "control-plane.chart" . }}
     spec:
+      {{- list .Values.apiService .Values.distributor | dict "context" . "indent" 6 "bases" | include "keptn.image.pullSecrets" }}
       securityContext:
         fsGroup: 65532
       containers:
         - name: api-service
-          image: {{ .Values.apiService.image.repository }}:{{ .Values.apiService.image.tag | default .Chart.AppVersion }}
+          image: {{ dict "space" .Values.apiService "context" . | include "keptn.image.name" }}
           livenessProbe:
             httpGet:
               path: /health
@@ -130,7 +131,7 @@ spec:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
         - name: distributor
-          image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
+          image: {{ include "keptn.distributor.imageName" . }}
           {{- include "control-plane.dist.livenessProbe" . | nindent 10 }}
           {{- include "control-plane.dist.readinessProbe" . | nindent 10 }}
           imagePullPolicy: IfNotPresent
@@ -199,11 +200,12 @@ spec:
         app.kubernetes.io/version: {{ .Values.bridge.image.tag | default .Chart.AppVersion }}
         helm.sh/chart: {{ include "control-plane.chart" . }}
     spec:
+      {{- list .Values.bridge | dict "context" . "indent" 6 "bases" | include "keptn.image.pullSecrets" }}
       securityContext:
         fsGroup: 65532
       containers:
         - name: bridge
-          image: {{ .Values.bridge.image.repository }}:{{ .Values.bridge.image.tag | default .Chart.AppVersion }}
+          image: {{ dict "space" .Values.bridge "context" . | include "keptn.image.name" }}
           imagePullPolicy: IfNotPresent
           env:
             - name: API_URL
@@ -323,12 +325,13 @@ spec:
         app.kubernetes.io/version: {{ .Values.shipyardController.image.tag | default .Chart.AppVersion }}
         helm.sh/chart: {{ include "control-plane.chart" . }}
     spec:
+      {{- list .Values.shipyardController .Values.distributor | dict "context" . "indent" 6 "bases" | include "keptn.image.pullSecrets" }}
       securityContext:
         fsGroup: 65532
       serviceAccountName: keptn-shipyard-controller
       containers:
         - name: shipyard-controller
-          image: {{ .Values.shipyardController.image.repository }}:{{ .Values.shipyardController.image.tag | default .Chart.AppVersion }}
+          image: {{ dict "space" .Values.shipyardController "context" . | include "keptn.image.name" }}
           livenessProbe:
             httpGet:
               path: /health
@@ -392,7 +395,7 @@ spec:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
         - name: distributor
-          image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
+          image: {{ include "keptn.distributor.imageName" . }}
           {{- include "control-plane.dist.livenessProbe" . | nindent 10 }}
           {{- include "control-plane.dist.readinessProbe" . | nindent 10 }}
           imagePullPolicy: IfNotPresent
@@ -499,12 +502,13 @@ spec:
         app.kubernetes.io/version: {{ .Values.secretService.image.tag | default .Chart.AppVersion }}
         helm.sh/chart: {{ include "control-plane.chart" . }}
     spec:
+      {{- list .Values.secretService | dict "context" . "indent" 6 "bases" | include "keptn.image.pullSecrets" }}
       securityContext:
         fsGroup: 65532
       serviceAccountName: keptn-secret-service
       containers:
         - name: secret-service
-          image: {{ .Values.secretService.image.repository }}:{{ .Values.secretService.image.tag | default .Chart.AppVersion }}
+          image: {{ dict "space" .Values.secretService "context" . | include "keptn.image.name" }}
           livenessProbe:
             httpGet:
               path: /health
@@ -621,11 +625,12 @@ spec:
         app.kubernetes.io/version: {{ .Values.configurationService.image.tag | default .Chart.AppVersion }}
         helm.sh/chart: {{ include "control-plane.chart" . }}
     spec:
+      {{- list .Values.configurationService | dict "context" . "indent" 6 "bases" | include "keptn.image.pullSecrets" }}
       securityContext:
         fsGroup: 65532
       initContainers:
       - name: change-user-init
-        image: {{ .Values.configurationService.image.repository }}:{{ .Values.configurationService.image.tag | default .Chart.AppVersion }}
+        image: {{ dict "space" .Values.alpine "context" . | include "keptn.image.name" }}
         securityContext:
           runAsUser: 0
         volumeMounts:
@@ -637,7 +642,7 @@ spec:
           - chown -R 65532 /data/config
       containers:
         - name: configuration-service
-          image: {{ .Values.configurationService.image.repository }}:{{ .Values.configurationService.image.tag | default .Chart.AppVersion }}
+          image: {{ dict "space" .Values.configurationService "context" . | include "keptn.image.name" }}
           livenessProbe:
             httpGet:
               path: /health
@@ -740,12 +745,13 @@ spec:
         app.kubernetes.io/version: {{ .Values.statisticsService.image.tag | default .Chart.AppVersion }}
         helm.sh/chart: {{ include "control-plane.chart" . }}
     spec:
+      {{- list .Values.statisticsService .Values.distributor | dict "context" . "indent" 6 "bases" | include "keptn.image.pullSecrets" }}
       securityContext:
         fsGroup: 65532
       serviceAccountName: keptn-default
       containers:
         - name: statistics-service
-          image: {{ .Values.statisticsService.image.repository }}:{{ .Values.statisticsService.image.tag | default .Chart.AppVersion }}
+          image: {{ dict "space" .Values.statisticsService "context" . | include "keptn.image.name" }}
           livenessProbe:
             httpGet:
               path: /health
@@ -799,7 +805,7 @@ spec:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
         - name: distributor
-          image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
+          image: {{ include "keptn.distributor.imageName" . }}
           {{- include "control-plane.dist.livenessProbe" . | nindent 10 }}
           {{- include "control-plane.dist.readinessProbe" . | nindent 10 }}
           imagePullPolicy: IfNotPresent
@@ -872,12 +878,13 @@ spec:
         app.kubernetes.io/version: {{ .Values.approvalService.image.tag | default .Chart.AppVersion }}
         helm.sh/chart: {{ include "control-plane.chart" . }}
     spec:
+      {{- list .Values.approvalService .Values.distributor | dict "context" . "indent" 6 "bases" | include "keptn.image.pullSecrets" }}
       securityContext:
         fsGroup: 65532
       serviceAccountName: keptn-default
       containers:
         - name: approval-service
-          image: {{ .Values.approvalService.image.repository }}:{{ .Values.approvalService.image.tag | default .Chart.AppVersion }}
+          image: {{ dict "space" .Values.approvalService "context" . | include "keptn.image.name" }}
           livenessProbe:
             httpGet:
               path: /health
@@ -913,7 +920,7 @@ spec:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
         - name: distributor
-          image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
+          image: {{ include "keptn.distributor.imageName" . }}
           {{- include "control-plane.dist.livenessProbe" . | nindent 10 }}
           {{- include "control-plane.dist.readinessProbe" . | nindent 10 }}
           imagePullPolicy: IfNotPresent
@@ -993,7 +1000,7 @@ spec:
       serviceAccountName: keptn-webhook-service
       containers:
         - name: webhook-service
-          image: {{ .Values.webhookService.image.repository }}:{{ .Values.webhookService.image.tag | default .Chart.AppVersion }}
+          image: {{ dict "space" .Values.webhookService "context" . | include "keptn.image.name" }}
           livenessProbe:
             httpGet:
               path: /health
@@ -1029,7 +1036,7 @@ spec:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
         - name: distributor
-          image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
+          image: {{ include "keptn.distributor.imageName" . }}
           {{- include "control-plane.dist.livenessProbe" . | nindent 10 }}
           {{- include "control-plane.dist.readinessProbe" . | nindent 10 }}
           imagePullPolicy: IfNotPresent

--- a/installer/manifests/keptn/charts/control-plane/templates/mongodb-datastore.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/mongodb-datastore.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "control-plane.name" . }}
     app.kubernetes.io/version: {{ .Values.mongodbDatastore.image.tag | default .Chart.AppVersion }}
-    helm.sh/chart: {{ include "control-plane.chart" . }}     
+    helm.sh/chart: {{ include "control-plane.chart" . }}
 spec:
   selector:
     matchLabels:
@@ -28,14 +28,15 @@ spec:
         app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
         app.kubernetes.io/component: {{ include "control-plane.name" . }}
         app.kubernetes.io/version: {{ .Values.mongodbDatastore.image.tag | default .Chart.AppVersion }}
-        helm.sh/chart: {{ include "control-plane.chart" . }}     
+        helm.sh/chart: {{ include "control-plane.chart" . }}
     spec:
+      {{- list .Values.mongodbDatastore .Values.distributor | dict "context" . "indent" 6 "bases" | include "keptn.image.pullSecrets" }}
       securityContext:
         fsGroup: 65532
       serviceAccountName: keptn-default
       containers:
       - name: mongodb-datastore
-        image: {{ .Values.mongodbDatastore.image.repository }}:{{ .Values.mongodbDatastore.image.tag | default .Chart.AppVersion }}
+        image: {{ dict "space" .Values.mongodbDatastore "context" . | include "keptn.image.name" }}
         livenessProbe:
           httpGet:
             path: /health
@@ -89,7 +90,7 @@ spec:
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
       - name: distributor
-        image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
+        image: {{ include "keptn.distributor.imageName" . }}
         {{- include "control-plane.dist.livenessProbe" . | nindent 8 }}
         {{- include "control-plane.dist.readinessProbe" . | nindent 8 }}
         imagePullPolicy: IfNotPresent
@@ -124,7 +125,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "control-plane.name" . }}
-    helm.sh/chart: {{ include "control-plane.chart" . }}         
+    helm.sh/chart: {{ include "control-plane.chart" . }}
 spec:
   ports:
   - port: 8080

--- a/installer/manifests/keptn/charts/control-plane/templates/quality-gates.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/quality-gates.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "control-plane.name" . }}
     app.kubernetes.io/version: {{ .Values.lighthouseService.image.tag | default .Chart.AppVersion }}
-    helm.sh/chart: {{ include "control-plane.chart" . }} 
+    helm.sh/chart: {{ include "control-plane.chart" . }}
 spec:
   selector:
     matchLabels:
@@ -20,20 +20,21 @@ spec:
   replicas: 1
   template:
     metadata:
-      labels:        
+      labels:
         app.kubernetes.io/name: lighthouse-service
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
         app.kubernetes.io/component: {{ include "control-plane.name" . }}
         app.kubernetes.io/version: {{ .Values.lighthouseService.image.tag | default .Chart.AppVersion }}
-        helm.sh/chart: {{ include "control-plane.chart" . }}         
+        helm.sh/chart: {{ include "control-plane.chart" . }}
     spec:
+      {{- list .Values.lighthouseService .Values.distributor | dict "context" . "indent" 6 "bases" | include "keptn.image.pullSecrets" }}
       securityContext:
         fsGroup: 65532
       containers:
         - name: lighthouse-service
-          image: {{ .Values.lighthouseService.image.repository }}:{{ .Values.lighthouseService.image.tag | default .Chart.AppVersion }}
+          image: {{ dict "space" .Values.lighthouseService "context" . | include "keptn.image.name" }}
           livenessProbe:
             httpGet:
               path: /health
@@ -77,7 +78,7 @@ spec:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
         - name: distributor
-          image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
+          image: {{ include "keptn.distributor.imageName" . }}
           {{- include "control-plane.dist.livenessProbe" . | nindent 10 }}
           {{- include "control-plane.dist.readinessProbe" . | nindent 10 }}
           lifecycle:
@@ -116,8 +117,8 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "control-plane.name" . }}    
-    helm.sh/chart: {{ include "control-plane.chart" . }} 
+    app.kubernetes.io/component: {{ include "control-plane.name" . }}
+    helm.sh/chart: {{ include "control-plane.chart" . }}
 spec:
   ports:
     - port: 8080

--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -31,19 +31,16 @@ apiGatewayNginx:
   port: 80
   nodePort: 31090
   image:
-    registry: docker.io
     repository: nginxinc/nginx-unprivileged
     tag: 1.21.3-alpine
 
 remediationService:
   image:
-    registry: docker.io
     repository: keptn/remediation-service
     tag: ''
 
 apiService:
   image:
-    registry: docker.io
     repository: keptn/api
     tag: ''
   config:
@@ -52,7 +49,6 @@ apiService:
 
 bridge:
   image:
-    registry: docker.io
     repository: keptn/bridge2
     tag: ''
   cliDownloadLink:
@@ -77,13 +73,11 @@ distributor:
     hostname:
     namespace:
   image:
-    registry: docker.io
     repository: keptn/distributor
     tag: ''
 
 shipyardController:
   image:
-    registry: docker.io
     repository: keptn/shipyard-controller
     tag: ''
   config:
@@ -92,13 +86,11 @@ shipyardController:
 
 secretService:
   image:
-    registry: docker.io
     repository: keptn/secret-service
     tag: ''
 
 configurationService:
   image:
-    registry: docker.io
     repository: keptn/configuration-service
     tag: ''
   # storage and storageClass are the settings for the PVC used by the configuration-storage
@@ -107,38 +99,32 @@ configurationService:
 
 mongodbDatastore:
   image:
-    registry: docker.io
     repository: keptn/mongodb-datastore
     tag: ''
 
 lighthouseService:
   image:
-    registry: docker.io
     repository: keptn/lighthouse-service
     tag: ''
 
 statisticsService:
   image:
-    registry: docker.io
     repository: keptn/statistics-service
     tag: ''
 
 approvalService:
   image:
-    registry: docker.io
     repository: keptn/approval-service
     tag: ''
 
 webhookService:
   enabled: true
   image:
-    registry: docker.io
     repository: keptn/webhook-service
     tag: ''
 
 alpine:
   image:
-    registry: docker.io
     repository: alpine
     tag: '3.13'
 

--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -15,7 +15,7 @@ mongo:
   external:
     connectionString:
 
-prefixPath: ""
+prefixPath: ''
 
 keptnSpecVersion: latest
 
@@ -31,102 +31,116 @@ apiGatewayNginx:
   port: 80
   nodePort: 31090
   image:
-    repository: docker.io/nginxinc/nginx-unprivileged
+    registry: docker.io
+    repository: nginxinc/nginx-unprivileged
     tag: 1.21.3-alpine
 
 remediationService:
   image:
-    repository: docker.io/keptn/remediation-service
-    tag: ""
+    registry: docker.io
+    repository: keptn/remediation-service
+    tag: ''
 
 apiService:
   image:
-    repository: docker.io/keptn/api
-    tag: ""
+    registry: docker.io
+    repository: keptn/api
+    tag: ''
   config:
-    maxAuthRequestsPerSecond: "1.0"
-    maxAuthRequestBurst: "2"
+    maxAuthRequestsPerSecond: '1.0'
+    maxAuthRequestBurst: '2'
 
 bridge:
   image:
-    repository: docker.io/keptn/bridge2
-    tag: ""
-  cliDownloadLink: null
-  integrationsPageLink: null
+    registry: docker.io
+    repository: keptn/bridge2
+    tag: ''
+  cliDownloadLink:
+  integrationsPageLink:
   secret:
     enabled: true
   versionCheck:
     enabled: true
   showApiToken:
     enabled: true
-  installationType: null
-  lookAndFeelUrl: null
+  installationType:
+  lookAndFeelUrl:
   oauth:
     enabled: false
-    discovery: ""
+    discovery: ''
     secureCookie: false
-    trustProxy: ""
-    sessionTimeoutMin: ""
+    trustProxy: ''
+    sessionTimeoutMin: ''
 
 distributor:
   metadata:
     hostname:
     namespace:
   image:
-    repository: docker.io/keptn/distributor
-    tag: ""
+    registry: docker.io
+    repository: keptn/distributor
+    tag: ''
 
 shipyardController:
   image:
-    repository: docker.io/keptn/shipyard-controller
-    tag: ""
+    registry: docker.io
+    repository: keptn/shipyard-controller
+    tag: ''
   config:
     taskStartedWaitDuration: "10m"
     uniformIntegrationTTL: "48h"
 
 secretService:
   image:
-    repository: docker.io/keptn/secret-service
-    tag: ""
+    registry: docker.io
+    repository: keptn/secret-service
+    tag: ''
 
 configurationService:
   image:
-    repository: docker.io/keptn/configuration-service
-    tag: ""
+    registry: docker.io
+    repository: keptn/configuration-service
+    tag: ''
   # storage and storageClass are the settings for the PVC used by the configuration-storage
   storage: 100Mi
-  storageClass: null
+  storageClass:
 
 mongodbDatastore:
   image:
-    repository: docker.io/keptn/mongodb-datastore
-    tag: ""
+    registry: docker.io
+    repository: keptn/mongodb-datastore
+    tag: ''
 
 lighthouseService:
   image:
-    repository: docker.io/keptn/lighthouse-service
-    tag: ""
+    registry: docker.io
+    repository: keptn/lighthouse-service
+    tag: ''
 
 statisticsService:
   image:
-    repository: docker.io/keptn/statistics-service
-    tag: ""
+    registry: docker.io
+    repository: keptn/statistics-service
+    tag: ''
 
 approvalService:
   image:
-    repository: docker.io/keptn/approval-service
-    tag: ""
+    registry: docker.io
+    repository: keptn/approval-service
+    tag: ''
 
 webhookService:
   enabled: true
   image:
-    repository: docker.io/keptn/webhook-service
-    tag: ""
+    registry: docker.io
+    repository: keptn/webhook-service
+    tag: ''
 
 alpine:
   image:
-    repository: docker.io/alpine
-    tag: "3.13"
+    registry: docker.io
+    repository: alpine
+    tag: '3.13'
 
 ingress:
   enabled: false

--- a/installer/manifests/keptn/templates/_helpers.tpl
+++ b/installer/manifests/keptn/templates/_helpers.tpl
@@ -71,3 +71,99 @@ resources:
     memory: "32Mi"
     cpu: "100m"
 {{- end }}
+
+{{/*
+Return the proper image name
+{{ dict "imageRoot" .Values.path.to.the.image "context" $ | include "keptn.images.image" }}
+*/}}
+{{- define "keptn.images.image" -}}
+  {{- $global := .context.Values.global -}}
+  {{- $registryName := .imageRoot.registry -}}
+  {{- $repositoryName := .imageRoot.repository -}}
+  {{- $tag := default .context.Chart.AppVersion .imageRoot.tag | toString -}}
+  {{- if and (not $registryName) $global }}
+    {{- if $global.imageRegistry }}
+       {{- $registryName = $global.imageRegistry -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if $registryName }}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+  {{- else -}}
+    {{- printf "%s:%s" $repositoryName $tag -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names evaluating values as templates
+{{ list .Values.path.to.the.image1 .Values.path.to.the.image2 | dict "context" $ "images" | include "keptn.images.renderPullSecrets" }}
+*/}}
+{{- define "keptn.images.renderPullSecrets" -}}
+  {{- $pullSecrets := list }}
+  {{- $context := .context }}
+
+  {{- if $context.Values.global }}
+    {{- range $context.Values.global.imagePullSecrets -}}
+      {{- $pullSecrets = dict "value" . "context" $context | include "keptn.tplvalues.render" | append $pullSecrets -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- range .images -}}
+    {{- range .pullSecrets -}}
+      {{- $pullSecrets = dict "value" . "context" $context | include "keptn.tplvalues.render" | append $pullSecrets -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if empty $pullSecrets | not -}}
+imagePullSecrets:
+    {{- range $pullSecrets }}
+- name: {{ . }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{/*
+Renders a value that contains template.
+Usage:
+{{ dict "value" .Values.path.to.the.Value "context" $ | include "keptn.tplvalues.render" }}
+*/}}
+{{- define "keptn.tplvalues.render" -}}
+  {{- if typeIs "string" .value }}
+    {{- tpl .value .context }}
+  {{- else }}
+    {{- tpl (toYaml .value) .context }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Return the image name.
+Usage:
+{{ dict "space" .Values.imageNameSpace "context" $ | include "keptn.image.name" }}
+*/}}
+{{- define "keptn.image.name" }}
+{{- dict "imageRoot" .space.image "context" .context | include "keptn.images.image" }}
+{{- end }}
+
+{{/*
+Return the proper Docker Image Registry Secret Names.
+Usage:
+{{ list .Values.imageNameSpace0 .Values.imageNameSpace1 | dict "context" $ "indent" $number "bases" | include "keptn.image.pullSecrets" }}
+*/}}
+{{- define "keptn.image.pullSecrets" }}
+{{- $images := list }}
+{{- range .bases }}
+  {{- $images = append $images .image }}
+{{- end }}
+{{- $content := dict "images" $images "context" .context | include "keptn.images.renderPullSecrets" }}
+{{- if $content }}
+  {{- nindent .indent $content }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the distributor image name.
+Usage:
+{{ include "keptn.distributor.imageName" $ }}
+*/}}
+{{- define "keptn.distributor.imageName" }}
+{{- dict "space" .Values.distributor "context" . | include "keptn.image.name" }}
+{{- end }}

--- a/jmeter-service/chart/README.md
+++ b/jmeter-service/chart/README.md
@@ -11,14 +11,18 @@ The following table lists the configurable parameters of the Jmeter-service char
 
 | Parameter                | Description             | Default        |
 | ------------------------ | ----------------------- | -------------- |
-| `jmeterservice.image.repository` | Container image name | `"docker.io/keptn/jmeter-service"` |
+| `global.imagePullSecrets` | An array of image registry secrets | `[]` |
+| `global.imageRegistry` | Registry where all images are located |  |
+| `jmeterservice.image.registry` | Registry where the image is located |  |
+| `jmeterservice.image.repository` | Container image name | `"keptn/jmeter-service"` |
 | `jmeterservice.image.pullPolicy` | Kubernetes image pull policy | `"IfNotPresent"` |
 | `jmeterservice.image.tag` | Container tag | `""` |
 | `jmeterservice.service.enabled` | Creates a kubernetes service for the jmeter-service | `true` |
 | `distributor.stageFilter` | Sets the stage this helm service belongs to | `""` |
 | `distributor.serviceFilter` | Sets the service this helm service belongs to | `""` |
 | `distributor.projectFilter` | Sets the project this helm service belongs to | `""` |
-| `distributor.image.repository` | Container image name | `"docker.io/keptn/distributor"` |
+| `distributor.image.registry` | Registry where the image is located |  |
+| `distributor.image.repository` | Container image name | `"keptn/distributor"` |
 | `distributor.image.pullPolicy` | Kubernetes image pull policy | `"IfNotPresent"` |
 | `distributor.image.tag` | Container tag | `""` |
 | `remoteControlPlane.enabled` | Enables remote execution plane mode | `false` |

--- a/jmeter-service/chart/templates/_helpers.tpl
+++ b/jmeter-service/chart/templates/_helpers.tpl
@@ -61,3 +61,90 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Return the proper image name
+{{ dict "imageRoot" .Values.path.to.the.image "context" $ | include "jmeter-service.images.image" }}
+*/}}
+{{- define "jmeter-service.images.image" -}}
+  {{- $global := .context.Values.global -}}
+  {{- $registryName := .imageRoot.registry -}}
+  {{- $repositoryName := .imageRoot.repository -}}
+  {{- $tag := default .context.Chart.AppVersion .imageRoot.tag | toString -}}
+  {{- if and (not $registryName) $global }}
+    {{- if $global.imageRegistry }}
+       {{- $registryName = $global.imageRegistry -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if $registryName }}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+  {{- else -}}
+    {{- printf "%s:%s" $repositoryName $tag -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names evaluating values as templates
+{{ list .Values.path.to.the.image1 .Values.path.to.the.image2 | dict "context" $ "images" | include "jmeter-service.images.renderPullSecrets" }}
+*/}}
+{{- define "jmeter-service.images.renderPullSecrets" -}}
+  {{- $pullSecrets := list }}
+  {{- $context := .context }}
+
+  {{- if $context.Values.global }}
+    {{- range $context.Values.global.imagePullSecrets -}}
+      {{- $pullSecrets = dict "value" . "context" $context | include "jmeter-service.tplvalues.render" | append $pullSecrets -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- range .images -}}
+    {{- range .pullSecrets -}}
+      {{- $pullSecrets = dict "value" . "context" $context | include "jmeter-service.tplvalues.render" | append $pullSecrets -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if empty $pullSecrets | not -}}
+imagePullSecrets:
+    {{- range $pullSecrets }}
+- name: {{ . }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{/*
+Renders a value that contains template.
+Usage:
+{{ dict "value" .Values.path.to.the.Value "context" $ | include "jmeter-service.tplvalues.render" }}
+*/}}
+{{- define "jmeter-service.tplvalues.render" -}}
+  {{- if typeIs "string" .value }}
+    {{- tpl .value .context }}
+  {{- else }}
+    {{- tpl (toYaml .value) .context }}
+  {{- end }}
+{{- end }}
+
+{{/*
+Return the image name.
+Usage:
+{{ dict "space" .Values.imageNameSpace "context" $ | include "jmeter-service.image.name" }}
+*/}}
+{{- define "jmeter-service.image.name" }}
+{{- dict "imageRoot" .space.image "context" .context | include "jmeter-service.images.image" }}
+{{- end }}
+
+{{/*
+Return the proper Docker Image Registry Secret Names.
+Usage:
+{{ list .Values.imageNameSpace0 .Values.imageNameSpace1 | dict "context" $ "indent" $number "bases" | include "jmeter-service.image.pullSecrets" }}
+*/}}
+{{- define "jmeter-service.image.pullSecrets" }}
+{{- $images := list }}
+{{- range .bases }}
+  {{- $images = append $images .image }}
+{{- end }}
+{{- $content := dict "images" $images "context" .context | include "jmeter-service.images.renderPullSecrets" }}
+{{- if $content }}
+  {{- nindent .indent $content }}
+{{- end }}
+{{- end }}

--- a/jmeter-service/chart/templates/deployment.yaml
+++ b/jmeter-service/chart/templates/deployment.yaml
@@ -19,10 +19,7 @@ spec:
       labels:
         {{- include "jmeter-service.labels" . | nindent 8 }}
     spec:
-      {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- list .Values.jmeterservice .Values.distributor | dict "context" . "indent" 6 "bases" | include "jmeter-service.image.pullSecrets" }}
       serviceAccountName: {{ include "jmeter-service.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
@@ -33,7 +30,7 @@ spec:
           {{- if .Values.image }}
           image: {{ .Values.image }} # use image from .Values.image (e.g., when starting via skaffold)
           {{- else }}
-          image: "{{ .Values.jmeterservice.image.repository }}:{{ .Values.jmeterservice.image.tag | default .Chart.AppVersion }}"
+          image: {{ dict "space" .Values.jmeterservice "context" . | include "jmeter-service.image.name" }}
           {{- end }}
           imagePullPolicy: {{ .Values.jmeterservice.image.pullPolicy }}
           ports:
@@ -60,7 +57,7 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
         - name: distributor
-          image: "{{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}"
+          image: {{ dict "space" .Values.distributor "context" . | include "jmeter-service.image.name" }}
           livenessProbe:
             httpGet:
               path: /health

--- a/jmeter-service/chart/values.schema.json
+++ b/jmeter-service/chart/values.schema.json
@@ -1,6 +1,50 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
+  "definitions": {
+    "dnsSubdomainName": {
+      "pattern": "^([a-z0-9]|[a-z0-9][a-z0-9-.]{0,251}[a-z0-9])$"
+    },
+    "hostname": {
+      "pattern": "^(([a-z0-9]|[a-z0-9][a-z0-9-.]{0,251}[a-z0-9])(:[0-9]+)?)$"
+    },
+    "image": {
+      "properties": {
+        "registry": {
+          "$ref": "#/definitions/hostname"
+        },
+        "repository": {
+          "pattern": "^([a-z0-9][a-z0-9-.]{2,63})(:[0-9]+)?([a-z0-9-./]{1,128})$"
+        },
+        "pullPolicy": {
+          "enum": [
+            "IfNotPresent",
+            "Always"
+          ]
+        },
+        "pullSecrets": {
+          "$ref": "#/definitions/pullSecrets"
+        }
+      }
+    },
+    "pullSecrets": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/dnsSubdomainName"
+      }
+    }
+  },
   "properties": {
+    "global": {
+      "type": "object",
+      "properties": {
+        "imagePullSecrets": {
+          "$ref": "#/definitions/pullSecrets"
+        },
+        "imageRegistry": {
+          "$ref": "#/definitions/hostname"
+        }
+      }
+    },
     "remoteControlPlane": {
       "type": "object",
       "required": [
@@ -55,17 +99,7 @@
       ],
       "properties": {
         "image": {
-          "properties": {
-            "repository": {
-              "pattern": "^([a-z0-9][a-z0-9-.]{2,63})(:[0-9]+)?([a-z0-9-./]{1,128})$"
-            },
-            "pullPolicy": {
-              "enum": [
-                "IfNotPresent",
-                "Always"
-              ]
-            }
-          }
+          "$ref": "#/definitions/image"
         },
         "service": {
           "properties": {
@@ -83,17 +117,7 @@
       ],
       "properties": {
         "image": {
-          "properties": {
-            "repository": {
-              "pattern": "^([a-z0-9][a-z0-9-.]{2,63})(:[0-9]+)?([a-z0-9-./]{1,128})$"
-            },
-            "pullPolicy": {
-              "enum": [
-                "IfNotPresent",
-                "Always"
-              ]
-            }
-          }
+          "$ref": "#/definitions/image"
         },
         "stageFilter": {
           "pattern": "^$|[A-Za-z0-9-.]{2,63}$"

--- a/jmeter-service/chart/values.yaml
+++ b/jmeter-service/chart/values.yaml
@@ -1,6 +1,10 @@
+global:
+  imagePullSecrets: []                         # Secrets to use for container registry credentials
+
 jmeterservice:
   image:
-    repository: docker.io/keptn/jmeter-service # Container Image Name
+    registry: docker.io
+    repository: keptn/jmeter-service # Container Image Name
     pullPolicy: IfNotPresent                   # Kubernetes Image Pull Policy
     tag: ""                                    # Container Tag
   service:
@@ -11,7 +15,8 @@ distributor:
   serviceFilter: ""                          # Sets the service this helm service belongs to
   projectFilter: ""                          # Sets the project this helm service belongs to
   image:
-    repository: docker.io/keptn/distributor  # Container Image Name
+    registry: docker.io
+    repository: keptn/distributor  # Container Image Name
     pullPolicy: IfNotPresent                 # Kubernetes Image Pull Policy
     tag: ""                                  # Container Tag
 
@@ -22,8 +27,6 @@ remoteControlPlane:
     hostname: ""                             # Hostname of the control plane cluster (and Port)
     apiValidateTls: true                     # Defines if the control plane certificate should be validated
     token: ""                                # Keptn API Token
-
-imagePullSecrets: []                         # Secrets to use for container registry credentials
 
 serviceAccount:
   create: true                               # Enables the service account creation

--- a/jmeter-service/chart/values.yaml
+++ b/jmeter-service/chart/values.yaml
@@ -3,7 +3,6 @@ global:
 
 jmeterservice:
   image:
-    registry: docker.io
     repository: keptn/jmeter-service # Container Image Name
     pullPolicy: IfNotPresent                   # Kubernetes Image Pull Policy
     tag: ""                                    # Container Tag
@@ -15,7 +14,6 @@ distributor:
   serviceFilter: ""                          # Sets the service this helm service belongs to
   projectFilter: ""                          # Sets the project this helm service belongs to
   image:
-    registry: docker.io
     repository: keptn/distributor  # Container Image Name
     pullPolicy: IfNotPresent                 # Kubernetes Image Pull Policy
     tag: ""                                  # Container Tag


### PR DESCRIPTION
# This PR
allow user to globally customize image pull registry & pull secrets

## Related Issues
closes #4933
fixes #5248

## Notes
follows [bitnami example](https://github.com/bitnami/charts/tree/master/bitnami/common/)
refactoring repetitive code into a [library chart](https://helm.sh/docs/topics/library_charts/) may be warranted