### PR TITLE
feat(jmeter-service): Implement a retry loop for checkEndpointAvailability (#5619)

### DIFF
--- a/jmeter-service/main.go
+++ b/jmeter-service/main.go
@@ -265,11 +265,9 @@ func checkEndpointAvailable(timeout time.Duration, serviceURL *url.URL) error {
 
 	_ = retry.Retry(func() error {
 		if _, err = net.DialTimeout("tcp", hostWithPort, timeout); err != nil {
-			fmt.Printf("checkEndpointAvailable failed: %v", err)
 			return err
 		}
 
-		fmt.Printf("checkEndpointAvailable succeeded!")
 		return nil
 	}, retry.DelayBetweenRetries(time.Second*5), retry.NumberOfRetries(3))
 


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR

- adds a retry logic based on go-utils `retry.Retry` functionality 
@warber @bacherfl am I using this correctly? Also the return value?
 
### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #5619

### Notes

Tested using podtato-head, all green :partying_face: 
![image](https://user-images.githubusercontent.com/56065213/137954557-0f51269f-8e9a-4bf5-9788-d656aa3af6fe.png)

**Best case, it will work on the first try, so we are not changing the "good case" scenarios. However, in the edge case as describedin #5619 this should improve the behaviour**

FYI, this also unblocks PR #5561 
![image](https://user-images.githubusercontent.com/56065213/137957189-716d543b-7311-42ab-8b3d-6204e4686823.png)


### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->
Deploy the image for jmeter, and run a full Continuous delivery project with jmeter tests included (e.g., carts, podtato-head)
