### PR TITLE
fix(shipyard-controller): Clean up list of open .triggered events when completing a sequence (#5601) 

### DIFF
--- a/test/go-tests/sequencecontrol_test.go
+++ b/test/go-tests/sequencecontrol_test.go
@@ -106,6 +106,15 @@ func Test_SequenceControl_Abort(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, resp.Response().StatusCode)
 
+	resp, err = ApiGETRequest("/controlPlane/v1/event/triggered/" + keptnv2.GetTriggeredEventType("task1"))
+	require.Nil(t, err)
+
+	openTriggeredEvents := &OpenTriggeredEventsResponse{}
+	err = resp.ToJSON(openTriggeredEvents)
+	require.Nil(t, err)
+
+	require.Empty(t, openTriggeredEvents.Events)
+
 	t.Log("sending task finished event")
 	_, err = keptn.SendTaskFinishedEvent(&keptnv2.EventData{
 		Result: keptnv2.ResultPass,

--- a/test/go-tests/test_utils.go
+++ b/test/go-tests/test_utils.go
@@ -32,6 +32,10 @@ const (
 type APIEventSender struct {
 }
 
+type OpenTriggeredEventsResponse struct {
+	Events []*models.KeptnContextExtendedCE `json:"events"`
+}
+
 func (sender *APIEventSender) Send(ctx context.Context, event v2.Event) error {
 	return sender.SendEvent(event)
 }


### PR DESCRIPTION
Forward port of #5605

