### PR TITLE
chore(shipyard-controller): Do not interpret absence of configurationChange property as an error (#5979)

### DIFF
--- a/shipyard-controller/common/keptn_helpers.go
+++ b/shipyard-controller/common/keptn_helpers.go
@@ -182,9 +182,9 @@ func CreateEventWithPayload(keptnContext, triggeredID, eventType string, payload
 	return event
 }
 
-func ExtractImageOfDeploymentEvent(deploymentTriggeredEventData keptnv2.DeploymentTriggeredEventData) (string, error) {
+func ExtractImageOfDeploymentEvent(deploymentTriggeredEventData keptnv2.DeploymentTriggeredEventData) string {
 	if imageValue, ok := deploymentTriggeredEventData.ConfigurationChange.Values["image"].(string); ok {
-		return imageValue, nil
+		return imageValue
 	}
-	return "", errors.New("could not extract image name of event: could not find property configurationChange.Values['image'] of type string")
+	return ""
 }

--- a/shipyard-controller/common/keptn_helpers_test.go
+++ b/shipyard-controller/common/keptn_helpers_test.go
@@ -3,6 +3,7 @@ package common
 import (
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
 )
@@ -85,10 +86,9 @@ func TestExtractImageOfDeploymentEvent(t *testing.T) {
 		eventData keptnv2.DeploymentTriggeredEventData
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    string
-		wantErr bool
+		name string
+		args args
+		want string
 	}{
 		{
 			name: "extract image property from correctly structured event",
@@ -101,8 +101,7 @@ func TestExtractImageOfDeploymentEvent(t *testing.T) {
 					},
 				},
 			},
-			want:    "my-image",
-			wantErr: false,
+			want: "my-image",
 		},
 		{
 			name: "image property has different type than expected",
@@ -118,20 +117,14 @@ func TestExtractImageOfDeploymentEvent(t *testing.T) {
 					},
 				},
 			},
-			want:    "",
-			wantErr: true,
+			want: "",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ExtractImageOfDeploymentEvent(tt.args.eventData)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ExtractImageOfDeploymentEvent() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("ExtractImageOfDeploymentEvent() got = %v, want %v", got, tt.want)
-			}
+			got := ExtractImageOfDeploymentEvent(tt.args.eventData)
+
+			require.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/shipyard-controller/db/mongodb_project_mv_repo.go
+++ b/shipyard-controller/db/mongodb_project_mv_repo.go
@@ -493,10 +493,7 @@ func (mv *MongoDBProjectMVRepo) UpdateEventOfService(e models.Event) error {
 				return errors.New("unable to decode deployment.triggered event data: " + err.Error())
 			}
 
-			deployedImage, err := common.ExtractImageOfDeploymentEvent(*triggeredData)
-			if err != nil {
-				return fmt.Errorf("could not determine deployed image: %s", err.Error())
-			}
+			deployedImage := common.ExtractImageOfDeploymentEvent(*triggeredData)
 			service.DeployedImage = deployedImage
 		}
 		return nil

--- a/shipyard-controller/handler/sequence_migrator.go
+++ b/shipyard-controller/handler/sequence_migrator.go
@@ -261,10 +261,7 @@ func processTaskEventTaskEvent(scope models.EventScope, event models.Event, stag
 		if err := keptnv2.Decode(event.Data, deploymentTriggeredEventData); err != nil {
 			return nil, fmt.Errorf("could not decode deployment.triggered event data: %s", err.Error())
 		}
-		deployedImage, err := common.ExtractImageOfDeploymentEvent(*deploymentTriggeredEventData)
-		if err != nil {
-			return nil, fmt.Errorf("could not determine deployed image: %s", err.Error())
-		}
+		deployedImage := common.ExtractImageOfDeploymentEvent(*deploymentTriggeredEventData)
 		stageState.Image = deployedImage
 	}
 

--- a/shipyard-controller/handler/sequencehooks/sequencestate.go
+++ b/shipyard-controller/handler/sequencehooks/sequencestate.go
@@ -259,10 +259,8 @@ func (smv *SequenceStateMaterializedView) updateImageOfSequence(event models.Eve
 		return fmt.Errorf("could not decode deployment.triggered event data: %s", err.Error())
 	}
 
-	deployedImage, err := common.ExtractImageOfDeploymentEvent(*deploymentTriggeredEventData)
-	if err != nil {
-		return fmt.Errorf("could not determine deployed image: %s", err.Error())
-	}
+	deployedImage := common.ExtractImageOfDeploymentEvent(*deploymentTriggeredEventData)
+
 	eventScope, err := models.NewEventScope(event)
 	if err != nil {
 		return fmt.Errorf("could not determine event scope: %s", err.Error())


### PR DESCRIPTION
Closes #5979

Note: The problem described in #5979 that prevented the delivery sequence was caused by a misconfiguration of the remote-exec plane helm-service. However, the missing `configurationChange` property should not be interpreted as an error since `deployment.triggered` events do not have the strict requirement of having this property.