### PR TITLE
test: Ensure dependencies in integration test module are up to date

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -465,7 +465,7 @@ jobs:
         continue-on-error: true
         env:
           KEPTN_ENDPOINT: ${{ steps.authenticate_keptn_cli.outputs.KEPTN_ENDPOINT }}
-        run: cd test/go-tests && go test -run UniformRegistration -v
+        run: cd test/go-tests && go get ./... && go test -run UniformRegistration -v
 
       - name: Test Log Ingestion
         # do not run this test for the airgapped scenario


### PR DESCRIPTION
This PR ensures that the dependencies in our integration test package are up to date by executing `go get ./...` before executing the first integration test

Closes #5712 