### PR TITLE
test(bridge): Fix bug where UI test screenshots were not attached to CI runs anymore

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -316,6 +316,10 @@ jobs:
         run: |
           docker run --rm -v "$PWD/shared:/shared" $IMAGE_NAME
 
+      - name: Debugging
+        run: |
+          ls -la "$PWD/shared"
+
       - name: Report test coverage for ${{ matrix.config.artifact }}
         if: ((needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (matrix.config.should-run == 'true'))
         uses: codecov/codecov-action@v2
@@ -330,7 +334,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: bridge-e2e-screenshots
-          path: /shared/screenshots
+          path: ./shared/screenshots
 
   unit-tests-cli:
     name: Unit Tests CLI (multi OS/arch)

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -318,7 +318,7 @@ jobs:
 
       - name: Debugging
         run: |
-          ls -la "$PWD/shared"
+          ls -laR "$PWD/shared"
 
       - name: Report test coverage for ${{ matrix.config.artifact }}
         if: ((needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (matrix.config.should-run == 'true'))

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -325,6 +325,13 @@ jobs:
           move_coverage_to_trash: true
           flags: ${{ matrix.config.artifact }}
 
+      - name: Upload Test Screenshots
+        if: always() && matrix.config.artifact == 'bridge2' && matrix.config.docker-test-target == 'builder-test-ui'
+        uses: actions/upload-artifact@v2
+        with:
+          name: bridge-e2e-screenshots
+          path: /shared/screenshots
+
   unit-tests-cli:
     name: Unit Tests CLI (multi OS/arch)
     needs: prepare_ci_run

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -316,10 +316,6 @@ jobs:
         run: |
           docker run --rm -v "$PWD/shared:/shared" $IMAGE_NAME
 
-      - name: Debugging
-        run: |
-          ls -laR "$PWD/shared"
-
       - name: Report test coverage for ${{ matrix.config.artifact }}
         if: ((needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (matrix.config.should-run == 'true'))
         uses: codecov/codecov-action@v2

--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /usr/src/app
 COPY package.json yarn.lock /usr/src/app/
 RUN yarn install --frozen-lockfile
 COPY . /usr/src/app
-CMD yarn test:ui
+CMD yarn test:ui && mv ./dist/cypress/screenshots /shared/screenshots
 
 FROM node:14-alpine3.14 as builder-test-base
 WORKDIR /usr/src/app


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- fixes a regression where the UI test screenshots from cypress were not attached to CI pipeline runs anymore

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #5897 

### Notes
Here is a proof that this PR works: https://github.com/keptn/keptn/actions/runs/1475503194