### PR TITLE
chore(jmeter-service): bump version of jmeter binary to 5.4.1

### DIFF
--- a/jmeter-service/Dockerfile
+++ b/jmeter-service/Dockerfile
@@ -48,7 +48,7 @@ LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
     org.opencontainers.image.version="${version}"
 
 ENV env=production
-ARG JMETER_VERSION="5.1.1"
+ARG JMETER_VERSION="5.4.1"
 ENV JMETER_HOME /opt/apache-jmeter-${JMETER_VERSION}
 ENV	JMETER_BIN	${JMETER_HOME}/bin
 ENV	JMETER_DOWNLOAD_URL  https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-${JMETER_VERSION}.tgz


### PR DESCRIPTION
This PR bumps the jmeter version to **v5.4.1**
closes #6031 

Integration Test Run: https://github.com/keptn/keptn/actions/runs/1471910850
