### PR TITLE
style(bridge): Improve text for aborted dialog (#5153)

### DIFF
--- a/bridge/client/app/_components/_dialogs/ktb-confirmation-dialog/ktb-confirmation-dialog.component.html
+++ b/bridge/client/app/_components/_dialogs/ktb-confirmation-dialog/ktb-confirmation-dialog.component.html
@@ -1,14 +1,19 @@
-<div class="mb-3" fxLayout="row" fxLayoutAlign="space-between center">
-  <div class="bold">Are you absolutely sure?</div>
+<div class="mb-2" fxLayout="row" fxLayoutAlign="space-between center">
+  <div class="bold">Abort sequence</div>
   <button dt-icon-button variant="nested" (click)="dialogRef.close()">
     <dt-icon name="abort"></dt-icon>
   </button>
 </div>
-<div class="mt-3" fxLayout="column" fxLayoutAlign="stretch">
+<div fxLayout="column" fxLayoutAlign="stretch">
   <div class="mb-1">
     <p>
-      This action cannot be undone. This will abort the sequence
-      <span class="bold">{{ data.sequence.shkeptncontext }}</span> .
+      This action will abort the
+      <span class="bold">{{ data.sequence.name }}</span> sequence for service
+      <span class="bold">{{ data.sequence.service }}.</span>
+    </p>
+    <p>
+      All <span class="bold">currently running tasks</span> will be completed before the sequence is aborted.<br />The
+      sequence cannot be restarted afterwards, so please be certain.
     </p>
   </div>
   <button dt-button class="danger-button" (click)="confirm()">


### PR DESCRIPTION
Signed-off-by: Elisabeth Lang <elisabeth.lang@dynatrace.com>

![image](https://user-images.githubusercontent.com/2674029/137330103-7ed2689c-82c4-40db-a9bd-829070894eaf.png)

Link to documentation is not provided, as it does not provide additional info. It would just bloat the dialog.

Closes #5153 