### PR TITLE
ci: Fix create release branch pipeline

### DIFF
--- a/.github/workflows/create_release_branch.yml
+++ b/.github/workflows/create_release_branch.yml
@@ -78,8 +78,8 @@ jobs:
         with:
           token: ${{ secrets.KEPTN_BOT_TOKEN }}
           commit-message: "Prepare release ${{ github.event.inputs.versionName }}"
-          committer: ${{ secrets.KEPTN_BOT_USER }}
-          author: ${{ secrets.KEPTN_BOT_USER }}
+          committer: ${{ env.KEPTN_BOT_USER }}
+          author: ${{ env.KEPTN_BOT_USER }}
           signoff: true
           branch: ${{ env.RELEASE_BRANCH_NAME }}
           delete-branch: true


### PR DESCRIPTION
### This PR
* makes use of the correct env variables for keptn bot user instead of secrets