### PR TITLE
feat: introduce swappable logger in `go-sdk`

### DIFF
--- a/go-sdk/go.mod
+++ b/go-sdk/go.mod
@@ -7,6 +7,5 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/keptn/go-utils v0.11.0
-	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 )

--- a/go-sdk/go.sum
+++ b/go-sdk/go.sum
@@ -80,10 +80,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
-github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
-github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
@@ -143,9 +140,7 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7 h1:iGu644GcxtEcrInvDsQRCwJjtCIOlT2V7IRt6ah2Whw=
 golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/go-sdk/pkg/sdk/keptn.go
+++ b/go-sdk/pkg/sdk/keptn.go
@@ -43,6 +43,10 @@ type IKeptn interface {
 	SendStartedEvent(event KeptnEvent) error
 	// SendFinishedEvent sends a finished event for the given input event to the Keptn API
 	SendFinishedEvent(event KeptnEvent, result interface{}) error
+	// Logger returns the logger used by the sdk
+	// Per default DefaultLogger is used which internally just uses the go logging package
+	// Another logger can be configured using the sdk.WithLogger function
+	Logger() Logger
 }
 
 //go:generate moq -out ./taskhandler_mock.go . TaskHandler
@@ -198,6 +202,10 @@ func (k *Keptn) SendFinishedEvent(event KeptnEvent, result interface{}) error {
 		return err
 	}
 	return k.send(*finishedEvent)
