### PR TITLE
chore: Updated go-utils dependency in mongodb-datastore (#5968)

### DIFF
--- a/mongodb-datastore/go.mod
+++ b/mongodb-datastore/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/go-test/deep v1.0.8
 	github.com/jeremywohl/flatten v0.0.0-20190921043622-d936035e55cf
 	github.com/jessevdk/go-flags v1.4.0
-	github.com/keptn/go-utils v0.10.1-0.20211102080258-6ac1aa413ca0
+	github.com/keptn/go-utils v0.10.1-0.20211109102150-90baf286404d
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.7.0
 	go.mongodb.org/mongo-driver v1.7.3

--- a/mongodb-datastore/go.sum
+++ b/mongodb-datastore/go.sum
@@ -181,6 +181,8 @@ github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaR
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
 github.com/keptn/go-utils v0.10.1-0.20211102080258-6ac1aa413ca0 h1:4fqrfSXOz09iejZD06lPANC3ZNomKYmRoV5M6iw8qgo=
 github.com/keptn/go-utils v0.10.1-0.20211102080258-6ac1aa413ca0/go.mod h1:ub4G0WZUckc3TizUoe5jKqfCOOLiH5pnf4M1SDCOT0M=
+github.com/keptn/go-utils v0.10.1-0.20211109102150-90baf286404d h1:jgGpbn/6+wPg5i7UZgKX+2RNyhIh5wWEkDWdmP7rHGw=
+github.com/keptn/go-utils v0.10.1-0.20211109102150-90baf286404d/go.mod h1:ub4G0WZUckc3TizUoe5jKqfCOOLiH5pnf4M1SDCOT0M=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/klauspost/compress v1.9.5/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.13.6 h1:P76CopJELS0TiO2mebmnzgWaajssP/EszplttgQxcgc=


### PR DESCRIPTION
Closes #5968

The previous version of the go-utils that was imported by the mongodb-datastore was still using the `MONGO_DB_NAME` env var to determine the name of the mongodb database. This has recently been changed to `MONGODB_NAME` and therefore the go-utils needed to be upgraded to the latest version to account for that.