### PR TITLE
fix: Added standalone pipeline to validate semantic PRs instead of using GH App (#5528)

### DIFF
--- a/.github/workflows/validate-semantic-pr.yml
+++ b/.github/workflows/validate-semantic-pr.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Validate Pull Request
-        uses: amannn/action-semantic-pull-request@v3.4.2
+        uses: amannn/action-semantic-pull-request@25e3275e19cd5b3577a99478084255065002897c # pin@v3.4.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -59,5 +59,3 @@ jobs:
           # merge commit, and it's easy to commit this by mistake. Enable this option
           # to also validate the commit message for one commit PRs.
           validateSingleCommit: true
-
-


### PR DESCRIPTION
### This PR
* fixes the issue where PRs with a single commit would still show a successful check even though the single commit is not semantic

### Related Issues
Fixes #5528 

### Follow-up tasks
* disable semantic PR GH app