### PR TITLE
ci: Pass bot triggered builds by not pushing docker images

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -376,6 +376,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: DEBUG GitHub actor
+        run: |
+          echo "$GITHUB_ACTOR"
+
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         # only run docker login on pushes; also for PRs, but only if this is not a fork

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -213,6 +213,10 @@ jobs:
           echo "::set-output name=TIME::$(date +'%H%M')"
           echo "::set-output name=DATETIME::$(date +'%Y%m%d')$(date +'%H%M')"
 
+      - name: DEBUG GitHub actor
+        run: |
+          echo "$GITHUB_ACTOR"
+
   store-output-in-build-config:
     name: "Store output of last step in build-config.env"
     needs: prepare_ci_run
@@ -375,10 +379,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-
-      - name: DEBUG GitHub actor
-        run: |
-          echo "$GITHUB_ACTOR"
 
       - name: Login to Docker Hub
         uses: docker/login-action@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -213,10 +213,6 @@ jobs:
           echo "::set-output name=TIME::$(date +'%H%M')"
           echo "::set-output name=DATETIME::$(date +'%Y%m%d')$(date +'%H%M')"
 
-      - name: DEBUG GitHub actor
-        run: |
-          echo "$GITHUB_ACTOR"
-
   store-output-in-build-config:
     name: "Store output of last step in build-config.env"
     needs: prepare_ci_run
@@ -383,7 +379,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         # only run docker login on pushes; also for PRs, but only if this is not a fork
-        if: ( github.actor != 'renovate' && github.actor != 'dependabot' ) && (matrix.config.should-push-image == 'true' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository))
+        if: ( github.actor != 'renovate[bot]' && github.actor != 'dependabot[bot]' ) && (matrix.config.should-push-image == 'true' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository))
         # note: GH does not allow to access secrets for PRs from a forked repositories due to security reasons
         # that's fine, but it means we can't push images to dockerhub
         with:
@@ -401,5 +397,5 @@ jobs:
             keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}.${{ env.DATETIME }}
           build-args: |
             version=${{ env.VERSION }}
-          push: ${{ matrix.config.should-push-image && ( github.actor != 'renovate' && github.actor != 'dependabot' ) }}
+          push: ${{ matrix.config.should-push-image && ( github.actor != 'renovate[bot]' && github.actor != 'dependabot[bot]' ) }}
           pull: true


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This PR adds a condition for bot triggered builds to the docker login and docker build steps in the CI pipelines.
This change ensures that builds that were triggered by dependabot or the renovate bot still pass and become green automatically.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #5521