### PR TITLE
fix: Fix bug where DCO check always fails on dependabot PRs

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -4,5 +4,5 @@ on:
 jobs:
   check:
     uses: keptn/gh-automation/.github/workflows/dco.yml@v1
-
-
+    with:
+      exclude-emails: '49699333+dependabot[bot]@users.noreply.github.com'


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- ignores the dependabot email address from DCO check since the check will never succeed there. This is because dependabot commits have a different author and signoff email address (`49699333+dependabot[bot]@users.noreply.github.com` vs. `support@github.com`)
