### PR TITLE
feat:  Added probes for readiness and liveness (#5303)

### DIFF
--- a/approval-service/main.go
+++ b/approval-service/main.go
@@ -29,7 +29,6 @@ func main() {
 		log.Fatalf("Failed to process env var: %s", err)
 	}
 
-	go keptnapi.RunHealthEndpoint("10998")
 	os.Exit(_main(os.Args[1:], env))
 }
 
@@ -37,7 +36,7 @@ func _main(args []string, env envConfig) int {
 	ctx := context.Background()
 	ctx = cloudevents.WithEncodingStructured(ctx)
 
-	p, err := cloudevents.NewHTTP(cloudevents.WithPath(env.Path), cloudevents.WithPort(env.Port))
+	p, err := cloudevents.NewHTTP(cloudevents.WithPath(env.Path), cloudevents.WithPort(env.Port), cloudevents.WithGetHandlerFunc(keptnapi.HealthEndpointHandler))
 	if err != nil {
 		log.Fatalf("failed to create client, %v", err)
 	}

--- a/configuration-service/restapi/configure_configuration_service.go
+++ b/configuration-service/restapi/configure_configuration_service.go
@@ -14,7 +14,6 @@ import (
 
 	errors "github.com/go-openapi/errors"
 	runtime "github.com/go-openapi/runtime"
-	keptnapi "github.com/keptn/go-utils/pkg/api/utils"
 	handlers "github.com/keptn/keptn/configuration-service/handlers"
 	"github.com/keptn/keptn/configuration-service/restapi/operations"
 	"github.com/keptn/keptn/configuration-service/restapi/operations/project"
@@ -172,11 +171,14 @@ func setupGlobalMiddleware(handler http.Handler) http.Handler {
 		}
 	}
 
-	go keptnapi.RunHealthEndpoint("10998")
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Serving ./swagger-ui/
 		if strings.Index(r.URL.Path, "/swagger-ui/") == 0 {
 			http.StripPrefix("/swagger-ui/", http.FileServer(http.Dir("swagger-ui"))).ServeHTTP(w, r)
+			return
+		}
+		if strings.Index(r.URL.Path, "/health") == 0 {
+			w.WriteHeader(http.StatusOK)
 			return
 		}
 

--- a/distributor/pkg/lib/events/forwarder.go
+++ b/distributor/pkg/lib/events/forwarder.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	cenats "github.com/cloudevents/sdk-go/protocol/nats/v2"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
+	api "github.com/keptn/go-utils/pkg/api/utils"
 	"github.com/keptn/go-utils/pkg/lib/v0_2_0"
 	"github.com/keptn/keptn/distributor/pkg/config"
 	logger "github.com/sirupsen/logrus"
@@ -35,6 +36,7 @@ func NewForwarder(httpClient *http.Client) *Forwarder {
 func (f *Forwarder) Start(ctx *ExecutionContext) error {
 	serverURL := fmt.Sprintf("localhost:%d", config.Global.APIProxyPort)
 	mux := http.NewServeMux()
+	mux.Handle("/health", http.HandlerFunc(api.HealthEndpointHandler))
 	mux.Handle(config.Global.EventForwardingPath, http.HandlerFunc(f.handleEvent))
 	mux.Handle(config.Global.APIProxyPath, http.HandlerFunc(f.apiProxyHandler))
 
@@ -63,6 +65,7 @@ func (f *Forwarder) Start(ctx *ExecutionContext) error {
 }
 
 func (f *Forwarder) handleEvent(rw http.ResponseWriter, req *http.Request) {
+
 	body, err := ioutil.ReadAll(req.Body)
 	if err != nil {
 		logger.Errorf("Failed to read body from request: %v", err)

--- a/helm-service/main.go
+++ b/helm-service/main.go
@@ -79,7 +79,6 @@ func gotEvent(ctx context.Context, event cloudevents.Event) error {
 	}
 
 	//create dependencies
-
 	mesh := mesh.NewIstioMesh()
 	keptnHandler.Logger.Debug("Got event of type " + event.Type())
 

--- a/helm-service/main.go
+++ b/helm-service/main.go
@@ -41,7 +41,7 @@ func main() {
 	if err := envconfig.Process("", &env); err != nil {
 		log.Fatalf("Failed to process env var: %s", err)
 	}
-	go keptnapi.RunHealthEndpoint("10998")
+
 	os.Exit(_main(os.Args[1:], env))
 }
 
@@ -178,7 +178,7 @@ func _main(args []string, env envConfig) int {
 	ctx := context.Background()
 	ctx = cloudevents.WithEncodingStructured(ctx)
 
-	p, err := cloudevents.NewHTTP(cloudevents.WithPath(env.Path), cloudevents.WithPort(env.Port))
+	p, err := cloudevents.NewHTTP(cloudevents.WithPath(env.Path), cloudevents.WithPort(env.Port), cloudevents.WithGetHandlerFunc(keptnapi.HealthEndpointHandler))
 	if err != nil {
 		log.Fatalf("failed to create client, %v", err)
 	}

--- a/installer/manifests/keptn/charts/control-plane/templates/_helpers.tpl
+++ b/installer/manifests/keptn/charts/control-plane/templates/_helpers.tpl
@@ -66,7 +66,7 @@ Create the name of the service account to use
 livenessProbe:
   httpGet:
     path: /health
-    port: {{.port | default 10999}}
+    port: {{.port | default 8080}}
   initialDelaySeconds: {{.initialDelaySeconds | default 10}}
   periodSeconds: 5
 {{- end }}
@@ -75,7 +75,7 @@ livenessProbe:
 readinessProbe:
   httpGet:
     path: /health
-    port: {{.port | default 10999}}
+    port: {{.port | default 8080}}
   initialDelaySeconds: {{.initialDelaySeconds | default 5}}
   periodSeconds: 5
 {{- end }}

--- a/installer/manifests/keptn/charts/control-plane/templates/core.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/core.yaml
@@ -81,11 +81,12 @@ spec:
           livenessProbe:
             httpGet:
               path: /health
-              port: 10998
+              port: 8080
             initialDelaySeconds: 10
             periodSeconds: 5
           readinessProbe:
-            tcpSocket:
+            httpGet:
+              path: /health
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 5
@@ -503,7 +504,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /health
-              port: 10998
+              port: 8080
             initialDelaySeconds: 10
             periodSeconds: 5
           readinessProbe:
@@ -635,13 +636,13 @@ spec:
           livenessProbe:
             httpGet:
               path: /health
-              port: 10998
+              port: 8080
             initialDelaySeconds: 10
             periodSeconds: 5
           readinessProbe:
             httpGet:
               path: /health
-              port: 10998
+              port: 8080
           imagePullPolicy: IfNotPresent
           env:
             - name: PREFIX_PATH
@@ -871,11 +872,12 @@ spec:
           livenessProbe:
             httpGet:
               path: /health
-              port: 10998
+              port: 8080
             initialDelaySeconds: 10
             periodSeconds: 5
           readinessProbe:
-            tcpSocket:
+            httpGet:
+              path: /health
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 5

--- a/jmeter-service/main.go
+++ b/jmeter-service/main.go
@@ -36,7 +36,6 @@ func main() {
 		log.Fatalf("Failed to process env var: %s", err)
 	}
 
-	go keptnapi.RunHealthEndpoint("10998")
 	os.Exit(_main(os.Args[1:], env))
 }
 
@@ -347,7 +346,7 @@ func _main(args []string, env envConfig) int {
 	ctx := context.Background()
 	ctx = cloudevents.WithEncodingStructured(ctx)
 
-	p, err := cloudevents.NewHTTP(cloudevents.WithPath(env.Path), cloudevents.WithPort(env.Port))
+	p, err := cloudevents.NewHTTP(cloudevents.WithPath(env.Path), cloudevents.WithPort(env.Port), cloudevents.WithGetHandlerFunc(keptnapi.HealthEndpointHandler))
 	if err != nil {
 		log.Fatalf("failed to create client, %v", err)
 	}

--- a/lighthouse-service/main.go
+++ b/lighthouse-service/main.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	"context"
+	keptnapi "github.com/keptn/go-utils/pkg/api/utils"
 	"log"
 	"os"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/kelseyhightower/envconfig"
 
-	keptnapi "github.com/keptn/go-utils/pkg/api/utils"
 	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
 	"github.com/keptn/keptn/lighthouse-service/event_handler"
 )
@@ -25,7 +25,6 @@ func main() {
 		log.Fatalf("Failed to process env var: %s", err)
 	}
 
-	go keptnapi.RunHealthEndpoint("10998")
 	os.Exit(_main(os.Args[1:], env))
 }
 
@@ -33,7 +32,7 @@ func _main(args []string, env envConfig) int {
 	ctx := context.Background()
 	ctx = cloudevents.WithEncodingStructured(ctx)
 
-	p, err := cloudevents.NewHTTP(cloudevents.WithPath(env.Path), cloudevents.WithPort(env.Port))
+	p, err := cloudevents.NewHTTP(cloudevents.WithPath(env.Path), cloudevents.WithPort(env.Port), cloudevents.WithGetHandlerFunc(keptnapi.HealthEndpointHandler))
 	if err != nil {
 		log.Fatalf("failed to create client, %v", err)
 	}

--- a/mongodb-datastore/restapi/configure_mongodb_datastore.go
+++ b/mongodb-datastore/restapi/configure_mongodb_datastore.go
@@ -121,6 +121,10 @@ func setupGlobalMiddleware(handler http.Handler) http.Handler {
 			http.StripPrefix("/swagger-ui/", http.FileServer(http.Dir(pathToSwaggerUI))).ServeHTTP(w, r)
 			return
 		}
+		if strings.Index(r.URL.Path, "/health") == 0 {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
 		handler.ServeHTTP(w, r)
 	})
 }

--- a/mongodb-datastore/restapi/configure_mongodb_datastore.go
+++ b/mongodb-datastore/restapi/configure_mongodb_datastore.go
@@ -121,10 +121,6 @@ func setupGlobalMiddleware(handler http.Handler) http.Handler {
 			http.StripPrefix("/swagger-ui/", http.FileServer(http.Dir(pathToSwaggerUI))).ServeHTTP(w, r)
 			return
 		}
-		if strings.Index(r.URL.Path, "/health") == 0 {
-			w.WriteHeader(http.StatusOK)
-			return
-		}
 		handler.ServeHTTP(w, r)
 	})
 }

