### PR TITLE
fix(bridge): Only allow tasks / sequences from shipyard to fail a sequence (#5684)

### DIFF
--- a/bridge/client/app/_models/trace.ts
+++ b/bridge/client/app/_models/trace.ts
@@ -32,7 +32,8 @@ class Trace extends tc {
       return data;
     }
 
-    const plainEvent = JSON.parse(JSON.stringify(data));
+    // remove isShipyardEvent property to hide from payload
+    const { isShipyardEvent, ...plainEvent } = JSON.parse(JSON.stringify(data));
     const trace: Trace = Object.assign(new this(), data, { plainEvent });
 
     if (trace.data?.evaluationHistory?.length) {
@@ -110,7 +111,8 @@ class Trace extends tc {
 
   isFaulty(stageName?: string): boolean {
     let result = false;
-    if (this.data) {
+    // Property isShipyardEvent can be undefined, that we ignore it and test isFaulty
+    if (this.data && this.isShipyardEvent !== false) {
       if (
         this.isFailed() ||
         (this.isProblem() && !this.isProblemResolvedOrClosed()) ||

--- a/bridge/server/services/data-service.ts
+++ b/bridge/server/services/data-service.ts
@@ -435,7 +435,7 @@ export class DataService {
     projectName?: string | undefined,
     fromTime?: string | undefined
   ): Promise<EventResult> {
-    let tasksDict: { [type: string]: string } | undefined;
+    let tasksDict: { [type: string]: boolean | undefined } | undefined;
     let result: EventResult = {
       events: [],
       pageSize: 0,
@@ -475,35 +475,33 @@ export class DataService {
     return result;
   }
 
-  private async getTaskDict(projectName: string): Promise<{ [type: string]: string } | undefined> {
-    const dict: { [type: string]: string } = {};
-
+  private async getTaskDict(projectName: string): Promise<{ [type: string]: boolean | undefined } | undefined> {
+    const dict: { [type: string]: boolean | undefined } = {};
     const shipyard = await this.getShipyard(projectName);
 
-    const prefix = 'sh.keptn.event.';
     for (const stage of shipyard.spec.stages) {
       if (stage.sequences) {
         for (const sequence of stage.sequences) {
-          const seqPrefix = prefix + stage.name + '.' + sequence.name + '.';
-          dict[seqPrefix + SequenceState.TRIGGERED] = seqPrefix + SequenceState.TRIGGERED;
-          dict[seqPrefix + SequenceState.STARTED] = seqPrefix + SequenceState.STARTED;
-          dict[seqPrefix + SequenceState.FINISHED] = seqPrefix + SequenceState.FINISHED;
+          const seqPrefix = EventTypes.PREFIX + stage.name + '.' + sequence.name + '.';
+          dict[seqPrefix + SequenceState.TRIGGERED] = true;
+          dict[seqPrefix + SequenceState.STARTED] = true;
+          dict[seqPrefix + SequenceState.FINISHED] = true;
 
           for (const task of sequence.tasks) {
-            const taskPrefix = prefix + task.name + '.';
+            const taskPrefix = EventTypes.PREFIX + task.name + '.';
             if (!dict[taskPrefix + SequenceState.TRIGGERED]) {
-              dict[taskPrefix + SequenceState.TRIGGERED] = taskPrefix + SequenceState.TRIGGERED;
-              dict[taskPrefix + SequenceState.STARTED] = taskPrefix + SequenceState.STARTED;
-              dict[taskPrefix + SequenceState.FINISHED] = taskPrefix + SequenceState.FINISHED;
+              dict[taskPrefix + SequenceState.TRIGGERED] = true;
+              dict[taskPrefix + SequenceState.STARTED] = true;
+              dict[taskPrefix + SequenceState.FINISHED] = true;
             }
           }
         }
       }
       // Evaluation sequence is not defined in shipyard but needed for every stage
-      const evalPrefix = prefix + stage.name + '.evaluation.';
-      dict[evalPrefix + SequenceState.TRIGGERED] = evalPrefix + SequenceState.TRIGGERED;
-      dict[evalPrefix + SequenceState.STARTED] = evalPrefix + SequenceState.STARTED;
-      dict[evalPrefix + SequenceState.FINISHED] = evalPrefix + SequenceState.FINISHED;
+      const evalPrefix = EventTypes.PREFIX + stage.name + '.evaluation.';
+      dict[evalPrefix + SequenceState.TRIGGERED] = true;
+      dict[evalPrefix + SequenceState.STARTED] = true;
+      dict[evalPrefix + SequenceState.FINISHED] = true;
     }
 
     if (Object.keys(dict).length !== 0) {

--- a/bridge/server/services/data-service.ts
+++ b/bridge/server/services/data-service.ts
@@ -482,32 +482,32 @@ export class DataService {
     for (const stage of shipyard.spec.stages) {
       if (stage.sequences) {
         for (const sequence of stage.sequences) {
-          const seqPrefix = EventTypes.PREFIX + stage.name + '.' + sequence.name + '.';
-          dict[seqPrefix + SequenceState.TRIGGERED] = true;
-          dict[seqPrefix + SequenceState.STARTED] = true;
-          dict[seqPrefix + SequenceState.FINISHED] = true;
+          setEventsForDict(EventTypes.PREFIX + stage.name + '.' + sequence.name + '.');
 
           for (const task of sequence.tasks) {
             const taskPrefix = EventTypes.PREFIX + task.name + '.';
             if (!dict[taskPrefix + SequenceState.TRIGGERED]) {
-              dict[taskPrefix + SequenceState.TRIGGERED] = true;
-              dict[taskPrefix + SequenceState.STARTED] = true;
-              dict[taskPrefix + SequenceState.FINISHED] = true;
+              setEventsForDict(taskPrefix);
             }
           }
         }
       }
       // Evaluation sequence is not defined in shipyard but needed for every stage
-      const evalPrefix = EventTypes.PREFIX + stage.name + '.evaluation.';
-      dict[evalPrefix + SequenceState.TRIGGERED] = true;
-      dict[evalPrefix + SequenceState.STARTED] = true;
-      dict[evalPrefix + SequenceState.FINISHED] = true;
+      setEventsForDict(EventTypes.PREFIX + stage.name + '.evaluation.');
     }
+    // get-sli event is not defined in shipyard but needed
+    setEventsForDict(EventTypes.PREFIX + 'get-sli.');
 
     if (Object.keys(dict).length !== 0) {
       return dict;
     }
     return undefined;
+
+    function setEventsForDict(prefix: string): void {
+      dict[prefix + SequenceState.TRIGGERED] = true;
+      dict[prefix + SequenceState.STARTED] = true;
+      dict[prefix + SequenceState.FINISHED] = true;
+    }
   }
 
   public async getTraces(

--- a/bridge/shared/models/trace.ts
+++ b/bridge/shared/models/trace.ts
@@ -106,6 +106,7 @@ export class Trace {
   type!: EventTypes | string;
   time?: Date;
   data!: TraceData;
+  isShipyardEvent?: boolean;
 
   public getShortImageName(): string | undefined {
     let image;


### PR DESCRIPTION
Signed-off-by: Elisabeth Lang <elisabeth.lang@dynatrace.com>

The fix now limits the determination of failed results. For that, it uses the list of tasks and sequences of the shipyard file.
e.g. `sh.keptn.event.dev.delivery.finished`, `sh.keptn.event.deployment.finished`

Limitations:
* The original bug occurred because of a nested `sh.keptn.event.deployment.finished.finished` event that was sent from the webhook-service. When this gets fixed, the event will fail the task / sequence again - but it should then be visible in the task list.
* get-sli will always succeed a sequence, even if the task failed. It is not defined in the shipyard.yaml file.