### PR TITLE
fix(cli): Set log level of config file hint to verbose (#5731)

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -88,7 +88,7 @@ func initConfig() {
 		cfgMgr.CLIConfigPath = cfgFile
 	}
 
-	logging.PrintLog(fmt.Sprintf("Using config file: %s", cfgMgr.CLIConfigPath), logging.InfoLevel)
+	logging.PrintLog(fmt.Sprintf("Using config file: %s", cfgMgr.CLIConfigPath), logging.VerboseLevel)
 
 	var err error
 	rootCLIConfig, err = cfgMgr.LoadCLIConfig()


### PR DESCRIPTION
Closes #5731