### PR TITLE
feat(bridge): Feature flags for bridge server (#6073)

### DIFF
--- a/bridge/client/app/_models/keptn-info.ts
+++ b/bridge/client/app/_models/keptn-info.ts
@@ -1,4 +1,4 @@
-import { KeptnInfoResult } from './keptn-info-result';
+import { KeptnInfoResult } from '../../../shared/interfaces/keptn-info-result';
 import { KeptnVersions } from './keptn-versions';
 import { Metadata } from './metadata';
 

--- a/bridge/client/app/_services/_mockData/api-responses/bridgeInfo-response.mock.ts
+++ b/bridge/client/app/_services/_mockData/api-responses/bridgeInfo-response.mock.ts
@@ -1,5 +1,6 @@
 const bridgeInfo = {
   bridgeVersion: '0.10.0',
+  featureFlags: {},
   keptnInstallationType: 'QUALITY_GATES,CONTINUOUS_OPERATIONS,CONTINUOUS_DELIVERY',
   apiUrl: 'http://example.com/api',
   apiToken: 'random_api_token',

--- a/bridge/client/app/_services/api.service.mock.ts
+++ b/bridge/client/app/_services/api.service.mock.ts
@@ -2,7 +2,7 @@
 import { Injectable } from '@angular/core';
 import { ApiService } from './api.service';
 import { Observable, of } from 'rxjs';
-import { KeptnInfoResult } from '../_models/keptn-info-result';
+import { KeptnInfoResult } from '../../../shared/interfaces/keptn-info-result';
 import moment from 'moment';
 import { KeptnVersions } from '../_models/keptn-versions';
 import { Project } from '../_models/project';

--- a/bridge/client/app/_services/api.service.ts
+++ b/bridge/client/app/_services/api.service.ts
@@ -10,7 +10,7 @@ import { SequenceResult } from '../_models/sequence-result';
 import { Project } from '../_models/project';
 import { UniformRegistrationLogResponse } from '../../../shared/interfaces/uniform-registration-log';
 import { Secret } from '../_models/secret';
-import { KeptnInfoResult } from '../_models/keptn-info-result';
+import { KeptnInfoResult } from '../../../shared/interfaces/keptn-info-result';
 import { KeptnVersions } from '../_models/keptn-versions';
 import { EventResult } from '../_interfaces/event-result';
 import { ProjectResult } from '../_interfaces/project-result';

--- a/bridge/client/app/_services/data.service.ts
+++ b/bridge/client/app/_services/data.service.ts
@@ -15,7 +15,7 @@ import { HttpResponse } from '@angular/common/http';
 import { SequenceResult } from '../_models/sequence-result';
 import { EventResult } from '../../../shared/interfaces/event-result';
 import { KeptnInfo } from '../_models/keptn-info';
-import { KeptnInfoResult } from '../_models/keptn-info-result';
+import { KeptnInfoResult } from '../../../shared/interfaces/keptn-info-result';
 import { UniformRegistration } from '../_models/uniform-registration';
 import { UniformSubscription } from '../_models/uniform-subscription';
 import { SequenceState } from '../../../shared/models/sequence';

--- a/bridge/client/app/_services/feature-flags.service.spec.ts
+++ b/bridge/client/app/_services/feature-flags.service.spec.ts
@@ -2,6 +2,9 @@ import { TestBed } from '@angular/core/testing';
 import { AppModule } from '../app.module';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { FeatureFlagsService } from './feature-flags.service';
+import { ApiService } from './api.service';
+import { ApiServiceMock } from './api.service.mock';
+import { DataService } from './data.service';
 
 describe('FeatureFlagsService', () => {
   let service: FeatureFlagsService;
@@ -10,6 +13,7 @@ describe('FeatureFlagsService', () => {
     TestBed.configureTestingModule({
       declarations: [],
       imports: [AppModule, HttpClientTestingModule],
+      providers: [{ provide: ApiService, useClass: ApiServiceMock }],
     });
 
     service = TestBed.inject(FeatureFlagsService);
@@ -17,5 +21,11 @@ describe('FeatureFlagsService', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should set feature flags', () => {
+    const dataService = TestBed.inject(DataService);
+    dataService.loadKeptnInfo();
+    expect(service.featureFlags).toEqual({});
   });
 });

--- a/bridge/client/app/_services/feature-flags.service.ts
+++ b/bridge/client/app/_services/feature-flags.service.ts
@@ -1,14 +1,18 @@
 import { Injectable } from '@angular/core';
-import { environment } from '../../environments/environment';
-import { FeatureFlags } from '../../../shared/interfaces/feature-flags';
+import { DataService } from './data.service';
+import { KeptnInfo } from '../_models/keptn-info';
+import { filter } from 'rxjs/operators';
+import { IClientFeatureFlags } from '../../../shared/interfaces/feature-flags';
 
 @Injectable({
   providedIn: 'root',
 })
 export class FeatureFlagsService {
-  public featureFlags: FeatureFlags;
+  public featureFlags?: IClientFeatureFlags;
 
-  constructor() {
-    this.featureFlags = environment.featureFlags;
+  constructor(dataService: DataService) {
+    dataService.keptnInfo.pipe(filter((info): info is KeptnInfo => !!info)).subscribe((info) => {
+      this.featureFlags = info.bridgeInfo.featureFlags;
+    });
   }
 }

--- a/bridge/client/app/_services/feature-flags.service.ts
+++ b/bridge/client/app/_services/feature-flags.service.ts
@@ -1,18 +1,30 @@
-import { Injectable } from '@angular/core';
+import { Injectable, OnDestroy } from '@angular/core';
 import { DataService } from './data.service';
 import { KeptnInfo } from '../_models/keptn-info';
-import { filter } from 'rxjs/operators';
+import { filter, takeUntil } from 'rxjs/operators';
 import { IClientFeatureFlags } from '../../../shared/interfaces/feature-flags';
+import { Subject } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
 })
-export class FeatureFlagsService {
+export class FeatureFlagsService implements OnDestroy {
   public featureFlags?: IClientFeatureFlags;
+  private unsubscribe$ = new Subject<void>();
 
   constructor(dataService: DataService) {
-    dataService.keptnInfo.pipe(filter((info): info is KeptnInfo => !!info)).subscribe((info) => {
-      this.featureFlags = info.bridgeInfo.featureFlags;
-    });
+    dataService.keptnInfo
+      .pipe(
+        filter((info): info is KeptnInfo => !!info),
+        takeUntil(this.unsubscribe$)
+      )
+      .subscribe((info) => {
+        this.featureFlags = info.bridgeInfo.featureFlags;
+      });
+  }
+
+  public ngOnDestroy(): void {
+    this.unsubscribe$.next();
+    this.unsubscribe$.complete();
   }
 }

--- a/bridge/client/environments/environment.dynamic.ts
+++ b/bridge/client/environments/environment.dynamic.ts
@@ -1,5 +1,3 @@
-import { FeatureFlags } from '../../shared/interfaces/feature-flags';
-
 export interface WindowConfig {
   appTitle: string;
   logoUrl: string;
@@ -20,14 +18,12 @@ export class DynamicEnvironment {
   public production: boolean;
   public appConfigUrl: string;
   public baseUrl: string;
-  public featureFlags: FeatureFlags;
   public pollingIntervalMillis?: number;
 
   constructor() {
     this.production = false;
     this.appConfigUrl = 'assets/default-branding/app-config.json';
     this.baseUrl = '/';
-    this.featureFlags = {};
   }
 
   public get config(): WindowConfig {

--- a/bridge/client/environments/environment.prod.ts
+++ b/bridge/client/environments/environment.prod.ts
@@ -6,8 +6,6 @@ class Environment extends DynamicEnvironment {
     this.production = true;
     this.appConfigUrl = 'assets/branding/app-config.json';
     this.baseUrl = '/bridge';
-
-    this.featureFlags = {};
   }
 }
 

--- a/bridge/client/environments/environment.test.ts
+++ b/bridge/client/environments/environment.test.ts
@@ -4,7 +4,6 @@ class Environment extends DynamicEnvironment {
   constructor() {
     super();
     this.pollingIntervalMillis = 0;
-    this.featureFlags = {};
   }
 }
 

--- a/bridge/client/environments/environment.ts
+++ b/bridge/client/environments/environment.ts
@@ -1,10 +1,5 @@
 import { DynamicEnvironment } from './environment.dynamic';
 
-class Environment extends DynamicEnvironment {
-  constructor() {
-    super();
-    this.featureFlags = {};
-  }
-}
+class Environment extends DynamicEnvironment {}
 
 export const environment = new Environment();

--- a/bridge/server/.jest/setupServer.ts
+++ b/bridge/server/.jest/setupServer.ts
@@ -2,7 +2,7 @@ import { init } from '../app';
 import Axios from 'axios';
 import https from 'https';
 
-const setup = async () => {
+const setup = async (): Promise<void> => {
   global.baseUrl = 'http://localhost/api/';
 
   global.axiosInstance = Axios.create({

--- a/bridge/server/api/index.ts
+++ b/bridge/server/api/index.ts
@@ -3,6 +3,9 @@ import { Method } from 'axios';
 import { currentPrincipal } from '../user/session';
 import { axios } from '../services/axios-instance';
 import { DataService } from '../services/data-service';
+import { KeptnInfoResult } from '../../shared/interfaces/keptn-info-result';
+import { EnvironmentUtils } from '../utils/environment.utils';
+import { ClientFeatureFlags } from '../feature-flags';
 
 const router = Router();
 
@@ -12,22 +15,31 @@ const apiRouter = (params: {
   cliDownloadLink: string;
   integrationsPageLink: string;
   authType: string;
+  clientFeatureFlags: ClientFeatureFlags;
 }): Router => {
   // fetch parameters for bridgeInfo endpoint
-  const { apiUrl, apiToken, cliDownloadLink, integrationsPageLink, authType } = params;
+  const {
+    apiUrl,
+    apiToken,
+    cliDownloadLink,
+    integrationsPageLink,
+    authType,
+    clientFeatureFlags: featureFlags,
+  } = params;
   const enableVersionCheckFeature = process.env.ENABLE_VERSION_CHECK !== 'false';
   const showApiToken = process.env.SHOW_API_TOKEN !== 'false';
   const bridgeVersion = process.env.VERSION;
-  const projectsPageSize = process.env.PROJECTS_PAGE_SIZE;
-  const servicesPageSize = process.env.SERVICES_PAGE_SIZE;
+  const projectsPageSize = EnvironmentUtils.getNumber(process.env.PROJECTS_PAGE_SIZE);
+  const servicesPageSize = EnvironmentUtils.getNumber(process.env.SERVICES_PAGE_SIZE);
   const keptnInstallationType = process.env.KEPTN_INSTALLATION_TYPE;
   const dataService = new DataService(apiUrl, apiToken);
 
   // bridgeInfo endpoint: Provide certain metadata for Bridge
   router.get('/bridgeInfo', async (req, res, next) => {
     const user = currentPrincipal(req);
-    const bridgeInfo = {
+    const bridgeInfo: KeptnInfoResult = {
       bridgeVersion,
+      featureFlags,
       keptnInstallationType,
       apiUrl,
       ...(showApiToken && { apiToken }),

--- a/bridge/server/app.ts
+++ b/bridge/server/app.ts
@@ -8,10 +8,12 @@ import express, { Express, NextFunction, Request, Response } from 'express';
 import { fileURLToPath, URL } from 'url';
 import logger from 'morgan';
 import cookieParser from 'cookie-parser';
-import admZip from 'adm-zip';
+import AdmZip from 'adm-zip';
 import { apiRouter } from './api';
 import { execSync } from 'child_process';
 import { AxiosError } from 'axios';
+import { EnvironmentUtils } from './utils/environment.utils';
+import { ClientFeatureFlags, ServerFeatureFlags } from './feature-flags';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -27,84 +29,18 @@ const cleanBucketsInterval = +(process.env.CLEAN_BUCKET_INTERVAL || 60) * 60 * 1
 const throttleBucket: { [ip: string]: number[] } = {};
 const rootFolder = join(__dirname, '../../../');
 const serverFolder = join(rootFolder, 'server');
+const oneWeek = 7 * 24 * 3_600_000; // 3600000msec == 1hour
+const serverFeatureFlags = new ServerFeatureFlags();
+const clientFeatureFlags = new ClientFeatureFlags();
+EnvironmentUtils.setFeatureFlags(process.env, serverFeatureFlags);
+EnvironmentUtils.setFeatureFlags(process.env, clientFeatureFlags);
 
 if (process.env.NODE_ENV !== 'test') {
-  try {
-    console.log('Installing default Look-and-Feel');
-
-    const destDir = join(rootFolder, 'dist/assets/branding');
-    const srcDir = join(
-      rootFolder,
-      `${process.env.NODE_ENV === 'development' ? 'client' : 'dist'}/assets/default-branding`
-    );
-    const brandingFiles = ['app-config.json', 'logo.png', 'logo_inverted.png'];
-
-    if (!existsSync(destDir)) {
-      mkdirSync(destDir, { recursive: true });
-    }
-
-    brandingFiles.forEach((file) => {
-      copyFileSync(join(srcDir, file), join(destDir, file));
-    });
-  } catch (e) {
-    console.error(`Error while downloading custom Look-and-Feel file. Cause : ${e}`);
-    process.exit(1);
-  }
+  setupDefaultLookAndFeel();
 }
 if (lookAndFeelUrl) {
-  let fl: WriteStream | undefined;
-
-  try {
-    console.log('Downloading custom Look-and-Feel file from', lookAndFeelUrl);
-
-    const destDir = join(rootFolder, 'dist/assets/branding');
-    const destFile = join(destDir, '/lookandfeel.zip');
-
-    if (!existsSync(destDir)) {
-      mkdirSync(destDir, { recursive: true });
-    }
-
-    fl = createWriteStream(destFile);
-    const file: WriteStream = fl;
-    const parsedUrl = new URL(lookAndFeelUrl);
-    const lib = parsedUrl.protocol === 'https:' ? https : http;
-
-    lib
-      .get(lookAndFeelUrl, async (response) => {
-        response.pipe(file);
-        file.on('finish', () => {
-          file.end();
-          try {
-            const zip = new admZip(destFile);
-            zip.extractAllToAsync(destDir, true, () => {
-              unlinkSync(destFile);
-              console.log('Custom Look-and-Feel downloaded and extracted successfully');
-            });
-          } catch (err) {
-            console.error(`[ERROR] Error while extracting custom Look-and-Feel file. ${err}`);
-          }
-        });
-        file.on('error', async (err) => {
-          file.end();
-          try {
-            await unlink(destFile);
-          } catch (error) {
-            console.error(`[ERROR] Error while saving custom Look-and-Feel file. ${error}`);
-          }
-          console.error(`[ERROR] Error while saving custom Look-and-Feel file. ${err}`);
-        });
-      })
-      .on('error', (err) => {
-        file.end();
-        console.error(`[ERROR] Error while downloading custom Look-and-Feel file. ${err}`);
-      });
-  } catch (err) {
-    fl?.end();
-    console.error(`[ERROR] Error while downloading custom Look-and-Feel file. ${err}`);
-  }
+  setupLookAndFeel(lookAndFeelUrl);
 }
-
-const oneWeek = 7 * 24 * 3_600_000; // 3600000msec == 1hour
 
 async function init(): Promise<Express> {
   if (!apiUrl) {
@@ -180,7 +116,7 @@ async function init(): Promise<Express> {
   const authType: string = await setAuth();
 
   // everything starting with /api is routed to the api implementation
-  app.use('/api', apiRouter({ apiUrl, apiToken, cliDownloadLink, integrationsPageLink, authType }));
+  app.use('/api', apiRouter({ apiUrl, apiToken, cliDownloadLink, integrationsPageLink, authType, clientFeatureFlags }));
 
   // fallback: go to index.html
   app.use((req, res) => {
@@ -252,7 +188,7 @@ async function setBasisAUTH(): Promise<void> {
 
 async function setAuth(): Promise<string> {
   let authType;
-  if (process.env.OAUTH_ENABLED === 'true') {
+  if (serverFeatureFlags.OAUTH_ENABLED) {
     await setOAUTH();
     authType = 'OAUTH';
   } else if (process.env.BASIC_AUTH_USERNAME && process.env.BASIC_AUTH_PASSWORD) {
@@ -264,6 +200,83 @@ async function setAuth(): Promise<string> {
   }
 
   return authType;
+}
+
+function setupDefaultLookAndFeel(): void {
+  try {
+    console.log('Installing default Look-and-Feel');
+
+    const destDir = join(rootFolder, 'dist/assets/branding');
+    const srcDir = join(
+      rootFolder,
+      `${process.env.NODE_ENV === 'development' ? 'client' : 'dist'}/assets/default-branding`
+    );
+    const brandingFiles = ['app-config.json', 'logo.png', 'logo_inverted.png'];
+
+    if (!existsSync(destDir)) {
+      mkdirSync(destDir, { recursive: true });
+    }
+
+    brandingFiles.forEach((file) => {
+      copyFileSync(join(srcDir, file), join(destDir, file));
+    });
+  } catch (e) {
+    console.error(`Error while downloading custom Look-and-Feel file. Cause : ${e}`);
+    process.exit(1);
+  }
+}
+
+function setupLookAndFeel(url: string): void {
+  let fl: WriteStream | undefined;
+
+  try {
+    console.log('Downloading custom Look-and-Feel file from', lookAndFeelUrl);
+
+    const destDir = join(rootFolder, 'dist/assets/branding');
+    const destFile = join(destDir, '/lookandfeel.zip');
+
+    if (!existsSync(destDir)) {
+      mkdirSync(destDir, { recursive: true });
+    }
+
+    fl = createWriteStream(destFile);
+    const file: WriteStream = fl;
+    const parsedUrl = new URL(url);
+    const lib = parsedUrl.protocol === 'https:' ? https : http;
+
+    lib
+      .get(url, async (response) => {
+        response.pipe(file);
+        file.on('finish', () => {
+          file.end();
+          try {
+            const zip = new AdmZip(destFile);
+            zip.extractAllToAsync(destDir, true, () => {
+              unlinkSync(destFile);
+              console.log('Custom Look-and-Feel downloaded and extracted successfully');
+            });
+          } catch (err) {
+            console.error(`[ERROR] Error while extracting custom Look-and-Feel file. ${err}`);
+          }
+        });
+        file.on('error', async (err) => {
+          file.end();
+          try {
+            await unlink(destFile);
+          } catch (error) {
+            console.error(`[ERROR] Error while saving custom Look-and-Feel file. ${error}`);
+          }
+          console.error(`[ERROR] Error while saving custom Look-and-Feel file. ${err}`);
+        });
+      })
+      .on('error', (err) => {
+        file.end();
+        console.error(`[ERROR] Error while downloading custom Look-and-Feel file. ${err}`);
+      });
+  } catch (err) {
+    fl?.end();
+    console.error(`[ERROR] Error while downloading custom Look-and-Feel file. ${err}`);
+  }
 }
 
 function updateBucket(loginAttempt: boolean, userIP?: string): void {

--- a/bridge/server/feature-flags.ts
+++ b/bridge/server/feature-flags.ts
@@ -1,0 +1,7 @@
+import { IClientFeatureFlags, IServerFeatureFlags } from '../shared/interfaces/feature-flags';
+
+export class ClientFeatureFlags implements IClientFeatureFlags {}
+
+export class ServerFeatureFlags implements IServerFeatureFlags {
+  OAUTH_ENABLED = false;
+}

--- a/bridge/server/test/environment.utils.spec.ts
+++ b/bridge/server/test/environment.utils.spec.ts
@@ -1,0 +1,75 @@
+import { EnvironmentUtils } from '../utils/environment.utils';
+import { ServerFeatureFlags } from '../feature-flags';
+
+describe('Test environment utils', () => {
+  it('should format number and return undefined', () => {
+    for (const input of [undefined, 'undefined', 'not a number']) {
+      expect(EnvironmentUtils.getNumber(input)).toBe(undefined);
+    }
+  });
+
+  it('should format number and return positive integer', () => {
+    expect(EnvironmentUtils.getNumber('10')).toBe(10);
+    expect(EnvironmentUtils.getNumber('-10')).toBe(10);
+    expect(EnvironmentUtils.getNumber('2.55')).toBe(2);
+  });
+
+  it('should format number and return integer', () => {
+    expect(EnvironmentUtils.getNumber('10', false)).toBe(10);
+    expect(EnvironmentUtils.getNumber('-10', false)).toBe(-10);
+  });
+
+  it('should set server feature flags to true', () => {
+    // given
+    const flags = { OAUTH_ENABLED: false };
+    // when
+    EnvironmentUtils.setFeatureFlags(
+      {
+        OAUTH_ENABLED: 'true',
+      },
+      flags
+    );
+    // then
+    expect(flags).toEqual({ OAUTH_ENABLED: true });
+  });
+
+  it('should set server feature flag to false', () => {
+    for (const input of ['false', '', 'FALSE', 'TRUE']) {
+      // given
+      const flags = { OAUTH_ENABLED: true };
+      // when
+      EnvironmentUtils.setFeatureFlags(
+        {
+          OAUTH_ENABLED: input,
+        },
+        flags
+      );
+      // then
+      expect(flags).toEqual({ OAUTH_ENABLED: false });
+    }
+  });
+
+  it('should use default server feature flag if not provided', () => {
+    // given
+    const flags = new ServerFeatureFlags();
+    // when
+    EnvironmentUtils.setFeatureFlags({}, flags);
+    // then
+    expect(flags).toEqual({ OAUTH_ENABLED: false });
+  });
+
+  it('should not add additional server feature flags', () => {
+    // given
+    const flags = { OAUTH_ENABLED: false };
+    // when
+    EnvironmentUtils.setFeatureFlags(
+      {
+        OAUTH_ENABLED: 'true',
+        ANOTHER_FLAG: 'true',
+      },
+      flags
+    );
+    // then
+    expect(flags).toEqual({ OAUTH_ENABLED: true });
+  });
+});

--- a/bridge/server/utils/environment.utils.ts
+++ b/bridge/server/utils/environment.utils.ts
@@ -1,0 +1,26 @@
+import { ClientFeatureFlags, ServerFeatureFlags } from '../feature-flags';
+
+export class EnvironmentUtils {
+  public static getNumber(num: string | undefined, positive = true): number | undefined {
+    let result = undefined;
+
+    if (num !== undefined) {
+      const count = parseInt(num, 10);
+      if (!isNaN(count)) {
+        result = positive ? Math.abs(count) : count;
+      }
+    }
+    return result;
+  }
+
+  public static setFeatureFlags(
+    env: Record<string, string | undefined>,
+    defaultFlags: ServerFeatureFlags | ClientFeatureFlags
+  ): void {
+    for (const flag of Object.keys(defaultFlags)) {
+      if (flag in env) {
+        (defaultFlags as Record<string, boolean>)[flag] = env[flag] === 'true';
+      }
+    }
+  }
+}

--- a/bridge/shared/interfaces/feature-flags.ts
+++ b/bridge/shared/interfaces/feature-flags.ts
@@ -1,2 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface FeatureFlags {}
+export interface IClientFeatureFlags {}
+
+export interface IServerFeatureFlags {
+  OAUTH_ENABLED: boolean;
+}

--- a/bridge/shared/interfaces/keptn-info-result.ts
+++ b/bridge/shared/interfaces/keptn-info-result.ts
@@ -1,4 +1,7 @@
+import { IClientFeatureFlags } from './feature-flags';
+
 export interface KeptnInfoResult {
+  featureFlags: IClientFeatureFlags;
   bridgeVersion?: string;
   keptnInstallationType?: string;
   apiUrl?: string;


### PR DESCRIPTION
Closes #6073

Feature flags are now split into `Server` and `Client`. Only the `Client` feature flags are sent to the client.

Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>