### PR TITLE
ci: Fix bug where release cannot be pushed to protected maintenance branch

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -241,7 +241,7 @@ jobs:
   pre-release:
     name: "Pre-Release"
     runs-on: ubuntu-20.04
-    needs: [docker_build, build-helm-charts, build-cli]
+    needs: [prepare, docker_build, build-helm-charts, build-cli]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
@@ -292,7 +292,7 @@ jobs:
         uses: benjefferies/branch-protection-bot@6d0ac2b2d9bfd39794b017f8241adb7da7f0ab98 # pin@1.0.7
         with:
           access_token: ${{ secrets.KEPTN_BOT_TOKEN }}
-          branch: ${{ github.event.repository.default_branch }}
+          branch: ${{ needs.prepare.outputs.branch }}
           enforce_admins: false
 
       - name: Create pre-release package
@@ -326,7 +326,7 @@ jobs:
         if: always() # Force to always run this step to ensure "include administrators" is always turned back on
         with:
           access_token: ${{ secrets.KEPTN_BOT_TOKEN }}
-          branch: ${{ github.event.repository.default_branch }}
+          branch: ${{ needs.prepare.outputs.branch }}
           enforce_admins: true
 
       - name: Create GitHub Pre-Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,7 +238,7 @@ jobs:
   release:
     name: "Release"
     runs-on: ubuntu-20.04
-    needs: [docker_build, build-helm-charts, build-cli]
+    needs: [prepare, docker_build, build-helm-charts, build-cli]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
@@ -292,7 +292,7 @@ jobs:
         uses: benjefferies/branch-protection-bot@6d0ac2b2d9bfd39794b017f8241adb7da7f0ab98 # pin@1.0.7
         with:
           access_token: ${{ secrets.KEPTN_BOT_TOKEN }}
-          branch: ${{ github.event.repository.default_branch }}
+          branch: ${{ needs.prepare.outputs.branch }}
           enforce_admins: false
 
       - name: Create release package
@@ -322,7 +322,7 @@ jobs:
         if: always() # Force to always run this step to ensure "include administrators" is always turned back on
         with:
           access_token: ${{ secrets.KEPTN_BOT_TOKEN }}
-          branch: ${{ github.event.repository.default_branch }}
+          branch: ${{ needs.prepare.outputs.branch }}
           enforce_admins: true
 
       - name: Create GitHub Release


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- fixes a bug where the release pipeline would fail because the branch protection rules were not correctly disabled for non-default branches