### PR TITLE
feat(lighthouse-service): Added SIGTERM for lighthouse handlers (#5304)

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/templates/quality-gates.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/quality-gates.yaml
@@ -78,6 +78,13 @@ spec:
           image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
           {{- include "control-plane.dist.livenessProbe" . | nindent 10 }}
           {{- include "control-plane.dist.readinessProbe" . | nindent 10 }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - sleep 30
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/installer/manifests/keptn/charts/control-plane/templates/quality-gates.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/quality-gates.yaml
@@ -102,6 +102,7 @@ spec:
             runAsUser: 65532
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
+      terminationGracePeriodSeconds: 60
       serviceAccountName: keptn-lighthouse-service
 ---
 apiVersion: v1

--- a/lighthouse-service/event_handler/configure_monitoring_handler.go
+++ b/lighthouse-service/event_handler/configure_monitoring_handler.go
@@ -55,7 +55,6 @@ func (eh *ConfigureMonitoringHandler) HandleEvent(ctx context.Context) error {
 	ctx.Value("Wg").(*sync.WaitGroup).Add(1)
 	defer func() {
 		ctx.Value("Wg").(*sync.WaitGroup).Done()
-		eh.Logger.Info("Terminating Configuration-monitoring handler")
 	}()
 
 	var keptnContext string

--- a/lighthouse-service/event_handler/configure_monitoring_handler.go
+++ b/lighthouse-service/event_handler/configure_monitoring_handler.go
@@ -5,6 +5,7 @@ import (
 	"github.com/sirupsen/logrus"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"os"
+	"sync"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	keptnevents "github.com/keptn/go-utils/pkg/lib"
@@ -50,7 +51,12 @@ func NewConfigureMonitoringHandler(event cloudevents.Event, logger *logrus.Logge
 	return cmh, nil
 }
 
-func (eh *ConfigureMonitoringHandler) HandleEvent() error {
+func (eh *ConfigureMonitoringHandler) HandleEvent(ctx context.Context) error {
+	ctx.Value("Wg").(*sync.WaitGroup).Add(1)
+	defer func() {
+		ctx.Value("Wg").(*sync.WaitGroup).Done()
+		eh.Logger.Info("Terminating Configuration-monitoring handler")
+	}()
 
 	var keptnContext string
 	_ = eh.Event.ExtensionAs("shkeptncontext", &keptnContext)

--- a/lighthouse-service/event_handler/configure_monitoring_handler_test.go
+++ b/lighthouse-service/event_handler/configure_monitoring_handler_test.go
@@ -1,6 +1,7 @@
 package event_handler
 
 import (
+	"context"
 	"errors"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 	"github.com/sirupsen/logrus"
@@ -10,6 +11,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 	"reflect"
+	"sync"
 	"testing"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -82,7 +84,8 @@ func TestConfigureMonitoringHandler_getSLISourceConfigMap(t *testing.T) {
 
 func TestConfigureMonitoringHandler_HandleEvent_ConfigMapDoesntExistYet(t *testing.T) {
 	ce := cloudevents.NewEvent()
-
+	wg := &sync.WaitGroup{}
+	ctx := cloudevents.WithEncodingStructured(context.WithValue(context.Background(), "Wg", wg))
 	configureMonitoringData := &keptnevents.ConfigureMonitoringEventData{
 		Project: "my-project",
 		Service: "my-service",
@@ -98,7 +101,7 @@ func TestConfigureMonitoringHandler_HandleEvent_ConfigMapDoesntExistYet(t *testi
 	handler, err := NewConfigureMonitoringHandler(ce, logger, WithK8sClient(fakeK8sClient))
 	require.Nil(t, err)
 
-	err = handler.HandleEvent()
+	err = handler.HandleEvent(ctx)
 	require.Nil(t, err)
 	require.Len(t, fakeK8sClient.Actions(), 1)
 	require.Equal(t, "create", fakeK8sClient.Actions()[0].GetVerb())
@@ -106,7 +109,8 @@ func TestConfigureMonitoringHandler_HandleEvent_ConfigMapDoesntExistYet(t *testi
 
 func TestConfigureMonitoringHandler_HandleEvent_ConfigMapDoesntExistYetAndCreateFails(t *testing.T) {
 	ce := cloudevents.NewEvent()
-
+	wg := &sync.WaitGroup{}
+	ctx := cloudevents.WithEncodingStructured(context.WithValue(context.Background(), "Wg", wg))
 	configureMonitoringData := &keptnevents.ConfigureMonitoringEventData{
 		Project: "my-project",
 		Service: "my-service",
@@ -126,7 +130,7 @@ func TestConfigureMonitoringHandler_HandleEvent_ConfigMapDoesntExistYetAndCreate
 	handler, err := NewConfigureMonitoringHandler(ce, logger, WithK8sClient(fakeK8sClient))
 	require.Nil(t, err)
 
-	err = handler.HandleEvent()
+	err = handler.HandleEvent(ctx)
 	require.NotNil(t, err)
 	require.Len(t, fakeK8sClient.Actions(), 1)
 	require.Equal(t, "create", fakeK8sClient.Actions()[0].GetVerb())
@@ -139,7 +143,8 @@ func TestConfigureMonitoringHandler_HandleEvent_ConfigMapDoesntExistYetAndCreate
 
 func TestConfigureMonitoringHandler_HandleEvent_ConfigMapAlreadyExists(t *testing.T) {
 	ce := cloudevents.NewEvent()
-
+	wg := &sync.WaitGroup{}
+	ctx := cloudevents.WithEncodingStructured(context.WithValue(context.Background(), "Wg", wg))
 	configureMonitoringData := &keptnevents.ConfigureMonitoringEventData{
 		Project: "my-project",
 		Service: "my-service",
@@ -156,7 +161,7 @@ func TestConfigureMonitoringHandler_HandleEvent_ConfigMapAlreadyExists(t *testin
 	handler, err := NewConfigureMonitoringHandler(ce, logger, WithK8sClient(fakeK8sClient))
 	require.Nil(t, err)
 
-	err = handler.HandleEvent()
+	err = handler.HandleEvent(ctx)
 	require.Nil(t, err)
 	require.Len(t, fakeK8sClient.Actions(), 2)
 	require.Equal(t, "create", fakeK8sClient.Actions()[0].GetVerb())
@@ -165,7 +170,8 @@ func TestConfigureMonitoringHandler_HandleEvent_ConfigMapAlreadyExists(t *testin
 
 func TestConfigureMonitoringHandler_HandleEvent_ConfigMapAlreadyExistsUpdateFails(t *testing.T) {
 	ce := cloudevents.NewEvent()
-
+	wg := &sync.WaitGroup{}
+	ctx := cloudevents.WithEncodingStructured(context.WithValue(context.Background(), "Wg", wg))
 	configureMonitoringData := &keptnevents.ConfigureMonitoringEventData{
 		Project: "my-project",
 		Service: "my-service",
@@ -186,7 +192,7 @@ func TestConfigureMonitoringHandler_HandleEvent_ConfigMapAlreadyExistsUpdateFail
 	handler, err := NewConfigureMonitoringHandler(ce, logger, WithK8sClient(fakeK8sClient))
 	require.Nil(t, err)
 
-	err = handler.HandleEvent()
+	err = handler.HandleEvent(ctx)
 	require.NotNil(t, err)
 	require.Len(t, fakeK8sClient.Actions(), 2)
 	require.Equal(t, "create", fakeK8sClient.Actions()[0].GetVerb())

--- a/lighthouse-service/event_handler/evaluate_sli_handler_test.go
+++ b/lighthouse-service/event_handler/evaluate_sli_handler_test.go
@@ -1,6 +1,7 @@
 package event_handler
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -15,6 +16,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -3147,11 +3149,12 @@ func TestEvaluateSLIHandler_getPreviousEvaluations(t *testing.T) {
 }
 
 func TestEvaluateSLIHandler_HandleEvent(t *testing.T) {
+	wg := &sync.WaitGroup{}
+	ctx := cloudevents.WithEncodingStructured(context.WithValue(context.Background(), "Wg", wg))
 	incomingEvent := cloudevents.NewEvent()
 	incomingEvent.SetID("my-id")
 	incomingEvent.SetSource("my-source")
 	incomingEvent.SetExtension("shkeptncontext", "my-context")
-
 	keptn, _ := keptnv2.NewKeptn(&incomingEvent, keptncommon.KeptnOpts{
 		EventSender: &keptnfake.EventSender{},
 	})
@@ -3260,7 +3263,7 @@ func TestEvaluateSLIHandler_HandleEvent(t *testing.T) {
 				SLOFileRetriever: tt.fields.SLOFileRetriever,
 				EventStore:       tt.fields.EventStore,
 			}
-			if err := eh.HandleEvent(); (err != nil) != tt.wantErr {
+			if err := eh.HandleEvent(ctx); (err != nil) != tt.wantErr {
 				t.Errorf("HandleEvent() error = %v, wantErr %v", err, tt.wantErr)
 			}
 

--- a/lighthouse-service/event_handler/handler.go
+++ b/lighthouse-service/event_handler/handler.go
@@ -1,6 +1,7 @@
 package event_handler
 
 import (
+	"context"
 	keptnapi "github.com/keptn/go-utils/pkg/api/utils"
 	"github.com/sirupsen/logrus"
 	"net/http"
@@ -13,7 +14,7 @@ import (
 )
 
 type EvaluationEventHandler interface {
-	HandleEvent() error
+	HandleEvent(ctx context.Context) error
 }
 
 func NewEventHandler(event cloudevents.Event, logger *keptncommon.Logger) (EvaluationEventHandler, error) {

--- a/lighthouse-service/event_handler/start_evaluation_handler_test.go
+++ b/lighthouse-service/event_handler/start_evaluation_handler_test.go
@@ -1,6 +1,7 @@
 package event_handler
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -14,6 +15,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -63,7 +65,8 @@ func TestStartEvaluationHandler_HandleEvent(t *testing.T) {
 		Type string `json:"type"`
 	}
 	ch := make(chan string)
-
+	wg := &sync.WaitGroup{}
+	ctx := cloudevents.WithEncodingStructured(context.WithValue(context.Background(), "Wg", wg))
 	var returnSlo bool
 	var sloFileContent string
 	var returnServiceNotFound bool
@@ -263,7 +266,7 @@ func TestStartEvaluationHandler_HandleEvent(t *testing.T) {
 				},
 				SLOFileRetriever: tt.fields.SLOFileRetriever,
 			}
-			if err := eh.HandleEvent(); (err != nil) != tt.wantErr {
+			if err := eh.HandleEvent(ctx); (err != nil) != tt.wantErr {
 				t.Errorf("HandleEvent() error = %v, wantErr %v", err, tt.wantErr)
 			}
 

--- a/lighthouse-service/main.go
+++ b/lighthouse-service/main.go
@@ -11,8 +11,6 @@ import (
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/kelseyhightower/envconfig"
-
-	keptnapi "github.com/keptn/go-utils/pkg/api/utils"
 	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
 	"github.com/keptn/keptn/lighthouse-service/event_handler"
 )

--- a/lighthouse-service/main.go
+++ b/lighthouse-service/main.go
@@ -68,6 +68,7 @@ func gotEvent(ctx context.Context, event cloudevents.Event) error {
 	return nil
 }
 
+// storing wait group into context to sync before shutdown
 func getGracefulContext() context.Context {
 
 	ch := make(chan os.Signal, 1)

--- a/lighthouse-service/main.go
+++ b/lighthouse-service/main.go
@@ -62,7 +62,7 @@ func gotEvent(ctx context.Context, event cloudevents.Event) error {
 		return err
 	}
 	if handler != nil {
-		return handler.HandleEvent()
+		return handler.HandleEvent(ctx)
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: RealAnna <anna.reale@dynatrace.com>

## This PR
- adds context with cancel to all handlers
- pass a wait group via context 
- uses the wait group to to ensure the service terminates before shutdown
- introduces a pre-stop hook to the distributor to delay its shutdown so that the service can communicate 
- adjust the graceperiod of the pod

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #5304 

### Follow-up Tasks
This can be replicated in most services,  pre-stophook does not add downtime: Pods that shut down slowly cannot continue to serve traffic as load balancers (like the service proxy) remove the Pod from the list of endpoints as soon as the termination grace period begins, that is contemporary to the start of the pre-stophook. 
This ensure the services will stop receiving traffic and thus events as soon as the SIGTERM is sent independently from how long the shutdown sequence will be.
Pre-stop hook may need to be extended in case of longer executions.  In case of possibly too long running services, like jmeter, it is sufficient to send a finished event and force the shutdown.

### How to test

Manually kill a pod wile running a sequence, wait after the lighthouse has sent a start event and before the finish event. 
Integration test: https://github.com/keptn/keptn/actions/runs/1434969307