### PR TITLE
fix(bridge): Use helmet middlewares to prevent XSS

### DIFF
--- a/bridge/server/app.ts
+++ b/bridge/server/app.ts
@@ -157,6 +157,7 @@ async function init(): Promise<Express> {
   app.use(express.json());
   app.use(express.urlencoded({ extended: false }));
   app.use(cookieParser());
+
   app.use(helmet.contentSecurityPolicy());
   app.use(helmet.hidePoweredBy());
   app.use(helmet.noSniff());

--- a/bridge/server/app.ts
+++ b/bridge/server/app.ts
@@ -9,7 +9,7 @@ import { fileURLToPath, URL } from 'url';
 import logger from 'morgan';
 import cookieParser from 'cookie-parser';
 import admZip from 'adm-zip';
-import { apiRouter } from './api/index';
+import { apiRouter } from './api';
 import { execSync } from 'child_process';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -157,7 +157,13 @@ async function init(): Promise<Express> {
   app.use(express.json());
   app.use(express.urlencoded({ extended: false }));
   app.use(cookieParser());
+  app.use(helmet.contentSecurityPolicy());
+  app.use(helmet.hidePoweredBy());
+  app.use(helmet.noSniff());
+  app.use(helmet.permittedCrossDomainPolicies());
+  app.use(helmet.referrerPolicy());
   app.use(helmet.frameguard());
+  app.use(helmet.xssFilter());
 
   const authType: string = await setAuth();
 


### PR DESCRIPTION
Signed-off-by: Elisabeth Lang <elisabeth.lang@dynatrace.com>

As described in the [Express](https://expressjs.com/en/advanced/best-practice-security.html) documentation, helmet is one of the best choices to prevent XSS. I did a small research of the headers that are set when calling `app.use(helmet());` and chose the ones that make most sense for Keptn Bridge.
A detailed description of which headers are set can be found in the helmetjs [docs](https://helmetjs.github.io/).

```
  app.use(helmet.contentSecurityPolicy());
  app.use(helmet.hidePoweredBy());
  app.use(helmet.noSniff());
  app.use(helmet.permittedCrossDomainPolicies());
  app.use(helmet.referrerPolicy());
  app.use(helmet.frameguard());
  app.use(helmet.xssFilter());
```