### PR TITLE
fix(shipyard-controller): Reduce log noise for sequence watcher component

### DIFF
--- a/shipyard-controller/handler/sequencewatcher.go
+++ b/shipyard-controller/handler/sequencewatcher.go
@@ -86,7 +86,6 @@ func (sw *SequenceWatcher) cleanUpOrphanedTasksOfProject(project string) error {
 		if err != nil {
 			// events in the .triggered collection were stored in this format previously
 			fallbackTimeFormat := "2006-01-02T15:04:05.000000000Z"
-			log.WithError(err).Errorf("could not parse event timestamp of event with id %s. Trying to parse with format %s", event.ID, fallbackTimeFormat)
 			eventSentTime, err = time.Parse(fallbackTimeFormat, event.Time)
 			if err != nil {
 				log.WithError(err).Errorf("could not parse event timestamp of event with id %s.", event.ID)


### PR DESCRIPTION
The log output of the sequence watcher was getting too verbose when too many events with a time stamp that does not match the default time format are available. To reduce the noise in the logs, an error is now only logged if the timestamp can not be logged at all.