### PR TITLE
ci: Fix renovate config bug

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,7 +25,7 @@
       "addLabels": ["github_actions"]
     },
     {
-      "matchManagers": ["docker"],
+      "matchManagers": ["dockerfile"],
       "addLabels": ["docker"]
     }
   ]


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- fixes a config bug in the renovate config where the wrong package manager name was given
Fixes #6210 