### PR TITLE
test: Use time format defined in go-utils for lighthouse-service unit tests

### DIFF
--- a/lighthouse-service/event_handler/start_evaluation_handler_test.go
+++ b/lighthouse-service/event_handler/start_evaluation_handler_test.go
@@ -391,8 +391,8 @@ func Test_getEvaluationTimestamps(t *testing.T) {
 					},
 				},
 			},
-			wantStart: timeutils.GetKeptnTimeStamp(time.Now().UTC().Add(-10 * time.Minute).Round(time.Minute)),
-			wantEnd:   timeutils.GetKeptnTimeStamp(time.Now().UTC().Round(time.Minute)),
+			wantStart: timeutils.GetKeptnTimeStamp(time.Now().UTC().Add(-10 * time.Minute)),
+			wantEnd:   timeutils.GetKeptnTimeStamp(time.Now().UTC()),
 			wantErr:   false,
 		},
 		{


### PR DESCRIPTION
This PR should fix the problem where in some rare cases the resulting timestamps of the `getEvaluationTimestamp` function were wrongly interpreted in the lighthouse service tests