### PR TITLE
ci: Upload release helm charts from release pipelines instead of integration tests pipeline

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -995,24 +995,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload Helm Charts to Google Cloud
-        id: upload_helm_charts
-        env:
-          GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
-          GCLOUD_PROJECT_NAME: ${{ secrets.GCLOUD_PROJECT_NAME }}
-          CLOUDSDK_COMPUTE_ZONE: "us-east1-b"
-          CLOUDSDK_REGION: "us-east1"
-        run: |
-          if [[ "$BRANCH" == "release-"* ]]; then
-            echo "Installing gcloud CLI"
-            export OS_TYPE="linux"
-            mkdir ~/downloads
-            ./test/utils/download_and_install_gcloud.sh
-            echo ${GCLOUD_SERVICE_KEY} | base64 --decode > ~/gcloud-service-key.json
-            gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
-            gh-actions-scripts/upload_helm_chart_to_google_cloud.sh dist/keptn-installer/
-          fi
-
   #######################################################################
   # This job deploys Keptn with Keptn                                   #
   #######################################################################

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -344,6 +344,22 @@ jobs:
           gh release upload "$RELEASE_TAG" ./dist/keptn-installer/*.tgz
           gh release upload "$RELEASE_TAG" ./dist/keptn-cli/*.tar.gz
 
+      - name: Upload Helm Charts to Google Cloud
+        id: upload_helm_charts
+        env:
+          GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
+          GCLOUD_PROJECT_NAME: ${{ secrets.GCLOUD_PROJECT_NAME }}
+          CLOUDSDK_COMPUTE_ZONE: "us-east1-b"
+          CLOUDSDK_REGION: "us-east1"
+        run: |
+          echo "Installing GCloud CLI"
+          export OS_TYPE="linux"
+          mkdir ~/downloads
+          ./test/utils/download_and_install_gcloud.sh
+          echo ${GCLOUD_SERVICE_KEY} | base64 --decode > ~/gcloud-service-key.json
+          gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
+          gh-actions-scripts/upload_helm_chart_to_google_cloud.sh dist/keptn-installer/
+
   ############################################################################
   # Push Docker Images to alternative Registries
   ############################################################################

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -340,6 +340,22 @@ jobs:
           gh release upload "$RELEASE_TAG" ./dist/keptn-installer/*.tgz
           gh release upload "$RELEASE_TAG" ./dist/keptn-cli/*.tar.gz
 
+      - name: Upload Helm Charts to Google Cloud
+        id: upload_helm_charts
+        env:
+          GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
+          GCLOUD_PROJECT_NAME: ${{ secrets.GCLOUD_PROJECT_NAME }}
+          CLOUDSDK_COMPUTE_ZONE: "us-east1-b"
+          CLOUDSDK_REGION: "us-east1"
+        run: |
+            echo "Installing GCloud CLI"
+            export OS_TYPE="linux"
+            mkdir ~/downloads
+            ./test/utils/download_and_install_gcloud.sh
+            echo ${GCLOUD_SERVICE_KEY} | base64 --decode > ~/gcloud-service-key.json
+            gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
+            gh-actions-scripts/upload_helm_chart_to_google_cloud.sh dist/keptn-installer/
+
   ############################################################################
   # Push Docker Images to alternative Registries
   ############################################################################


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- moves the helm chart upload step from the integration test pipeline to the new release pipelines where the charts are now built and uploaded from

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #6149 
