### PR TITLE
chore: Cancel integration tests when mismatch between CLI and kube context is detected (#5743)

### DIFF
--- a/test/go-tests/init_test.go
+++ b/test/go-tests/init_test.go
@@ -1,0 +1,54 @@
+package go_tests
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	if err := setup(); err != nil {
+		os.Exit(-1)
+	}
+	code := m.Run()
+	os.Exit(code)
+}
+
+func setup() error {
+	match, err := endpointsMatch()
+	if err != nil {
+		return fmt.Errorf("could not compare endpoints of kubectl context and keptn CLI: %s", err.Error())
+	}
+	if !match {
+		return errors.New("endpoint mismatch between CLI and kubectl detected")
+	}
+	return nil
+}
+
+func endpointsMatch() (bool, error) {
+	_, keptnAPIURL, err := GetApiCredentials()
+	if err != nil {
+		return false, err
+	}
+	statusCmdOutput, err := ExecuteCommand("keptn status")
+	if err != nil {
+		return false, err
+	}
+	statusOutputLines := strings.Split(statusCmdOutput, "\n")
+
+	var apiURLFromStatusCommand string
+	for _, line := range statusOutputLines {
+		if strings.Contains(line, "Successfully authenticated") {
+			endpointLineSplit := strings.Split(line, " ")
+			apiURLFromStatusCommand = endpointLineSplit[len(endpointLineSplit)-1]
+			break
+		}
+	}
+
+	if apiURLFromStatusCommand != keptnAPIURL {
+		return false, nil
+	}
+	return true, nil
+}

--- a/test/go-tests/init_test.go
+++ b/test/go-tests/init_test.go
@@ -17,6 +17,9 @@ func TestMain(m *testing.M) {
 }
 
 func setup() error {
+	// before executing the tests, we check whether the context of the Keptn CLI matches the one of the kubectl CLI
+	// i.e. The kubectl CLI should be connected to the cluster the Keptn CLI is currently authenticated against.
+	// this prevents unintended kubectl commands from being executed against a different cluster than the one containing the Keptn instance that should be tested
 	match, err := endpointsMatch()
 	if err != nil {
 		return fmt.Errorf("could not compare endpoints of kubectl context and keptn CLI: %s", err.Error())

--- a/test/go-tests/sequencetrigger_test.go
+++ b/test/go-tests/sequencetrigger_test.go
@@ -30,11 +30,6 @@ spec:
             - name: "mytask"
             - name: "othertask"`
 
-func TestMain(m *testing.M) {
-	code := m.Run()
-	os.Exit(code)
-}
-
 func Test_SequenceLoopIntegrationTest(t *testing.T) {
 	projectName := "sequence-loop"
 	serviceName := "my-service"


### PR DESCRIPTION
Closes #5743