### PR TITLE
ci: Disable DCO check on pushes to master

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,9 +1,6 @@
 name: DCO
 on:
   pull_request:
-  push:
-    branches:
-      - "master"
 jobs:
   check:
     uses: keptn/gh-automation/.github/workflows/dco.yml@v1


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- disables DCO checks on pushes to master

### Notes
This follows the same behaviour that the probot/dco GH apps has: Only check the DCO on PRs and by only allowing pushes to master through PRs you ensure that only signed off code gets there.
