### PR TITLE
fix(statistics-service): migration of keptn service execution data

### DIFF
--- a/statistics-service/db/migrator.go
+++ b/statistics-service/db/migrator.go
@@ -124,7 +124,10 @@ func noDotsInKeys(statistics *operations.Statistics) bool {
 					return false
 				}
 			}
-			for _, keptnService := range service.KeptnServiceExecutions {
+			for keptnServiceExecutionsKey, keptnService := range service.KeptnServiceExecutions {
+				if strings.Contains(keptnServiceExecutionsKey, ".") {
+					return false
+				}
 				for eventType := range keptnService.Executions {
 					if strings.Contains(eventType, ".") {
 						return false

--- a/statistics-service/db/migrator.go
+++ b/statistics-service/db/migrator.go
@@ -157,8 +157,8 @@ func transform(statistics *operations.Statistics, tansformFn func(string) string
 	if err != nil {
 		return nil, err
 	}
-	for _, stat := range copiedStatistics.(*operations.Statistics).Projects {
-		for _, service := range stat.Services {
+	for _, proj := range copiedStatistics.(*operations.Statistics).Projects {
+		for _, service := range proj.Services {
 			newExecutedSequencesPerType := make(map[string]int)
 			for eventType, numExecutedSequencesPerType := range service.ExecutedSequencesPerType {
 				newExecutedSequencesPerType[tansformFn(eventType)] = numExecutedSequencesPerType
@@ -171,13 +171,16 @@ func transform(statistics *operations.Statistics, tansformFn func(string) string
 			}
 			service.Events = newEvents
 
-			for _, keptnService := range service.KeptnServiceExecutions {
+			newKeptnServiceExecutions := make(map[string]*operations.KeptnService)
+			for keptnServiceExecutionKey, keptnService := range service.KeptnServiceExecutions {
 				newServiceExecutions := make(map[string]int)
 				for eventType2, numExecutions := range keptnService.Executions {
 					newServiceExecutions[tansformFn(eventType2)] = numExecutions
 				}
 				keptnService.Executions = newServiceExecutions
+				newKeptnServiceExecutions[tansformFn(keptnServiceExecutionKey)] = keptnService
 			}
+			service.KeptnServiceExecutions = newKeptnServiceExecutions
 		}
 	}
 	return copiedStatistics.(*operations.Statistics), nil

--- a/statistics-service/db/migrator_test.go
+++ b/statistics-service/db/migrator_test.go
@@ -17,11 +17,9 @@ func Test_Migrate(t *testing.T) {
 		From: time.Now(),
 		To:   time.Now().Add(time.Second),
 		Projects: map[string]*operations.Project{
-			"my-project": {
-				Name: "my-project",
+			"my.project": {
 				Services: map[string]*operations.Service{
-					"my-service": {
-						Name: "my-service",
+					"my.service": {
 						Events: map[string]int{
 							"my.keptn.event.type": 2, // <-DOT
 						},
@@ -79,11 +77,9 @@ func Test_Transform_Encode_Decode(t *testing.T) {
 		From: time.Now(),
 		To:   time.Now().Add(time.Second),
 		Projects: map[string]*operations.Project{
-			"my-project": {
-				Name: "my-project",
+			"my.project": {
 				Services: map[string]*operations.Service{
-					"my-service": {
-						Name: "my-service",
+					"my.service": {
 						Events: map[string]int{
 							"my.keptn.event.type": 2, // <-DOT
 						},
@@ -108,11 +104,9 @@ func Test_Transform_Encode_Decode(t *testing.T) {
 		From: time.Now(),
 		To:   time.Now().Add(time.Second),
 		Projects: map[string]*operations.Project{
-			"my-project": {
-				Name: "my-project",
+			"my~pproject": {
 				Services: map[string]*operations.Service{
-					"my-service": {
-						Name: "my-service",
+					"my~pservice": {
 						Events: map[string]int{
 							"my~pkeptn~pevent~ptype": 2,
 						},
@@ -241,6 +235,54 @@ func Test_noDotsInKeys(t *testing.T) {
 						"a": {
 							Events: map[string]int{
 								".": 2,
+							},
+							KeptnServiceExecutions: map[string]*operations.KeptnService{
+								"a": {
+									Executions: map[string]int{
+										"a": 1,
+									},
+								},
+							},
+							ExecutedSequencesPerType: map[string]int{
+								"a": 0,
+							},
+						},
+					},
+				},
+			},
+		}}, false},
+		{"dots in Service field", args{&operations.Statistics{
+			Projects: map[string]*operations.Project{
+				"my-project": {
+					Name: "a",
+					Services: map[string]*operations.Service{
+						".": {
+							Events: map[string]int{
+								"a": 2,
+							},
+							KeptnServiceExecutions: map[string]*operations.KeptnService{
+								"a": {
+									Executions: map[string]int{
+										"a": 1,
+									},
+								},
+							},
+							ExecutedSequencesPerType: map[string]int{
+								"a": 0,
+							},
+						},
+					},
+				},
+			},
+		}}, false},
+		{"dots in Project field", args{&operations.Statistics{
+			Projects: map[string]*operations.Project{
+				".": {
+					Name: "a",
+					Services: map[string]*operations.Service{
+						"a": {
+							Events: map[string]int{
+								"a": 2,
 							},
 							KeptnServiceExecutions: map[string]*operations.KeptnService{
 								"a": {


### PR DESCRIPTION
part of #6266

This PR also considers the `KeptnServiceExecutions` key which could also contain dots, during migration.