### PR TITLE
chore: Added go-sdk and webhook-service to dependencies-and-licenses check

### DIFF
--- a/.github/workflows/dependencies-and-licenses.yml
+++ b/.github/workflows/dependencies-and-licenses.yml
@@ -41,7 +41,7 @@ jobs:
       - name: GO dependencies and licenses
         run: |
           TMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'keptndeps')
-          MODULES="api approval-service cli configuration-service distributor helm-service jmeter-service lighthouse-service mongodb-datastore remediation-service secret-service shipyard-controller statistics-service"
+          MODULES="api approval-service cli configuration-service distributor go-sdk helm-service jmeter-service lighthouse-service mongodb-datastore remediation-service secret-service shipyard-controller statistics-service webhook-service"
           for MODULE in $MODULES; do
              echo "🔍 Analyzing dependencies in module $MODULE"
              ( cd keptn/keptn/"$MODULE" || return ; go mod tidy > /dev/null 2>&1; go list -m -json all | go-licence-detector -depsTemplate=../.dependencies/templates/dependencies.csv.tmpl -depsOut="${TMP_DIR}"/"${MODULE}"-dependencies.txt  -overrides=../.dependencies/overrides/overrides.json )


### PR DESCRIPTION
chore: This PR adds the two modules `gosdk` and `webhook-service` to the dependencies&licenses check