### PR TITLE
fix(distributor): Sanitized logs and cleaned up forwarder lifecycle

### DIFF
--- a/distributor/cmd/main.go
+++ b/distributor/cmd/main.go
@@ -84,14 +84,14 @@ func _main(env config.EnvConfig) int {
 		httpEventPoller := events.NewPoller(env, eventSender, httpClient)
 		uniformWatch.RegisterListener(httpEventPoller)
 		if err := httpEventPoller.Start(executionContext); err != nil {
-			logger.Fatalf("Unable to start HTTP event poller: %v", err)
+			logger.Fatalf("Could not start HTTP event poller: %v", err)
 		}
 	} else {
 		logger.Info("Starting NATS event Receiver")
 		natsEventReceiver := events.NewNATSEventReceiver(env, eventSender)
 		uniformWatch.RegisterListener(natsEventReceiver)
 		if err := natsEventReceiver.Start(executionContext); err != nil {
-			logger.Fatalf("Unable to start NATS event receiver: %v", err)
+			logger.Fatalf("Could not start NATS event receiver: %v", err)
 		}
 	}
 	executionContext.Wg.Wait()

--- a/distributor/cmd/main.go
+++ b/distributor/cmd/main.go
@@ -61,11 +61,9 @@ func _main(env config.EnvConfig) int {
 
 	// Start event forwarder
 	logger.Info("Starting Event Forwarder")
-	go func() {
-		if err := forwarder.Start(executionContext); err != nil {
-			logger.WithError(err).Error("Could not start event forwarder")
-		}
-	}()
+	if err := forwarder.Start(executionContext); err != nil {
+		logger.WithError(err).Error("Could not start event forwarder")
+	}
 
 	// Eventually start registration process
 	if shallRegister() {

--- a/distributor/cmd/main.go
+++ b/distributor/cmd/main.go
@@ -61,9 +61,7 @@ func _main(env config.EnvConfig) int {
 
 	// Start event forwarder
 	logger.Info("Starting Event Forwarder")
-	if err := forwarder.Start(executionContext); err != nil {
-		logger.WithError(err).Error("Could not start event forwarder")
-	}
+	forwarder.Start(executionContext)
 
 	// Eventually start registration process
 	if shallRegister() {

--- a/distributor/pkg/config/envconfig.go
+++ b/distributor/pkg/config/envconfig.go
@@ -40,7 +40,7 @@ type EnvConfig struct {
 func GetRegistrationInterval(env EnvConfig) time.Duration {
 	duration, err := time.ParseDuration(env.RegistrationInterval)
 	if err != nil {
-		logger.Warnf("Unable to parse REGISTRATION_INTERVAL environment variable as duration: %s", env.RegistrationInterval)
+		logger.Warnf("Could not parse REGISTRATION_INTERVAL environment variable as duration: %s", env.RegistrationInterval)
 		return 10 * time.Second
 	}
 	return duration

--- a/distributor/pkg/lib/events/forwarder.go
+++ b/distributor/pkg/lib/events/forwarder.go
@@ -54,7 +54,7 @@ func (f *Forwarder) Start(ctx *ExecutionContext) {
 		<-ctx.Done()
 		logger.Info("Terminating event forwarder")
 		if err := svr.Shutdown(context.Background()); err != nil {
-			logger.Fatalf("Could not gracefully shutdown http server of forwarder: %v", err)
+			logger.Fatalf("Could not gracefully shutdown http server of event forwarder: %v", err)
 		}
 	}()
 }

--- a/distributor/pkg/lib/events/forwarder.go
+++ b/distributor/pkg/lib/events/forwarder.go
@@ -32,7 +32,7 @@ func NewForwarder(httpClient *http.Client) *Forwarder {
 	}
 }
 
-func (f *Forwarder) Start(ctx *ExecutionContext) error {
+func (f *Forwarder) Start(ctx *ExecutionContext) {
 	mux := http.NewServeMux()
 	mux.Handle("/health", http.HandlerFunc(api.HealthEndpointHandler))
 	mux.Handle(config.Global.EventForwardingPath, http.HandlerFunc(f.handleEvent))
@@ -57,7 +57,6 @@ func (f *Forwarder) Start(ctx *ExecutionContext) error {
 			logger.Fatalf("Could not gracefully shutdown http server of forwarder: %v", err)
 		}
 	}()
-	return nil
 }
 
 func (f *Forwarder) handleEvent(rw http.ResponseWriter, req *http.Request) {

--- a/distributor/pkg/lib/events/forwarder.go
+++ b/distributor/pkg/lib/events/forwarder.go
@@ -58,14 +58,12 @@ func (f *Forwarder) Start(ctx *ExecutionContext) error {
 	if err != nil {
 		return err
 	}
-
 	logger.Info("Terminating event forwarder")
 	ctx.Wg.Done()
 	return nil
 }
 
 func (f *Forwarder) handleEvent(rw http.ResponseWriter, req *http.Request) {
-
 	body, err := ioutil.ReadAll(req.Body)
 	if err != nil {
 		logger.Errorf("Failed to read body from request: %v", err)
@@ -89,7 +87,7 @@ func (f *Forwarder) handleEvent(rw http.ResponseWriter, req *http.Request) {
 }
 
 func (f *Forwarder) forwardEvent(event cloudevents.Event) error {
-	logger.Infof("Received CloudEvent with ID %s - Forwarding to Keptn\n", event.ID())
+	logger.Infof("Received CloudEvent with ID %s - Forwarding to Keptn", event.ID())
 	select {
 	case f.EventChannel <- event:
 		// no-op
@@ -101,7 +99,7 @@ func (f *Forwarder) forwardEvent(event cloudevents.Event) error {
 		return nil
 	}
 	if config.Global.KeptnAPIEndpoint == "" {
-		logger.Error("No external API endpoint defined. Forwarding directly to NATS server")
+		logger.Debug("No external API endpoint defined. Forwarding directly to NATS server")
 		return f.forwardEventToNATSServer(event)
 	}
 	return f.forwardEventToAPI(event)
@@ -115,24 +113,21 @@ func (f *Forwarder) forwardEventToNATSServer(event cloudevents.Event) error {
 
 	c, err := cloudevents.NewClient(pubSubConnection)
 	if err != nil {
-		logger.Errorf("Failed to create client, %v\n", err)
+		logger.Errorf("Failed to create cloudevents client: %v", err)
 		return err
 	}
 
 	cloudevents.WithEncodingStructured(context.Background())
 
 	if result := c.Send(context.Background(), event); cloudevents.IsUndelivered(result) {
-		logger.Errorf("Failed to send: %v\n", err)
+		logger.Errorf("Failed to send cloud event: %v", err)
 	} else {
 		logger.Infof("Sent: %s, accepted: %t", event.ID(), cloudevents.IsACK(result))
 	}
-
 	return nil
 }
 
 func (f *Forwarder) forwardEventToAPI(event cloudevents.Event) error {
-	logger.Infof("Keptn API endpoint: %s", config.Global.KeptnAPIEndpoint)
-
 	payload, err := event.MarshalJSON()
 	if err != nil {
 		return err
@@ -193,20 +188,18 @@ func (f *Forwarder) apiProxyHandler(rw http.ResponseWriter, req *http.Request) {
 	} else {
 		path = req.URL.Path
 	}
-
-	logger.Infof("Incoming request: host=%s, path=%s, URL=%s", req.URL.Host, path, req.URL.String())
-
+	logger.Debugf("Incoming request: host=%s, path=%s, URL=%s", req.URL.Host, path, req.URL.String())
 	proxyScheme, proxyHost, proxyPath := config.Global.GetProxyHost(path)
 
 	if proxyScheme == "" || proxyHost == "" {
-		logger.Error("Could not get proxy Host URL - got empty values")
+		logger.Error("Could not get proxy Host URL - got empty values of 'proxyScheme' or 'proxyHost'")
 		rw.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
 	forwardReq, err := http.NewRequest(req.Method, req.URL.String(), req.Body)
 	if err != nil {
-		logger.Errorf("Unable to create request to be forwarded: %v", err)
+		logger.Errorf("Could not create request to be forwarded: %v", err)
 		rw.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -222,8 +215,7 @@ func (f *Forwarder) apiProxyHandler(rw http.ResponseWriter, req *http.Request) {
 
 	forwardReq.URL = parsedProxyURL
 	forwardReq.URL.RawQuery = req.URL.RawQuery
-
-	logger.Infof("Forwarding request to host=%s, path=%s, URL=%s", proxyHost, proxyPath, forwardReq.URL.String())
+	logger.Debugf("Forwarding request to host=%s, path=%s, URL=%s", proxyHost, proxyPath, forwardReq.URL.String())
 
 	if config.Global.KeptnAPIToken != "" {
 		logger.Debug("Adding x-token header to HTTP request")
@@ -254,7 +246,7 @@ func (f *Forwarder) apiProxyHandler(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	logger.Infof("Received response from API: Status=%d", resp.StatusCode)
+	logger.Debugf("Received response from API: Status=%d", resp.StatusCode)
 	if _, err := rw.Write(respBytes); err != nil {
 		logger.Errorf("could not send response from API: %v", err)
 	}

--- a/distributor/pkg/lib/events/nats_connection_handler.go
+++ b/distributor/pkg/lib/events/nats_connection_handler.go
@@ -51,7 +51,7 @@ func (nch *NatsConnectionHandler) Connect() error {
 // RemoveAllSubscriptions removes all current subscriptions from the NATS handler
 func (nch *NatsConnectionHandler) RemoveAllSubscriptions() error {
 	if nch.natsConnection == nil || !nch.natsConnection.IsConnected() {
-		return fmt.Errorf("unable to remove all subscriptions, because not connected to NATS")
+		return fmt.Errorf("could not remove all subscriptions, because not connected to NATS")
 	}
 	for _, sub := range nch.subscriptions {
 		_ = sub.Unsubscribe()
@@ -74,18 +74,18 @@ func (nch *NatsConnectionHandler) QueueSubscribeToTopics(topics []string, queueG
 	nch.mux.Lock()
 	defer nch.mux.Unlock()
 	if nch.natsConnection == nil || !nch.natsConnection.IsConnected() {
-		return errors.New("unable to remove all subscriptions, because not connected to NATS")
+		return errors.New("could not remove all subscriptions, because not connected to NATS")
 	}
 
 	if len(topics) > 0 && !IsEqual(nch.topics, topics) {
 		err := nch.RemoveAllSubscriptions()
 		if err != nil {
-			return fmt.Errorf("unable to remove all subscriptions: %w", err)
+			return fmt.Errorf("could not remove all subscriptions: %w", err)
 		}
 		nch.topics = topics
 
 		for _, topic := range nch.topics {
-			logger.Infof("Subscribing to topic <%s> with queue group <%s>", topic, queueGroup)
+			logger.Infof("Subscribing to topic '%s' with queue group '%s'", topic, queueGroup)
 			sub, err := nch.natsConnection.QueueSubscribe(topic, queueGroup, nch.messageHandler)
 			if err != nil {
 				return errors.New("failed to subscribe to topic: " + err.Error())

--- a/distributor/pkg/lib/events/uniformwatch.go
+++ b/distributor/pkg/lib/events/uniformwatch.go
@@ -27,12 +27,12 @@ func NewUniformWatch(controlPlane controlplane.IControlPlane) *UniformWatch {
 }
 
 func (sw *UniformWatch) Start(ctx context.Context) string {
-	logger.Infof("Registering Keptn Intgration")
+	logger.Info("Registering Keptn Intgration")
 	var id string
 	_ = retry.Retry(func() error {
 		integrationID, err := sw.controlPlane.Register()
 		if err != nil {
-			logger.Warnf("Unable to register to Keptn's control plane: %s", err.Error())
+			logger.Warnf("Could notregister to Keptn's control plane: %v", err)
 			return err
 		}
 		logger.Infof("Registered Keptn Integration with id %s", integrationID)
@@ -47,7 +47,7 @@ func (sw *UniformWatch) Start(ctx context.Context) string {
 			case <-time.After(sw.pingInterval):
 				integrationData, err := sw.controlPlane.Ping()
 				if err != nil {
-					logger.Errorf("Unable to send heart beat to Keptn's control plane: %s", err.Error())
+					logger.Errorf("Could not send heart beat to Keptn's control plane: %v", err)
 					continue
 				}
 

--- a/distributor/pkg/lib/events/utils.go
+++ b/distributor/pkg/lib/events/utils.go
@@ -8,7 +8,6 @@ import (
 	"github.com/keptn/go-utils/pkg/common/sliceutils"
 	"github.com/keptn/go-utils/pkg/lib/v0_2_0"
 	"github.com/keptn/keptn/distributor/pkg/config"
-	logger "github.com/sirupsen/logrus"
 	"strings"
 	"sync"
 )
@@ -74,7 +73,6 @@ func DecodeNATSMessage(data []byte) (*cloudevents.Event, error) {
 	event := cloudevents.NewEvent(cv.SpecVersion)
 
 	if err := json.Unmarshal(data, &event); err != nil {
-		logger.Errorf("Could not unmarshal CloudEvent: %v", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
closes #6007 
This PR contains:
* cleaned up logging
* detangling of weird Forwarder::Start logic with graceful shutdown

Integration Test Run: https://github.com/keptn/keptn/actions/runs/1471867743