### PR TITLE
fix(api): Remove multiple types in event model (#5948)

### DIFF
--- a/api/restapi/embedded_spec.go
+++ b/api/restapi/embedded_spec.go
@@ -137,10 +137,7 @@ func init() {
           "type": "string"
         },
         "data": {
-          "type": [
-            "object",
-            "string"
-          ]
+          "type": "object"
         },
         "extensions": {
           "type": "object"
@@ -180,10 +177,7 @@ func init() {
           "type": "string"
         },
         "keptnservices": {
-          "type": [
-            "object",
-            "string"
-          ]
+          "type": "object"
         },
         "keptnversion": {
           "type": "string"
@@ -330,10 +324,7 @@ func init() {
           "type": "string"
         },
         "data": {
-          "type": [
-            "object",
-            "string"
-          ]
+          "type": "object"
         },
         "extensions": {
           "type": "object"
@@ -373,10 +364,7 @@ func init() {
           "type": "string"
         },
         "keptnservices": {
-          "type": [
-            "object",
-            "string"
-          ]
+          "type": "object"
         },
         "keptnversion": {
           "type": "string"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -93,7 +93,7 @@ definitions:
       contenttype:
         type: string
       data:
-        type: [ "object", "string" ]
+        type: object
       id:
         type: string
       time:
@@ -125,4 +125,4 @@ definitions:
       bridgeversion:
         type: string
       keptnservices:
-        type: [ "object", "string" ]
+        type: object


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

-  since Swagger does not support OpenAPiI 3.0 changed  type [" object" , " string "] to  type object 

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #5948 



