### PR TITLE
fix(configuration-service): Create tmpdir for unarchiving in /data/config

### DIFF
--- a/configuration-service/handlers/service_resource.go
+++ b/configuration-service/handlers/service_resource.go
@@ -255,7 +255,7 @@ func PostProjectProjectNameStageStageNameServiceServiceNameResourceHandlerFunc(
 func untarHelm(res *models.Resource, filePath string) error {
 	// unarchive the Helm chart
 	logger.Debug("Unarchive the Helm chart: " + *res.ResourceURI)
-	tmpDir, err := ioutil.TempDir("", "")
+	tmpDir, err := ioutil.TempDir(config.ConfigDir, "*")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
During the unarchive operation the configuration service tried to create a tmp directory in the file system root - since it does not have the permissions to write anything there, the temp directory is now created within /data/config