### PR TITLE
fix(cli): Make sure the release version is set in command descriptions (#5762)

### DIFF
--- a/cli/cmd/auth.go
+++ b/cli/cmd/auth.go
@@ -122,7 +122,7 @@ func verifyAuthParams(authParams *authCmdParams) error {
 
 		err = smartFetchKeptnAuthParameters()
 		if err != nil {
-			return fmt.Errorf(err.Error()+parametersRequiredMessage, keptnReleaseDocsURL, namespace, namespace)
+			return fmt.Errorf(err.Error()+parametersRequiredMessage, getReleaseDocsURL(), namespace, namespace)
 		}
 	}
 	return nil

--- a/cli/cmd/configure_monitoring.go
+++ b/cli/cmd/configure_monitoring.go
@@ -36,7 +36,7 @@ var monitoringCmd = &cobra.Command{
 	Long: `Configure a monitoring solution for the deployments managed by Keptn.
 
 **Note:** If you are executing *keptn configure monitoring dynatrace*, the service flag is optional since Keptn automatically detects the services of a project. 
-See https://keptn.sh/docs/` + keptnReleaseDocsURL + `/monitoring/dynatrace/install/ for more information.
+See https://keptn.sh/docs/` + getReleaseDocsURL() + `/monitoring/dynatrace/install/ for more information.
 `,
 	Example: `keptn configure monitoring dynatrace --project=PROJECTNAME
 keptn configure monitoring prometheus --project=PROJECTNAME --service=SERVICENAME`,

--- a/cli/cmd/create_project.go
+++ b/cli/cmd/create_project.go
@@ -41,7 +41,7 @@ The shipyard file describes the used stages. These stages are defined by name, a
 By executing the *create project* command, Keptn initializes an internal Git repository that is used to maintain all project-related resources. 
 To upstream this internal Git repository to a remote repository, the Git user (*--git-user*), an access token (*--git-token*), and the remote URL (*--git-remote-url*) are required.
 
-For more information about Shipyard, creating projects, or upstream repositories, please go to [Manage Keptn](https://keptn.sh/docs/` + keptnReleaseDocsURL + `/manage/)
+For more information about Shipyard, creating projects, or upstream repositories, please go to [Manage Keptn](https://keptn.sh/docs/` + getReleaseDocsURL() + `/manage/)
 `,
 	Example: `keptn create project PROJECTNAME --shipyard=FILEPATH
 keptn create project PROJECTNAME --shipyard=FILEPATH --git-user=GIT_USER --git-token=GIT_TOKEN --git-remote-url=GIT_REMOTE_URL`,

--- a/cli/cmd/delete_project.go
+++ b/cli/cmd/delete_project.go
@@ -27,7 +27,7 @@ var delProjectCmd = &cobra.Command{
 * If a Git upstream is configured for this project, the referenced upstream repository (e.g., on GitHub) will not be deleted. 
 * Services that have been deployed to the Kubernetes cluster are not deleted.
 * Namespaces that have been created on the Kubernetes cluster are not deleted.
-* Helm-releases created for deployments are not deleted. To clean-up deployed Helm releases, please see [Clean-up after deleting a project](https://keptn.sh/docs/` + keptnReleaseDocsURL + `/continuous_delivery/deployment_helm/#clean-up-after-deleting-a-project)
+* Helm-releases created for deployments are not deleted. To clean-up deployed Helm releases, please see [Clean-up after deleting a project](https://keptn.sh/docs/` + getReleaseDocsURL() + `/continuous_delivery/deployment_helm/#clean-up-after-deleting-a-project)
 `,
 	Example:      `keptn delete project sockshop`,
 	SilenceUsage: true,

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -75,7 +75,7 @@ func NewInstallCmd(helmHelper helm.IHelper, namespaceHandler kube.IKeptnNamespac
 		Short: "Installs Keptn on a Kubernetes cluster",
 		Long: `The Keptn CLI allows installing Keptn on any Kubernetes derivative to which your kube config is pointing to, and on OpenShift.
 
-For more information, please follow the installation guide [Install Keptn](https://keptn.sh/docs/` + keptnReleaseDocsURL + `/operate/install/#install-keptn)
+For more information, please follow the installation guide [Install Keptn](https://keptn.sh/docs/` + getReleaseDocsURL() + `/operate/install/#install-keptn)
 `,
 		Example: `keptn install                                                          # install on Kubernetes
 
@@ -140,7 +140,7 @@ keptn install --hide-sensitive-data                                    # install
 			if *installParams.PlatformIdentifier != platform.OpenShiftIdentifier {
 				if isNewerVersion, err := kube.CheckKubeServerVersion(KubeServerVersionConstraints); err != nil {
 					logging.PrintLog(err.Error(), logging.VerboseLevel)
-					logging.PrintLog("See https://keptn.sh/docs/"+keptnReleaseDocsURL+"/operate/k8s_support/ for details.", logging.VerboseLevel)
+					logging.PrintLog("See https://keptn.sh/docs/"+getReleaseDocsURL()+"/operate/k8s_support/ for details.", logging.VerboseLevel)
 					return fmt.Errorf("Failed to check kubernetes server version: %w", err)
 				} else if isNewerVersion {
 					logging.PrintLog("The Kubernetes server version is higher than the one officially supported. This is not recommended and could have negative impacts on the stability of Keptn - use at your own risk.", logging.InfoLevel)
@@ -314,12 +314,12 @@ func (i *InstallCmdHandler) doInstallation(installParams installCmdParams) error
 		endpoint, err := getAPIEndpoint(keptnNamespace, installParams.EndPointServiceType.String())
 		if err == nil {
 			showFallbackConnectMessage = false
-			common.PrintQuickAccessInstructions(keptnNamespace, keptnReleaseDocsURL, endpoint)
+			common.PrintQuickAccessInstructions(keptnNamespace, getReleaseDocsURL(), endpoint)
 		}
 	}
 
 	if showFallbackConnectMessage {
-		common.PrintQuickAccessInstructions(keptnNamespace, keptnReleaseDocsURL, "http://localhost:8080/api")
+		common.PrintQuickAccessInstructions(keptnNamespace, getReleaseDocsURL(), "http://localhost:8080/api")
 	}
 
 	return nil

--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -27,7 +27,7 @@ This command does *not* delete:
 * Prometheus monitoring
 * Any (third-party) service installed in addition to Keptn (e.g., notification-service, slackbot-service, ...)
 
-Besides, deployed services and the configuration on the Git upstream (i.e., GitHub, GitLab, or Bitbucket) are not deleted. To clean-up created projects and services, please see [Delete a project](https://keptn.sh/docs/` + keptnReleaseDocsURL + `/manage/project/#delete-a-project).
+Besides, deployed services and the configuration on the Git upstream (i.e., GitHub, GitLab, or Bitbucket) are not deleted. To clean-up created projects and services, please see [Delete a project](https://keptn.sh/docs/` + getReleaseDocsURL() + `/manage/project/#delete-a-project).
 
 **Note:** This command requires a *Kubernetes current context* pointing to the cluster where Keptn should get uninstalled from.
 `,

--- a/cli/cmd/update_project.go
+++ b/cli/cmd/update_project.go
@@ -32,7 +32,7 @@ Updating a shipyard file is not possible.
 By executing the update project command, Keptn will add the provided upstream repository to the existing internal Git repository that is used to maintain all project-related resources. 
 To upstream this internal Git repository to a remote repository, the Git user (--git-user), an access token (--git-token), and the remote URL (--git-remote-url) are required.
 
-For more information about updating projects or upstream repositories, please go to [Manage Keptn](https://keptn.sh/docs/` + keptnReleaseDocsURL + `/manage/)
+For more information about updating projects or upstream repositories, please go to [Manage Keptn](https://keptn.sh/docs/` + getReleaseDocsURL() + `/manage/)
 `,
 	Example:      `keptn update project PROJECTNAME --git-user=GIT_USER --git-token=GIT_TOKEN --git-remote-url=GIT_REMOTE_URL`,
 	SilenceUsage: true,

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -56,7 +56,7 @@ func NewUpgraderCommand(vChecker *version.KeptnVersionChecker) *cobra.Command {
 		Short: "Upgrades Keptn on a Kubernetes cluster and supports upgrading the shipyard of a project to a new specification.",
 		Long: `The Keptn CLI allows upgrading Keptn on any Kubernetes derivative to which your kube config is pointing to, and on OpenShift. Also, it supports upgrading the shipyard of an existing project to a new specification.
 
-For more information, please follow the installation guide [Upgrade Keptn](https://keptn.sh/docs/` + keptnReleaseDocsURL + `/operate/upgrade/)
+For more information, please follow the installation guide [Upgrade Keptn](https://keptn.sh/docs/` + getReleaseDocsURL() + `/operate/upgrade/)
 `,
 		Example: `keptn upgrade # upgrades Keptn
 
@@ -162,7 +162,7 @@ func doUpgradePreRunCheck(vChecker *version.KeptnVersionChecker) error {
 	if *upgradeParams.PlatformIdentifier != platform.OpenShiftIdentifier {
 		if isNewerVersion, err := kube.CheckKubeServerVersion(KubeServerVersionConstraints); err != nil {
 			logging.PrintLog(err.Error(), logging.VerboseLevel)
-			logging.PrintLog("See https://keptn.sh/docs/"+keptnReleaseDocsURL+"/operate/k8s_support/ for details.", logging.VerboseLevel)
+			logging.PrintLog("See https://keptn.sh/docs/"+getReleaseDocsURL()+"/operate/k8s_support/ for details.", logging.VerboseLevel)
 			return fmt.Errorf("Failed to check kubernetes server version: %w", err)
 		} else if isNewerVersion {
 			logging.PrintLog("The Kubernetes server version is higher than the one officially supported. This is not recommended and could have negative impacts on the stability of Keptn - use at your own risk.", logging.InfoLevel)

--- a/cli/cmd/upgrade_project.go
+++ b/cli/cmd/upgrade_project.go
@@ -44,7 +44,7 @@ This command will upgrade the shipyard of the project to the specified version
 
 By executing the update project command, Keptn will fetch the current shipyard.yaml file of the project and convert it to the version specified in the 'toVersion'' flag.
 
-For more information about upgrading projects, go to [Manage Keptn](https://keptn.sh/docs/` + keptnReleaseDocsURL + `/operate/upgrade)
+For more information about upgrading projects, go to [Manage Keptn](https://keptn.sh/docs/` + getReleaseDocsURL() + `/operate/upgrade)
 `,
 	Example:      `keptn upgrade project PROJECTNAME --shipyard --fromVersion=0.1.0 --toVersion=0.2.0`,
 	SilenceUsage: true,

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -99,24 +99,6 @@ func NewVersionCommand(vChecker *version.VersionChecker) *cobra.Command {
 	return versionCmd
 }
 
-// SetVersion sets version, versionCheckInfo and extracts and sets {Major} and {Minor} version for keptnReleaseDocsURL
-func SetVersion(vers string) {
-	Version = vers
-	v, err := versionCheck.NewSemver(vers)
-	keptnReleaseDocsURL = "0.8.x" //fallback version if provided doc version is invalid
-	if err == nil {
-		segments := v.Segments()
-		if len(segments) == 3 {
-			keptnReleaseDocsURL = strconv.Itoa(segments[0]) + "." + strconv.Itoa(segments[1]) + ".x"
-		}
-	}
-
-	versionCheckInfo = `Daily version check is %s. 
-Keptn will%s collect statistical data and will%s notify about new versions and security patches for Keptn. Details can be found at: https://keptn.sh/docs/` + keptnReleaseDocsURL + `/reference/version_check
----------------------------------------------------
-`
-}
-
 func init() {
 	rootCmd.AddCommand(versionCmd)
 }

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -101,17 +101,14 @@ func NewVersionCommand(vChecker *version.VersionChecker) *cobra.Command {
 
 // SetVersion sets version, versionCheckInfo and extracts and sets {Major} and {Minor} version for keptnReleaseDocsURL
 func SetVersion(vers string) {
-	fmt.Println("SetVersion(): " + vers)
 	Version = vers
 	v, err := versionCheck.NewSemver(vers)
 	keptnReleaseDocsURL = "0.8.x" //fallback version if provided doc version is invalid
 	if err == nil {
 		segments := v.Segments()
-		fmt.Println(fmt.Sprintf("segments =  %v", segments))
 		if len(segments) == 3 {
 			keptnReleaseDocsURL = strconv.Itoa(segments[0]) + "." + strconv.Itoa(segments[1]) + ".x"
 		}
-		fmt.Println("keptnReleaseDocsURL =  " + keptnReleaseDocsURL)
 	}
 
 	versionCheckInfo = `Daily version check is %s. 

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -101,8 +101,34 @@ func NewVersionCommand(vChecker *version.VersionChecker) *cobra.Command {
 
 // SetVersion sets version, versionCheckInfo and extracts and sets {Major} and {Minor} version for keptnReleaseDocsURL
 func SetVersion(vers string) {
+	fmt.Println("SetVersion(): " + vers)
 	Version = vers
 	v, err := versionCheck.NewSemver(vers)
+	keptnReleaseDocsURL = "0.8.x" //fallback version if provided doc version is invalid
+	if err == nil {
+		segments := v.Segments()
+		fmt.Println(fmt.Sprintf("segments =  %v", segments))
+		if len(segments) == 3 {
+			keptnReleaseDocsURL = strconv.Itoa(segments[0]) + "." + strconv.Itoa(segments[1]) + ".x"
+		}
+		fmt.Println("keptnReleaseDocsURL =  " + keptnReleaseDocsURL)
+	}
+
+	versionCheckInfo = `Daily version check is %s. 
+Keptn will%s collect statistical data and will%s notify about new versions and security patches for Keptn. Details can be found at: https://keptn.sh/docs/` + keptnReleaseDocsURL + `/reference/version_check
+---------------------------------------------------
+`
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}
+
+func getReleaseDocsURL() string {
+	if keptnReleaseDocsURL != "" {
+		return keptnReleaseDocsURL
+	}
+	v, err := versionCheck.NewSemver(Version)
 	keptnReleaseDocsURL = "0.8.x" //fallback version if provided doc version is invalid
 	if err == nil {
 		segments := v.Segments()
@@ -115,10 +141,7 @@ func SetVersion(vers string) {
 Keptn will%s collect statistical data and will%s notify about new versions and security patches for Keptn. Details can be found at: https://keptn.sh/docs/` + keptnReleaseDocsURL + `/reference/version_check
 ---------------------------------------------------
 `
-}
-
-func init() {
-	rootCmd.AddCommand(versionCmd)
+	return keptnReleaseDocsURL
 }
 
 func isLastCheckStale() (bool, error) {

--- a/cli/main.go
+++ b/cli/main.go
@@ -24,8 +24,6 @@ func init() {
 }
 
 func main() {
-	cmd.SetVersion(Version)
-
 	if len(KubeServerVersionConstraints) > 0 {
 		if _, err := version.NewConstraint(KubeServerVersionConstraints); err != nil {
 			cmd.KubeServerVersionConstraints = DefaultKubeServerVersionConstraints

--- a/make-scripts/build/build-cli.sh
+++ b/make-scripts/build/build-cli.sh
@@ -9,7 +9,7 @@ cd ./cli/ || return
 
 echo "Building Keptn CLI"
 env go mod download
-env go build -v -x -ldflags="-X 'main.Version=$VERSION' -X 'main.KubeServerVersionConstraints=$KUBE_CONSTRAINTS'" -o "${OUTPUT_EXECUTABLE_NAME}"
+env go build -v -x -ldflags="-X 'github.com/keptn/keptn/cli/cmd.Version=$VERSION' -X 'main.KubeServerVersionConstraints=$KUBE_CONSTRAINTS'" -o "${OUTPUT_EXECUTABLE_NAME}"
 
 # shellcheck disable=SC2181
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
Closes #5762

The reason why the keptnReleaseDocsURL was not set properly was the order of the initialization within the cli project:

The commands, including their description including the `keptnReleaseNotesURL` are located in the `cmd` subpackage and are therefore initialized before the `main` package, where the `Version` property was set using the ldflags. 