### PR TITLE
test: Temporarily disable backup/restore test

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -72,7 +72,7 @@ jobs:
             RUN_QUALITY_GATES_TEST: "true"
             RUN_CONTINUOUS_DELIVERY_TEST: "true"
             REMOTE_EXECUTION_PLANE: "true"
-            BACKUP_RESTORE: "true"
+            BACKUP_RESTORE: "false"
             COLLECT_RESOURCE_LIMITS: "false"
           - CLOUD_PROVIDER: "GKE"
             PLATFORM_VERSION: "1.21"
@@ -82,7 +82,7 @@ jobs:
             RUN_QUALITY_GATES_TEST: "true"
             RUN_CONTINUOUS_DELIVERY_TEST: "true"
             REMOTE_EXECUTION_PLANE: "false"
-            BACKUP_RESTORE: "true"
+            BACKUP_RESTORE: "false"
             COLLECT_RESOURCE_LIMITS: "true"
     env:
       CLOUD_PROVIDER: ${{ matrix.CLOUD_PROVIDER }}


### PR DESCRIPTION
Signed-off-by: odubajDT <ondrej.dubaj@dynatrace.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- disables backup_restore_test due to integration tests failures

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

The backup/restore test needs some rework and further debugging, which is why it is disabled for now. We have created a dedicated ticket to keep track of that issue:  #6239

