### PR TITLE
fix: Fixed bug where MongoDB would not come up in airgapped setup

### DIFF
--- a/installer/airgapped/install_keptn.sh
+++ b/installer/airgapped/install_keptn.sh
@@ -22,7 +22,7 @@ kubectl create namespace "${KEPTN_NAMESPACE}"
 
 helm upgrade keptn "${KEPTN_HELM_CHART}" --install --create-namespace -n "${KEPTN_NAMESPACE}" --wait \
 --set="control-plane.apiGatewayNginx.type=${KEPTN_SERVICE_TYPE},continuous-delivery.enabled=true,\
-control-plane.mongo.image.registry=${TARGET_INTERNAL_DOCKER_REGISTRY},\
+control-plane.mongo.image.registry=${TARGET_INTERNAL_DOCKER_REGISTRY%/},\
 control-plane.nats.nats.image=${TARGET_INTERNAL_DOCKER_REGISTRY}nats:2.1.9-alpine3.12,\
 control-plane.nats.reloader.image=${TARGET_INTERNAL_DOCKER_REGISTRY}connecteverything/nats-server-config-reloader:0.6.0,\
 control-plane.nats.exporter.image=${TARGET_INTERNAL_DOCKER_REGISTRY}synadia/prometheus-nats-exporter:0.5.0,\


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- fixes a small bug where the airgapped installer had a double slash in the MongoDB image name after setting up a private registry

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #5938


