### PR TITLE
fix(installer): readiness liveness probes (#5303)

### DIFF
--- a/approval-service/main.go
+++ b/approval-service/main.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"keptn/approval-service/pkg/handler"
 	"log"
+	"net/http"
 	"os"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/kelseyhightower/envconfig"
 
-	keptnapi "github.com/keptn/go-utils/pkg/api/utils"
 	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 )
@@ -29,7 +29,6 @@ func main() {
 		log.Fatalf("Failed to process env var: %s", err)
 	}
 
-	go keptnapi.RunHealthEndpoint("10998")
 	os.Exit(_main(os.Args[1:], env))
 }
 
@@ -37,7 +36,7 @@ func _main(args []string, env envConfig) int {
 	ctx := context.Background()
 	ctx = cloudevents.WithEncodingStructured(ctx)
 
-	p, err := cloudevents.NewHTTP(cloudevents.WithPath(env.Path), cloudevents.WithPort(env.Port))
+	p, err := cloudevents.NewHTTP(cloudevents.WithPath(env.Path), cloudevents.WithPort(env.Port), cloudevents.WithGetHandlerFunc(healthEndpointHandler))
 	if err != nil {
 		log.Fatalf("failed to create client, %v", err)
 	}
@@ -48,6 +47,12 @@ func _main(args []string, env envConfig) int {
 	log.Fatal(c.StartReceiver(ctx, gotEvent))
 
 	return 0
+}
+
+func healthEndpointHandler(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path == "/health" {
+		w.WriteHeader(http.StatusOK)
+	}
 }
 
 func gotEvent(ctx context.Context, event cloudevents.Event) error {

--- a/approval-service/main.go
+++ b/approval-service/main.go
@@ -3,13 +3,12 @@ package main
 import (
 	"context"
 	"fmt"
-	"keptn/approval-service/pkg/handler"
-	"log"
-	"net/http"
-	"os"
-
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/kelseyhightower/envconfig"
+	api "github.com/keptn/go-utils/pkg/api/utils"
+	"keptn/approval-service/pkg/handler"
+	"log"
+	"os"
 
 	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
@@ -36,7 +35,8 @@ func _main(args []string, env envConfig) int {
 	ctx := context.Background()
 	ctx = cloudevents.WithEncodingStructured(ctx)
 
-	p, err := cloudevents.NewHTTP(cloudevents.WithPath(env.Path), cloudevents.WithPort(env.Port), cloudevents.WithGetHandlerFunc(healthEndpointHandler))
+	p, err := cloudevents.NewHTTP(cloudevents.WithPath(env.Path), cloudevents.WithPort(env.Port), cloudevents.WithGetHandlerFunc(api.HealthEndpointHandler))
+
 	if err != nil {
 		log.Fatalf("failed to create client, %v", err)
 	}
@@ -47,12 +47,6 @@ func _main(args []string, env envConfig) int {
 	log.Fatal(c.StartReceiver(ctx, gotEvent))
 
 	return 0
-}
-
-func healthEndpointHandler(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Path == "/health" {
-		w.WriteHeader(http.StatusOK)
-	}
 }
 
 func gotEvent(ctx context.Context, event cloudevents.Event) error {

--- a/distributor/cmd/main.go
+++ b/distributor/cmd/main.go
@@ -38,7 +38,7 @@ func main() {
 		logger.Errorf("Failed to process env var: %v", err)
 		os.Exit(1)
 	}
-	go keptnapi.RunHealthEndpoint("10999")
+
 	os.Exit(_main(config.Global))
 }
 
@@ -80,6 +80,9 @@ func _main(env config.EnvConfig) int {
 		uniformWatch.RegisterListener(natsEventReceiver)
 		go natsEventReceiver.Start(executionContext)
 	}
+
+	go keptnapi.RunHealthEndpoint("10998")
+
 	executionContext.Wg.Wait()
 	return 0
 }

--- a/distributor/deploy/distributor.yaml
+++ b/distributor/deploy/distributor.yaml
@@ -29,6 +29,18 @@ spec:
       containers:
       - name: distributor
         image: keptn/distributor:latest
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 10998
+          initialDelaySeconds: 20
+          periodSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 10998
+          initialDelaySeconds: 20
+          periodSeconds: 5
         ports:
         - containerPort: 8080
         resources:

--- a/helm-service/main.go
+++ b/helm-service/main.go
@@ -7,14 +7,13 @@ import (
 	"github.com/keptn/keptn/helm-service/pkg/configurationchanger"
 	"github.com/keptn/keptn/helm-service/pkg/helm"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"net/http"
 	"net/url"
 
+	api "github.com/keptn/go-utils/pkg/api/utils"
 	"github.com/keptn/keptn/helm-service/pkg/namespacemanager"
+	keptnutils "github.com/keptn/kubernetes-utils/pkg"
 	"log"
 	"os"
-
-	keptnutils "github.com/keptn/kubernetes-utils/pkg"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/kelseyhightower/envconfig"
@@ -178,7 +177,7 @@ func _main(args []string, env envConfig) int {
 	ctx := context.Background()
 	ctx = cloudevents.WithEncodingStructured(ctx)
 
-	p, err := cloudevents.NewHTTP(cloudevents.WithPath(env.Path), cloudevents.WithPort(env.Port), cloudevents.WithGetHandlerFunc(healthEndpointHandler))
+	p, err := cloudevents.NewHTTP(cloudevents.WithPath(env.Path), cloudevents.WithPort(env.Port), cloudevents.WithGetHandlerFunc(api.HealthEndpointHandler))
 	if err != nil {
 		log.Fatalf("failed to create client, %v", err)
 	}
@@ -189,12 +188,6 @@ func _main(args []string, env envConfig) int {
 	log.Fatal(c.StartReceiver(ctx, gotEvent))
 
 	return 0
-}
-
-func healthEndpointHandler(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Path == "/health" {
-		w.WriteHeader(http.StatusOK)
-	}
 }
 
 // hasAdminRights checks if the current pod is assigned the Admin Role

--- a/helm-service/main.go
+++ b/helm-service/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/keptn/keptn/helm-service/pkg/configurationchanger"
 	"github.com/keptn/keptn/helm-service/pkg/helm"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
 	"net/url"
 
 	"github.com/keptn/keptn/helm-service/pkg/namespacemanager"
@@ -18,7 +19,6 @@ import (
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/kelseyhightower/envconfig"
 	configutils "github.com/keptn/go-utils/pkg/api/utils"
-	keptnapi "github.com/keptn/go-utils/pkg/api/utils"
 	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 
@@ -41,7 +41,7 @@ func main() {
 	if err := envconfig.Process("", &env); err != nil {
 		log.Fatalf("Failed to process env var: %s", err)
 	}
-	go keptnapi.RunHealthEndpoint("10998")
+
 	os.Exit(_main(os.Args[1:], env))
 }
 
@@ -178,7 +178,7 @@ func _main(args []string, env envConfig) int {
 	ctx := context.Background()
 	ctx = cloudevents.WithEncodingStructured(ctx)
 
-	p, err := cloudevents.NewHTTP(cloudevents.WithPath(env.Path), cloudevents.WithPort(env.Port))
+	p, err := cloudevents.NewHTTP(cloudevents.WithPath(env.Path), cloudevents.WithPort(env.Port), cloudevents.WithGetHandlerFunc(healthEndpointHandler))
 	if err != nil {
 		log.Fatalf("failed to create client, %v", err)
 	}
@@ -189,6 +189,12 @@ func _main(args []string, env envConfig) int {
 	log.Fatal(c.StartReceiver(ctx, gotEvent))
 
 	return 0
+}
+
+func healthEndpointHandler(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path == "/health" {
+		w.WriteHeader(http.StatusOK)
+	}
 }
 
 // hasAdminRights checks if the current pod is assigned the Admin Role

--- a/installer/manifests/keptn/charts/control-plane/templates/_helpers.tpl
+++ b/installer/manifests/keptn/charts/control-plane/templates/_helpers.tpl
@@ -66,7 +66,7 @@ Create the name of the service account to use
 livenessProbe:
   httpGet:
     path: /health
-    port: {{.port | default 10999}}
+    port: {{.port | default 10998}}
   initialDelaySeconds: {{.initialDelaySeconds | default 10}}
   periodSeconds: 5
 {{- end }}
@@ -75,7 +75,7 @@ livenessProbe:
 readinessProbe:
   httpGet:
     path: /health
-    port: {{.port | default 10999}}
+    port: {{.port | default 10998}}
   initialDelaySeconds: {{.initialDelaySeconds | default 5}}
   periodSeconds: 5
 {{- end }}

--- a/installer/manifests/keptn/charts/control-plane/templates/continuous-operations.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/continuous-operations.yaml
@@ -38,11 +38,12 @@ spec:
         livenessProbe:
           httpGet:
             path: /health
-            port: 10998
+            port: 8080
           initialDelaySeconds: 10
           periodSeconds: 5
         readinessProbe:
-          tcpSocket:
+          httpGet:
+            path: /health
             port: 8080
           initialDelaySeconds: 10
           periodSeconds: 5

--- a/installer/manifests/keptn/charts/control-plane/templates/core.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/core.yaml
@@ -868,11 +868,12 @@ spec:
           livenessProbe:
             httpGet:
               path: /health
-              port: 10998
+              port: 8080
             initialDelaySeconds: 10
             periodSeconds: 5
           readinessProbe:
-            tcpSocket:
+            thttpGet:
+              path: /health
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 5
@@ -980,11 +981,12 @@ spec:
           livenessProbe:
             httpGet:
               path: /health
-              port: 10998
+              port: 8080
             initialDelaySeconds: 10
             periodSeconds: 5
           readinessProbe:
-            tcpSocket:
+            httpGet:
+              path: /health
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 5

--- a/installer/manifests/keptn/charts/control-plane/templates/core.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/core.yaml
@@ -981,13 +981,13 @@ spec:
           livenessProbe:
             httpGet:
               path: /health
-              port: 8080
+              port: 10988
             initialDelaySeconds: 10
             periodSeconds: 5
           readinessProbe:
             httpGet:
               path: /health
-              port: 8080
+              port: 10988
             initialDelaySeconds: 10
             periodSeconds: 5
           imagePullPolicy: IfNotPresent

--- a/installer/manifests/keptn/charts/control-plane/templates/mongodb-datastore.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/mongodb-datastore.yaml
@@ -39,7 +39,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /health
-            port: 10998
+            port: 8080
           initialDelaySeconds: 10
           periodSeconds: 5
         readinessProbe:

--- a/installer/manifests/keptn/charts/control-plane/templates/quality-gates.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/quality-gates.yaml
@@ -37,11 +37,12 @@ spec:
           livenessProbe:
             httpGet:
               path: /health
-              port: 10998
+              port: 8080
             initialDelaySeconds: 10
             periodSeconds: 5
           readinessProbe:
-            tcpSocket:
+            httpGet:
+              path: /health
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 5

--- a/jmeter-service/main.go
+++ b/jmeter-service/main.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	api "github.com/keptn/go-utils/pkg/api/utils"
 	"log"
 	"net"
-	"net/http"
 	"net/url"
 	"os"
 	"strconv"
@@ -346,7 +346,8 @@ func _main(args []string, env envConfig) int {
 	ctx := context.Background()
 	ctx = cloudevents.WithEncodingStructured(ctx)
 
-	p, err := cloudevents.NewHTTP(cloudevents.WithPath(env.Path), cloudevents.WithPort(env.Port), cloudevents.WithGetHandlerFunc(healthEndpointHandler))
+	p, err := cloudevents.NewHTTP(cloudevents.WithPath(env.Path), cloudevents.WithPort(env.Port), cloudevents.WithGetHandlerFunc(api.HealthEndpointHandler))
+
 	if err != nil {
 		log.Fatalf("failed to create client, %v", err)
 	}
@@ -357,12 +358,6 @@ func _main(args []string, env envConfig) int {
 
 	log.Fatal(c.StartReceiver(ctx, gotEvent))
 	return 0
-}
-
-func healthEndpointHandler(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Path == "/health" {
-		w.WriteHeader(http.StatusOK)
-	}
 }
 
 func sendEvent(event cloudevents.Event) error {

--- a/lighthouse-service/main.go
+++ b/lighthouse-service/main.go
@@ -3,11 +3,11 @@ package main
 import (
 	"context"
 	"log"
-	"net/http"
 	"os"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/kelseyhightower/envconfig"
+	api "github.com/keptn/go-utils/pkg/api/utils"
 
 	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
 	"github.com/keptn/keptn/lighthouse-service/event_handler"
@@ -32,7 +32,8 @@ func _main(args []string, env envConfig) int {
 	ctx := context.Background()
 	ctx = cloudevents.WithEncodingStructured(ctx)
 
-	p, err := cloudevents.NewHTTP(cloudevents.WithPath(env.Path), cloudevents.WithPort(env.Port), cloudevents.WithGetHandlerFunc(healthEndpointHandler))
+	p, err := cloudevents.NewHTTP(cloudevents.WithPath(env.Path), cloudevents.WithPort(env.Port), cloudevents.WithGetHandlerFunc(api.HealthEndpointHandler))
+
 	if err != nil {
 		log.Fatalf("failed to create client, %v", err)
 	}
@@ -43,12 +44,6 @@ func _main(args []string, env envConfig) int {
 	log.Fatal(c.StartReceiver(ctx, gotEvent))
 
 	return 0
-}
-
-func healthEndpointHandler(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Path == "/health" {
-		w.WriteHeader(http.StatusOK)
-	}
 }
 
 func gotEvent(ctx context.Context, event cloudevents.Event) error {

--- a/mongodb-datastore/restapi/configure_mongodb_datastore.go
+++ b/mongodb-datastore/restapi/configure_mongodb_datastore.go
@@ -14,7 +14,6 @@ import (
 	middleware "github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/swag"
 
-	keptnapi "github.com/keptn/go-utils/pkg/api/utils"
 	"github.com/keptn/keptn/mongodb-datastore/handlers"
 	"github.com/keptn/keptn/mongodb-datastore/models"
 	"github.com/keptn/keptn/mongodb-datastore/restapi/operations"
@@ -107,7 +106,6 @@ func setupGlobalMiddleware(handler http.Handler) http.Handler {
 		}
 	}
 
-	go keptnapi.RunHealthEndpoint("10998")
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Serving ./swagger-ui/
 		if strings.Index(r.URL.Path, "/swagger-ui/") == 0 {
@@ -119,6 +117,12 @@ func setupGlobalMiddleware(handler http.Handler) http.Handler {
 			http.StripPrefix("/swagger-ui/", http.FileServer(http.Dir(pathToSwaggerUI))).ServeHTTP(w, r)
 			return
 		}
+
+		if strings.Index(r.URL.Path, "/health") == 0 {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
 		handler.ServeHTTP(w, r)
 	})
 }

--- a/remediation-service/main.go
+++ b/remediation-service/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	api "github.com/keptn/go-utils/pkg/api/utils"
 	"github.com/keptn/keptn/go-sdk/pkg/sdk"
 	"github.com/keptn/keptn/remediation-service/handler"
 	"log"
@@ -12,7 +11,6 @@ const serviceName = "remediation-service"
 
 func main() {
 
-	go api.RunHealthEndpoint("10998")
 	log.Fatal(sdk.NewKeptn(
 		serviceName,
 		sdk.WithTaskHandler(

--- a/secret-service/main.go
+++ b/secret-service/main.go
@@ -3,14 +3,14 @@ package main
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/keptn/go-utils/pkg/common/osutils"
-	keptnapi "github.com/keptn/go-utils/pkg/api/utils"
+	_ "github.com/keptn/keptn/secret-service/docs"
 	"github.com/keptn/keptn/secret-service/pkg/backend"
 	"github.com/keptn/keptn/secret-service/pkg/controller"
 	"github.com/keptn/keptn/secret-service/pkg/handler"
 	"github.com/keptn/keptn/secret-service/pkg/repository"
-	_ "github.com/keptn/keptn/secret-service/docs"
 	log "github.com/sirupsen/logrus"
 	"io/ioutil"
+	"net/http"
 	"os"
 )
 
@@ -51,11 +51,10 @@ func main() {
 	secretController := controller.NewSecretController(handler.NewSecretHandler(secretsBackend))
 	secretController.Inject(apiV1)
 
-	go keptnapi.RunHealthEndpoint("10998")
-
 	engine.Static("/swagger-ui", "./swagger-ui")
 	err := engine.Run()
 	if err != nil {
 		log.Fatalf("Unable to start service: %s", err.Error())
 	}
+	engine.GET("/health", func(c *gin.Context) { c.Status(http.StatusOK) })
 }


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
- adds health endpoints to core services 
- verifies all services have readiness and liveness probes working 'properly'
- modifies installer yaml files accordingly

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #5303 

### Notes
a probe is 'proper' if defined on an existing service endpoint and not on a fictitious one. The health checks are shallow since they do not verify any dependency but the endpoint is setup as the very last thing. In most cases readiness and liveness still correspond. 
