### PR TITLE
fix(webhook-service): Avoid .finished.finished/.started.finished events (#5954)

### DIFF
--- a/webhook-service/handler/handler.go
+++ b/webhook-service/handler/handler.go
@@ -151,6 +151,10 @@ func removeSecretsFromMessage(errMsg string, secrets map[string]string) string {
 }
 
 func (th *TaskHandler) sendFinishedEvent(keptnHandler sdk.IKeptn, event sdk.KeptnEvent, result map[string]interface{}) {
+	// ensure that finished events are only sent as responses for .triggered events
+	if !keptnv2.IsTaskEventType(*event.Type) || !keptnv2.IsTriggeredEventType(*event.Type) {
+		return
+	}
 	if err := keptnHandler.SendFinishedEvent(event, result); err != nil {
 		logger.WithError(err).Error("could not send .finished event")
 	}

--- a/webhook-service/handler/handler_test.go
+++ b/webhook-service/handler/handler_test.go
@@ -244,6 +244,39 @@ func Test_HandleIncomingFinishedEvent(t *testing.T) {
 	require.Empty(t, fakeKeptn.GetEventSender().SentEvents)
 }
 
+func Test_HandleIncomingFinishedEventWithResultingError(t *testing.T) {
+	templateEngineMock := &fake.ITemplateEngineMock{ParseTemplateFunc: func(data interface{}, templateStr string) (string, error) {
+		tplE := &lib.TemplateEngine{}
+		return tplE.ParseTemplate(data, templateStr)
+	}}
+
+	secretReaderMock := &fake.ISecretReaderMock{}
+	secretReaderMock.ReadSecretFunc = func(name string, key string) (string, error) {
+		return "my-secret-value", nil
+	}
+
+	curlExecutorMock := &fake.ICurlExecutorMock{}
+	curlExecutorMock.CurlFunc = func(curlCmd string) (string, error) {
+		return "", errors.New("oops")
+	}
+
+	taskHandler := handler.NewTaskHandler(templateEngineMock, curlExecutorMock, secretReaderMock)
+
+	fakeKeptn := sdk.NewFakeKeptn(
+		"test-webhook-svc")
+	fakeKeptn.SetResourceHandler(sdk.StringResourceHandler{ResourceContent: webHookContentWithFinishedEvent})
+	fakeKeptn.AddTaskHandler("*", taskHandler)
+	fakeKeptn.SetAutomaticResponse(false)
+	fakeKeptn.Start()
+	fakeKeptn.NewEvent(newWebhookTriggeredEvent("test/events/test-webhook.finished.json"))
+
+	require.Len(t, curlExecutorMock.CurlCalls(), 1)
+	assert.Equal(t, "curl http://localhost:8080 myproject my-secret-value", curlExecutorMock.CurlCalls()[0].CurlCmd)
+
+	//verify sent events
+	require.Empty(t, fakeKeptn.GetEventSender().SentEvents)
+}
+
 func Test_HandleIncomingTriggeredEvent_SendMultipleRequests(t *testing.T) {
 	templateEngineMock := &fake.ITemplateEngineMock{ParseTemplateFunc: func(data interface{}, templateStr string) (string, error) {
 		tplE := &lib.TemplateEngine{}

--- a/webhook-service/handler/handler_test.go
+++ b/webhook-service/handler/handler_test.go
@@ -211,6 +211,39 @@ func Test_HandleIncomingStartedEvent(t *testing.T) {
 	require.Empty(t, fakeKeptn.GetEventSender().SentEvents)
 }
 
+func Test_HandleIncomingStartedEventWithResultingError(t *testing.T) {
+	templateEngineMock := &fake.ITemplateEngineMock{ParseTemplateFunc: func(data interface{}, templateStr string) (string, error) {
+		tplE := &lib.TemplateEngine{}
+		return tplE.ParseTemplate(data, templateStr)
+	}}
+
+	secretReaderMock := &fake.ISecretReaderMock{}
+	secretReaderMock.ReadSecretFunc = func(name string, key string) (string, error) {
+		return "my-secret-value", nil
+	}
+
+	curlExecutorMock := &fake.ICurlExecutorMock{}
+	curlExecutorMock.CurlFunc = func(curlCmd string) (string, error) {
+		return "", errors.New("oops")
+	}
+
+	taskHandler := handler.NewTaskHandler(templateEngineMock, curlExecutorMock, secretReaderMock)
+
+	fakeKeptn := sdk.NewFakeKeptn(
+		"test-webhook-svc")
+	fakeKeptn.SetResourceHandler(sdk.StringResourceHandler{ResourceContent: webHookContentWithStartedEvent})
+	fakeKeptn.AddTaskHandler("*", taskHandler)
+	fakeKeptn.SetAutomaticResponse(false)
+	fakeKeptn.Start()
+	fakeKeptn.NewEvent(newWebhookTriggeredEvent("test/events/test-webhook.started.json"))
+
+	require.Len(t, curlExecutorMock.CurlCalls(), 1)
+	assert.Equal(t, "curl http://localhost:8080 myproject my-secret-value", curlExecutorMock.CurlCalls()[0].CurlCmd)
+
+	//verify sent events
+	require.Empty(t, fakeKeptn.GetEventSender().SentEvents)
+}
+
 func Test_HandleIncomingFinishedEvent(t *testing.T) {
 	templateEngineMock := &fake.ITemplateEngineMock{ParseTemplateFunc: func(data interface{}, templateStr string) (string, error) {
 		tplE := &lib.TemplateEngine{}


### PR DESCRIPTION
Closes #5954 

This fixes a problem that caused the webhook service to respond with <task>.finished.finished or <task>.started.finished events when the webhook execution failed