### PR TITLE
fix(bridge): Fix problem with redirect and headers on cluster

### DIFF
--- a/bridge/client/index.html
+++ b/bridge/client/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8" />
     <title>keptn</title>
     <base id="base-href" href="/" />
+    <script>
+      // NOTE: if changed, update tests in app.component.spec.ts
+      function getBridgeBaseHref(origin, path) {
+        if (path.indexOf('/bridge') !== -1)
+          return [origin, path.substring(0, path.indexOf('/bridge')), '/bridge/'].join('');
+        else return origin;
+      }
+
+      document.getElementById('base-href').href = getBridgeBaseHref(window.location.origin, window.location.pathname);
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link id="appFavicon" rel="icon" type="image/png" href="assets/branding/logo_inverted.png" />
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap" rel="stylesheet" />

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -9,7 +9,7 @@
     "start:server:dev": "cd ./server && yarn dev",
     "start:ci": "ng serve --port=3000 --no-live-reload --configuration=test",
     "ng": "ng",
-    "build": "ng build --prod --base-href=/bridge/",
+    "build": "ng build --prod --base-href=./",
     "test": "jest --config=jest.config.ts --maxWorkers=1",
     "lint:check": "eslint ./",
     "lint:fix": "eslint --fix ./",

--- a/bridge/server/app.ts
+++ b/bridge/server/app.ts
@@ -302,26 +302,27 @@ function isAxiosError(err: Error | AxiosError): err is AxiosError {
   return err.hasOwnProperty('isAxiosError');
 }
 
-function handleError(err: Error | AxiosError, req: Request, res: Response, authType: string): number {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function handleError(err: any, req: Request, res: Response, authType: string): number {
   // set locals, only providing error in development
   res.locals.message = err.message;
   res.locals.error = req.app.get('env') === 'development' ? err : {};
 
-  if (isAxiosError(err)) {
-    // render the error page
-    if (err.response?.data?.message) {
-      err.message = err.response?.data.message;
-    }
-    if (err.response?.status === 401) {
-      res.setHeader('keptn-auth-type', authType);
-    }
+  // render the error page
+  if (err.response?.data?.message) {
+    err.message = err.response?.data.message;
+  }
+  if (err.response?.status === 401) {
+    res.setHeader('keptn-auth-type', authType);
+  }
 
+  if (isAxiosError(err)) {
     console.error(`Error for ${err.request.method} ${err.request.path}: ${err.message}`);
-    return err.response?.status || 500;
   } else {
     console.error(err);
-    return 500;
   }
+
+  return err.response?.status || 500;
 }
 
 export { init };

--- a/bridge/server/app.ts
+++ b/bridge/server/app.ts
@@ -128,9 +128,6 @@ async function init(): Promise<Express> {
     integrationsPageLink = 'https://get.keptn.sh/integrations.html';
   }
 
-  // Remove the X-Powered-By headers.
-  app.disable('x-powered-by');
-
   // server static files - Images & CSS
   app.use('/static', express.static(join(serverFolder, 'views/static'), { maxAge: oneWeek }));
 
@@ -163,16 +160,17 @@ async function init(): Promise<Express> {
     helmet.contentSecurityPolicy({
       useDefaults: true,
       directives: {
-        'script-src': ["'self'", 'unsafe-eval'],
+        'script-src': ["'self'", "'unsafe-eval'", "'sha256-9Ts7nfXdJQSKqVPxtB4Jwhf9pXSA/krLvgk8JROkI6g='"],
         'upgrade-insecure-requests': null,
       },
     })
   );
-  app.use(helmet.hidePoweredBy());
   app.use(helmet.noSniff());
   app.use(helmet.permittedCrossDomainPolicies());
   app.use(helmet.frameguard());
   app.use(helmet.xssFilter());
+  // Remove the X-Powered-By headers, has to be done via express and not helmet
+  app.disable('x-powered-by');
 
   const authType: string = await setAuth();
 


### PR DESCRIPTION
* The X-Powered-By header removal from helmetjs should not be used when using express, as stated in the docs. I moved the removal by `app.disable` to the configurations for the other headers to have it in one place.
* I also re-added the functionality for the inline script to execute the redirect, as route `/bridge` (without ending slash) will not work otherwise. I therefore added the script hash to Content-Security-Policy header to ensure it can be executed.
* Logging was not correctly returning the 401 response so that the server returned a 500 error

Fixes #6150