### PR TITLE
fix(cli): Remove unused printQuickAccessInstructionsForWindows func

### DIFF
--- a/cli/pkg/common/quick_access_instructions.go
+++ b/cli/pkg/common/quick_access_instructions.go
@@ -17,12 +17,6 @@ func printQuickAccessInstructionsForUnix(keptnNamespace, keptnReleaseDocsURL str
 	printExposeEndpointInstructions(keptnReleaseDocsURL)
 }
 
-func printQuickAccessInstructionsForWindows(keptnReleaseDocsURL string) {
-	fmt.Println("* To quickly access Keptn, you can use a port-forward and then authenticate your Keptn CLI as described here: https://keptn.sh/docs/" + keptnReleaseDocsURL + "/operate/install/#authenticate-keptn-cli\n")
-
-	printExposeEndpointInstructions(keptnReleaseDocsURL)
-}
-
 func printExposeEndpointInstructions(keptnReleaseDocsURL string) {
 	fmt.Println("* To expose Keptn on a public endpoint, please continue with the installation guidelines provided at:\n" +
 		" - https://keptn.sh/docs/" + keptnReleaseDocsURL + "/operate/install#install-keptn\n")


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- adds this new feature

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1234523

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

