### PR TITLE
fix(bridge): show correct name validation message (#5483)

### DIFF
--- a/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.html
+++ b/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.html
@@ -17,8 +17,8 @@
           />
           <dt-error *ngIf="getFormControl('name')?.errors?.required">Must not be empty</dt-error>
           <dt-error *ngIf="getFormControl('name')?.errors?.pattern"
-            >Name must consist of lower case alphanumeric characters and '-' and must start and end with an
-            alphanumeric character
+            >Name must consist of lower case alphanumeric characters and '-' and must start and end with an alphanumeric
+            character
           </dt-error>
         </dt-form-field>
 


### PR DESCRIPTION
## This PR
- makes sure we show the correct validation message for secret names

### Related Issues
Fixes #5483 

Signed-off-by: ermin.muratovic <ermin.muratovic@gmail.com>