### PR TITLE
ci: Remove docker cache because of pipeline errors

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -299,32 +299,15 @@ jobs:
         with:
           install: true
 
-      - name: Docker Cache
-        id: docker_cache
-        if: matrix.config.should-run == 'true' || ( needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true' && needs.prepare_ci_run.outputs.LAST_SUCCESSFUL_RUN_ID == 'null' )
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-test-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-test-
-
       - name: Build ${{ matrix.config.artifact }} test image
         if: ((needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (matrix.config.should-run == 'true'))
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.config.working-dir }}
           tags: ${{ matrix.config.artifact }}-test-${{ github.sha }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
           target: ${{ matrix.config.docker-test-target }}
           load: true
           push: false
-
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
       - name: Test ${{ matrix.config.artifact }}
         if: ((needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (matrix.config.should-run == 'true'))
@@ -572,12 +555,6 @@ jobs:
           registry: "quay.io"
           username: ${{ secrets.QUAY_USER }}
           password: ${{ secrets.QUAY_TOKEN }}
-
-      - id: docker_cache
-        name: Docker Cache
-        if: matrix.config.should-push-image == 'true' && ( matrix.config.should-run == 'true' || needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true' || needs.prepare_ci_run.outputs.LAST_SUCCESSFUL_RUN_ID == 'null' )
-        uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
 
       - id: docker_build_image
         name: "Docker Build keptn/${{ matrix.config.artifact }}"


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- removes the docker cache steps from the CI pipeline since they cause more errors and pains than they serve their purpose