### PR TITLE
ci: Build everything builds should always build everything

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -575,13 +575,13 @@ jobs:
 
       - id: docker_cache
         name: Docker Cache
-        if: matrix.config.should-push-image == 'true' && (matrix.config.should-run == 'true' || ( needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true' && needs.prepare_ci_run.outputs.LAST_SUCCESSFUL_RUN_ID == 'null' ))
+        if: matrix.config.should-push-image == 'true' && ( matrix.config.should-run == 'true' || needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true' || needs.prepare_ci_run.outputs.LAST_SUCCESSFUL_RUN_ID == 'null' )
         uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true
 
       - id: docker_build_image
         name: "Docker Build keptn/${{ matrix.config.artifact }}"
-        if: matrix.config.should-push-image == 'true' && ( matrix.config.should-run == 'true' || ( needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true' && needs.prepare_ci_run.outputs.LAST_SUCCESSFUL_RUN_ID == 'null' ) )
+        if: matrix.config.should-push-image == 'true' && ( matrix.config.should-run == 'true' || needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true' || needs.prepare_ci_run.outputs.LAST_SUCCESSFUL_RUN_ID == 'null' )
         env:
           VERSION: ${{ env.VERSION }}
           DATETIME: ${{ env.DATETIME }}
@@ -613,7 +613,7 @@ jobs:
       - name: "Download Build Config from last successful build"
         uses: dawidd6/action-download-artifact@v2.15.0
         id: download_last_build_config
-        if: matrix.config.should-push-image == 'true' && matrix.config.should-run == 'false' && needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true' && needs.prepare_ci_run.outputs.LAST_SUCCESSFUL_RUN_ID != 'null'
+        if: matrix.config.should-run == 'false' && needs.prepare_ci_run.outputs.BUILD_EVERYTHING != 'true' && needs.prepare_ci_run.outputs.LAST_SUCCESSFUL_RUN_ID != 'null' && matrix.config.should-push-image == 'true'
         with:
           # Download last successful artifact from a CI build
           github_token: ${{secrets.GITHUB_TOKEN}}
@@ -625,7 +625,7 @@ jobs:
 
       - id: docker_retag_image
         name: "Docker Retag keptn/${{ matrix.config.artifact }}"
-        if: matrix.config.should-run == 'false' && needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true' && needs.prepare_ci_run.outputs.LAST_SUCCESSFUL_RUN_ID != 'null' && matrix.config.should-push-image == 'true'
+        if: matrix.config.should-run == 'false' && needs.prepare_ci_run.outputs.BUILD_EVERYTHING != 'true' && needs.prepare_ci_run.outputs.LAST_SUCCESSFUL_RUN_ID != 'null' && matrix.config.should-push-image == 'true'
         env:
           VERSION: ${{ env.VERSION }}
           DATETIME: ${{ env.DATETIME }}


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- changes the behaviour of the CI pipeline so that it builds all docker images if the `build-everything` tag is present on the PR at hand

