### PR TITLE
fix(configuration-service): changed bad order of extracting and adding resources to services (#5975)

### DIFF
--- a/configuration-service/common/common.go
+++ b/configuration-service/common/common.go
@@ -7,3 +7,6 @@ const StageDoesNotExistErrorMsg = "Stage does not exist"
 const ServiceDoesNotExistErrorMsg = "Service does not exist"
 
 const CannotCheckOutBranchErrorMsg = "Could not check out branch"
+
+const CannotAddResourceErrorMsg = "Could not add resource"
+const CannotUpdateResourceErrorMsg = "Could not update resource"

--- a/configuration-service/deploy/service.yaml
+++ b/configuration-service/deploy/service.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: keptn-configuration-service
       containers:
       - name: configuration-service
-        image: keptn/configuration-service:latest
+        image: keptn/configuration-service:0.10.1-dev
         env:
           - name: PREFIX_PATH
             value: ""


### PR DESCRIPTION
…g resources to services

Signed-off-by: odubajDT <ondrej.dubaj@dynatrace.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- fixes bad order of extracting and adding resources to services
-  follow-up task: https://github.com/keptn/keptn/issues/6035

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #5975

### Notes
<!-- any additional notes for this PR -->
This issue is caused only by bad order of the actions when adding new resources to the service. Currently, by looping through the (helm) resource(s), the code actually adds the resource to the git repository and then tries to extract it. From my POV, we should first extract the file and check if it is valid and if yes, then add it to the repository.

