### PR TITLE
chore(shipyard-controller): Adapted log level

### DIFF
--- a/shipyard-controller/handler/sequencedispatcher.go
+++ b/shipyard-controller/handler/sequencedispatcher.go
@@ -124,6 +124,7 @@ func (sd *SequenceDispatcher) dispatchSequence(queuedSequence models.QueueItem) 
 	// first, check if the sequence is currently paused
 	if sd.eventQueueRepo.IsSequenceOfEventPaused(queuedSequence.Scope) {
 		log.Infof("Sequence %s is currently paused. Will not start it yet.", queuedSequence.Scope.KeptnContext)
+		return ErrSequenceBlocked
 	}
 	// fetch all sequences that are currently running in the stage of the project where the sequence should run
 	taskExecutions, err := sd.sequenceRepo.GetTaskExecutions(queuedSequence.Scope.Project, models.TaskExecution{

--- a/shipyard-controller/handler/sequencedispatcher.go
+++ b/shipyard-controller/handler/sequencedispatcher.go
@@ -86,7 +86,7 @@ func (sd *SequenceDispatcher) Run(ctx context.Context, startSequenceFunc func(ev
 		for {
 			select {
 			case <-ctx.Done():
-				log.Info("cancelling sequence dispatcher loop")
+				log.Info("Cancelling sequence dispatcher loop")
 				return
 			case <-ticker.C:
 				log.Debugf("%.2f seconds have passed. Dispatching sequences", sd.syncInterval.Seconds())
@@ -103,16 +103,16 @@ func (sd *SequenceDispatcher) dispatchSequences() {
 			// if no sequences are in the queue, we can return here
 			return
 		}
-		log.WithError(err).Error("could not load queued sequences")
+		log.WithError(err).Error("Could not load queued sequences")
 		return
 	}
 
 	for _, queuedSequence := range queuedSequences {
 		if err := sd.dispatchSequence(queuedSequence); err != nil {
 			if errors.Is(err, ErrSequenceBlocked) {
-				log.Infof("could not dispatch sequence with keptnContext %s. Sequence is currently blocked by other sequence", queuedSequence.Scope.KeptnContext)
+				log.Infof("Could not dispatch sequence with keptnContext %s. Sequence is currently blocked by other sequence", queuedSequence.Scope.KeptnContext)
 			} else {
-				log.WithError(err).Errorf("could not dispatch sequence with keptnContext %s", queuedSequence.Scope.KeptnContext)
+				log.WithError(err).Errorf("Could not dispatch sequence with keptnContext %s", queuedSequence.Scope.KeptnContext)
 			}
 		}
 	}
@@ -136,7 +136,7 @@ func (sd *SequenceDispatcher) dispatchSequence(queuedSequence models.QueueItem) 
 
 	// if there is a sequence running in the stage, we cannot trigger this sequence yet
 	if sd.areActiveSequencesBlockingQueuedSequences(taskExecutions) {
-		log.Infof("sequence %s cannot be started yet because sequences are still running in stage %s", queuedSequence.Scope.KeptnContext, queuedSequence.Scope.Stage)
+		log.Infof("Sequence %s cannot be started yet because sequences are still running in stage %s", queuedSequence.Scope.KeptnContext, queuedSequence.Scope.Stage)
 		return ErrSequenceBlocked
 	}
 


### PR DESCRIPTION
The message indicating that a sequence is currently blocked was logged with an `error` level, which should not be the case. Changed it to `info` instead