### PR TITLE
fix(shipyard-controller): Correctly handle time format in evaluation manager

### DIFF
--- a/shipyard-controller/handler/evaluationmanager.go
+++ b/shipyard-controller/handler/evaluationmanager.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"time"
+
 	"github.com/google/uuid"
 	"github.com/keptn/go-utils/pkg/common/strutils"
 	"github.com/keptn/go-utils/pkg/common/timeutils"
@@ -10,10 +12,9 @@ import (
 	"github.com/keptn/keptn/shipyard-controller/db"
 	"github.com/keptn/keptn/shipyard-controller/models"
 	"github.com/keptn/keptn/shipyard-controller/operations"
-	"time"
 )
 
-const userFriendlyTimeFormat = "2006-01-02T15:04:05.000Z"
+const userFriendlyTimeFormat = "2006-01-02T15:04:05"
 
 const (
 	evaluationErrInvalidTimeframe = iota

--- a/shipyard-controller/handler/evaluationmanager_test.go
+++ b/shipyard-controller/handler/evaluationmanager_test.go
@@ -127,6 +127,114 @@ func TestEvaluationManager_CreateEvaluation(t *testing.T) {
 			wantErr:      &models.Error{Code: evaluationErrSendEventFailed},
 			wantEvents:   []eventTypeWithPayload{},
 		},
+		{
+			name: "time w/ timezone w/o millis",
+			fields: fields{
+				EventSender: &keptnfake.EventSender{},
+				ServiceAPI: &db_mock.ServicesDbOperationsMock{GetServiceFunc: func(project string, stage string, service string) (*models.ExpandedService, error) {
+					return &models.ExpandedService{}, nil
+				}},
+			},
+			args: args{
+				project: "test-project",
+				stage:   "test-stage",
+				service: "test-service",
+				params: &operations.CreateEvaluationParams{
+					Labels:    map[string]string{"foo": "bar"},
+					Start:     "2020-01-02T15:00:00Z",
+					End:       "2020-01-02T16:00:00Z",
+					Timeframe: "",
+				},
+			},
+			wantResponse: false,
+			wantErr:      &models.Error{Code: evaluationErrInvalidTimeframe},
+			wantEvents:   []eventTypeWithPayload{},
+		},
+		{
+			name: "time w/ timezone w/o millis",
+			fields: fields{
+				EventSender: &keptnfake.EventSender{},
+				ServiceAPI: &db_mock.ServicesDbOperationsMock{GetServiceFunc: func(project string, stage string, service string) (*models.ExpandedService, error) {
+					return &models.ExpandedService{}, nil
+				}},
+			},
+			args: args{
+				project: "test-project",
+				stage:   "test-stage",
+				service: "test-service",
+				params: &operations.CreateEvaluationParams{
+					Labels:    map[string]string{"foo": "bar"},
+					Start:     "2020-01-02T15:00:00Z",
+					End:       "2020-01-02T16:00:00Z",
+					Timeframe: "",
+				},
+			},
+			wantResponse: false,
+			wantErr:      &models.Error{Code: evaluationErrInvalidTimeframe},
+			wantEvents:   []eventTypeWithPayload{},
+		},
+		{
+			name: "time w/ timezone w/o millis w/ offset",
+			fields: fields{
+				EventSender: &keptnfake.EventSender{},
+				ServiceAPI: &db_mock.ServicesDbOperationsMock{GetServiceFunc: func(project string, stage string, service string) (*models.ExpandedService, error) {
+					return &models.ExpandedService{}, nil
+				}},
+			},
+			args: args{
+				project: "test-project",
+				stage:   "test-stage",
+				service: "test-service",
+				params: &operations.CreateEvaluationParams{
+					Labels:    map[string]string{"foo": "bar"},
+					Start:     "2020-01-02T15:00:00Z-0700",
+					End:       "2020-01-02T16:00:00Z-0700",
+					Timeframe: "",
+				},
+			},
+			wantResponse: false,
+			wantErr:      &models.Error{Code: evaluationErrInvalidTimeframe},
+			wantEvents:   []eventTypeWithPayload{},
+		},
+		{
+			name: "time w/o timezone w/o millis",
+			fields: fields{
+				EventSender: &keptnfake.EventSender{},
+				ServiceAPI: &db_mock.ServicesDbOperationsMock{GetServiceFunc: func(project string, stage string, service string) (*models.ExpandedService, error) {
+					return &models.ExpandedService{}, nil
+				}},
+			},
+			args: args{
+				project: "test-project",
+				stage:   "test-stage",
+				service: "test-service",
+				params: &operations.CreateEvaluationParams{
+					Labels:    map[string]string{"foo": "bar"},
+					Start:     "2020-01-02T15:00:00",
+					End:       "2020-01-02T16:00:00",
+					Timeframe: "",
+				},
+			},
+			wantResponse: true,
+			wantErr:      nil,
+			wantEvents: []eventTypeWithPayload{
+				{
+					eventType: keptnv2.GetTriggeredEventType("test-stage." + keptnv2.EvaluationTaskName),
+					payload: &keptnv2.EvaluationTriggeredEventData{
+						EventData: keptnv2.EventData{
+							Project: "test-project",
+							Stage:   "test-stage",
+							Service: "test-service",
+							Labels:  map[string]string{"foo": "bar"},
+						},
+						Evaluation: keptnv2.Evaluation{
+							Start: "2020-01-02T15:00:00.000Z",
+							End:   "2020-01-02T16:00:00.000Z",
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Giovanni Liva <giovanni.liva@dynatrace.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
Revert partially #5274 so that the trigger evaluation endpoint still accepts the expected time format. 


