### PR TITLE
feat(lighthouse-service): Add compared value to payload (#5496)

### DIFF
--- a/lighthouse-service/deploy/service.yaml
+++ b/lighthouse-service/deploy/service.yaml
@@ -28,6 +28,18 @@ spec:
       containers:
         - name: lighthouse-service
           image: keptn/lighthouse-service:latest
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 0
+            periodSeconds: 5
+          readinessProbe:
+              httpGet:
+                path: /health
+                port: 8080
+              initialDelaySeconds: 5
+              periodSeconds: 5
           ports:
             - containerPort: 8080
           resources:
@@ -53,7 +65,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
         - name: distributor
-          image: keptn/distributor:0.8.4
+          image: keptn/distributor:latest
           ports:
             - containerPort: 8080
           resources:

--- a/lighthouse-service/event_handler/evaluate_sli_handler.go
+++ b/lighthouse-service/event_handler/evaluate_sli_handler.go
@@ -250,8 +250,7 @@ func evaluateObjectives(e *keptnv2.GetSLIFinishedEventData, sloConfig *keptn.Ser
 		} else {
 			isWarning = false
 		}
-		aggregatedValues, _ := aggregateValues(previousSLIResults, sloConfig.Comparison)
-		sliEvaluationResult.Value.ComparedValue = aggregatedValues
+
 		sliEvaluationResult.PassTargets = passTargets
 		sliEvaluationResult.WarningTargets = warningTargets
 		sliEvaluationResult.KeySLI = objective.KeySLI
@@ -398,10 +397,10 @@ func evaluateComparison(sliResult *keptnv2.SLIResult, co *criteriaObject, previo
 	var targetValue float64
 
 	aggregatedValue, skip := aggregateValues(previousResults, comparison)
+	sliResult.ComparedValue = aggregatedValue
 	if skip {
 		return true, nil
 	}
-
 	// calculate the comparison value
 	if co.CheckPercentage && co.CheckIncrease {
 		targetValue = (aggregatedValue * (100.0 + co.Value)) / 100.0
@@ -497,6 +496,9 @@ func calculatePercentile(values sort.Float64Slice, perc float64) float64 {
 
 func evaluateFixedThreshold(sliResult *keptnv2.SLIResult, co *criteriaObject, violation *keptnv2.SLITarget) (bool, error) {
 	violation.TargetValue = co.Value
+	//compared value is used only if the criteria is a comparison,
+	//otherwise we just need to set targetValue
+	//sliResult.ComparedValue = co.Value
 	return evaluateValue(sliResult.Value, co.Value, co.Operator)
 }
 

--- a/lighthouse-service/event_handler/evaluate_sli_handler.go
+++ b/lighthouse-service/event_handler/evaluate_sli_handler.go
@@ -384,6 +384,10 @@ func evaluateSingleCriteria(sliResult *keptnv2.SLIResult, criteria string, previ
 	}
 
 	if !co.IsComparison {
+		//compared value is used only if the criteria is a comparison without fixed threshold,
+		//anyway we calculate it here to allow Bridge to display it
+		sliResult.ComparedValue, _ = aggregateValues(previousResults, comparison)
+
 		// do a fixed threshold comparison
 		return evaluateFixedThreshold(sliResult, co, violation)
 	}
@@ -496,9 +500,6 @@ func calculatePercentile(values sort.Float64Slice, perc float64) float64 {
 
 func evaluateFixedThreshold(sliResult *keptnv2.SLIResult, co *criteriaObject, violation *keptnv2.SLITarget) (bool, error) {
 	violation.TargetValue = co.Value
-	//compared value is used only if the criteria is a comparison,
-	//otherwise we just need to set targetValue
-	//sliResult.ComparedValue = co.Value
 	return evaluateValue(sliResult.Value, co.Value, co.Operator)
 }
 

--- a/lighthouse-service/event_handler/evaluate_sli_handler_test.go
+++ b/lighthouse-service/event_handler/evaluate_sli_handler_test.go
@@ -1603,10 +1603,11 @@ func TestEvaluateObjectives(t *testing.T) {
 						{
 							Score: 1,
 							Value: &keptnv2.SLIResult{
-								Metric:  "my-test-metric-1",
-								Value:   10.0,
-								Success: true,
-								Message: "",
+								Metric:        "my-test-metric-1",
+								Value:         10.0,
+								ComparedValue: 10.0,
+								Success:       true,
+								Message:       "",
 							},
 							WarningTargets: []*keptnv2.SLITarget{
 								{
@@ -1746,10 +1747,11 @@ func TestEvaluateObjectives(t *testing.T) {
 						{
 							Score: 0.5,
 							Value: &keptnv2.SLIResult{
-								Metric:  "my-test-metric-1",
-								Value:   16.0,
-								Success: true,
-								Message: "",
+								Metric:        "my-test-metric-1",
+								Value:         16.0,
+								ComparedValue: 10.0,
+								Success:       true,
+								Message:       "",
 							},
 							WarningTargets: []*keptnv2.SLITarget{
 								{
@@ -1900,10 +1902,11 @@ func TestEvaluateObjectives(t *testing.T) {
 						{
 							Score: 1,
 							Value: &keptnv2.SLIResult{
-								Metric:  "my-test-metric-1",
-								Value:   10.0,
-								Success: true,
-								Message: "",
+								Metric:        "my-test-metric-1",
+								Value:         10.0,
+								ComparedValue: 10.0,
+								Success:       true,
+								Message:       "",
 							},
 							WarningTargets: []*keptnv2.SLITarget{
 								{
@@ -1935,10 +1938,11 @@ func TestEvaluateObjectives(t *testing.T) {
 						{
 							Score: 0,
 							Value: &keptnv2.SLIResult{
-								Metric:  "my-log-metric",
-								Value:   30.0,
-								Success: true,
-								Message: "",
+								Metric:        "my-log-metric",
+								Value:         30.0,
+								ComparedValue: 0,
+								Success:       true,
+								Message:       "",
 							},
 							Status: "info",
 						},
@@ -2066,10 +2070,11 @@ func TestEvaluateObjectives(t *testing.T) {
 						{
 							Score: 1,
 							Value: &keptnv2.SLIResult{
-								Metric:  "my-test-metric-1",
-								Value:   10.0,
-								Success: true,
-								Message: "",
+								Metric:        "my-test-metric-1",
+								Value:         10.0,
+								ComparedValue: 10.0,
+								Success:       true,
+								Message:       "",
 							},
 							WarningTargets: []*keptnv2.SLITarget{
 								{
@@ -2101,10 +2106,11 @@ func TestEvaluateObjectives(t *testing.T) {
 						{
 							Score: 0,
 							Value: &keptnv2.SLIResult{
-								Metric:  "my-log-metric",
-								Value:   30.0,
-								Success: true,
-								Message: "",
+								Metric:        "my-log-metric",
+								Value:         30.0,
+								ComparedValue: 0.0,
+								Success:       true,
+								Message:       "",
 							},
 							Status: "info",
 						},
@@ -2986,10 +2992,11 @@ func TestCalculateScore(t *testing.T) {
 						{
 							Score: 1,
 							Value: &keptnv2.SLIResult{
-								Metric:  "my-test-metric-1",
-								Value:   10.0,
-								Success: true,
-								Message: "",
+								Metric:        "my-test-metric-1",
+								Value:         10.0,
+								ComparedValue: 0.0,
+								Success:       true,
+								Message:       "",
 							},
 							PassTargets:    nil,
 							WarningTargets: nil,
@@ -2999,10 +3006,11 @@ func TestCalculateScore(t *testing.T) {
 						{
 							Score: 1,
 							Value: &keptnv2.SLIResult{
-								Metric:  "my-key-metric",
-								Value:   10.0,
-								Success: true,
-								Message: "",
+								Metric:        "my-key-metric",
+								Value:         10.0,
+								ComparedValue: 0.0,
+								Success:       true,
+								Message:       "",
 							},
 							PassTargets:    nil,
 							WarningTargets: nil,

--- a/lighthouse-service/go.mod
+++ b/lighthouse-service/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/cloudevents/sdk-go/v2 v2.6.1
 	github.com/go-test/deep v1.0.8
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.11.0
+	github.com/keptn/go-utils v0.11.1-0.20211125125903-d0ae1dd74ba0
 	github.com/nats-io/nats-server/v2 v2.6.4
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0

--- a/lighthouse-service/go.sum
+++ b/lighthouse-service/go.sum
@@ -163,8 +163,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
-github.com/keptn/go-utils v0.11.0 h1:cwr9BDkDQcsURwj9pkkTzTs4M2HDqlgv1mrllPfysxY=
-github.com/keptn/go-utils v0.11.0/go.mod h1:wOOwrQxPrKNzEzP7xK58MLikUuQXi/HPvKlOmuS5qMk=
+github.com/keptn/go-utils v0.11.1-0.20211125125903-d0ae1dd74ba0 h1:KypUb5tenMkAL8+BrB7RaKVejg9ePBJnIY5hSGYVLgU=
+github.com/keptn/go-utils v0.11.1-0.20211125125903-d0ae1dd74ba0/go.mod h1:wOOwrQxPrKNzEzP7xK58MLikUuQXi/HPvKlOmuS5qMk=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.13.4 h1:0zhec2I8zGnjWcKyLl6i3gPqKANCCn5e9xmviEEeX6s=


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

When receiving an SLI result each metric is compared with previous values, those are aggregated following a certain aggregation strategy defined in the SLO. In case of comparison criterias this values stays the same for all comparisons and influence the target values used to decide whether the metric passes or fails. 

In this PR we store the aggregated value in each evaluation result as ComparedValue, to facilitate understanding of why the metric passes or fails a comparison criteria. 

For criterias with fixed targets the pass or fail is dependent only on the TargetValue, anyhow ComparedValue is calculated.

- unit tests modified
- integration test checked


### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #5496 


