### PR TITLE
fix(installer): Disable nats config reloader per default (#6316)

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -25,6 +25,8 @@ nats:
 
   natsbox:
     enabled: false
+  reloader:
+    enabled: false
 
 apiGatewayNginx:
   type: ClusterIP


### PR DESCRIPTION
Closes #6316 

The PR disables the nats config reloader per default. If it is needed nevertheless, it can be enabled using the option `nats.reloader.enabled` of the control plane helm chart