### PR TITLE
fix(install): use correct images in airgapped installation 

### DIFF
--- a/installer/airgapped/install_keptn.sh
+++ b/installer/airgapped/install_keptn.sh
@@ -39,6 +39,7 @@ control-plane.statisticsService.image.repository=${TARGET_INTERNAL_DOCKER_REGIST
 control-plane.lighthouseService.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/lighthouse-service,\
 control-plane.secretService.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/secret-service,\
 control-plane.approvalService.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/approval-service,\
+control-plane.webhookService.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/webhook-service,\
 continuous-delivery.distributor.image.repository=${TARGET_INTERNAL_DOCKER_REGISTRY}keptn/distributor"
 
 echo ""

--- a/installer/airgapped/pull_and_retag_images.sh
+++ b/installer/airgapped/pull_and_retag_images.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-KEPTN_TAG=${KEPTN_TAG:-"0.8.4"}
+KEPTN_TAG=${KEPTN_TAG:-"0.10.0"}
 
 if [[ $# -ne 1 ]]; then
     echo "Please provide the target registry as a param, e.g., $1 gcr.io/your-registry/"
@@ -9,8 +9,8 @@ fi
 
 TARGET_INTERNAL_DOCKER_REGISTRY=${1}
 
-IMAGES_CONTROL_PLANE_THIRD_PARTY="centos/mongodb-36-centos7:1 nats:2.1.9-alpine3.12 connecteverything/nats-server-config-reloader:0.6.0 synadia/prometheus-nats-exporter:0.5.0 nginxinc/nginx-unprivileged:1.19.4-alpine"
-IMAGES_CONTROL_PLANE="keptn/api:${KEPTN_TAG} keptn/bridge2:${KEPTN_TAG} keptn/configuration-service:${KEPTN_TAG} keptn/distributor:${KEPTN_TAG} keptn/secret-service:${KEPTN_TAG} keptn/shipyard-controller:${KEPTN_TAG} keptn/remediation-service:${KEPTN_TAG} keptn/mongodb-datastore:${KEPTN_TAG} keptn/statistics-service:${KEPTN_TAG} keptn/lighthouse-service:${KEPTN_TAG} keptn/approval-service:${KEPTN_TAG}"
+IMAGES_CONTROL_PLANE_THIRD_PARTY="centos/mongodb-36-centos7:1 nats:2.1.9-alpine3.14 connecteverything/nats-server-config-reloader:0.6.0 synadia/prometheus-nats-exporter:0.5.0 nginxinc/nginx-unprivileged:1.19.4-alpine"
+IMAGES_CONTROL_PLANE="keptn/api:${KEPTN_TAG} keptn/bridge2:${KEPTN_TAG} keptn/configuration-service:${KEPTN_TAG} keptn/distributor:${KEPTN_TAG} keptn/secret-service:${KEPTN_TAG} keptn/shipyard-controller:${KEPTN_TAG} keptn/remediation-service:${KEPTN_TAG} keptn/mongodb-datastore:${KEPTN_TAG} keptn/statistics-service:${KEPTN_TAG} keptn/lighthouse-service:${KEPTN_TAG} keptn/approval-service:${KEPTN_TAG} keptn/webhook-service:${KEPTN_TAG}"
 IMAGES_CONTINUOUS_DELIVERY="keptn/helm-service:${KEPTN_TAG} keptn/jmeter-service:${KEPTN_TAG}"
 
 IMAGES="$IMAGES_CONTROL_PLANE_THIRD_PARTY $IMAGES_CONTROL_PLANE $IMAGES_CONTINUOUS_DELIVERY"


### PR DESCRIPTION
## This PR

- updates the airgapped installation to be compatible with the latest changes in master branch (and resp. for the upcoming 0.10.0 release).

### Related Issues

Every integration test failure in the last couple of days has an issue with k3d integration tests.
E.g.,
- https://github.com/keptn/keptn/issues/5493
- https://github.com/keptn/keptn/issues/5512


### Notes


### Follow-up Tasks

- Update docs for advanced install option with webhookService
- Update docs for advanced install option with the updated nats image


### How to test

- Integration tests are running (WIP)

