### PR TITLE
test: added test case to verify data among pages based on project change and refactoring of other tests

### DIFF
--- a/bridge/cypress/fixtures/bridgeInfo.mock.json
+++ b/bridge/cypress/fixtures/bridgeInfo.mock.json
@@ -1,8 +1,11 @@
 {
-  "apiUrl": "http://example.com/api",
-  "apiToken": "123456789qwertzuiopasdfghjkl",
-  "cliDownloadLink": "https://github.com/keptn/keptn/releases",
+  "bridgeVersion": "0.10.0-next.1",
+  "keptnInstallationType": "QUALITY_GATES",
+  "apiUrl": "",
+  "apiToken": "",
+  "cliDownloadLink": "https://github.com/keptn/keptn/releases/tag/0.10.0-next.1",
   "enableVersionCheckFeature": false,
   "showApiToken": true,
-  "authType": "NONE"
+  "authType": "OAUTH",
+  "user": "claus.keptn-dev@ruxitlabs.com"
 }

--- a/bridge/cypress/fixtures/get.approval.json
+++ b/bridge/cypress/fixtures/get.approval.json
@@ -72,7 +72,7 @@
             "state": "finished",
             "stages": [
               {
-                "name": "quality-gate",
+                "name": "prj-quality-gate",
                 "state": "finished",
                 "latestEvaluation": {
                   "result": "pass",

--- a/bridge/cypress/fixtures/get.approval.testproj.json
+++ b/bridge/cypress/fixtures/get.approval.testproj.json
@@ -1,0 +1,22 @@
+{
+  "stages": [
+    {
+      "services": [
+        {
+          "lastEventTypes": {},
+          "openRemediations": null,
+          "openApprovals": [],
+          "creationDate": "1629190178019300348",
+          "serviceName": "newService"
+        }
+      ],
+      "stageName": "newproj-quality-gate"
+    }
+  ],
+  "creationDate": "1629211070179837245",
+  "gitRemoteURI": "https://github.com/carpe-github/claus-tenant-dev-testproj.git",
+  "gitUser": "carpe-github-testproj",
+  "projectName": "testproject",
+  "shipyard": "apiVersion: \"spec.keptn.sh/0.2.0\"\nkind: \"Shipyard\"\nmetadata:\n  name: \"shipyard-quality-gates\"\nspec:\n  stages:\n    - name: \"newproj-quality-gate\"",
+  "shipyardVersion": "spec.keptn.sh/0.2.0"
+}

--- a/bridge/cypress/fixtures/get.uniform.json
+++ b/bridge/cypress/fixtures/get.uniform.json
@@ -1,0 +1,113 @@
+[
+  {
+    "id": "d410b1578c8814bcd0fcdcae81a60c8f95510083",
+    "name": "remediation-service",
+    "metadata": {
+      "hostname": "Cloud Automation",
+      "integrationversion": "0.9.0",
+      "distributorversion": "0.9.0",
+      "location": "control-plane",
+      "kubernetesmetadata": {
+        "namespace": "Cloud Automation",
+        "podname": "remediation-service-766ffbb654-whk6j",
+        "deploymentname": "remediation-service"
+      },
+      "lastseen": "2021-10-07T12:10:11.115Z"
+    },
+    "subscription": {
+      "topics": null,
+      "status": "",
+      "filter": {
+        "project": "",
+        "stage": "",
+        "service": ""
+      }
+    },
+    "subscriptions": [
+      {
+        "id": "e9057389-62f9-4ee9-b088-68f37989330a",
+        "event": "sh.keptn.event.get-action.triggered",
+        "filter": {
+          "projects": [],
+          "stages": [],
+          "services": []
+        }
+      }
+    ],
+    "unreadEventsCount": 0
+  },
+  {
+    "id": "574e7d9723714e94e009b91d52e773b360964f23",
+    "name": "approval-service",
+    "metadata": {
+      "hostname": "Cloud Automation",
+      "integrationversion": "0.9.0",
+      "distributorversion": "0.9.0",
+      "location": "control-plane",
+      "kubernetesmetadata": {
+        "namespace": "Cloud Automation",
+        "podname": "approval-service-855c6746b-p85fg",
+        "deploymentname": "approval-service"
+      },
+      "lastseen": "2021-10-07T12:10:05.463Z"
+    },
+    "subscription": {
+      "topics": null,
+      "status": "",
+      "filter": {
+        "project": "",
+        "stage": "",
+        "service": ""
+      }
+    },
+    "subscriptions": [
+      {
+        "id": "a24bb6ad-ff67-4298-ac54-0e4648a88ad9",
+        "event": "sh.keptn.event.approval.>",
+        "filter": {
+          "projects": [],
+          "stages": [],
+          "services": []
+        }
+      }
+    ],
+    "unreadEventsCount": 0
+  },
+  {
+    "id": "4b4d28a8f3bf811aa735f9531bae6bebf0df0f78",
+    "name": "dynatrace-service",
+    "metadata": {
+      "hostname": "Cloud Automation",
+      "integrationversion": "0.16.1-dev-PR-497.202109231206",
+      "distributorversion": "0.9.0",
+      "location": "control-plane",
+      "kubernetesmetadata": {
+        "namespace": "Cloud Automation",
+        "podname": "dynatrace-service-584bffcc69-28wmr",
+        "deploymentname": "dynatrace-service"
+      },
+      "lastseen": "2021-10-07T12:10:13.008Z"
+    },
+    "subscription": {
+      "topics": null,
+      "status": "",
+      "filter": {
+        "project": "",
+        "stage": "",
+        "service": ""
+      }
+    },
+    "subscriptions": [
+      {
+        "id": "40552a94-badf-4bae-82ff-afc6c26d078e",
+        "event": "sh.keptn.>",
+        "filter": {
+          "projects": [],
+          "stages": [],
+          "services": []
+        }
+      }
+    ],
+    "unreadEventsCount": 0
+  }
+]

--- a/bridge/cypress/fixtures/multi.projects.mock.json
+++ b/bridge/cypress/fixtures/multi.projects.mock.json
@@ -1,0 +1,187 @@
+{
+  "nextPageKey": "0",
+  "projects": [
+    {
+      "creationDate": "1621493016550266259",
+      "gitRemoteURI": "https://github.com/carpe-github/claus-tenant-dev.git",
+      "gitUser": "carpe-github",
+      "projectName": "dynatrace",
+      "shipyard": "apiVersion: spec.keptn.sh/0.2.0\nkind: Shipyard\nmetadata:\n    name: shipyard-quality-gates\nspec:\n    stages:\n        - name: quality-gate\n          sequences: []\n",
+      "shipyardVersion": "spec.keptn.sh/0.2.0",
+      "stages": [
+        {
+          "services": [
+            {
+              "creationDate": "1629190178019300348",
+              "openRemediations": null,
+              "serviceName": "cartsc"
+            },
+            {
+              "creationDate": "1633232077002690194",
+              "openRemediations": null,
+              "serviceName": "bridge_env_service119"
+            },
+            {
+              "creationDate": "1633339357114336020",
+              "lastEventTypes": {
+                "sh.keptn.event.evaluation.finished": {
+                  "eventId": "b07c9e7f-78d1-4cb5-8ec4-ebbc21fbbe44",
+                  "keptnContext": "24001149-fbf4-40ea-ba09-59f8cbc32f80",
+                  "time": "1633512188925299381"
+                },
+                "sh.keptn.event.evaluation.started": {
+                  "eventId": "33cf8912-1af5-4f47-8c82-e1589451a1b2",
+                  "keptnContext": "24001149-fbf4-40ea-ba09-59f8cbc32f80",
+                  "time": "1633512169900628065"
+                },
+                "sh.keptn.event.evaluation.triggered": {
+                  "eventId": "c48172c2-d975-4137-b708-7e3dc7da5c6b",
+                  "keptnContext": "24001149-fbf4-40ea-ba09-59f8cbc32f80",
+                  "time": "1633512169896466021"
+                },
+                "sh.keptn.event.get-sli.finished": {
+                  "eventId": "280ac2fa-82e7-47b0-981c-d968b9ed028a",
+                  "keptnContext": "24001149-fbf4-40ea-ba09-59f8cbc32f80",
+                  "time": "1633512186041588909"
+                },
+                "sh.keptn.event.get-sli.started": {
+                  "eventId": "050c3135-8ae9-4dba-9acc-f05106654c01",
+                  "keptnContext": "24001149-fbf4-40ea-ba09-59f8cbc32f80",
+                  "time": "1633512172420746546"
+                },
+                "sh.keptn.event.get-sli.triggered": {
+                  "eventId": "55a78a77-b8a1-43d9-861f-1abfca5796ce",
+                  "keptnContext": "24001149-fbf4-40ea-ba09-59f8cbc32f80",
+                  "time": "1633512171120060484"
+                },
+                "sh.keptn.event.quality-gate.evaluation.finished": {
+                  "eventId": "59de0b5c-cbd7-4c81-a1d2-6511317b6c29",
+                  "keptnContext": "24001149-fbf4-40ea-ba09-59f8cbc32f80",
+                  "time": "1633512189039134250"
+                },
+                "sh.keptn.event.quality-gate.evaluation.triggered": {
+                  "eventId": "301087e4-6ef0-42da-8933-d5e719e47704",
+                  "keptnContext": "24001149-fbf4-40ea-ba09-59f8cbc32f80",
+                  "time": "1633512169083018842"
+                }
+              },
+              "openRemediations": null,
+              "serviceName": "health"
+            },
+            {
+              "creationDate": "1633339367577663994",
+              "lastEventTypes": {
+                "sh.keptn.event.evaluation.finished": {
+                  "eventId": "f00d84b1-c0b8-4fe4-a120-f72b25f0dcd2",
+                  "keptnContext": "36ef49c9-1981-47f8-a0f6-5f65a7390820",
+                  "time": "1633511537018004620"
+                },
+                "sh.keptn.event.evaluation.started": {
+                  "eventId": "a3b9aa96-002e-42b4-ac46-d7c40d0e4288",
+                  "keptnContext": "36ef49c9-1981-47f8-a0f6-5f65a7390820",
+                  "time": "1633511514504053698"
+                },
+                "sh.keptn.event.evaluation.triggered": {
+                  "eventId": "e2b2192d-7440-4010-88f6-147049d13c27",
+                  "keptnContext": "36ef49c9-1981-47f8-a0f6-5f65a7390820",
+                  "time": "1633511514499196372"
+                },
+                "sh.keptn.event.get-sli.finished": {
+                  "eventId": "f7961113-d865-4d7d-b619-8182c7db578b",
+                  "keptnContext": "36ef49c9-1981-47f8-a0f6-5f65a7390820",
+                  "time": "1633511534595070486"
+                },
+                "sh.keptn.event.get-sli.started": {
+                  "eventId": "be0e3d5a-0f60-4ce6-9a38-ee1d2c00df7e",
+                  "keptnContext": "36ef49c9-1981-47f8-a0f6-5f65a7390820",
+                  "time": "1633511516837232649"
+                },
+                "sh.keptn.event.get-sli.triggered": {
+                  "eventId": "6657b28e-2682-4acd-a2bb-f8057076712d",
+                  "keptnContext": "36ef49c9-1981-47f8-a0f6-5f65a7390820",
+                  "time": "1633511515820906575"
+                },
+                "sh.keptn.event.quality-gate.evaluation.finished": {
+                  "eventId": "cd87f6aa-7d1c-44be-9e6a-2f0d8416e6d7",
+                  "keptnContext": "36ef49c9-1981-47f8-a0f6-5f65a7390820",
+                  "time": "1633511537298856888"
+                },
+                "sh.keptn.event.quality-gate.evaluation.triggered": {
+                  "eventId": "a8496705-7472-4554-8cea-e79d63330620",
+                  "keptnContext": "36ef49c9-1981-47f8-a0f6-5f65a7390820",
+                  "time": "1633511513349240279"
+                }
+              },
+              "openRemediations": null,
+              "serviceName": "items"
+            }
+          ],
+          "stageName": "dyantrace-quality-gate"
+        }
+      ]
+    },
+    {
+      "creationDate": "1629211070179837245",
+      "gitRemoteURI": "https://github.com/carpe-github/claus-tenant-dev-testproj.git",
+      "gitUser": "carpe-github-testproj",
+      "projectName": "testproject",
+      "shipyard": "apiVersion: \"spec.keptn.sh/0.2.0\"\nkind: \"Shipyard\"\nmetadata:\n  name: \"shipyard-quality-gates\"\nspec:\n  stages:\n    - name: \"quality-gate-test\"",
+      "shipyardVersion": "spec.keptn.sh/0.2.0",
+      "stages": [
+        {
+          "services": [
+            {
+              "creationDate": "1629190178019300348",
+              "openRemediations": null,
+              "serviceName": "newService",
+              "lastEventTypes": {
+                "sh.keptn.event.evaluation.finished": {
+                  "eventId": "b07c9e7f-78d1-4cb5-8ec4-ebbc21fbbe44",
+                  "keptnContext": "24001149-fbf4-40ea-ba09-59f8cbc32f80",
+                  "time": "1633512188925299381"
+                },
+                "sh.keptn.event.evaluation.started": {
+                  "eventId": "33cf8912-1af5-4f47-8c82-e1589451a1b2",
+                  "keptnContext": "24001149-fbf4-40ea-ba09-59f8cbc32f80",
+                  "time": "1633512169900628065"
+                },
+                "sh.keptn.event.evaluation.triggered": {
+                  "eventId": "c48172c2-d975-4137-b708-7e3dc7da5c6b",
+                  "keptnContext": "24001149-fbf4-40ea-ba09-59f8cbc32f80",
+                  "time": "1633512169896466021"
+                },
+                "sh.keptn.event.get-sli.finished": {
+                  "eventId": "280ac2fa-82e7-47b0-981c-d968b9ed028a",
+                  "keptnContext": "24001149-fbf4-40ea-ba09-59f8cbc32f80",
+                  "time": "1633512186041588909"
+                },
+                "sh.keptn.event.get-sli.started": {
+                  "eventId": "050c3135-8ae9-4dba-9acc-f05106654c01",
+                  "keptnContext": "24001149-fbf4-40ea-ba09-59f8cbc32f80",
+                  "time": "1633512172420746546"
+                },
+                "sh.keptn.event.get-sli.triggered": {
+                  "eventId": "55a78a77-b8a1-43d9-861f-1abfca5796ce",
+                  "keptnContext": "24001149-fbf4-40ea-ba09-59f8cbc32f80",
+                  "time": "1633512171120060484"
+                },
+                "sh.keptn.event.quality-gate.evaluation.finished": {
+                  "eventId": "59de0b5c-cbd7-4c81-a1d2-6511317b6c29",
+                  "keptnContext": "24001149-fbf4-40ea-ba09-59f8cbc32f80",
+                  "time": "1633512189039134250"
+                },
+                "sh.keptn.event.quality-gate.evaluation.triggered": {
+                  "eventId": "301087e4-6ef0-42da-8933-d5e719e47704",
+                  "keptnContext": "24001149-fbf4-40ea-ba09-59f8cbc32f80",
+                  "time": "1633512169083018842"
+                }
+              }
+            }
+          ],
+          "stageName": "newproj-quality-gate"
+        }
+      ]
+    }
+  ],
+  "totalCount": 2
+}

--- a/bridge/cypress/integration/navigation-buttons-evaluation-screen-test.ts
+++ b/bridge/cypress/integration/navigation-buttons-evaluation-screen-test.ts
@@ -16,7 +16,9 @@ describe('Test Navigation Buttons In Evaluation Screen', () => {
       fixture: 'get.project.json',
     }).as('initProjects');
 
-    cy.intercept('GET', 'api/controlPlane/v1/sequence/dynatrace?*', { fixture: 'project.sequences.json' });
+    cy.intercept('GET', 'api/controlPlane/v1/sequence/dynatrace?*', { fixture: 'project.sequences.json' }).as(
+      'getSequence'
+    );
 
     cy.intercept('PUT', 'api/controlPlane/v1/project', {
       statusCode: 200,
@@ -66,7 +68,9 @@ describe('Test Navigation Buttons In Evaluation Screen', () => {
     ).as('getEventEvalFinishedWithProject');
 
     cy.visit('/');
+    cy.wait(500);
     basePage.clickProjectTile('dynatrace');
+
     basePage
       .goToServicesPage()
       .clickOnServicePanelByName('items')

--- a/bridge/cypress/integration/page-data-update-project-switch.spec.ts
+++ b/bridge/cypress/integration/page-data-update-project-switch.spec.ts
@@ -52,6 +52,7 @@ describe('verify Page data update when project is switched', () => {
 
     cy.visit('/');
     cy.wait('@metadataCmpl');
+    cy.wait(500);
     basePage.clickProjectTile(PROJECT_DYNATRACE);
     cy.get(envPage.STAGE_HEADER_LOC).contains(QG_DYNATRACE);
 

--- a/bridge/cypress/integration/page-data-update-project-switch.spec.ts
+++ b/bridge/cypress/integration/page-data-update-project-switch.spec.ts
@@ -20,7 +20,7 @@ describe('verify Page data update when project is switched', () => {
     const SERVICE_TEST_PROJ = 'newService';
     const UNIFORM_REMEDIATION = 'remediation-service';
     const UNIFORM_APPROVAL_SERVICE = 'approval-service';
-    const UNIOFORM_DYNATRACE_SERVICE = 'dynatrace-service';
+    const UNIFORM_DYNATRACE_SERVICE = 'dynatrace-service';
 
     cy.intercept('/api/bridgeInfo', { fixture: 'bridgeInfo.mock' });
     cy.intercept('GET', 'api/v1/metadata', { fixture: 'metadata.json' }).as('metadataCmpl');
@@ -67,12 +67,12 @@ describe('verify Page data update when project is switched', () => {
     basePage.goToUniformPage();
     cy.get(uniformPage.UNIFORM_NAME_LOC).contains(UNIFORM_APPROVAL_SERVICE);
     cy.get(uniformPage.UNIFORM_NAME_LOC).contains(UNIFORM_REMEDIATION);
-    cy.get(uniformPage.UNIFORM_NAME_LOC).contains(UNIOFORM_DYNATRACE_SERVICE);
+    cy.get(uniformPage.UNIFORM_NAME_LOC).contains(UNIFORM_DYNATRACE_SERVICE);
 
     basePage.chooseProjectFromHeaderMenu(PROJECT_TEST);
     cy.get(uniformPage.UNIFORM_NAME_LOC).contains(UNIFORM_APPROVAL_SERVICE);
     cy.get(uniformPage.UNIFORM_NAME_LOC).contains(UNIFORM_REMEDIATION);
-    cy.get(uniformPage.UNIFORM_NAME_LOC).contains(UNIOFORM_DYNATRACE_SERVICE);
+    cy.get(uniformPage.UNIFORM_NAME_LOC).contains(UNIFORM_DYNATRACE_SERVICE);
 
     basePage.gotoSettingsPage();
     cy.get(settingsPage.GIT_USER_LOC).should('have.value', 'carpe-github-testproj');

--- a/bridge/cypress/integration/page-data-update-project-switch.spec.ts
+++ b/bridge/cypress/integration/page-data-update-project-switch.spec.ts
@@ -1,0 +1,88 @@
+/// <reference types="cypress" />
+import EnvironmentPage from 'cypress/support/pageobjects/EnvironmentPage';
+import ServicesPage from 'cypress/support/pageobjects/ServicesPage';
+import SettingsPage from 'cypress/support/pageobjects/SettingsPage';
+import UnifromPage from 'cypress/support/pageobjects/UniformPage';
+import BasePage from '../support/pageobjects/BasePage';
+
+describe('verify Page data update when project is switched', () => {
+  it('testing the data change/update ', () => {
+    const basePage = new BasePage();
+    const envPage = new EnvironmentPage();
+    const servicePage = new ServicesPage();
+    const uniformPage = new UnifromPage();
+    const settingsPage = new SettingsPage();
+    const PROJECT_DYNATRACE = 'dynatrace';
+    const PROJECT_TEST = 'testproject';
+    const QG_DYNATRACE = 'quality-gate';
+    const QG_TEST_PROJ = 'newproj-quality-gate';
+    const SERVICE_DYNATRACE = 'items';
+    const SERVICE_TEST_PROJ = 'newService';
+    const UNIFORM_REMEDIATION = 'remediation-service';
+    const UNIFORM_APPROVAL_SERVICE = 'approval-service';
+    const UNIOFORM_DYNATRACE_SERVICE = 'dynatrace-service';
+
+    cy.intercept('/api/bridgeInfo', { fixture: 'bridgeInfo.mock' });
+    cy.intercept('GET', 'api/v1/metadata', { fixture: 'metadata.json' }).as('metadataCmpl');
+    cy.intercept('GET', 'api/controlPlane/v1/project?disableUpstreamSync=true&pageSize=50', {
+      statusCode: 200,
+      fixture: 'multi.projects.mock.json',
+    }).as('initProjects');
+
+    cy.intercept('GET', 'api/controlPlane/v1/sequence/*', { statusCode: 200 });
+
+    cy.intercept('POST', 'api/hasUnreadUniformRegistrationLogs', {
+      statusCode: 200,
+    }).as('hasUnreadUniformRegistrationLogs');
+
+    cy.intercept('GET', 'api/project/dynatrace?approval=true&remediation=true', {
+      statusCode: 200,
+      fixture: 'get.approval.json',
+    }).as('getApproval');
+
+    cy.intercept('GET', 'api/project/testproject?approval=true&remediation=true', {
+      statusCode: 200,
+      fixture: 'get.approval.testproj.json',
+    }).as('getApproval');
+
+    cy.intercept('POST', 'api/uniform/registration', {
+      statusCode: 200,
+      fixture: 'get.uniform.json',
+    }).as('postUniform');
+
+    cy.visit('/');
+    cy.wait('@metadataCmpl');
+    basePage.clickProjectTile(PROJECT_DYNATRACE);
+    cy.get(envPage.STAGE_HEADER_LOC).contains(QG_DYNATRACE);
+
+    basePage.chooseProjectFromHeaderMenu(PROJECT_TEST);
+    cy.get(envPage.STAGE_HEADER_LOC).contains(QG_TEST_PROJ);
+
+    basePage.goToServicesPage();
+    cy.get(servicePage.SERVICE_PANEL_TEXT_LOC).contains(SERVICE_TEST_PROJ);
+
+    basePage.chooseProjectFromHeaderMenu(PROJECT_DYNATRACE);
+    cy.get(servicePage.SERVICE_PANEL_TEXT_LOC).contains(SERVICE_DYNATRACE);
+
+    basePage.goToUniformPage();
+    cy.get(uniformPage.UNIFORM_NAME_LOC).contains(UNIFORM_APPROVAL_SERVICE);
+    cy.get(uniformPage.UNIFORM_NAME_LOC).contains(UNIFORM_REMEDIATION);
+    cy.get(uniformPage.UNIFORM_NAME_LOC).contains(UNIOFORM_DYNATRACE_SERVICE);
+
+    basePage.chooseProjectFromHeaderMenu(PROJECT_TEST);
+    cy.get(uniformPage.UNIFORM_NAME_LOC).contains(UNIFORM_APPROVAL_SERVICE);
+    cy.get(uniformPage.UNIFORM_NAME_LOC).contains(UNIFORM_REMEDIATION);
+    cy.get(uniformPage.UNIFORM_NAME_LOC).contains(UNIOFORM_DYNATRACE_SERVICE);
+
+    basePage.gotoSettingsPage();
+    cy.get(settingsPage.GIT_USER_LOC).should('have.value', 'carpe-github-testproj');
+    cy.get(settingsPage.GIT_URL_INPUT_LOC).should(
+      'have.value',
+      'https://github.com/carpe-github/claus-tenant-dev-testproj.git'
+    );
+
+    basePage.chooseProjectFromHeaderMenu(PROJECT_DYNATRACE);
+    cy.get(settingsPage.GIT_USER_LOC).should('have.value', 'carpe-github');
+    cy.get(settingsPage.GIT_URL_INPUT_LOC).should('have.value', 'https://github.com/carpe-github/claus-tenant-dev.git');
+  });
+});

--- a/bridge/cypress/integration/project-delete.spec.ts
+++ b/bridge/cypress/integration/project-delete.spec.ts
@@ -29,6 +29,8 @@ describe('Project delete test', () => {
 
     cy.visit('/');
     cy.wait('@metadataCmpl');
+    cy.wait('@initProjects');
+    cy.wait(500);
     basePage.clickProjectTile('dynatrace');
     basePage.gotoSettingsPage().clickDeleteProjectButton().typeProjectNameToDelete('dynatrace').submitDelete();
   });

--- a/bridge/cypress/integration/uniform-integrations.spec.ts
+++ b/bridge/cypress/integration/uniform-integrations.spec.ts
@@ -1,43 +1,50 @@
 import { interceptIntegrations } from '../support/intercept';
+import UniformPage from '../support/pageobjects/UniformPage';
 
 describe('Integrations', () => {
+  const uniformPage = new UniformPage();
+
   beforeEach(() => {
     interceptIntegrations();
     cy.visit('/project/sockshop/uniform/services');
   });
 
   it('should be on page uniform', () => {
-    const buttons = cy.byTestId('uniform-submenu').find('button');
+    const buttons = cy.byTestId(uniformPage.UNIFORM_SUBMENU_LOC).find('button');
     buttons.first().should('have.class', 'active');
   });
 
   it('should select an integration and show related subscriptions', () => {
     // given, when
-    cy.byTestId('keptn-uniform-integrations-table').get('dt-row').first().click();
+    cy.byTestId(uniformPage.UNIFORM_INTEGRATION_TABLE_LOC).get('dt-row').first().click();
 
     // then
-    cy.get('ktb-expandable-tile h3').first().should('have.text', 'Subscriptions');
-    cy.get('ktb-expandable-tile h3').last().should('have.text', 'Error events');
+    cy.get(uniformPage.SUBSCRIPTION_EXP_HEADER_LOC).first().should('have.text', 'Subscriptions');
+    cy.get(uniformPage.SUBSCRIPTION_EXP_HEADER_LOC).last().should('have.text', 'Error events');
   });
 
   it('should add a simple subscription', () => {
     // given, when
-    cy.byTestId('keptn-uniform-integrations-table').find('dt-row').eq(1).click();
-    cy.get('ktb-expandable-tile dt-expandable-panel ktb-subscription-item').should('have.length', 1);
-    cy.get('ktb-expandable-tile').first().find('dt-expandable-panel').byTestId('addSubscriptionButton').click();
+    cy.byTestId(uniformPage.UNIFORM_INTEGRATION_TABLE_LOC).find('dt-row').eq(1).click();
+    cy.get(uniformPage.SUBSCRIPTION_DETAILS_LOC).should('have.length', 1);
+    cy.get(uniformPage.SUBSCRIPTION_EXPANDABLE_LOC)
+      .first()
+      .find('dt-expandable-panel')
+      .byTestId('addSubscriptionButton')
+      .click();
 
     // Fill in all form fields
-    cy.byTestId('edit-subscription-field-isGlobal')
+    cy.byTestId(uniformPage.EDIT_SUBSCRIPTION_FIELD_GLOBAL_ID)
       .click()
       .find('dt-checkbox')
       .should('have.class', 'dt-checkbox-checked');
-    cy.byTestId('edit-subscription-field-task').find('dt-select').focus().type('dep');
-    cy.byTestId('edit-subscription-field-suffix').find('dt-select').focus().type('fin');
+    cy.byTestId(uniformPage.EDIT_SUBSCRIPTION_FIELD_TASK_ID).find('dt-select').focus().type('dep');
+    cy.byTestId(uniformPage.EDIT_SUBSCRIPTION_FIELD_SUFFIX_ID).find('dt-select').focus().type('fin');
     cy.byTestId('edit-subscription-field-filterStageService')
       .find('input')
       .focus()
       .type('St{enter}de{enter}Ser{enter}cart{enter}');
-    cy.byTestId('updateSubscriptionButton').click();
+    cy.byTestId(uniformPage.UPDATE_SUBSCRIPTION_BUTTON_ID).click();
 
     // then
     // It should redirect after successfully sending the subscription
@@ -48,50 +55,54 @@ describe('Integrations', () => {
   });
 
   it('should add a webhook subscription', () => {
-    cy.byTestId('keptn-uniform-integrations-table').find('dt-row').eq(0).click();
-    cy.get('ktb-expandable-tile').first().find('dt-expandable-panel').byTestId('addSubscriptionButton').click();
+    cy.byTestId(uniformPage.UNIFORM_INTEGRATION_TABLE_LOC).find('dt-row').eq(0).click();
+    cy.get(uniformPage.SUBSCRIPTION_EXPANDABLE_LOC)
+      .first()
+      .find('dt-expandable-panel')
+      .byTestId('addSubscriptionButton')
+      .click();
 
     // then
     cy.get('h2').eq(1).should('have.text', 'Webhook configuration');
-    cy.byTestId('edit-subscription-field-isGlobal').should('not.exist');
+    cy.byTestId(uniformPage.EDIT_SUBSCRIPTION_FIELD_GLOBAL_ID).should('not.exist');
 
-    cy.byTestId('edit-subscription-field-task').find('dt-select').focus().type('dep');
-    cy.byTestId('edit-subscription-field-suffix').find('dt-select').focus().type('fin');
+    cy.byTestId(uniformPage.EDIT_SUBSCRIPTION_FIELD_TASK_ID).find('dt-select').focus().type('dep');
+    cy.byTestId(uniformPage.EDIT_SUBSCRIPTION_FIELD_SUFFIX_ID).find('dt-select').focus().type('fin');
     cy.byTestId('edit-webhook-field-method').find('dt-select').focus().type('GET');
 
     // URL: insert text and add secret
-    cy.byTestId('edit-webhook-field-url').find('input').focus().type('https://example.com?secret=');
-    cy.byTestId('edit-webhook-field-url').find('.dt-form-field-suffix button').click();
+    cy.byTestId(uniformPage.EDIT_WEBHOOK_FIELD_URL_ID).find('input').focus().type('https://example.com?secret=');
+    cy.byTestId(uniformPage.EDIT_WEBHOOK_FIELD_URL_ID).find('.dt-form-field-suffix button').click();
     addSecret();
-    cy.byTestId('edit-webhook-field-url')
+    cy.byTestId(uniformPage.EDIT_WEBHOOK_FIELD_URL_ID)
       .find('input')
       .should('have.value', 'https://example.com?secret={{.secret.SecretA.key1}}');
 
     // Payload: insert text and add secret
-    cy.byTestId('edit-webhook-field-payload').find('textarea').focus().type("{id: '123456789', secret: ");
-    cy.byTestId('edit-webhook-field-payload').find('.dt-form-field-suffix button').click();
+    cy.byTestId(uniformPage.EDIT_WEBHOOK_PAYLOAD_ID).find('textarea').focus().type("{id: '123456789', secret: ");
+    cy.byTestId(uniformPage.EDIT_WEBHOOK_PAYLOAD_ID).find('.dt-form-field-suffix button').click();
     addSecret();
-    cy.byTestId('edit-webhook-field-payload').find('textarea').focus().type('}');
-    cy.byTestId('edit-webhook-field-payload')
+    cy.byTestId(uniformPage.EDIT_WEBHOOK_PAYLOAD_ID).find('textarea').focus().type('}');
+    cy.byTestId(uniformPage.EDIT_WEBHOOK_PAYLOAD_ID)
       .find('textarea')
       .should('have.value', "{id: '123456789', secret: {{.secret.SecretA.key1}}}");
 
     cy.byTestId('edit-webhook-field-proxy').find('input').focus().type('https://proxy.com');
 
-    cy.byTestId('edit-webhook-field-headerName').should('not.exist');
-    cy.byTestId('edit-webhook-field-headerValue').should('not.exist');
+    cy.byTestId(uniformPage.EDIT_WEBHOOK_FIELD_HEADER_NAME_ID).should('not.exist');
+    cy.byTestId(uniformPage.EDIT_WEBHOOK_FIELD_HEADER_VALUE_ID).should('not.exist');
     cy.byTestId('ktb-webhook-settings-add-header-button').click();
-    cy.byTestId('edit-webhook-field-headerName').should('exist');
-    cy.byTestId('edit-webhook-field-headerValue').should('exist');
-    cy.byTestId('edit-webhook-field-headerName').find('input').focus().type('x-token');
-    cy.byTestId('edit-webhook-field-headerValue').find('input').focus().type('Bearer: ');
-    cy.byTestId('edit-webhook-field-headerValue').find('.dt-form-field-suffix button').click();
+    cy.byTestId(uniformPage.EDIT_WEBHOOK_FIELD_HEADER_NAME_ID).should('exist');
+    cy.byTestId(uniformPage.EDIT_WEBHOOK_FIELD_HEADER_VALUE_ID).should('exist');
+    cy.byTestId(uniformPage.EDIT_WEBHOOK_FIELD_HEADER_NAME_ID).find('input').focus().type('x-token');
+    cy.byTestId(uniformPage.EDIT_WEBHOOK_FIELD_HEADER_VALUE_ID).find('input').focus().type('Bearer: ');
+    cy.byTestId(uniformPage.EDIT_WEBHOOK_FIELD_HEADER_VALUE_ID).find('.dt-form-field-suffix button').click();
     addSecret();
-    cy.byTestId('edit-webhook-field-headerValue')
+    cy.byTestId(uniformPage.EDIT_WEBHOOK_FIELD_HEADER_VALUE_ID)
       .find('input')
       .should('have.value', 'Bearer: {{.secret.SecretA.key1}}');
 
-    cy.byTestId('updateSubscriptionButton').click();
+    cy.byTestId(uniformPage.UPDATE_SUBSCRIPTION_BUTTON_ID).click();
     // It should redirect after successfully sending the subscription
     cy.location('pathname').should(
       'eq',

--- a/bridge/cypress/support/pageobjects/BasePage.ts
+++ b/bridge/cypress/support/pageobjects/BasePage.ts
@@ -69,6 +69,12 @@ class BasePage {
   clickMainHeaderKeptn(): void {
     cy.get('.brand > p').contains('keptn').click();
   }
+
+  chooseProjectFromHeaderMenu(projectName: string): this {
+    cy.get('dt-select[aria-label="Choose project"]').click();
+    cy.get('dt-option[id^="dt-option"]').contains(projectName).click();
+    return this;
+  }
 }
 
 export default BasePage;

--- a/bridge/cypress/support/pageobjects/EnvironmentPage.ts
+++ b/bridge/cypress/support/pageobjects/EnvironmentPage.ts
@@ -1,4 +1,6 @@
 /// <reference types="cypress" />
 
-class EnvironmentPage {}
+class EnvironmentPage {
+  STAGE_HEADER_LOC = 'div > h2';
+}
 export default EnvironmentPage;

--- a/bridge/cypress/support/pageobjects/ServicesPage.ts
+++ b/bridge/cypress/support/pageobjects/ServicesPage.ts
@@ -1,6 +1,8 @@
 /// <reference types="cypress" />
 
 class ServicesPage {
+  SERVICE_PANEL_TEXT_LOC = 'dt-info-group-title.dt-info-group-title > div > h2';
+
   clickOnServicePanelByName(serviceName: string): this {
     cy.get('div.dt-info-group-content').get('h2').contains(serviceName).click();
     return this;

--- a/bridge/cypress/support/pageobjects/SettingsPage.ts
+++ b/bridge/cypress/support/pageobjects/SettingsPage.ts
@@ -1,6 +1,9 @@
 /// <reference types="cypress" />
 
 class SettingsPage {
+  GIT_USER_LOC = 'input[formcontrolname="gitUser"]';
+  GIT_URL_INPUT_LOC = 'input[formcontrolname="gitUrl"]';
+
   inputGitUrl(GIT_URL: string): this {
     cy.get('input[formcontrolname="gitUrl"]').type(GIT_URL);
     return this;

--- a/bridge/cypress/support/pageobjects/UniformPage.ts
+++ b/bridge/cypress/support/pageobjects/UniformPage.ts
@@ -1,0 +1,19 @@
+/// <reference types="cypress" />
+
+class UniformPage {
+  UNIFORM_NAME_LOC = 'span.ng-star-inserted';
+  UNIFORM_SUBMENU_LOC = 'uniform-submenu';
+  UNIFORM_INTEGRATION_TABLE_LOC = 'keptn-uniform-integrations-table';
+  SUBSCRIPTION_EXP_HEADER_LOC = 'ktb-expandable-tile h3';
+  SUBSCRIPTION_DETAILS_LOC = 'ktb-expandable-tile dt-expandable-panel ktb-subscription-item';
+  SUBSCRIPTION_EXPANDABLE_LOC = 'ktb-expandable-tile';
+  EDIT_WEBHOOK_PAYLOAD_ID = 'edit-webhook-field-payload';
+  EDIT_WEBHOOK_FIELD_HEADER_NAME_ID = 'edit-webhook-field-headerName';
+  EDIT_WEBHOOK_FIELD_HEADER_VALUE_ID = 'edit-webhook-field-headerValue';
+  UPDATE_SUBSCRIPTION_BUTTON_ID = 'updateSubscriptionButton';
+  EDIT_SUBSCRIPTION_FIELD_GLOBAL_ID = 'edit-subscription-field-isGlobal';
+  EDIT_SUBSCRIPTION_FIELD_TASK_ID = 'edit-subscription-field-task';
+  EDIT_SUBSCRIPTION_FIELD_SUFFIX_ID = 'edit-subscription-field-suffix';
+  EDIT_WEBHOOK_FIELD_URL_ID = 'edit-webhook-field-url';
+}
+export default UniformPage;


### PR DESCRIPTION
in scope of this PR:

1. added test case to verify data among pages based on project change - page-data-update-project-switch.spec.ts.
2. made improvements in support/commands.ts
3. improved bridge/cypress/integration/uniform-integrations.spec.ts to store locators in page object classes as constants