### PR TITLE
fix: Remove hardcoded namespace reference in installer

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/templates/ingress.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/ingress.yaml
@@ -9,7 +9,7 @@ metadata:
   {{- end }}
 {{- end }}
   name: keptn-ingress
-  namespace: keptn
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: ingress
     app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->
- Removes a hardcoded namespace reference from the installer
- Hardcoded namespace affects custom Kubernetes deployments in different namespaces.
