### PR TITLE
fix: Fix version not showing up anymore in API (#5783)

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,7 +1,6 @@
 # Use the official Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 FROM golang:1.16.2-alpine as builder-base
-ARG version=develop
 
 WORKDIR /go/src/github.com/keptn/keptn/api
 
@@ -27,13 +26,13 @@ FROM builder-base as builder-test
 CMD go test -coverprofile=coverage.txt -covermode=atomic -v ./handlers/... ./utils/... && mv ./coverage.txt /shared/coverage.txt
 
 FROM builder-base as builder
+ARG version=develop
 ARG debugBuild
 
 # set buildflags for debug build
 RUN if [ ! -z "$debugBuild" ]; then export BUILDFLAGS='-gcflags "all=-N -l"'; fi
 
-ENV REPLACE="version: ${version}"
-RUN sed -i "s/version: develop/${REPLACE}/g" /go/src/github.com/keptn/keptn/api/swagger.yaml
+RUN sed -i "s/version: develop/version: ${version}/g" /go/src/github.com/keptn/keptn/api/swagger.yaml
 
 
 # Build the command inside the container.
@@ -43,12 +42,14 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v cmd/api-ser
 
 
 FROM alpine:3.14 as production
+ARG version=develop
 LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
     org.opencontainers.image.url = "https://keptn.sh" \
     org.opencontainers.image.title="Keptn API" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \
-    org.opencontainers.image.licenses="Apache-2.0"
+    org.opencontainers.image.licenses="Apache-2.0" \
+    org.opencontainers.image.version="${version}"
 
 
 # we need to install ca-certificates and libc6-compat for go programs to work properly

--- a/approval-service/Dockerfile
+++ b/approval-service/Dockerfile
@@ -2,7 +2,6 @@
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.16.2-alpine as builder-base
-ARG version=develop
 
 WORKDIR /go/src/github.com/keptn/keptn/approval-service
 
@@ -40,12 +39,14 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o approval
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.14 as production
+ARG version=develop
 LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
     org.opencontainers.image.url = "https://keptn.sh" \
     org.opencontainers.image.title="Keptn Approval Service" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \
-    org.opencontainers.image.licenses="Apache-2.0"
+    org.opencontainers.image.licenses="Apache-2.0" \
+    org.opencontainers.image.version="${version}"
 
 # we need to install ca-certificates and libc6-compat for go programs to work properly
 RUN apk add --no-cache ca-certificates libc6-compat

--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -51,22 +51,21 @@ RUN yarn build && \
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM node:14-alpine3.14 as production
+ARG version=develop
 LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
     org.opencontainers.image.url = "https://keptn.sh" \
     org.opencontainers.image.title="Keptn Bridge" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \
-    org.opencontainers.image.licenses="Apache-2.0"
+    org.opencontainers.image.licenses="Apache-2.0" \
+    org.opencontainers.image.version="${version}"
 
-
-EXPOSE 3000
-
-ENV NODE_ENV "production"
-WORKDIR /usr/src/app
-ARG version=develop
 ENV VERSION="${version}"
+ENV NODE_ENV "production"
 ENV API_URL "http://api-gateway-nginx.keptn.svc.cluster.local"
 ENV API_TOKEN ""
+
+WORKDIR /usr/src/app
 
 # copy angular output from angularBuilder
 COPY --from=bridge-builder /usr/src/app/dist /usr/src/app/dist
@@ -82,4 +81,5 @@ RUN addgroup mygroup --gid 65532 && adduser -D -G mygroup myuser --uid 65532 && 
 # Set user
 USER myuser
 
+EXPOSE 3000
 CMD ["npm", "start", "--prefix", "./server"]

--- a/configuration-service/Dockerfile
+++ b/configuration-service/Dockerfile
@@ -1,7 +1,6 @@
 # Use the official Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 FROM golang:1.16.2-alpine as builder-base
-ARG version=develop
 
 WORKDIR /go/src/github.com/keptn/keptn/configuration-service
 
@@ -23,13 +22,13 @@ RUN go mod download
 COPY . .
 
 FROM builder-base as builder-test
+ARG version=develop
 
 CMD go test -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
 
 FROM builder-base as builder
 
-ENV REPLACE="version: ${version}"
-RUN sed -i "s/version: develop/${REPLACE}/g" /go/src/github.com/keptn/keptn/configuration-service/swagger.yaml
+RUN sed -i "s/version: develop/version: ${version}/g" /go/src/github.com/keptn/keptn/configuration-service/swagger.yaml
 
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
@@ -41,13 +40,14 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 
 # Use a Docker multi-stage build to create a lean production image.
 FROM alpine:3.14 as production
+ARG version=develop
 LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
     org.opencontainers.image.url = "https://keptn.sh" \
     org.opencontainers.image.title="Keptn Configuration Service" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \
-    org.opencontainers.image.licenses="Apache-2.0"
-
+    org.opencontainers.image.licenses="Apache-2.0" \
+    org.opencontainers.image.version="${version}"
 
 ENV env=production
 

--- a/distributor/Dockerfile
+++ b/distributor/Dockerfile
@@ -2,7 +2,6 @@
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.16.2-alpine as builder-base
-ARG version=develop
 
 ARG debugBuild
 
@@ -42,12 +41,14 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.14 as production
+ARG version=develop
 LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
     org.opencontainers.image.url = "https://keptn.sh" \
     org.opencontainers.image.title="Keptn Distributor" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \
-    org.opencontainers.image.licenses="Apache-2.0"
+    org.opencontainers.image.licenses="Apache-2.0" \
+    org.opencontainers.image.version="${version}"
 
 RUN apk add --no-cache ca-certificates libc6-compat
 

--- a/helm-service/Dockerfile
+++ b/helm-service/Dockerfile
@@ -2,7 +2,6 @@
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.16.2-alpine as builder-base
-ARG version=develop
 
 WORKDIR /go/src/github.com/keptn/keptn/helm-service
 
@@ -39,12 +38,14 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.14 as production
+ARG version=develop
 LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
     org.opencontainers.image.url = "https://keptn.sh" \
     org.opencontainers.image.title="Keptn Helm Service" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \
-    org.opencontainers.image.licenses="Apache-2.0"
+    org.opencontainers.image.licenses="Apache-2.0" \
+    org.opencontainers.image.version="${version}"
 
 # we need to install ca-certificates and libc6-compat for go programs to work properly
 RUN apk add --no-cache ca-certificates libc6-compat

--- a/jmeter-service/Dockerfile
+++ b/jmeter-service/Dockerfile
@@ -2,7 +2,6 @@
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.16.2-alpine as builder-base
-ARG version=develop
 
 WORKDIR /go/src/github.com/keptn/keptn/jmeter-service
 
@@ -39,12 +38,14 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.14 as production
+ARG version=develop
 LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
     org.opencontainers.image.url = "https://keptn.sh" \
     org.opencontainers.image.title="Keptn JMeter Service" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \
-    org.opencontainers.image.licenses="Apache-2.0"
+    org.opencontainers.image.licenses="Apache-2.0" \
+    org.opencontainers.image.version="${version}"
 
 ENV env=production
 ARG JMETER_VERSION="5.1.1"

--- a/lighthouse-service/Dockerfile
+++ b/lighthouse-service/Dockerfile
@@ -2,7 +2,6 @@
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.16.2-alpine as builder-base
-ARG version=develop
 
 # Copy local code to the container image.
 WORKDIR /go/src/github.com/keptn/keptn/lighthouse-service
@@ -39,12 +38,14 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.14 as production
+ARG version=develop
 LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
     org.opencontainers.image.url = "https://keptn.sh" \
     org.opencontainers.image.title="Keptn Lighthouse Service" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \
-    org.opencontainers.image.licenses="Apache-2.0"
+    org.opencontainers.image.licenses="Apache-2.0" \
+    org.opencontainers.image.version="${version}"
 
 # we need to install ca-certificates and libc6-compat for go programs to work properly
 RUN apk add --no-cache ca-certificates libc6-compat

--- a/mongodb-datastore/Dockerfile
+++ b/mongodb-datastore/Dockerfile
@@ -2,7 +2,6 @@
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.16.2-alpine as builder-base
-ARG version=develop
 
 WORKDIR /go/src/github.com/keptn/keptn/mongodb-datastore
 
@@ -28,14 +27,13 @@ FROM builder-base as builder-test
 CMD go test -race -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
 
 FROM builder-base as builder
-
+ARG version=develop
 ARG debugBuild
 
 # set buildflags for debug build
 RUN if [ ! -z "$debugBuild" ]; then export BUILDFLAGS='-gcflags "all=-N -l"'; fi
 
-ENV REPLACE="version: ${version}"
-RUN sed -i "s/version: develop/${REPLACE}/g" /go/src/github.com/keptn/keptn/mongodb-datastore/swagger.yaml
+RUN sed -i "s/version: develop/version: ${version}/g" /go/src/github.com/keptn/keptn/mongodb-datastore/swagger.yaml
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
@@ -44,12 +42,14 @@ RUN cd cmd/mongodb-datastore-server && GOOS=linux go build -ldflags '-linkmode=e
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.14 as production
+ARG version=develop
 LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
     org.opencontainers.image.url = "https://keptn.sh" \
     org.opencontainers.image.title="Keptn MongoDB Datastore" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \
-    org.opencontainers.image.licenses="Apache-2.0"
+    org.opencontainers.image.licenses="Apache-2.0" \
+    org.opencontainers.image.version="${version}"
 
 # we need to install ca-certificates and libc6-compat for go programs to work properly
 RUN apk add --no-cache ca-certificates libc6-compat

--- a/platform-support/openshift-route-service/Dockerfile
+++ b/platform-support/openshift-route-service/Dockerfile
@@ -2,7 +2,7 @@
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.16.2-alpine as builder-base
-ARG version=develop
+
 # Copy local code to the container image.
 WORKDIR /go/src/github.com/keptn/keptn/platform-support/openshift-route-service
 
@@ -41,12 +41,14 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o  openshi
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.14 as production
+ARG version=develop
 LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
     org.opencontainers.image.url = "https://keptn.sh" \
     org.opencontainers.image.title="Keptn OpenShift Route Service" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \
-    org.opencontainers.image.licenses="Apache-2.0"
+    org.opencontainers.image.licenses="Apache-2.0" \
+    org.opencontainers.image.version="${version}"
 
 RUN apk add --no-cache ca-certificates libc6-compat
 

--- a/remediation-service/Dockerfile
+++ b/remediation-service/Dockerfile
@@ -2,7 +2,6 @@
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.16.2-alpine as builder-base
-ARG version=develop
 
 WORKDIR /go/src/github.com/keptn/keptn/remediation-service
 
@@ -39,12 +38,14 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.14 as production
+ARG version=develop
 LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
     org.opencontainers.image.url = "https://keptn.sh" \
     org.opencontainers.image.title="Keptn Remediation Service" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \
-    org.opencontainers.image.licenses="Apache-2.0"
+    org.opencontainers.image.licenses="Apache-2.0" \
+    org.opencontainers.image.version="${version}"
 
 # we need to install ca-certificates and libc6-compat for go programs to work properly
 RUN apk add --no-cache ca-certificates libc6-compat

--- a/secret-service/Dockerfile
+++ b/secret-service/Dockerfile
@@ -1,7 +1,6 @@
 # Use the official Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 FROM golang:1.16.2-alpine as builder-base
-ARG version=develop
 
 # install additional dependencies
 RUN apk add --no-cache gcc libc-dev git
@@ -31,8 +30,7 @@ FROM builder-base as builder-test
 CMD go test -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
 
 FROM builder-base as builder
-
-ENV REPLACE="version: ${version}"
+ARG version=develop
 
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
@@ -43,7 +41,7 @@ RUN GOOS=linux swag init --parseDependency
 # replace github.com/alecthomas/template; with text/template in docs/docs.go
 RUN sed -i "s|github.com/alecthomas/template|text/template|g" docs/docs.go
 # replace version "develop" with actual version
-RUN sed -i "s/version: develop/${REPLACE}/g" docs/swagger.yaml
+RUN sed -i "s/version: develop/version: ${version}/g" docs/swagger.yaml
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here,
@@ -52,12 +50,14 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 
 # Use a Docker multi-stage build to create a lean production image.
 FROM alpine:3.14 as production
+ARG version=develop
 LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
     org.opencontainers.image.url = "https://keptn.sh" \
     org.opencontainers.image.title="Keptn Secret Service" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \
-    org.opencontainers.image.licenses="Apache-2.0"
+    org.opencontainers.image.licenses="Apache-2.0" \
+    org.opencontainers.image.version="${version}"
 
 
 ENV env=production

--- a/shipyard-controller/Dockerfile
+++ b/shipyard-controller/Dockerfile
@@ -1,7 +1,6 @@
 # Use the official Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 FROM golang:1.16.2-alpine as builder-base
-ARG version=develop
 
 # install additional dependencies
 RUN apk add --no-cache gcc libc-dev git
@@ -27,7 +26,6 @@ RUN go mod download
 COPY . .
 
 FROM golang:1.16.2 as builder-test
-ARG version=develop
 
 # install additional dependencies
 RUN apt-get install -y gcc libc-dev git
@@ -55,8 +53,7 @@ COPY . .
 CMD go test -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
 
 FROM builder-base as builder
-
-ENV REPLACE="version: ${version}"
+ARG version=develop
 
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
@@ -67,7 +64,7 @@ RUN GOOS=linux swag init --parseDependency
 # replace github.com/alecthomas/template; with text/template in docs/docs.go
 RUN sed -i "s|github.com/alecthomas/template|text/template|g" docs/docs.go
 # replace version "develop" with actual version
-RUN sed -i "s/version: develop/${REPLACE}/g" docs/swagger.yaml
+RUN sed -i "s/version: develop/version: ${version}/g" docs/swagger.yaml
 
 # Build the command inside the container. 
 # (You may fetch or manage dependencies here, 
@@ -76,12 +73,14 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 
 # Use a Docker multi-stage build to create a lean production image.
 FROM alpine:3.14 as production
+ARG version=develop
 LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
     org.opencontainers.image.url = "https://keptn.sh" \
     org.opencontainers.image.title="Keptn Shipyard Controller" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \
-    org.opencontainers.image.licenses="Apache-2.0"
+    org.opencontainers.image.licenses="Apache-2.0" \
+    org.opencontainers.image.version="${version}"
 
 
 ENV env=production

--- a/statistics-service/Dockerfile
+++ b/statistics-service/Dockerfile
@@ -1,7 +1,6 @@
 # Use the official Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 FROM golang:1.16.2-alpine as builder-base
-ARG version=develop
 
 # install additional dependencies
 RUN apk add --no-cache gcc libc-dev git
@@ -31,8 +30,8 @@ FROM builder-base as builder-test
 CMD go test -race -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
 
 FROM builder-base as builder
+ARG version=develop
 
-ENV REPLACE="version: ${version}"
 
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
@@ -43,7 +42,7 @@ RUN GOOS=linux swag init --parseDependency
 # replace github.com/alecthomas/template; with text/template in docs/docs.go
 RUN sed -i "s|github.com/alecthomas/template|text/template|g" docs/docs.go
 # replace version "develop" with actual version
-RUN sed -i "s/version: develop/${REPLACE}/g" docs/swagger.yaml
+RUN sed -i "s/version: develop/version: ${version}/g" docs/swagger.yaml
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here,
@@ -52,13 +51,14 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 
 # Use a Docker multi-stage build to create a lean production image.
 FROM alpine:3.14 as production
+ARG version=develop
 LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
     org.opencontainers.image.url = "https://keptn.sh" \
     org.opencontainers.image.title="Keptn Statistics Service" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \
-    org.opencontainers.image.licenses="Apache-2.0"
-
+    org.opencontainers.image.licenses="Apache-2.0" \
+    org.opencontainers.image.version="${version}"
 
 ENV env=production
 

--- a/webhook-service/Dockerfile
+++ b/webhook-service/Dockerfile
@@ -2,7 +2,6 @@
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.16.2-alpine as builder-base
-ARG version=develop
 
 WORKDIR /go/src/github.com/keptn/keptn/webhook-service
 
@@ -39,6 +38,15 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.14 as production
+ARG version=develop
+LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
+    org.opencontainers.image.url = "https://keptn.sh" \
+    org.opencontainers.image.title="Keptn Webhook Service" \
+    org.opencontainers.image.vendor="Keptn" \
+    org.opencontainers.image.documentation="https://keptn.sh/docs/" \
+    org.opencontainers.image.licenses="Apache-2.0" \
+    org.opencontainers.image.version="${version}"
+
 # we need to install ca-certificates and libc6-compat for go programs to work properly
 RUN apk add --no-cache ca-certificates libc6-compat curl
 


### PR DESCRIPTION
## This PR
* fixes the version showing up correctly in the API's `swagger.yaml` file by correctly making use of the `version` docker build argument during image builds
* adds the version build argument also to the OCI image labels

Fixes #5783 