### PR TITLE
fix(installer): Disable nats config reloader per default (#6316) 

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -25,6 +25,8 @@ nats:
 
   natsbox:
     enabled: false
+  reloader:
+    enabled: false
 
 apiGatewayNginx:
   type: ClusterIP


### PR DESCRIPTION
Backport of #6318

Closes #6316