### PR TITLE
feat(bridge): Add hint for tree list select component and change texts (#5576)

### DIFF
--- a/bridge/client/app/_components/ktb-tree-list-select/ktb-tree-list-select.component.html
+++ b/bridge/client/app/_components/ktb-tree-list-select/ktb-tree-list-select.component.html
@@ -1,5 +1,8 @@
 <div class="select-overlay-header pl-3" fxLayout="row" fxLayoutAlign="space-between center">
-  <div>{{ options.headerText }}</div>
+  <div fxLayout="row">
+    {{ options.headerText }}
+    <dt-icon *ngIf="options.hintText" name="information" [dtOverlay]="overlay"></dt-icon>
+  </div>
   <button dt-icon-button variant="primary" (click)="closeDialog.emit()">
     <dt-icon name="abort"></dt-icon>
   </button>
@@ -18,4 +21,8 @@
 
 <ng-template #empty>
   <div class="container" [innerHTML]="options.emptyText"></div>
+</ng-template>
+
+<ng-template #overlay>
+  {{ options.hintText }}
 </ng-template>

--- a/bridge/client/app/_components/ktb-tree-list-select/ktb-tree-list-select.component.scss
+++ b/bridge/client/app/_components/ktb-tree-list-select/ktb-tree-list-select.component.scss
@@ -33,6 +33,15 @@
     border-color: transparent transparent $turquoise-600 transparent;
   }
 
+  > div > .dt-icon {
+    width: 20px;
+    height: 20px;
+    margin-left: 5px;
+    position: relative;
+    top: 2px;
+    fill: #ffffff;
+  }
+
 }
 
 .tree-entry-selectable {

--- a/bridge/client/app/_components/ktb-tree-list-select/ktb-tree-list-select.component.scss
+++ b/bridge/client/app/_components/ktb-tree-list-select/ktb-tree-list-select.component.scss
@@ -38,7 +38,7 @@
     height: 20px;
     margin-left: 5px;
     position: relative;
-    top: 2px;
+    top: 1px;
     fill: #ffffff;
   }
 

--- a/bridge/client/app/_components/ktb-tree-list-select/ktb-tree-list-select.component.ts
+++ b/bridge/client/app/_components/ktb-tree-list-select/ktb-tree-list-select.component.ts
@@ -33,6 +33,7 @@ export class SelectTreeFlatNode implements SelectTreeNode {
 export type TreeListSelectOptions = {
   headerText: string;
   emptyText: string;
+  hintText: string;
 };
 
 @Directive({
@@ -43,7 +44,7 @@ export class KtbTreeListSelectDirective implements OnInit {
   private contentRef: ComponentRef<KtbTreeListSelectComponent> | undefined;
 
   @Input() data: SelectTreeNode[] = [];
-  @Input() options: TreeListSelectOptions = { headerText: '', emptyText: '' };
+  @Input() options: TreeListSelectOptions = { headerText: '', emptyText: '', hintText: '' };
   @Output() selected: EventEmitter<string> = new EventEmitter<string>();
 
   @HostListener('click')
@@ -136,7 +137,7 @@ export class KtbTreeListSelectComponent {
     this.dataSource.data = data;
   }
 
-  @Input() options: TreeListSelectOptions = { headerText: '', emptyText: '' };
+  @Input() options: TreeListSelectOptions = { headerText: '', emptyText: '', hintText: '' };
 
   @Output() closeDialog: EventEmitter<void> = new EventEmitter<void>();
   @Output() selected: EventEmitter<string> = new EventEmitter<string>();

--- a/bridge/client/app/_components/ktb-variable-selector/ktb-variable-selector.component.ts
+++ b/bridge/client/app/_components/ktb-variable-selector/ktb-variable-selector.component.ts
@@ -11,6 +11,7 @@ export class KtbVariableSelectorComponent {
   public options: TreeListSelectOptions = {
     headerText: 'Select element',
     emptyText: 'No elements available.',
+    hintText: '',
   };
   @Output() changed: EventEmitter<void> = new EventEmitter<void>();
 
@@ -28,6 +29,11 @@ export class KtbVariableSelectorComponent {
   @Input()
   set emptyText(text: string) {
     this.options.emptyText = text;
+  }
+
+  @Input()
+  set hintText(text: string) {
+    this.options.hintText = text;
   }
 
   public setVariable(variable: string): void {

--- a/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.html
+++ b/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.html
@@ -177,9 +177,9 @@
     [title]="'Select secret'"
     [label]="'Add secret'"
     [emptyText]="
-      'No secrets for the scope keptn-webhook-service are available.<p>Configure secrets for the scope keptn-webhook-service under the menu entry &quot;Secrets&quot; in the Uniform to make them available for configuration.</p>'
+      'No secrets for the scope keptn-webhook-service are available.<p>Configure secrets for the scope keptn-webhook-service under the menu entry <span class=&quot;bold&quot;>Secrets</span> in the Uniform.</p>'
     "
-    [hintText]="'Only secrets of scope keptn-webhook-service are available for configuration.'"
+    [hintText]="'Only secrets of scope keptn-webhook-secret can be referenced.'"
     [control]="getFormControl(controlName, index)"
     [selectionStart]="selectionStart"
     (changed)="onWebhookFormChange()"

--- a/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.html
+++ b/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.html
@@ -177,8 +177,9 @@
     [title]="'Select secret'"
     [label]="'Add secret'"
     [emptyText]="
-      'No secrets can be found.<p>Secrets can be configured under the menu entry &quot;Secrets&quot; in the Uniform.</p>'
+      'No secrets for the scope keptn-webhook-service are available.<p>Configure secrets for the scope keptn-webhook-service under the menu entry &quot;Secrets&quot; in the Uniform to make them available for configuration.</p>'
     "
+    [hintText]="'Only secrets of scope keptn-webhook-service are available for configuration.'"
     [control]="getFormControl(controlName, index)"
     [selectionStart]="selectionStart"
     (changed)="onWebhookFormChange()"


### PR DESCRIPTION
* Add an (optional) hint with an overlay to the variable picker for more information.
* Text adaptions to have more emphasis on keptn-webhook-scope for secret selection.

Closes #5576 
