### PR TITLE
fix(distributor): Fix message filtering in distributor (#6074)

### DIFF
--- a/distributor/cmd/main.go
+++ b/distributor/cmd/main.go
@@ -64,7 +64,8 @@ func _main(env config.EnvConfig) int {
 	forwarder.Start(executionContext)
 
 	// Eventually start registration process
-	if shallRegister() {
+	register := shallRegister()
+	if register {
 		id := uniformWatch.Start(executionContext)
 		uniformLogger := controlplane.NewEventUniformLog(id, uniformLogHandler)
 		uniformLogger.Start(executionContext, forwarder.EventChannel)
@@ -84,7 +85,7 @@ func _main(env config.EnvConfig) int {
 		}
 	} else {
 		logger.Info("Starting NATS event Receiver")
-		natsEventReceiver := events.NewNATSEventReceiver(env, eventSender)
+		natsEventReceiver := events.NewNATSEventReceiver(env, eventSender, register)
 		uniformWatch.RegisterListener(natsEventReceiver)
 		if err := natsEventReceiver.Start(executionContext); err != nil {
 			logger.Fatalf("Could not start NATS event receiver: %v", err)

--- a/distributor/pkg/lib/events/receiver_test.go
+++ b/distributor/pkg/lib/events/receiver_test.go
@@ -28,7 +28,7 @@ func Test_ReceiveFromNATSAndForwardEvent(t *testing.T) {
 		PubSubTopic:     "sh.keptn.event.task.triggered,sh.keptn.event.task2.triggered",
 		PubSubURL:       natsURL,
 	}
-	receiver := NewNATSEventReceiver(config, eventSender)
+	receiver := NewNATSEventReceiver(config, eventSender, true)
 	ctx, cancelReceiver := context.WithCancel(context.Background())
 	executionContext := NewExecutionContext(ctx, 1)
 	go receiver.Start(executionContext)
@@ -89,7 +89,7 @@ func Test_ReceiveFromNATSAndForwardEventForOverlappingSubscriptions(t *testing.T
 		PubSubTopic:     "sh.keptn.event.task.triggered",
 		PubSubURL:       natsURL,
 	}
-	receiver := NewNATSEventReceiver(config, eventSender)
+	receiver := NewNATSEventReceiver(config, eventSender, true)
 	ctx, cancelReceiver := context.WithCancel(context.Background())
 	executionContext := NewExecutionContext(ctx, 1)
 	go receiver.Start(executionContext)
@@ -156,7 +156,7 @@ func Test_ReceiveFromNATS_AfterReconnecting(t *testing.T) {
 		PubSubTopic:     "sh.keptn.event.task.triggered",
 		PubSubURL:       natsURL,
 	}
-	receiver := NewNATSEventReceiver(config, eventSender)
+	receiver := NewNATSEventReceiver(config, eventSender, true)
 	ctx, cancelReceiver := context.WithCancel(context.Background())
 	executionContext := NewExecutionContext(ctx, 1)
 	go receiver.Start(executionContext)
@@ -208,7 +208,7 @@ func Test_ReceiveFromNATSAndForwardEventApplySubscriptionFilter(t *testing.T) {
 		PubSubTopic:     "sh.keptn.event.task.triggered",
 		PubSubURL:       natsURL,
 	}
-	receiver := NewNATSEventReceiver(config, eventSender)
+	receiver := NewNATSEventReceiver(config, eventSender, true)
 	ctx, cancelReceiver := context.WithCancel(context.Background())
 	executionContext := NewExecutionContext(ctx, 1)
 	go receiver.Start(executionContext)

--- a/distributor/pkg/lib/events/receiver_test.go
+++ b/distributor/pkg/lib/events/receiver_test.go
@@ -256,3 +256,47 @@ func Test_ReceiveFromNATSAndForwardEventApplySubscriptionFilter(t *testing.T) {
 	cancelReceiver()
 	executionContext.Wg.Wait()
 }
+
+func Test_ReceiveFromNATSAndForwardEventApplySubscriptionFilterNoMatch(t *testing.T) {
+	natsURL := fmt.Sprintf("nats://127.0.0.1:%d", TEST_PORT)
+	_, shutdownNats := RunServerOnPort(TEST_PORT)
+	defer shutdownNats()
+	natsPublisher, _ := nats.Connect(natsURL)
+
+	eventSender := &keptnv2.TestSender{}
+	config := config.EnvConfig{
+		PubSubRecipient: "http://127.0.0.1",
+		PubSubTopic:     "sh.keptn.event.task.triggered",
+		PubSubURL:       natsURL,
+	}
+	receiver := NewNATSEventReceiver(config, eventSender, true)
+	ctx, cancelReceiver := context.WithCancel(context.Background())
+	executionContext := NewExecutionContext(ctx, 1)
+	go receiver.Start(executionContext)
+
+	// make sure the message handler of the receiver is set before continuing with the test
+	require.Eventually(t, func() bool {
+		return receiver.natsConnectionHandler.messageHandler != nil
+	}, 5*time.Second, time.Second)
+	receiver.UpdateSubscriptions([]models.EventSubscription{
+		{
+			ID:    "id1",
+			Event: "sh.keptn.event.task.triggered",
+			Filter: models.EventSubscriptionFilter{
+				Projects: []string{"my-project"},
+				Stages:   []string{"stageX"},
+			},
+		},
+	})
+	//TODO: refactor test/implementation to get rid of sleep
+	time.Sleep(time.Second)
+	// send an event that matches both subscriptions
+	natsPublisher.Publish("sh.keptn.event.task.triggered", []byte(task1TriggerEvent))
+
+	time.Sleep(time.Second)
+
+	require.Empty(t, eventSender.SentEvents)
+
+	cancelReceiver()
+	executionContext.Wg.Wait()
+}


### PR DESCRIPTION
Closes #6074

This PR also updates the `uniform_registration` integration test to make sure the `echo-service` is using the same `distributor` image as the installed version of Keptn