--- a/remediation-service/main.go
+++ b/remediation-service/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	api "github.com/keptn/go-utils/pkg/api/utils"
 	"github.com/keptn/keptn/go-sdk/pkg/sdk"
 	"github.com/keptn/keptn/remediation-service/handler"
 	"log"
@@ -10,7 +11,7 @@ const getActionTriggeredEventType = "sh.keptn.event.get-action.triggered"
 const serviceName = "remediation-service"
 
 func main() {
-
+	go api.RunHealthEndpoint("8080")
 	log.Fatal(sdk.NewKeptn(
 		serviceName,
 		sdk.WithTaskHandler(

--- a/remediation-service/main.go
+++ b/remediation-service/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	api "github.com/keptn/go-utils/pkg/api/utils"
 	"github.com/keptn/keptn/go-sdk/pkg/sdk"
 	"github.com/keptn/keptn/remediation-service/handler"
 	"log"
@@ -12,7 +11,6 @@ const serviceName = "remediation-service"
 
 func main() {
 
-	go api.RunHealthEndpoint("10998")
 	log.Fatal(sdk.NewKeptn(
 		serviceName,
 		sdk.WithTaskHandler(

--- a/remediation-service/main.go
+++ b/remediation-service/main.go
@@ -11,7 +11,7 @@ const getActionTriggeredEventType = "sh.keptn.event.get-action.triggered"
 const serviceName = "remediation-service"
 
 func main() {
-	go api.RunHealthEndpoint("8080")
+	go api.RunHealthEndpoint("10998")
 	log.Fatal(sdk.NewKeptn(
 		serviceName,
 		sdk.WithTaskHandler(

--- a/secret-service/main.go
+++ b/secret-service/main.go
@@ -3,14 +3,14 @@ package main
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/keptn/go-utils/pkg/common/osutils"
-	keptnapi "github.com/keptn/go-utils/pkg/api/utils"
+	_ "github.com/keptn/keptn/secret-service/docs"
 	"github.com/keptn/keptn/secret-service/pkg/backend"
 	"github.com/keptn/keptn/secret-service/pkg/controller"
 	"github.com/keptn/keptn/secret-service/pkg/handler"
 	"github.com/keptn/keptn/secret-service/pkg/repository"
-	_ "github.com/keptn/keptn/secret-service/docs"
 	log "github.com/sirupsen/logrus"
 	"io/ioutil"
+	"net/http"
 	"os"
 )
 
@@ -51,7 +51,7 @@ func main() {
 	secretController := controller.NewSecretController(handler.NewSecretHandler(secretsBackend))
 	secretController.Inject(apiV1)
 
-	go keptnapi.RunHealthEndpoint("10998")
+	engine.GET("/health", func(c *gin.Context) { c.Status(http.StatusOK) })
 
 	engine.Static("/swagger-ui", "./swagger-ui")
 	err := engine.Run()


### PR DESCRIPTION

## This PR

- adds new health endpoints in all services
- changes installer yaml files
- modifies default liveness and readiness probes so that it autocompletes distributors correctly

### Related Issues

Fixes #5303 

### Notes
Liveness and readiness are the same for many services, the checks are shallow but endpoints are not ficticious anymore