+}
+
+func (k *Keptn) Logger() Logger {
+	return k.logger
 }
 
 func (k *Keptn) gotEvent(ctx context.Context, event cloudevents.Event) {

--- a/go-sdk/pkg/sdk/keptn_fake.go
+++ b/go-sdk/pkg/sdk/keptn_fake.go
@@ -62,7 +62,7 @@ func NewFakeKeptn(source string) *FakeKeptn {
 	eventReceiver := &TestReceiver{}
 	eventSender := &TestSender{}
 	resourceHandler := &TestResourceHandler{}
-
+	logger := NewDefaultLogger()
 	var fakeKeptn = &FakeKeptn{
 		TestResourceHandler: resourceHandler,
 		Keptn: &Keptn{
@@ -74,6 +74,7 @@ func NewFakeKeptn(source string) *FakeKeptn {
 			syncProcessing:         true,
 			automaticEventResponse: true,
 			gracefulShutdown:       false,
+			logger:                 logger,
 		},
 	}
 	return fakeKeptn

--- a/go-sdk/pkg/sdk/keptn_fake.go
+++ b/go-sdk/pkg/sdk/keptn_fake.go
@@ -29,6 +29,10 @@ func (f *FakeKeptn) SendFinishedEvent(event KeptnEvent, result interface{}) erro
 	return f.Keptn.SendFinishedEvent(event, result)
 }
 
+func (f *FakeKeptn) Logger() Logger {
+	return f.Keptn.Logger()
+}
+
 func (f *FakeKeptn) GetResourceHandler() ResourceHandler {
 	if f.TestResourceHandler == nil {
 		return &TestResourceHandler{}

--- a/go-sdk/pkg/sdk/keptn_test.go
+++ b/go-sdk/pkg/sdk/keptn_test.go
@@ -39,6 +39,7 @@ func Test_WhenReceivingAnEvent_StartedEventAndFinishedEventsAreSent(t *testing.T
 		eventReceiver:          eventReceiver,
 		taskRegistry:           taskRegistry,
 		automaticEventResponse: true,
+		logger:                 NewDefaultLogger(),
 	}
 
 	keptn.Start()
@@ -86,6 +87,7 @@ func Test_WhenReceivingEvent_OnlyStartedEventIsSent(t *testing.T) {
 		eventReceiver:          eventReceiver,
 		taskRegistry:           taskRegistry,
 		automaticEventResponse: false,
+		logger:                 NewDefaultLogger(),
 	}
 
 	keptn.Start()
@@ -126,6 +128,7 @@ func Test_WhenReceivingBadEvent_NoEventIsSent(t *testing.T) {
 		eventReceiver:          eventReceiver,
 		taskRegistry:           taskRegistry,
 		automaticEventResponse: true,
+		logger:                 NewDefaultLogger(),
 	}
 
 	keptn.Start()

--- a/go-sdk/pkg/sdk/log.go
+++ b/go-sdk/pkg/sdk/log.go
@@ -1,0 +1,77 @@
+package sdk
+
+import (
+	"log"
+	"os"
+)
+
+type Logger interface {
+	Debug(v ...interface{})
+	Debugf(format string, v ...interface{})
+	Info(v ...interface{})
+	Infof(format string, v ...interface{})
+	Warn(v ...interface{})
+	Warnf(format string, v ...interface{})
+	Error(v ...interface{})
+	Errorf(format string, v ...interface{})
+	Fatal(v ...interface{})
+	Fatalf(format string, v ...interface{})
+	Panic(v ...interface{})
+	Panicf(format string, v ...interface{})
+}
+
+type DefaultLogger struct {
+	logger *log.Logger
+}
+
+func NewDefaultLogger() *DefaultLogger {
+	return &DefaultLogger{logger: log.New(os.Stdout, "", 5)}
+}
+
+func (d DefaultLogger) Debug(v ...interface{}) {
+	d.logger.Println(v...)
+}
+
+func (d DefaultLogger) Debugf(format string, v ...interface{}) {
+	d.logger.Printf(format, v...)
+}
+
+func (d DefaultLogger) Info(v ...interface{}) {
+	d.logger.Println(v...)
+}
+
+func (d DefaultLogger) Infof(format string, v ...interface{}) {
+	d.logger.Printf(format, v...)
+}
+
+func (d DefaultLogger) Warn(v ...interface{}) {
+	d.logger.Println(v...)
+}
+
+func (d DefaultLogger) Warnf(format string, v ...interface{}) {
+	d.logger.Printf(format, v...)
+}
+
+func (d DefaultLogger) Error(v ...interface{}) {
+	d.logger.Print(v...)
+}
+
+func (d DefaultLogger) Errorf(format string, v ...interface{}) {
+	d.logger.Printf(format, v...)
+}
+
+func (d DefaultLogger) Fatal(v ...interface{}) {
+	d.logger.Fatal(v...)
+}
+
+func (d DefaultLogger) Fatalf(format string, v ...interface{}) {
+	d.logger.Fatalf(format, v...)
+}
+
+func (d DefaultLogger) Panic(v ...interface{}) {
+	d.logger.Panic(v...)
+}
+
+func (d DefaultLogger) Panicf(format string, v ...interface{}) {
+	d.logger.Panicf(format, v...)
+}

--- a/go-sdk/pkg/sdk/log.go
+++ b/go-sdk/pkg/sdk/log.go
@@ -5,6 +5,7 @@ import (
 	"os"
 )
 
+// Logger interface used by the go sdk
 type Logger interface {
 	Debug(v ...interface{})
 	Debugf(format string, v ...interface{})
@@ -16,14 +17,14 @@ type Logger interface {
 	Errorf(format string, v ...interface{})
 	Fatal(v ...interface{})
 	Fatalf(format string, v ...interface{})
-	Panic(v ...interface{})
-	Panicf(format string, v ...interface{})
 }
 
+// DefaultLogger implementation of Logger using the go log package
 type DefaultLogger struct {
 	logger *log.Logger
 }
 
+// NewDefaultLogger creates a new Default Logger
 func NewDefaultLogger() *DefaultLogger {
 	return &DefaultLogger{logger: log.New(os.Stdout, "", 5)}
 }
@@ -66,12 +67,4 @@ func (d DefaultLogger) Fatal(v ...interface{}) {
 
 func (d DefaultLogger) Fatalf(format string, v ...interface{}) {
 	d.logger.Fatalf(format, v...)
-}
-
-func (d DefaultLogger) Panic(v ...interface{}) {
-	d.logger.Panic(v...)
-}
-
-func (d DefaultLogger) Panicf(format string, v ...interface{}) {
-	d.logger.Panicf(format, v...)
 }

--- a/remediation-service/go.mod
+++ b/remediation-service/go.mod
@@ -6,7 +6,8 @@ require (
 	github.com/cloudevents/sdk-go/v2 v2.5.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/keptn/go-utils v0.11.1-0.20211201105141-7a265f3364fe
-	github.com/keptn/keptn/go-sdk v0.0.0-20211130151348-d13abbbd70a7
+	github.com/keptn/keptn/go-sdk v0.0.0-20211206093842-15831918acb2
+	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/remediation-service/go.sum
+++ b/remediation-service/go.sum
@@ -66,8 +66,8 @@ github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa
 github.com/keptn/go-utils v0.11.0/go.mod h1:wOOwrQxPrKNzEzP7xK58MLikUuQXi/HPvKlOmuS5qMk=
 github.com/keptn/go-utils v0.11.1-0.20211201105141-7a265f3364fe h1:ec9S4H03Ej0+NwhSgZBmQ2Bo5Q/cOmmR/3ewPRP2kAY=
 github.com/keptn/go-utils v0.11.1-0.20211201105141-7a265f3364fe/go.mod h1:wOOwrQxPrKNzEzP7xK58MLikUuQXi/HPvKlOmuS5qMk=
-github.com/keptn/keptn/go-sdk v0.0.0-20211130151348-d13abbbd70a7 h1:yMQxVzxLfx9uHUeZHINq6/q/bU3XvPJPq2nOWrT6S9w=
-github.com/keptn/keptn/go-sdk v0.0.0-20211130151348-d13abbbd70a7/go.mod h1:MuQBrF54qgurj9W592ORBfk875Jk2Zx7ZcJ1iDPyyTs=
+github.com/keptn/keptn/go-sdk v0.0.0-20211206093842-15831918acb2 h1:ocjaCqMLNziLDW6Buy+ljNYOWcat0e0QUQw2+hBxfHA=
+github.com/keptn/keptn/go-sdk v0.0.0-20211206093842-15831918acb2/go.mod h1:q0ZYJVGMbHSCyE1bqhjgWV/E/KU/ehzUza7U8lJyqHQ=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/remediation-service/main.go
+++ b/remediation-service/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/keptn/keptn/go-sdk/pkg/sdk"
 	"github.com/keptn/keptn/remediation-service/handler"
+	"github.com/sirupsen/logrus"
 	"log"
 )
 
@@ -15,5 +16,6 @@ func main() {
 		sdk.WithTaskHandler(
 			getActionTriggeredEventType,
 			handler.NewGetActionEventHandler()),
+		sdk.WithLogger(logrus.New()),
 	).Start())
 }

--- a/webhook-service/go.mod
+++ b/webhook-service/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/cloudevents/sdk-go/v2 v2.5.0
 	github.com/keptn/go-utils v0.11.0
-	github.com/keptn/keptn/go-sdk v0.0.0-20211130151348-d13abbbd70a7
+	github.com/keptn/keptn/go-sdk v0.0.0-20211206093842-15831918acb2
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b

--- a/webhook-service/go.sum
+++ b/webhook-service/go.sum
@@ -160,8 +160,8 @@ github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dv
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/keptn/go-utils v0.11.0 h1:cwr9BDkDQcsURwj9pkkTzTs4M2HDqlgv1mrllPfysxY=
 github.com/keptn/go-utils v0.11.0/go.mod h1:wOOwrQxPrKNzEzP7xK58MLikUuQXi/HPvKlOmuS5qMk=
-github.com/keptn/keptn/go-sdk v0.0.0-20211130151348-d13abbbd70a7 h1:yMQxVzxLfx9uHUeZHINq6/q/bU3XvPJPq2nOWrT6S9w=
-github.com/keptn/keptn/go-sdk v0.0.0-20211130151348-d13abbbd70a7/go.mod h1:MuQBrF54qgurj9W592ORBfk875Jk2Zx7ZcJ1iDPyyTs=
+github.com/keptn/keptn/go-sdk v0.0.0-20211206093842-15831918acb2 h1:ocjaCqMLNziLDW6Buy+ljNYOWcat0e0QUQw2+hBxfHA=
+github.com/keptn/keptn/go-sdk v0.0.0-20211206093842-15831918acb2/go.mod h1:q0ZYJVGMbHSCyE1bqhjgWV/E/KU/ehzUza7U8lJyqHQ=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/webhook-service/main.go
+++ b/webhook-service/main.go
@@ -53,6 +53,7 @@ func main() {
 			taskHandler,
 		),
 		sdk.WithAutomaticResponse(false),
+		sdk.WithLogger(log.New()),
 	).Start())
 }
 


### PR DESCRIPTION
closes #5945 

Added possibility to configure the logger implementation used by the SDK:

```go
func main() {
	log.Fatal(sdk.NewKeptn(
		serviceName,
		sdk.WithTaskHandler(
			getActionTriggeredEventType,
			handler.NewGetActionEventHandler()),
		sdk.WithLogger(logrus.New()),
	).Start())
}
``` 

adjusted `remediation-service` and `webhook-service` to pass an instance of the logrus logger.