### PR TITLE
fix(bridge): Integrations should not be able to register itself to service.* events (#5724)

### DIFF
--- a/bridge/server/services/data-service.ts
+++ b/bridge/server/services/data-service.ts
@@ -396,7 +396,7 @@ export class DataService {
 
   public async getTasks(projectName: string): Promise<string[]> {
     const shipyard = await this.getShipyard(projectName);
-    const tasks: string[] = ['service.delete', 'service.create', 'evaluation'];
+    const tasks: string[] = ['evaluation'];
     for (const stage of shipyard.spec.stages) {
       if (stage.sequences) {
         for (const sequence of stage.sequences) {


### PR DESCRIPTION
## This PR
- makes sure that integrations can't be configured to register to service.* events

### Related Issues
Fixes #5724 

Signed-off-by: ermin.muratovic <ermin.muratovic@gmail.com>