### PR TITLE
fix(configuration-service): Fix permission issues for configuration service (#6315)

### DIFF
--- a/configuration-service/common/git.go
+++ b/configuration-service/common/git.go
@@ -24,8 +24,11 @@ var namespace = os.Getenv("POD_NAMESPACE")
 const masterBranch = "master"
 const mainBranch = "main"
 
-const gitKeptnUser = "keptn"
-const gitKeptnEmail = "keptn@keptn.sh"
+const gitKeptnUserEnvVar = "GIT_KEPTN_USER"
+const gitKeptnEmailEnvVar = "GIT_KEPTN_EMAIL"
+
+const gitKeptnUserDefault = "keptn"
+const gitKeptnEmailDefault = "keptn@keptn.sh"
 
 //go:generate moq -pkg common_mock -skip-ensure -out ./fake/command_executor_mock.go . CommandExecutor
 type CommandExecutor interface {
@@ -355,11 +358,11 @@ func (g *Git) Reset(project string) error {
 
 func (g *Git) ConfigureGitUser(project string) error {
 	projectConfigPath := config.ConfigDir + "/" + project
-	_, err := g.Executor.ExecuteCommand("git", []string{"config", "user.name", gitKeptnUser}, projectConfigPath)
+	_, err := g.Executor.ExecuteCommand("git", []string{"config", "user.name", getGitKeptnUser()}, projectConfigPath)
 	if err != nil {
 		return fmt.Errorf("could not set git user.name: %w", err)
 	}
-	_, err = g.Executor.ExecuteCommand("git", []string{"config", "user.email", gitKeptnEmail}, projectConfigPath)
+	_, err = g.Executor.ExecuteCommand("git", []string{"config", "user.email", getGitKeptnEmail()}, projectConfigPath)
 	if err != nil {
 		return fmt.Errorf("could not set git user.email: %w", err)
 	}
@@ -584,4 +587,18 @@ func addVersionToMetadata(project string, metadata *models.Version) {
 	if err == nil {
 		metadata.Version = version
 	}
+}
+
+func getGitKeptnUser() string {
+	if keptnUser := os.Getenv(gitKeptnUserEnvVar); keptnUser != "" {
+		return keptnUser
+	}
+	return gitKeptnUserDefault
+}
+
+func getGitKeptnEmail() string {
+	if keptnEmail := os.Getenv(gitKeptnEmailEnvVar); keptnEmail != "" {
+		return keptnEmail
+	}
+	return gitKeptnEmailDefault
 }

--- a/configuration-service/common/git_test.go
+++ b/configuration-service/common/git_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/keptn/keptn/configuration-service/common_models"
 	"github.com/keptn/keptn/configuration-service/models"
 	"github.com/stretchr/testify/require"
+	"os"
 	"strings"
 	"testing"
 )
@@ -608,12 +609,12 @@ func TestGit_ConfigureGitUser(t *testing.T) {
 			}{
 				{
 					Command:   "git",
-					Args:      []string{"config", "user.name", gitKeptnUser},
+					Args:      []string{"config", "user.name", gitKeptnUserDefault},
 					Directory: "./debug/config/my-project",
 				},
 				{
 					Command:   "git",
-					Args:      []string{"config", "user.email", gitKeptnEmail},
+					Args:      []string{"config", "user.email", gitKeptnEmailDefault},
 					Directory: "./debug/config/my-project",
 				},
 			},
@@ -640,7 +641,7 @@ func TestGit_ConfigureGitUser(t *testing.T) {
 			}{
 				{
 					Command:   "git",
-					Args:      []string{"config", "user.name", gitKeptnUser},
+					Args:      []string{"config", "user.name", gitKeptnUserDefault},
 					Directory: "./debug/config/my-project",
 				},
 			},
@@ -667,12 +668,12 @@ func TestGit_ConfigureGitUser(t *testing.T) {
 			}{
 				{
 					Command:   "git",
-					Args:      []string{"config", "user.name", gitKeptnUser},
+					Args:      []string{"config", "user.name", gitKeptnUserDefault},
 					Directory: "./debug/config/my-project",
 				},
 				{
 					Command:   "git",
-					Args:      []string{"config", "user.email", gitKeptnEmail},
+					Args:      []string{"config", "user.email", gitKeptnEmailDefault},
 					Directory: "./debug/config/my-project",
 				},
 			},
@@ -690,6 +691,60 @@ func TestGit_ConfigureGitUser(t *testing.T) {
 			executedCommands := tt.fields.Executor.ExecuteCommandCalls()
 
 			assert.Equal(t, tt.expectedCommands, executedCommands)
+		})
+	}
+}
+
+func Test_getGitKeptnUser(t *testing.T) {
+	tests := []struct {
+		name        string
+		envVarValue string
+		want        string
+	}{
+		{
+			name:        "default value",
+			envVarValue: "",
+			want:        gitKeptnUserDefault,
+		},
+		{
+			name:        "env var value",
+			envVarValue: "my-user",
+			want:        "my-user",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_ = os.Setenv(gitKeptnUserEnvVar, tt.envVarValue)
+			if got := getGitKeptnUser(); got != tt.want {
+				t.Errorf("getGitKeptnUser() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getGitKeptnEmail(t *testing.T) {
+	tests := []struct {
+		name        string
+		envVarValue string
+		want        string
+	}{
+		{
+			name:        "default value",
+			envVarValue: "",
+			want:        gitKeptnEmailDefault,
+		},
+		{
+			name:        "env var value",
+			envVarValue: "my-user@keptn.sh",
+			want:        "my-user@keptn.sh",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_ = os.Setenv(gitKeptnEmailEnvVar, tt.envVarValue)
+			if got := getGitKeptnEmail(); got != tt.want {
+				t.Errorf("getGitKeptnEmail() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }

--- a/configuration-service/handlers/project.go
+++ b/configuration-service/handlers/project.go
@@ -76,6 +76,12 @@ func PostProjectHandlerFunc(params project.PostProjectParams) middleware.Respond
 			return project.NewPostProjectBadRequest().WithPayload(&models.Error{Code: http.StatusBadRequest, Message: swag.String("Could not initialize git repo")})
 		}
 	}
+	err = common.ConfigureGitUser(params.Project.ProjectName)
+	if err != nil {
+		logger.WithError(err).Errorf("Could not configure git during creating project %s", params.Project.ProjectName)
+		rollbackFunc()
+		return project.NewPostProjectDefault(http.StatusInternalServerError).WithPayload(&models.Error{Code: http.StatusInternalServerError, Message: swag.String("Could not configure git in project repo")})
+	}
 	////////////////////////////////////////////////////
 	newProjectMetadata := &projectMetadata{
 		ProjectName:       params.Project.ProjectName,

--- a/configuration-service/restapi/configure_configuration_service.go
+++ b/configuration-service/restapi/configure_configuration_service.go
@@ -9,7 +9,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"os/exec"
 	"strings"
 
 	errors "github.com/go-openapi/errors"
@@ -135,22 +134,6 @@ func configureServer(s *http.Server, scheme, addr string) {
 		log.WithError(err).Error("could not parse log level provided by 'LOG_LEVEL' env var")
 	} else {
 		log.SetLevel(logLevel)
-	}
-	if os.Getenv("env") == "production" {
-		///////// initialize git ////////////
-		log.Debug("Configuring git user.email")
-		cmd := exec.Command("git", "config", "--global", "user.email", "keptn@keptn.com")
-		_, err := cmd.Output()
-		if err != nil {
-			log.Error("Could not configure git user.email: " + err.Error())
-		}
-		log.Debug("Configuring git user.name")
-		cmd = exec.Command("git", "config", "--global", "user.name", "keptn")
-		_, err = cmd.Output()
-		if err != nil {
-			log.Error("Could not configure git user.name: " + err.Error())
-		}
-		////////////////////////////////////
 	}
 }
 

--- a/installer/manifests/keptn/charts/control-plane/templates/core.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/core.yaml
@@ -667,6 +667,7 @@ spec:
           securityContext:
             runAsNonRoot: true
             runAsUser: {{ .Values.configurationService.fsGroup | default 1001 }}
+            readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
       volumes:
         - name: configuration-volume

--- a/installer/manifests/keptn/charts/control-plane/templates/core.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/core.yaml
@@ -622,19 +622,7 @@ spec:
         helm.sh/chart: {{ include "control-plane.chart" . }}
     spec:
       securityContext:
-        fsGroup: 65532
-      initContainers:
-      - name: change-user-init
-        image: {{ .Values.configurationService.image.repository }}:{{ .Values.configurationService.image.tag | default .Chart.AppVersion }}
-        securityContext:
-          runAsUser: 0
-        volumeMounts:
-          - mountPath: /data/config
-            name: configuration-volume
-        command:
-          - sh
-          - -c
-          - chown -R 65532 /data/config
+        fsGroup: {{ .Values.configurationService.fsGroup | default 1001 }}
       containers:
         - name: configuration-service
           image: {{ .Values.configurationService.image.repository }}:{{ .Values.configurationService.image.tag | default .Chart.AppVersion }}
@@ -678,8 +666,7 @@ spec:
               name: configuration-volume
           securityContext:
             runAsNonRoot: true
-            runAsUser: 65532
-            readOnlyRootFilesystem: false # False is necessary because we have to write the git config file
+            runAsUser: {{ .Values.configurationService.fsGroup | default 1001 }}
             allowPrivilegeEscalation: false
       volumes:
         - name: configuration-volume

--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -96,6 +96,9 @@ configurationService:
   # storage and storageClass are the settings for the PVC used by the configuration-storage
   storage: 100Mi
   storageClass: null
+  env:
+    GIT_KEPTN_USER: "keptn"
+    GIT_KEPTN_EMAIL: "keptn@keptn.sh"
 
 mongodbDatastore:
   image:


### PR DESCRIPTION
Closes #6315 

This PR changes the behavior of the configuration service by moving the git config setup to the individual project repositores instead of doing it globally during the startup. This way, we also do not need the `initContainer`, which required enhanced privileges, anymore.
Also, the `fsGroup` used by the configuration service has been changed to `1001` per default (see #6315 for further details).  This `fsGroup` value can be overridden using the `configurationService.fsGroup` option in the installer helm chart.