### PR TITLE
fix(bridge): Remove inline script for base url and upgrade-insecure-requests header part

### DIFF
--- a/bridge/client/index.html
+++ b/bridge/client/index.html
@@ -4,16 +4,6 @@
     <meta charset="utf-8" />
     <title>keptn</title>
     <base id="base-href" href="/" />
-    <script>
-      // NOTE: if changed, update tests in app.component.spec.ts
-      function getBridgeBaseHref(origin, path) {
-        if (path.indexOf('/bridge') !== -1)
-          return [origin, path.substring(0, path.indexOf('/bridge')), '/bridge/'].join('');
-        else return origin;
-      }
-
-      document.getElementById('base-href').href = getBridgeBaseHref(window.location.origin, window.location.pathname);
-    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link id="appFavicon" rel="icon" type="image/png" href="assets/branding/logo_inverted.png" />
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap" rel="stylesheet" />

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -9,7 +9,7 @@
     "start:server:dev": "cd ./server && yarn dev",
     "start:ci": "ng serve --port=3000 --no-live-reload --configuration=test",
     "ng": "ng",
-    "build": "ng build --prod --base-href=./",
+    "build": "ng build --prod --base-href=/bridge/",
     "test": "jest --config=jest.config.ts --maxWorkers=1",
     "lint:check": "eslint ./",
     "lint:fix": "eslint --fix ./",

--- a/bridge/server/app.ts
+++ b/bridge/server/app.ts
@@ -158,7 +158,14 @@ async function init(): Promise<Express> {
   app.use(express.urlencoded({ extended: false }));
   app.use(cookieParser());
 
-  app.use(helmet.contentSecurityPolicy());
+  app.use(
+    helmet.contentSecurityPolicy({
+      useDefaults: true,
+      directives: {
+        'script-src': ["'self'", "'sha256-9Ts7nfXdJQSKqVPxtB4Jwhf9pXSA/krLvgk8JROkI6g='", "'unsafe-eval'"],
+      },
+    })
+  );
   app.use(helmet.hidePoweredBy());
   app.use(helmet.noSniff());
   app.use(helmet.permittedCrossDomainPolicies());

--- a/bridge/server/app.ts
+++ b/bridge/server/app.ts
@@ -158,19 +158,19 @@ async function init(): Promise<Express> {
   app.use(express.urlencoded({ extended: false }));
   app.use(cookieParser());
 
-  app.use(
-    helmet.contentSecurityPolicy({
-      useDefaults: true,
-      directives: {
-        'script-src': ["'self'", 'sha256-9Ts7nfXdJQSKqVPxtB4Jwhf9pXSA/krLvgk8JROkI6g=', 'unsafe-eval'],
-      },
-    })
-  );
-  // app.use(helmet.hidePoweredBy());
-  // app.use(helmet.noSniff());
-  // app.use(helmet.permittedCrossDomainPolicies());
+  // app.use(
+  //   helmet.contentSecurityPolicy({
+  //     useDefaults: true,
+  //     directives: {
+  //       'script-src': ["'self'", 'sha256-9Ts7nfXdJQSKqVPxtB4Jwhf9pXSA/krLvgk8JROkI6g=', 'unsafe-eval'],
+  //     },
+  //   })
+  // );
+  app.use(helmet.hidePoweredBy());
+  app.use(helmet.noSniff());
+  app.use(helmet.permittedCrossDomainPolicies());
   app.use(helmet.frameguard());
-  // app.use(helmet.xssFilter());
+  app.use(helmet.xssFilter());
 
   const authType: string = await setAuth();
 

--- a/bridge/server/app.ts
+++ b/bridge/server/app.ts
@@ -162,14 +162,13 @@ async function init(): Promise<Express> {
     helmet.contentSecurityPolicy({
       useDefaults: true,
       directives: {
-        'script-src': ["'self'", "'sha256-9Ts7nfXdJQSKqVPxtB4Jwhf9pXSA/krLvgk8JROkI6g='", "'unsafe-eval'"],
+        'script-src': ["'self'", "'sha256-9Ts7nfXdJQSKqVPxtB4Jwhf9pXSA/krLvgk8JROkI6g='", "'unsafe-eval '"],
       },
     })
   );
   app.use(helmet.hidePoweredBy());
   app.use(helmet.noSniff());
   app.use(helmet.permittedCrossDomainPolicies());
-  app.use(helmet.referrerPolicy());
   app.use(helmet.frameguard());
   app.use(helmet.xssFilter());
 

--- a/bridge/server/app.ts
+++ b/bridge/server/app.ts
@@ -162,15 +162,15 @@ async function init(): Promise<Express> {
     helmet.contentSecurityPolicy({
       useDefaults: true,
       directives: {
-        'script-src': ["'self'", "'sha256-9Ts7nfXdJQSKqVPxtB4Jwhf9pXSA/krLvgk8JROkI6g='", "'unsafe-eval '"],
+        'script-src': ["'self'", 'sha256-9Ts7nfXdJQSKqVPxtB4Jwhf9pXSA/krLvgk8JROkI6g=', 'unsafe-eval'],
       },
     })
   );
-  app.use(helmet.hidePoweredBy());
-  app.use(helmet.noSniff());
-  app.use(helmet.permittedCrossDomainPolicies());
+  // app.use(helmet.hidePoweredBy());
+  // app.use(helmet.noSniff());
+  // app.use(helmet.permittedCrossDomainPolicies());
   app.use(helmet.frameguard());
-  app.use(helmet.xssFilter());
+  // app.use(helmet.xssFilter());
 
   const authType: string = await setAuth();
 

--- a/bridge/server/app.ts
+++ b/bridge/server/app.ts
@@ -158,14 +158,15 @@ async function init(): Promise<Express> {
   app.use(express.urlencoded({ extended: false }));
   app.use(cookieParser());
 
-  // app.use(
-  //   helmet.contentSecurityPolicy({
-  //     useDefaults: true,
-  //     directives: {
-  //       'script-src': ["'self'", 'sha256-9Ts7nfXdJQSKqVPxtB4Jwhf9pXSA/krLvgk8JROkI6g=', 'unsafe-eval'],
-  //     },
-  //   })
-  // );
+  app.use(
+    helmet.contentSecurityPolicy({
+      useDefaults: true,
+      directives: {
+        'script-src': ["'self'", 'unsafe-eval'],
+        'upgrade-insecure-requests': null,
+      },
+    })
+  );
   app.use(helmet.hidePoweredBy());
   app.use(helmet.noSniff());
   app.use(helmet.permittedCrossDomainPolicies());


### PR DESCRIPTION
I removed the script that caused the page to load entirely and replaced it with the `--base-url` argument for the `yarn build` script. Also I removed the `upgrade-insecure-requests` header part of the CSP header in order to not cause switching requests from http to https - which causes `ERR_CONNECTION_REFUSED` errors on the client.

Signed-off-by: Elisabeth Lang <elisabeth.lang@dynatrace.com>