### PR TITLE
feat(bridge): Login via OpenID (#6076) (#6077)

### DIFF
--- a/bridge/.gitignore
+++ b/bridge/.gitignore
@@ -51,3 +51,8 @@ Thumbs.db
 # e2e screenshots
 e2e/screenshots/*
 !e2e/screenshots/.gitkeep
+
+# certificates
+*.pem
+*.crt
+*.key

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -79,12 +79,19 @@ Per default login attempts are throttled to 10 requests within 60 minutes. This 
 To set up a login via OpenID you have to register an application by the identity provider you want in order to get an ID (`CLIENT_ID`) and a secret (`CLIENT_SECRET`).
 After this is done the following environment variables have to be set:
 - `OAUTH_ENABLED` - Flag to enable login via OpenID. To enable it set it to `true`.
-- `OAUTH_BASE_URL` - URL of the bridge (e.g. http://localhost:3000 or https://myBridgeInstallation.com).
+- `OAUTH_BASE_URL` - URL of the bridge (e.g. `http://localhost:3000` or `https://myBridgeInstallation.com`).
 - `OAUTH_DISCOVERY` - Discovery URL of the identity provider (e.g. https://api.login.yahoo.com/.well-known/openid-configuration).
 - `OAUTH_CLIENT_ID` - Client ID.
 - `OAUTH_CLIENT_SECRET` (optional) - Client secret. Some identity providers require using the client secret.
 - `OAUTH_ID_TOKEN_ALG` (optional) - Algorithm that is used to verify the ID token (e.g. `ES256`). Default is `RS256`.
 - `OAUTH_NAME_PROPERTY` (optional) - The property of the ID token that identifies the user. Default is `name` and fallback to `nickname`, `preferred_username` and `email`.
+
+#### Additional information:
+- Make sure you add the redirect URI `https://${yourDomain}/${pathToBridge}/oauth/redirect` to your identity provider.
+- The identity provider has to support the grant types `authorization_code` and `refresh_token` and provide the endpoints `authorization_endpoint`, `token_endpoint` and `jwks_uri`.
+- The refresh of the token is done by the bridge server on demand. 
+- If the identity provider provides the endpoint `end_session_endpoint`, it will be used for the logout.
+- The bridge server itself is a confidential client.
 
 ### Custom Look And Feel
 

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -75,6 +75,17 @@ Per default login attempts are throttled to 10 requests within 60 minutes. This 
 - `REQUESTS_WITHIN_TIME` - how many login attempts in which timespan `REQUEST_TIME_LIMIT` (in minutes) are allowed per IP.
 - `CLEAN_BUCKET_INTERVAL` - the interval (in minutes) the saved login attempts should be checked and deleted if the last request of an IP is older than `REQUEST_TIME_LIMIT` minutes. Default is 60 minutes.
 
+### Setting up login via OpenID
+To set up a login via OpenID you have to register an application by the identity provider you want in order to get an ID (`CLIENT_ID`) and a secret (`CLIENT_SECRET`).
+After this is done the following environment variables have to be set:
+- `OAUTH_ENABLED` - Flag to enable login via OpenID. To enable it set it to `true`.
+- `OAUTH_BASE_URL` - URL of the bridge (e.g. http://localhost:3000 or https://myBridgeInstallation.com).
+- `OAUTH_DISCOVERY` - Discovery URL of the identity provider (e.g. https://api.login.yahoo.com/.well-known/openid-configuration).
+- `OAUTH_CLIENT_ID` - Client ID.
+- `OAUTH_CLIENT_SECRET` (optional) - Client secret. Some identity providers require using the client secret.
+- `OAUTH_ID_TOKEN_ALG` (optional) - Algorithm that is used to verify the ID token (e.g. `ES256`). Default is `RS256`.
+- `OAUTH_NAME_PROPERTY` (optional) - The property of the ID token that identifies the user. Default is `name` and fallback to `nickname`, `preferred_username` and `email`.
+
 ### Custom Look And Feel
 
 You can change the Look And Feel of the Keptn Bridge by creating a zip archive with your resources and make it downloadable from an URL.

--- a/bridge/client/app/_components/ktb-user/ktb-user.component.html
+++ b/bridge/client/app/_components/ktb-user/ktb-user.component.html
@@ -1,6 +1,11 @@
 <div class="user">
   <p>User: {{ user }}</p>
   <div>
-    <button (click)="logout()" dt-button>Logout</button>
+    <form (ngSubmit)="logout($event)" method="POST" [action]="formData.end_session_endpoint">
+      <input type="hidden" name="state" [value]="formData.state" />
+      <input type="hidden" name="post_logout_redirect_uri" [value]="formData.post_logout_redirect_uri" />
+      <input type="hidden" name="id_token_hint" [value]="formData.id_token_hint" />
+      <button type="submit" dt-button>Logout</button>
+    </form>
   </div>
 </div>

--- a/bridge/client/app/_components/ktb-user/ktb-user.component.spec.ts
+++ b/bridge/client/app/_components/ktb-user/ktb-user.component.spec.ts
@@ -1,11 +1,14 @@
 import { KtbUserComponent } from './ktb-user.component';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AppModule } from '../../app.module';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { EndSessionData } from '../../../../shared/interfaces/end-session-data';
+import { Location } from '@angular/common';
 
 describe('ktbUserComponentTest', () => {
   let component: KtbUserComponent;
   let fixture: ComponentFixture<KtbUserComponent>;
+  let httpMock: HttpTestingController;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -14,10 +17,33 @@ describe('ktbUserComponentTest', () => {
 
     fixture = TestBed.createComponent(KtbUserComponent);
     component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
   });
 
   it('should create', () => {
     fixture.detectChanges();
     expect(component).toBeDefined();
+  });
+
+  it('should send POST to logout', () => {
+    const submitForm = { target: { submit: (): void => {} } };
+    const submitSpy = jest.spyOn(submitForm.target, 'submit');
+    component.logout(submitForm);
+    httpMock.expectOne('./logout').flush({
+      id_token_hint: '',
+      end_session_endpoint: '',
+      post_logout_redirect_uri: '',
+      state: '',
+    } as EndSessionData);
+    expect(submitSpy).toHaveBeenCalled();
+  });
+
+  it('should redirect to root if no data for logout is returned', () => {
+    const submitForm = { target: { submit: (): void => {} } };
+    const location = TestBed.inject(Location);
+    const locationSpy = jest.spyOn(location, 'prepareExternalUrl');
+    component.logout(submitForm);
+    httpMock.expectOne('./logout').flush(null);
+    expect(locationSpy).toBeCalledWith('/');
   });
 });

--- a/bridge/client/app/_components/ktb-user/ktb-user.component.ts
+++ b/bridge/client/app/_components/ktb-user/ktb-user.component.ts
@@ -1,4 +1,6 @@
-import { Component, Input } from '@angular/core';
+import { ChangeDetectorRef, Component, Input } from '@angular/core';
+import { DataService } from '../../_services/data.service';
+import { EndSessionData } from '../../../../shared/interfaces/end-session-data';
 import { Location } from '@angular/common';
 
 @Component({
@@ -8,10 +10,28 @@ import { Location } from '@angular/common';
 })
 export class KtbUserComponent {
   @Input() user?: string;
+  public formData: EndSessionData = {
+    state: '',
+    post_logout_redirect_uri: '',
+    end_session_endpoint: '',
+    id_token_hint: '',
+  };
 
-  constructor(private readonly location: Location) {}
+  constructor(
+    private readonly dataService: DataService,
+    private readonly _changeDetectorRef: ChangeDetectorRef,
+    private readonly location: Location
+  ) {}
 
-  logout(): void {
-    window.location.href = this.location.prepareExternalUrl('/logout');
+  logout(submitEvent: { target: { submit: () => void } }): void {
+    this.dataService.logout().subscribe((response) => {
+      if (response) {
+        this.formData = response;
+        this._changeDetectorRef.detectChanges();
+        submitEvent.target.submit();
+      } else {
+        window.location.href = this.location.prepareExternalUrl('/');
+      }
+    });
   }
 }

--- a/bridge/client/app/_services/api.service.ts
+++ b/bridge/client/app/_services/api.service.ts
@@ -24,6 +24,7 @@ import { KeptnService } from '../../../shared/models/keptn-service';
 import { ServiceState } from '../../../shared/models/service-state';
 import { Deployment } from '../../../shared/interfaces/deployment';
 import { IServiceRemediationInformation } from '../_interfaces/service-remediation-information';
+import { EndSessionData } from '../../../shared/interfaces/end-session-data';
 
 @Injectable({
   providedIn: 'root',
@@ -475,5 +476,9 @@ export class ApiService {
       stages,
       services,
     });
+  }
+
+  public logout(): Observable<EndSessionData | undefined> {
+    return this.http.get<EndSessionData | undefined>(`./logout`);
   }
 }

--- a/bridge/client/app/_services/api.service.ts
+++ b/bridge/client/app/_services/api.service.ts
@@ -478,7 +478,7 @@ export class ApiService {
     });
   }
 
-  public logout(): Observable<EndSessionData | undefined> {
-    return this.http.get<EndSessionData | undefined>(`./logout`);
+  public logout(): Observable<EndSessionData | null> {
+    return this.http.get<EndSessionData | null>(`./logout`);
   }
 }

--- a/bridge/client/app/_services/data.service.ts
+++ b/bridge/client/app/_services/data.service.ts
@@ -744,7 +744,7 @@ export class DataService {
     return this.apiService.getIntersectedEvent(event, eventSuffix, projectName, stages, services);
   }
 
-  public logout(): Observable<EndSessionData | undefined> {
+  public logout(): Observable<EndSessionData | null> {
     return this.apiService.logout();
   }
 }

--- a/bridge/client/app/_services/data.service.ts
+++ b/bridge/client/app/_services/data.service.ts
@@ -28,6 +28,7 @@ import { Service } from '../_models/service';
 import { Deployment } from '../_models/deployment';
 import { ServiceState } from '../_models/service-state';
 import { ServiceRemediationInformation } from '../_models/service-remediation-information';
+import { EndSessionData } from '../../../shared/interfaces/end-session-data';
 
 @Injectable({
   providedIn: 'root',
@@ -741,5 +742,9 @@ export class DataService {
     services: string[]
   ): Observable<Record<string, unknown>> {
     return this.apiService.getIntersectedEvent(event, eventSuffix, projectName, stages, services);
+  }
+
+  public logout(): Observable<EndSessionData | undefined> {
+    return this.apiService.logout();
   }
 }

--- a/bridge/server/.jest/global.d.ts
+++ b/bridge/server/.jest/global.d.ts
@@ -1,11 +1,9 @@
-import { Express } from 'express';
 import { AxiosInstance } from 'axios';
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace NodeJS {
     interface Global {
-      app: Express;
       baseUrl: string;
       axiosInstance: AxiosInstance;
       issuer?: unknown;

--- a/bridge/server/.jest/global.d.ts
+++ b/bridge/server/.jest/global.d.ts
@@ -8,6 +8,7 @@ declare global {
       app: Express;
       baseUrl: string;
       axiosInstance: AxiosInstance;
+      issuer?: unknown;
     }
   }
 }

--- a/bridge/server/.jest/setupServer.ts
+++ b/bridge/server/.jest/setupServer.ts
@@ -1,8 +1,9 @@
 import { init } from '../app';
 import Axios from 'axios';
 import https from 'https';
+import { Express } from 'express';
 
-const setupServer = async (): Promise<void> => {
+const setupServer = async (): Promise<Express> => {
   global.baseUrl = 'http://localhost/api/';
 
   global.axiosInstance = Axios.create({
@@ -16,7 +17,7 @@ const setupServer = async (): Promise<void> => {
     },
   });
 
-  global.app = await init();
+  return init();
 };
 
 export { setupServer };

--- a/bridge/server/.jest/setupServer.ts
+++ b/bridge/server/.jest/setupServer.ts
@@ -2,7 +2,7 @@ import { init } from '../app';
 import Axios from 'axios';
 import https from 'https';
 
-const setup = async (): Promise<void> => {
+const setupServer = async (): Promise<void> => {
   global.baseUrl = 'http://localhost/api/';
 
   global.axiosInstance = Axios.create({
@@ -19,4 +19,4 @@ const setup = async (): Promise<void> => {
   global.app = await init();
 };
 
-export default setup();
+export { setupServer };

--- a/bridge/server/.jest/shutdownServer.ts
+++ b/bridge/server/.jest/shutdownServer.ts
@@ -1,1 +1,0 @@
-process.exit();

--- a/bridge/server/app.ts
+++ b/bridge/server/app.ts
@@ -146,11 +146,11 @@ async function setOAUTH(): Promise<void> {
   if (!process.env.OAUTH_CLIENT_ID) {
     throw Error(`OAUTH_CLIENT_ID ${errorSuffix}`);
   }
-  if (!process.env.OAUTH_CLIENT_URL) {
+  if (!process.env.OAUTH_BASE_URL) {
     throw Error(`OAUTH_CLIENT_URL ${errorSuffix}`);
   }
 
-  await setupOAuth(app, process.env.OAUTH_DISCOVERY, process.env.OAUTH_CLIENT_ID, process.env.OAUTH_CLIENT_URL);
+  await setupOAuth(app, process.env.OAUTH_DISCOVERY, process.env.OAUTH_CLIENT_ID, process.env.OAUTH_BASE_URL);
 }
 
 async function setBasisAUTH(): Promise<void> {

--- a/bridge/server/app.ts
+++ b/bridge/server/app.ts
@@ -136,19 +136,21 @@ async function init(): Promise<Express> {
 }
 
 async function setOAUTH(): Promise<void> {
+  const errorSuffix =
+    'must be defined when oauth based login (OAUTH_ENABLED) is activated.' +
+    ' Please check your environment variables.';
+
   if (!process.env.OAUTH_DISCOVERY) {
-    throw Error(
-      'OAUTH_DISCOVERY must be defined when oauth based login (OAUTH_ENABLED) is activated.' +
-        ' Please check your environment variables.'
-    );
+    throw Error(`OAUTH_DISCOVERY ${errorSuffix}`);
   }
   if (!process.env.OAUTH_CLIENT_ID) {
-    throw Error(
-      'OAUTH_CLIENT_ID must be defined when oauth based login (OAUTH_ENABLED) is activated.' +
-        ' Please check your environment variables.'
-    );
+    throw Error(`OAUTH_CLIENT_ID ${errorSuffix}`);
   }
-  await setupOAuth(app, process.env.OAUTH_DISCOVERY, process.env.OAUTH_CLIENT_ID);
+  if (!process.env.OAUTH_CLIENT_URL) {
+    throw Error(`OAUTH_CLIENT_URL ${errorSuffix}`);
+  }
+
+  await setupOAuth(app, process.env.OAUTH_DISCOVERY, process.env.OAUTH_CLIENT_ID, process.env.OAUTH_CLIENT_URL);
 }
 
 async function setBasisAUTH(): Promise<void> {

--- a/bridge/server/global.d.ts
+++ b/bridge/server/global.d.ts
@@ -5,6 +5,7 @@ declare global {
   namespace NodeJS {
     interface Global {
       axiosInstance?: AxiosInstance;
+      issuer?: unknown;
     }
   }
 }

--- a/bridge/server/jest.config.js
+++ b/bridge/server/jest.config.js
@@ -12,7 +12,5 @@ export default {
   collectCoverage: true,
   coverageDirectory: '<rootDir>/coverage',
   setupFiles: ['<rootDir>/.jest/setEnvVars.ts'],
-  setupFilesAfterEnv: ['<rootDir>/.jest/setupServer.ts'],
-  globalTeardown: '<rootDir>/.jest/shutdownServer.ts',
   testPathIgnorePatterns: ['<rootDir>/dist', '<rootDir>/node_modules'],
 };

--- a/bridge/server/package.json
+++ b/bridge/server/package.json
@@ -24,6 +24,7 @@
     "helmet": "4.6.0",
     "memorystore": "1.6.6",
     "morgan": "1.10.0",
+    "openid-client": "^5.1.0",
     "pug": "3.0.2",
     "semver": "7.3.5",
     "yaml": "1.10.2"

--- a/bridge/server/test/bridge-info.spec.ts
+++ b/bridge/server/test/bridge-info.spec.ts
@@ -1,6 +1,11 @@
 import request from 'supertest';
+import { setupServer } from '../.jest/setupServer';
 
 describe('Test /bridgeInfo', () => {
+  beforeAll(async () => {
+    await setupServer();
+  });
+
   it('should return bridgeInfo', async () => {
     const response = await request(global.app).get('/api/bridgeInfo');
     expect(response.body).toEqual({

--- a/bridge/server/test/bridge-info.spec.ts
+++ b/bridge/server/test/bridge-info.spec.ts
@@ -1,13 +1,16 @@
 import request from 'supertest';
 import { setupServer } from '../.jest/setupServer';
+import { Express } from 'express';
 
 describe('Test /bridgeInfo', () => {
+  let app: Express;
+
   beforeAll(async () => {
-    await setupServer();
+    app = await setupServer();
   });
 
   it('should return bridgeInfo', async () => {
-    const response = await request(global.app).get('/api/bridgeInfo');
+    const response = await request(app).get('/api/bridgeInfo');
     expect(response.body).toEqual({
       bridgeVersion: 'develop',
       apiUrl: global.baseUrl,

--- a/bridge/server/test/intersect-events.spec.ts
+++ b/bridge/server/test/intersect-events.spec.ts
@@ -8,11 +8,13 @@ import {
   IntersectDeploymentTriggeredResponse,
 } from '../../shared/fixtures/traces-response.mock';
 import { IntersectEventResponse } from '../fixtures/intersect-event-response.mock';
+import { setupServer } from '../.jest/setupServer';
 
 let axiosMock: MockAdapter;
 
 describe('Test /intersectEvents', () => {
-  beforeAll(() => {
+  beforeAll(async () => {
+    await setupServer();
     axiosMock = new MockAdapter(global.axiosInstance);
   });
 

--- a/bridge/server/test/intersect-events.spec.ts
+++ b/bridge/server/test/intersect-events.spec.ts
@@ -9,12 +9,15 @@ import {
 } from '../../shared/fixtures/traces-response.mock';
 import { IntersectEventResponse } from '../fixtures/intersect-event-response.mock';
 import { setupServer } from '../.jest/setupServer';
+import { Express } from 'express';
 
 let axiosMock: MockAdapter;
 
 describe('Test /intersectEvents', () => {
+  let app: Express;
+
   beforeAll(async () => {
-    await setupServer();
+    app = await setupServer();
     axiosMock = new MockAdapter(global.axiosInstance);
   });
 
@@ -45,7 +48,7 @@ describe('Test /intersectEvents', () => {
       .reply(200, {
         events: [event1],
       });
-    const response = await request(global.app)
+    const response = await request(app)
       .post(`/api/intersectEvents`)
       .send({
         projectName: 'sockshop',
@@ -85,7 +88,7 @@ describe('Test /intersectEvents', () => {
         },
       })
       .reply(200, IntersectDeploymentFinishedResponse);
-    const response = await request(global.app).post(`/api/intersectEvents`).send({
+    const response = await request(app).post(`/api/intersectEvents`).send({
       projectName: 'sockshop',
       stages: [],
       services: [],
@@ -156,7 +159,7 @@ describe('Test /intersectEvents', () => {
           },
         ],
       });
-    const response = await request(global.app)
+    const response = await request(app)
       .post(`/api/intersectEvents`)
       .send({
         projectName: 'sockshop',
@@ -199,7 +202,7 @@ describe('Test /intersectEvents', () => {
       .reply(200, {
         events: [],
       });
-    const response = await request(global.app)
+    const response = await request(app)
       .post(`/api/intersectEvents`)
       .send({
         projectName: 'sockshop',
@@ -213,7 +216,7 @@ describe('Test /intersectEvents', () => {
   });
 
   it('should send error if projectName is missing', async () => {
-    const response = await request(global.app).post(`/api/intersectEvents`).send({
+    const response = await request(app).post(`/api/intersectEvents`).send({
       event: 'sh.keptn.event.deployment',
       eventSuffix: 'finished',
     });
@@ -221,7 +224,7 @@ describe('Test /intersectEvents', () => {
   });
 
   it('should send error if event is missing', async () => {
-    const response = await request(global.app).post(`/api/intersectEvents`).send({
+    const response = await request(app).post(`/api/intersectEvents`).send({
       projectName: 'sockshop',
       eventSuffix: 'finished',
     });
@@ -229,7 +232,7 @@ describe('Test /intersectEvents', () => {
   });
 
   it('should send error if eventSuffix is missing', async () => {
-    const response = await request(global.app).post(`/api/intersectEvents`).send({
+    const response = await request(app).post(`/api/intersectEvents`).send({
       projectName: 'sockshop',
       event: 'sh.keptn.event.deployment',
     });

--- a/bridge/server/test/oauth.spec.ts
+++ b/bridge/server/test/oauth.spec.ts
@@ -1,0 +1,217 @@
+import { CallbackParamsType, TokenSet } from 'openid-client';
+import request from 'supertest';
+import { Express, Request } from 'express';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { init } from '../app';
+
+// import { jest } from '@jest/globals';
+
+interface OAuthParameters {
+  OAUTH_CLIENT_ID: string | undefined;
+  OAUTH_BASE_URL: string | undefined;
+  OAUTH_DISCOVERY: string | undefined;
+}
+
+const authorizationUrl = `http://localhost/authorization`;
+const endSessionEndpoint = 'http://localhost/end_session';
+const idToken =
+  'myHeader.' +
+  Buffer.from(
+    JSON.stringify({
+      name: 'myName',
+    })
+  ).toString('base64');
+
+describe('Test OAuth env variables', () => {
+  it('should exit if insufficient parameters', async () => {
+    const parameters: OAuthParameters[] = [
+      {
+        OAUTH_CLIENT_ID: 'myClientID',
+        OAUTH_BASE_URL: 'http://localhost',
+        OAUTH_DISCOVERY: undefined,
+      },
+      {
+        OAUTH_CLIENT_ID: 'myClientID',
+        OAUTH_BASE_URL: undefined,
+        OAUTH_DISCOVERY: 'http://localhost/.well-known/openid-configuration',
+      },
+      {
+        OAUTH_CLIENT_ID: undefined,
+        OAUTH_BASE_URL: 'http://localhost',
+        OAUTH_DISCOVERY: 'http://localhost/.well-known/openid-configuration',
+      },
+    ];
+    for (const parameter of parameters) {
+      process.env.OAUTH_ENABLED = 'true';
+      setOrDeleteProperty(process.env, parameter, 'OAUTH_CLIENT_ID');
+      setOrDeleteProperty(process.env, parameter, 'OAUTH_BASE_URL');
+      setOrDeleteProperty(process.env, parameter, 'OAUTH_DISCOVERY');
+
+      await expect(init()).rejects.toThrowError();
+    }
+  });
+
+  it('should not register OAuth endpoints if OAuth is not enabled', async () => {
+    delete process.env.OAUTH_ENABLED;
+    process.env.OAUTH_CLIENT_ID = 'myClientID';
+    process.env.OAUTH_BASE_URL = 'http://localhost';
+    process.env.OAUTH_DISCOVERY = 'http://localhost/.well-known/openid-configuration';
+    const app = await init();
+    for (const endpoint of ['/login', '/oauth/redirect', '/login']) {
+      const response = await request(app).get(endpoint);
+      expect(response.status).toBe(500);
+    }
+  });
+});
+
+describe('Test OAuth', () => {
+  let app: Express;
+  beforeAll(async () => {
+    mockOpenId(true);
+    app = await setupOAuth();
+  });
+
+  it('should redirect to authorizationUrl', async () => {
+    const response = await request(app).get('/login');
+    const state = response.headers.location?.split('state=').pop();
+    expect(response.redirect).toBe(true);
+    expect(response.headers.location).toEqual(`${authorizationUrl}?state=${state}`);
+  });
+
+  it('should reject token gain if state is not provided', async () => {
+    await request(app).get('/login');
+    const response = await request(app).get(`/oauth/redirect?code=someCode`);
+    expect(response.headers.location).toEqual('/');
+    expect(response.headers['set-cookie']?.length ?? 0).toBe(0);
+  });
+
+  it('should reject token gain if code is not provided', async () => {
+    await request(app).get('/login');
+    const response = await request(app).get(`/oauth/redirect?state=someState`);
+    expect(response.headers.location).toEqual('/');
+    expect(response.headers['set-cookie']?.length ?? 0).toBe(0);
+  });
+
+  it('should reject token gain if state is invalid', async () => {
+    await request(app).get('/login');
+    const response = await request(app).get(`/oauth/redirect?state=invalidState?code=someCode`);
+    expect(response.headers.location).toEqual('/');
+    expect(response.headers['set-cookie']?.length ?? 0).toBe(0);
+  });
+
+  it('should authenticate successfully', async () => {
+    const { response } = await login(app);
+    expect(response.headers['set-cookie']?.[0]?.split('=')[0]).toBe('KTSESSION');
+  });
+
+  it('should not be successful if state already used', async () => {
+    const { state } = await login(app);
+    const response = await request(app).get(`/oauth/redirect?state=${state}&code=someOtherCode`);
+    expect(response.headers['set-cookie']?.length ?? 0).toBe(0);
+  });
+
+  it('should logout and return end session data', async () => {
+    const { response } = await login(app);
+    const logoutResponse = await request(app).get(`/logout`).set('Cookie', response.headers['set-cookie']);
+    const { state, ...data } = logoutResponse.body;
+    expect(state).not.toBeUndefined();
+    expect(data).toEqual({
+      id_token_hint: idToken,
+      post_logout_redirect_uri: 'http://localhost/oauth/redirect',
+      end_session_endpoint: endSessionEndpoint,
+    });
+  });
+
+  it('should return nothing on logout if not authenticated', async () => {
+    await login(app);
+    const response = await request(app).get(`/logout`);
+    expect(response.body).toBe('');
+  });
+});
+
+describe('Test OAuth logout without end session endpoint', () => {
+  let app: Express;
+
+  beforeAll(async () => {
+    mockOpenId(false);
+    app = await setupOAuth();
+  });
+
+  it('should logout and not return nothing', async () => {
+    const { response } = await login(app);
+    const logoutResponse = await request(app).get(`/logout`).set('Cookie', response.headers['set-cookie']);
+    expect(logoutResponse.body).toBe('');
+  });
+});
+
+function mockOpenId(includeEndSessionEndpoint: boolean): void {
+  // jest currently does not really support mocking of ESM
+
+  const issuer = {
+    metadata: {
+      issuer: 'http://localhost',
+      authorization_endpoint: authorizationUrl,
+      token_endpoint: 'http://localhost/token',
+      ...(includeEndSessionEndpoint && { end_session_endpoint: endSessionEndpoint }),
+    },
+  };
+
+  class MockBaseClient {
+    issuer = issuer;
+    callbackParams(req: Request): CallbackParamsType {
+      return {
+        state: req.query.state?.toString(),
+        code: req.query.code?.toString(),
+      };
+    }
+    async callback(): Promise<TokenSet> {
+      return new TokenSet({
+        access_token: 'myAccessToken',
+        token_type: 'Bearer',
+        id_token: idToken,
+        refresh_token: 'myRefreshToken',
+        scope: 'openid',
+        expires_at: new Date().getTime() / 1000 + 10 * 60 * 1000,
+      });
+    }
+
+    authorizationUrl({ state }: { state: string }): string {
+      return `${authorizationUrl}?state=${state}`;
+    }
+  }
+
+  global.issuer = {
+    discover(): Promise<unknown> {
+      return new Promise((resolve) => {
+        resolve({ ...issuer, Client: MockBaseClient });
+      });
+    },
+  };
+}
+
+async function setupOAuth(): Promise<Express> {
+  process.env.OAUTH_ENABLED = 'true';
+  process.env.OAUTH_CLIENT_ID = 'myClientID';
+  process.env.OAUTH_BASE_URL = 'http://localhost';
+  process.env.OAUTH_DISCOVERY = 'http://localhost/.well-known/openid-configuration';
+  return init();
+}
+
+function setOrDeleteProperty(
+  env: Record<string, string | undefined>,
+  parameter: OAuthParameters,
+  key: keyof OAuthParameters
+): void {
+  if (parameter[key]) {
+    process.env[key] = parameter[key];
+  } else {
+    delete process.env[key];
+  }
+}
+
+async function login(app: Express): Promise<{ state: string; response: request.Response }> {
+  const authUrlResponse = await request(app).get('/login');
+  const state = authUrlResponse.headers.location?.split('state=').pop();
+  const response = await request(app).get(`/oauth/redirect?state=${state}&code=someCode`);
+  return { state, response };
+}

--- a/bridge/server/test/project.spec.ts
+++ b/bridge/server/test/project.spec.ts
@@ -32,12 +32,15 @@ import { KeptnService } from '../../shared/models/keptn-service';
 import { ProjectDetailsResponse } from '../fixtures/project-details-response.mock';
 import { ResultTypes } from '../../shared/models/result-types';
 import { setupServer } from '../.jest/setupServer';
+import { Express } from 'express';
 
 let axiosMock: MockAdapter;
 
 describe('Test project resources', () => {
+  let app: Express;
+
   beforeAll(async () => {
-    await setupServer();
+    app = await setupServer();
     axiosMock = new MockAdapter(global.axiosInstance);
   });
 
@@ -48,7 +51,7 @@ describe('Test project resources', () => {
   it('should retrieve service names', async () => {
     const projectName = 'sockshop';
     axiosMock.onGet(`${global.baseUrl}/controlPlane/v1/project/${projectName}/stage`).reply(200, StagesResponse);
-    const response = await request(global.app).get(`/api/project/${projectName}/services`);
+    const response = await request(app).get(`/api/project/${projectName}/services`);
     expect(response.body).toEqual(['carts', 'carts-db']);
     expect(response.statusCode).toBe(200);
   });
@@ -56,7 +59,7 @@ describe('Test project resources', () => {
   it('should return an error', async () => {
     const projectName = 'sockshop';
     axiosMock.onGet(`${global.baseUrl}/controlPlane/v1/project/${projectName}/stage`).reply(502);
-    const response = await request(global.app).get(`/api/project/${projectName}/services`);
+    const response = await request(app).get(`/api/project/${projectName}/services`);
     expect(response.statusCode).toBe(502);
   });
 
@@ -117,7 +120,7 @@ describe('Test project resources', () => {
       return [200, sequence];
     });
 
-    const response = await request(global.app).get(`/api/project/${projectName}?approval=true&remediation=true`);
+    const response = await request(app).get(`/api/project/${projectName}?approval=true&remediation=true`);
     expect(response.body).toEqual(ProjectDetailsResponse);
   });
 
@@ -173,7 +176,7 @@ describe('Test project resources', () => {
       .onGet(`${global.baseUrl}/controlPlane/v1/sequence/${projectName}`)
       .reply(200, SequenceResponseURLFallback);
 
-    const response = await request(global.app).get(`/api/project/${projectName}`);
+    const response = await request(app).get(`/api/project/${projectName}`);
     expect(response.body).toEqual(ProjectDetailsResponseURLFallback);
   });
 
@@ -219,7 +222,7 @@ describe('Test project resources', () => {
       .onGet(`${global.baseUrl}/controlPlane/v1/sequence/${projectName}`)
       .reply(200, SequenceResponseEvaluationFallback);
 
-    const response = await request(global.app).get(`/api/project/${projectName}`);
+    const response = await request(app).get(`/api/project/${projectName}`);
     expect(response.body).toEqual(ProjectDetailsResponseEvaluationFallback);
   });
 });

--- a/bridge/server/test/project.spec.ts
+++ b/bridge/server/test/project.spec.ts
@@ -31,11 +31,13 @@ import {
 import { KeptnService } from '../../shared/models/keptn-service';
 import { ProjectDetailsResponse } from '../fixtures/project-details-response.mock';
 import { ResultTypes } from '../../shared/models/result-types';
+import { setupServer } from '../.jest/setupServer';
 
 let axiosMock: MockAdapter;
 
 describe('Test project resources', () => {
-  beforeAll(() => {
+  beforeAll(async () => {
+    await setupServer();
     axiosMock = new MockAdapter(global.axiosInstance);
   });
 

--- a/bridge/server/test/service-deployment.spec.ts
+++ b/bridge/server/test/service-deployment.spec.ts
@@ -20,12 +20,15 @@ import {
 } from '../fixtures/sequence-response.mock';
 import { TestUtils } from '../.jest/test.utils';
 import { setupServer } from '../.jest/setupServer';
+import { Express } from 'express';
 
 let axiosMock: MockAdapter;
 
 describe('Test /project/:projectName/deployment/:keptnContext', () => {
+  let app: Express;
+
   beforeAll(async () => {
-    await setupServer();
+    app = await setupServer();
     axiosMock = new MockAdapter(global.axiosInstance);
   });
 
@@ -47,7 +50,7 @@ describe('Test /project/:projectName/deployment/:keptnContext', () => {
       .reply(200, DeploymentTracesResponseMock);
     init(ProjectResponse, SequenceDeliveryResponseMock, projectName, keptnContext);
 
-    const response = await request(global.app).get(`/api/project/${projectName}/deployment/${keptnContext}`);
+    const response = await request(app).get(`/api/project/${projectName}/deployment/${keptnContext}`);
     expect(response.body).toEqual(ServiceDeploymentMock);
     expect(response.statusCode).toBe(200);
   });
@@ -66,7 +69,7 @@ describe('Test /project/:projectName/deployment/:keptnContext', () => {
       .reply(200, DeploymentTracesResponseMock);
     init(ProjectResponse, SequenceDeliveryResponseMock, projectName, keptnContext);
 
-    const response = await request(global.app).get(
+    const response = await request(app).get(
       `/api/project/${projectName}/deployment/${keptnContext}?fromTime=2021-10-13T10:59:45.104Z`
     );
     expect(response.body).toEqual(ServiceDeploymentWithFromTimeMock);
@@ -97,7 +100,7 @@ describe('Test /project/:projectName/deployment/:keptnContext', () => {
       .reply(200, EvaluationFinishedStagingResponse);
     init(ProjectResponse, SequenceDeliveryTillStagingResponseMock, projectName, keptnContext);
 
-    const response = await request(global.app).get(`/api/project/${projectName}/deployment/${keptnContext}`);
+    const response = await request(app).get(`/api/project/${projectName}/deployment/${keptnContext}`);
     expect(response.body).toEqual(ServiceDeploymentWithApprovalMock);
     expect(response.statusCode).toBe(200);
   });

--- a/bridge/server/test/service-deployment.spec.ts
+++ b/bridge/server/test/service-deployment.spec.ts
@@ -19,11 +19,13 @@ import {
   SequenceDeliveryTillStagingResponseMock,
 } from '../fixtures/sequence-response.mock';
 import { TestUtils } from '../.jest/test.utils';
+import { setupServer } from '../.jest/setupServer';
 
 let axiosMock: MockAdapter;
 
 describe('Test /project/:projectName/deployment/:keptnContext', () => {
-  beforeAll(() => {
+  beforeAll(async () => {
+    await setupServer();
     axiosMock = new MockAdapter(global.axiosInstance);
   });
 

--- a/bridge/server/test/service-remediations.spec.ts
+++ b/bridge/server/test/service-remediations.spec.ts
@@ -5,11 +5,13 @@ import {
   ServiceRemediationWithConfigResponse,
   ServiceRemediationWithoutConfigResponse,
 } from '../../shared/fixtures/open-remediations-response.mock';
+import { setupServer } from '../.jest/setupServer';
 
 let axiosMock: MockAdapter;
 
 describe('Test /project/:projectName/service/:serviceName/openRemediations', () => {
-  beforeAll(() => {
+  beforeAll(async () => {
+    await setupServer();
     axiosMock = new MockAdapter(global.axiosInstance);
   });
 

--- a/bridge/server/test/service-remediations.spec.ts
+++ b/bridge/server/test/service-remediations.spec.ts
@@ -6,12 +6,15 @@ import {
   ServiceRemediationWithoutConfigResponse,
 } from '../../shared/fixtures/open-remediations-response.mock';
 import { setupServer } from '../.jest/setupServer';
+import { Express } from 'express';
 
 let axiosMock: MockAdapter;
 
 describe('Test /project/:projectName/service/:serviceName/openRemediations', () => {
+  let app: Express;
+
   beforeAll(async () => {
-    await setupServer();
+    app = await setupServer();
     axiosMock = new MockAdapter(global.axiosInstance);
   });
 
@@ -23,7 +26,7 @@ describe('Test /project/:projectName/service/:serviceName/openRemediations', () 
     const projectName = 'sockshop';
     const serviceName = 'carts';
     TestUtils.mockOpenRemediations(axiosMock, projectName);
-    const response = await request(global.app).get(
+    const response = await request(app).get(
       `/api/project/${projectName}/service/${serviceName}/openRemediations?config=true`
     );
     expect(response.body).toEqual(ServiceRemediationWithConfigResponse);
@@ -34,9 +37,7 @@ describe('Test /project/:projectName/service/:serviceName/openRemediations', () 
     const projectName = 'sockshop';
     const serviceName = 'carts';
     TestUtils.mockOpenRemediations(axiosMock, projectName);
-    const response = await request(global.app).get(
-      `/api/project/${projectName}/service/${serviceName}/openRemediations`
-    );
+    const response = await request(app).get(`/api/project/${projectName}/service/${serviceName}/openRemediations`);
     expect(response.body).toEqual(ServiceRemediationWithoutConfigResponse);
     expect(response.statusCode).toBe(200);
   });

--- a/bridge/server/test/service-states.spec.ts
+++ b/bridge/server/test/service-states.spec.ts
@@ -6,11 +6,13 @@ import {
   ServiceStateQualityGatesOnlyResponse,
   ServiceStateResponse,
 } from '../../shared/fixtures/service-state-response.mock';
+import { setupServer } from '../.jest/setupServer';
 
 let axiosMock: MockAdapter;
 
 describe('Test project/:projectName/serviceStates', () => {
-  beforeAll(() => {
+  beforeAll(async () => {
+    await setupServer();
     axiosMock = new MockAdapter(global.axiosInstance);
   });
 

--- a/bridge/server/test/service-states.spec.ts
+++ b/bridge/server/test/service-states.spec.ts
@@ -7,12 +7,15 @@ import {
   ServiceStateResponse,
 } from '../../shared/fixtures/service-state-response.mock';
 import { setupServer } from '../.jest/setupServer';
+import { Express } from 'express';
 
 let axiosMock: MockAdapter;
 
 describe('Test project/:projectName/serviceStates', () => {
+  let app: Express;
+
   beforeAll(async () => {
-    await setupServer();
+    app = await setupServer();
     axiosMock = new MockAdapter(global.axiosInstance);
   });
 
@@ -34,7 +37,7 @@ describe('Test project/:projectName/serviceStates', () => {
       })
       .reply(200, OpenRemediationsResponse);
 
-    const response = await request(global.app).get(`/api/project/${projectName}/serviceStates`);
+    const response = await request(app).get(`/api/project/${projectName}/serviceStates`);
     expect(response.body).toEqual(ServiceStateResponse);
     expect(response.statusCode).toBe(200);
   });
@@ -53,7 +56,7 @@ describe('Test project/:projectName/serviceStates', () => {
       })
       .reply(200, { states: [] });
 
-    const response = await request(global.app).get(`/api/project/${projectName}/serviceStates`);
+    const response = await request(app).get(`/api/project/${projectName}/serviceStates`);
     expect(response.body).toEqual(ServiceStateQualityGatesOnlyResponse);
     expect(response.statusCode).toBe(200);
   });

--- a/bridge/server/test/task-names.spec.ts
+++ b/bridge/server/test/task-names.spec.ts
@@ -2,12 +2,15 @@ import request from 'supertest';
 import MockAdapter from 'axios-mock-adapter';
 import { ShipyardResponse } from '../fixtures/shipyard-response.mock';
 import { setupServer } from '../.jest/setupServer';
+import { Express } from 'express';
 
 let axiosMock: MockAdapter;
 
 describe('Test /project/:projectName/tasks', () => {
+  let app: Express;
+
   beforeAll(async () => {
-    await setupServer();
+    app = await setupServer();
     axiosMock = new MockAdapter(global.axiosInstance);
   });
 
@@ -20,7 +23,7 @@ describe('Test /project/:projectName/tasks', () => {
     axiosMock
       .onGet(`${global.baseUrl}/configuration-service/v1/project/${projectName}/resource/shipyard.yaml`)
       .reply(200, ShipyardResponse);
-    const response = await request(global.app).get(`/api/project/${projectName}/tasks`);
+    const response = await request(app).get(`/api/project/${projectName}/tasks`);
     expect(response.body).toEqual(['evaluation', 'deployment', 'test', 'release', 'rollback', 'get-action', 'action']);
     expect(response.statusCode).toBe(200);
   });

--- a/bridge/server/test/task-names.spec.ts
+++ b/bridge/server/test/task-names.spec.ts
@@ -1,11 +1,13 @@
 import request from 'supertest';
 import MockAdapter from 'axios-mock-adapter';
 import { ShipyardResponse } from '../fixtures/shipyard-response.mock';
+import { setupServer } from '../.jest/setupServer';
 
 let axiosMock: MockAdapter;
 
 describe('Test /project/:projectName/tasks', () => {
-  beforeAll(() => {
+  beforeAll(async () => {
+    await setupServer();
     axiosMock = new MockAdapter(global.axiosInstance);
   });
 

--- a/bridge/server/user/oauth-routes.ts
+++ b/bridge/server/user/oauth-routes.ts
@@ -147,6 +147,8 @@ function validateStateTimes(): void {
   }
 }
 
-setInterval(validateStateTimes, 5_000);
+if (process.env.NODE_ENV !== 'test') {
+  setInterval(validateStateTimes, 5_000); // could lead to missing exit of jest without using fakeTimers
+}
 
 export { oauthRouter, getRootLocation, reduceRefreshDateBy };

--- a/bridge/server/user/oauth-routes.ts
+++ b/bridge/server/user/oauth-routes.ts
@@ -1,0 +1,149 @@
+import { Request, Response, Router } from 'express';
+import { authenticateSession, getLogoutHint, isAuthenticated, removeSession } from './session';
+import { BaseClient, errors, generators, TokenSet } from 'openid-client';
+
+const prefixPath = process.env.PREFIX_PATH;
+const codeVerifiers: { [state: string]: { codeVerifier: string; nonce: string; expiresAt: number } } = {};
+
+/**
+ * Build the root path. The exact path depends on the deployment & PREFIX_PATH value
+ *
+ * If PREFIX_PATH is defined, root location is set to <PREFIX_PATH> or <PREFIX_PATH>/bridge for production environments. Otherwise, root is set to / .
+ *
+ * Redirection to / will be either handled by Nginx (ex:- generic keptn deployment) OR the Express layer (ex:- local bridge development).
+ */
+function getRootLocation(): string {
+  if (prefixPath !== undefined) {
+    return process.env.NODE_ENV === 'production' ? `${prefixPath}/bridge` : prefixPath;
+  }
+
+  return '/';
+}
+
+function oauthRouter(client: BaseClient, redirectUri: string, reduceRefreshDateSeconds: number): Router {
+  const router = Router();
+
+  /**
+   * Router level middleware for login
+   */
+  router.get('/login', async (req: Request, res: Response) => {
+    const codeVerifier = generators.codeVerifier();
+    const codeChallenge = generators.codeChallenge(codeVerifier);
+    const nonce = generators.nonce();
+    const state = generators.state();
+    codeVerifiers[state] = { codeVerifier, nonce, expiresAt: new Date().getTime() + 5 * 60_000 }; // expires in 5 minutes
+
+    const authorizationUrl = client.authorizationUrl({
+      scope: 'openid',
+      state,
+      nonce,
+      code_challenge: codeChallenge,
+      code_challenge_method: 'S256',
+    });
+
+    res.redirect(authorizationUrl);
+    return res;
+  });
+
+  /**
+   * Router level middleware for redirect handling
+   */
+  router.get('/oauth/redirect', async (req: Request, res: Response) => {
+    const params = client.callbackParams(req);
+
+    if (!params.code || !params.state) {
+      return res.redirect(getRootLocation());
+    }
+
+    const verifiers = codeVerifiers[params.state];
+    if (verifiers) {
+      delete codeVerifiers[params.state];
+      params.state = undefined;
+    } else {
+      return res.render('error', {
+        title: 'Error',
+        message: 'Error while handling request. State does not exist.',
+        location: getRootLocation(),
+      });
+    }
+
+    try {
+      const tokenSet = await client.callback(redirectUri, params, {
+        code_verifier: verifiers.codeVerifier,
+        nonce: verifiers.nonce,
+        scope: 'openid',
+      });
+      reduceRefreshDateBy(tokenSet, reduceRefreshDateSeconds);
+      await authenticateSession(req, tokenSet);
+      res.redirect(getRootLocation());
+    } catch (error) {
+      const err = error as errors.OPError | errors.RPError;
+      console.log(`Error while handling the redirect. Cause : ${err.message}`);
+
+      if (err.response?.statusCode === 403) {
+        const response = {
+          title: 'Permission denied',
+          message: '',
+        };
+        response.message =
+          (err.response.body as Record<string, string>).message ?? 'User is not allowed access the instance.';
+        return res.render('error', response);
+      } else {
+        return res.render('error', {
+          title: 'Internal error',
+          message: 'Error while handling the redirect. Please retry and check whether the problem exists.',
+          location: getRootLocation(),
+        });
+      }
+    }
+  });
+
+  /**
+   * Router level middleware for logout
+   */
+  router.get('/logout', async (req: Request, res: Response) => {
+    if (!isAuthenticated(req.session)) {
+      // Session is not authenticated, redirect to root
+      return res.redirect(getRootLocation());
+    }
+
+    let logoutUrl;
+    if (client.issuer.metadata.end_session_endpoint) {
+      logoutUrl = client.endSessionUrl({
+        id_token_hint: getLogoutHint(req),
+        state: generators.state(),
+        post_logout_redirect_uri: redirectUri,
+      });
+    } else {
+      logoutUrl = getRootLocation();
+    }
+    removeSession(req);
+    return res.redirect(logoutUrl);
+  });
+
+  return router;
+}
+
+/**
+ * Sets the expiry date x seconds before the real one
+ * @param tokenSet
+ * @param seconds
+ */
+function reduceRefreshDateBy(tokenSet: TokenSet, seconds: number): void {
+  tokenSet.expires_at = tokenSet.expires_at ? tokenSet.expires_at - seconds : undefined; // token should be refreshed x seconds earlier
+}
+
+/**
+ * Delete states created by the authentication-flow if expiry is reached
+ */
+function validateStateTimes(): void {
+  for (const key of Object.keys(codeVerifiers)) {
+    if (new Date().getTime() > codeVerifiers[key]?.expiresAt) {
+      delete codeVerifiers[key];
+    }
+  }
+}
+
+setInterval(validateStateTimes, 5_000);
+
+export { oauthRouter, getRootLocation, reduceRefreshDateBy };

--- a/bridge/server/user/oauth-routes.ts
+++ b/bridge/server/user/oauth-routes.ts
@@ -8,15 +8,14 @@ const codeVerifiers: { [state: string]: { codeVerifier: string; nonce: string; e
 /**
  * Build the root path. The exact path depends on the deployment & PREFIX_PATH value
  *
- * If PREFIX_PATH is defined, root location is set to <PREFIX_PATH> or <PREFIX_PATH>/bridge for production environments. Otherwise, root is set to / .
+ * If PREFIX_PATH is defined, root location is set to <PREFIX_PATH>/bridge. Otherwise, root is set to / .
  *
  * Redirection to / will be either handled by Nginx (ex:- generic keptn deployment) OR the Express layer (ex:- local bridge development).
  */
 function getRootLocation(): string {
   if (prefixPath !== undefined) {
-    return process.env.NODE_ENV === 'production' ? `${prefixPath}/bridge` : prefixPath;
+    return `${prefixPath}/bridge`;
   }
-
   return '/';
 }
 

--- a/bridge/server/user/oauth-routes.ts
+++ b/bridge/server/user/oauth-routes.ts
@@ -1,8 +1,9 @@
 import { Request, Response, Router } from 'express';
 import { authenticateSession, getLogoutHint, isAuthenticated, removeSession } from './session';
-import { BaseClient, errors, generators, TokenSet } from 'openid-client';
+import oClient, { BaseClient, errors, TokenSet } from 'openid-client';
 import { EndSessionData } from '../../shared/interfaces/end-session-data';
 
+const generators = oClient.generators; // else jest isn't working
 const prefixPath = process.env.PREFIX_PATH;
 const codeVerifiers: { [state: string]: { codeVerifier: string; nonce: string; expiresAt: number } } = {};
 const stateExpireMilliSeconds = 60 * 60_000; // expires in 60 minutes

--- a/bridge/server/user/oauth.ts
+++ b/bridge/server/user/oauth.ts
@@ -6,8 +6,8 @@ import { BaseClient, errors, Issuer, TokenSet } from 'openid-client';
 const refreshPromises: { [sessionId: string]: Promise<TokenSet> } = {};
 const reduceRefreshDateSeconds = 10;
 
-async function setupOAuth(app: Express, discoveryEndpoint: string, clientId: string): Promise<void> {
-  const redirectUri = `${getRootLocation()}/oauth/redirect`;
+async function setupOAuth(app: Express, discoveryEndpoint: string, clientId: string, clientUrl: string): Promise<void> {
+  const redirectUri = `${clientUrl}/oauth/redirect`;
   // Initialise session middleware
   app.use(sessionRouter(app));
   const client = await setupClient(discoveryEndpoint, clientId, redirectUri);

--- a/bridge/server/user/oauth.ts
+++ b/bridge/server/user/oauth.ts
@@ -18,7 +18,9 @@ async function setupOAuth(app: Express, discoveryEndpoint: string, clientId: str
 }
 
 async function setupClient(discoveryEndpoint: string, clientId: string, redirectUri: string): Promise<BaseClient> {
-  const ssoIssuer = await Issuer.discover(discoveryEndpoint);
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const ssoIssuer = await (global.issuer ?? Issuer).discover(discoveryEndpoint);
   const clientSecret = process.env.OAUTH_CLIENT_SECRET;
 
   if (!ssoIssuer.metadata.authorization_endpoint) {

--- a/bridge/server/user/oauth.ts
+++ b/bridge/server/user/oauth.ts
@@ -1,225 +1,86 @@
-import { Request, Response, Router } from 'express';
-import axios, { AxiosError } from 'axios';
-import { authenticateSession, getLogoutHint, isAuthenticated, removeSession } from './session';
+import { isAuthenticated, removeSession, sessionRouter } from './session';
+import { Express, NextFunction, Request, Response } from 'express';
+import { getRootLocation, oauthRouter, reduceRefreshDateBy } from './oauth-routes';
+import { BaseClient, errors, Issuer, TokenSet } from 'openid-client';
 
-const router = Router();
-const AUTHORIZATION = 'authorization';
-const AUTH_URL = 'authorization_url';
-const TOKEN_DECISION = 'token_decision';
-const USER = 'user';
-const LOGOUT_HINT = 'logout_hint';
-const RP_LOGOUT = 'rp_logout';
-const LOGOUT_URL = 'logout_path';
-const prefixPath = process.env.PREFIX_PATH;
+const refreshPromises: { [sessionId: string]: Promise<TokenSet> } = {};
+const reduceRefreshDateSeconds = 10;
 
-/**
- * Build the root path. The exact path depends on the deployment & PREFIX_PATH value
- *
- * If PREFIX_PATH is defined, root location is set to <PREFIX_PATH>/bridge. Otherwise, root is set to / .
- *
- * Redirection to / will be either handled by Nginx (ex:- generic keptn deployment) OR the Express layer (ex:- local bridge development).
- */
-function getRootLocation(): string {
-  if (prefixPath !== undefined) {
-    return `${prefixPath}/bridge`;
-  }
-
-  return '/';
+async function setupOAuth(app: Express, discoveryEndpoint: string, clientId: string): Promise<void> {
+  const redirectUri = `${getRootLocation()}/oauth/redirect`;
+  // Initialise session middleware
+  app.use(sessionRouter(app));
+  const client = await setupClient(discoveryEndpoint, clientId, redirectUri);
+  setRoutes(app, client, redirectUri);
 }
 
-async function oauthRouter(): Promise<Router> {
-  console.log('Enabling OAuth for bridge.');
+async function setupClient(discoveryEndpoint: string, clientId: string, redirectUri: string): Promise<BaseClient> {
+  const ssoIssuer = await Issuer.discover(discoveryEndpoint);
+  const clientSecret = process.env.OAUTH_CLIENT_SECRET;
 
-  const discoveryEndpoint = process.env.OAUTH_DISCOVERY;
-
-  if (!discoveryEndpoint) {
-    throw Error(
-      'OAUTH_DISCOVERY must be defined when oauth based login (OAUTH_ENABLED) is activated.' +
-        ' Please check your environment variables.'
-    );
-  }
-
-  const discoveryResp = await axios({
-    method: 'get',
-    url: discoveryEndpoint,
-  });
-
-  if (discoveryResp.status !== 200) {
-    throw Error(`Invalid oauth service discovery response. Received status : ${discoveryResp.statusText}.`);
-  }
-
-  if (!discoveryResp.data.hasOwnProperty(AUTHORIZATION)) {
+  if (!ssoIssuer.metadata.authorization_endpoint) {
     throw Error('OAuth service discovery must contain the authorization endpoint.');
   }
 
-  if (!discoveryResp.data.hasOwnProperty(TOKEN_DECISION)) {
+  if (!ssoIssuer.metadata.token_endpoint) {
     throw Error('OAuth service discovery must contain the token_decision endpoint.');
   }
 
-  const authorizationEndpoint = discoveryResp.data[AUTHORIZATION];
-  const tokenDecisionEndpoint = discoveryResp.data[TOKEN_DECISION];
+  console.log(`Using authorization endpoint : ${ssoIssuer.metadata.authorization_endpoint}.`);
+  console.log(`Using token decision endpoint : ${ssoIssuer.metadata.token_endpoint}.`);
 
-  console.log(`Using authorization endpoint : ${authorizationEndpoint}.`);
-  console.log(`Using token decision endpoint : ${tokenDecisionEndpoint}.`);
-
-  let logoutEndpoint = '';
-
-  if (discoveryResp.data.hasOwnProperty(RP_LOGOUT)) {
-    logoutEndpoint = discoveryResp.data[RP_LOGOUT];
-    console.log(`RP logout is supported by OAuth service. Using logout endpoint : ${logoutEndpoint}.`);
+  if (ssoIssuer.metadata.end_session_endpoint) {
+    console.log(
+      `RP logout is supported by OAuth service. Using logout endpoint : ${ssoIssuer.metadata.end_session_endpoint}.`
+    );
   }
 
-  /**
-   * Router level middleware for login
-   */
-  router.get('/login', async (req: Request, res: Response) => {
-    let authResponse;
-    try {
-      authResponse = await axios({
-        method: 'get',
-        url: authorizationEndpoint,
-      });
-    } catch (error) {
-      const err = error as AxiosError;
-      console.log(`Error while handling the login request. Cause : ${err.message}`);
-      return res.render('error', {
-        title: 'Internal error',
-        message: 'Error while handling the login request.',
-        location: getRootLocation(),
-      });
-    }
-
-    if (!authResponse.data.hasOwnProperty(AUTH_URL)) {
-      return res.render('error', {
-        title: 'Invalid state',
-        message: 'Failure to obtain login details.',
-        location: getRootLocation(),
-      });
-    }
-
-    res.redirect(authResponse.data[AUTH_URL]);
-    return res;
+  return new ssoIssuer.Client({
+    client_id: clientId,
+    ...(clientSecret && { client_secret: clientSecret }),
+    redirect_uris: [redirectUri],
+    response_types: ['code'],
+    token_endpoint_auth_method: clientSecret ? 'client_secret_basic' : 'none',
+    id_token_signed_response_alg: process.env.OAUTH_ID_TOKEN_ALG || 'RS256',
   });
-
-  /**
-   * Router level middleware for redirect handling
-   */
-  router.get('/oauth/redirect', async (req: Request, res: Response) => {
-    const authCode = req.query.code;
-    const state = req.query.state;
-
-    if (authCode === undefined || state === undefined) {
-      return res.redirect(getRootLocation());
-    }
-
-    const tokensPayload = {
-      code: authCode,
-      state,
-    };
-
-    let tokenDecision;
-
-    try {
-      tokenDecision = await axios({
-        method: 'post',
-        url: tokenDecisionEndpoint,
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        data: tokensPayload,
-      });
-    } catch (error) {
-      const err = error as AxiosError;
-      console.log(`Error while handling the redirect. Cause : ${err.message}`);
-
-      if (err.response !== undefined && err.response.status === 403) {
-        const response = {
-          title: 'Permission denied',
-          message: '',
-        };
-
-        if (err.response.data.hasOwnProperty('message')) {
-          response.message = err.response.data.message;
-        } else {
-          response.message = 'User is not allowed access the instance.';
-        }
-
-        return res.render('error', response);
-      } else {
-        return res.render('error', {
-          title: 'Internal error',
-          message: 'Error while handling the redirect. Please retry and check whether the problem exists.',
-          location: getRootLocation(),
-        });
-      }
-    }
-
-    authenticateSession(req, tokenDecision.data[USER], tokenDecision.data[LOGOUT_HINT], () =>
-      res.redirect(getRootLocation())
-    );
-  });
-
-  /**
-   * Router level middleware for logout
-   */
-  router.get('/logout', async (req: Request, res: Response) => {
-    if (!isAuthenticated(req)) {
-      // Session is not authenticated, redirect to root
-      return res.redirect(getRootLocation());
-    }
-
-    if (!logoutEndpoint) {
-      removeSession(req);
-      return res.redirect(getRootLocation());
-    }
-
-    const hint = getLogoutHint(req);
-    removeSession(req);
-
-    let logoutResponse;
-
-    try {
-      logoutResponse = await axios({
-        method: 'post',
-        url: logoutEndpoint,
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        data: {
-          logout_hint: hint,
-        },
-      });
-    } catch (error) {
-      const err = error as AxiosError;
-      console.log(`Error while handling the RP logout. Cause : ${err.message}`);
-
-      return res.render('error', {
-        title: 'Internal error',
-        message:
-          'Logout was successfully handled.' +
-          ' However, there was an error while redirecting you to the correct endpoint.',
-        location: getRootLocation(),
-        locationMessage: 'Home',
-      });
-    }
-
-    if (!logoutResponse.data.hasOwnProperty(LOGOUT_URL)) {
-      console.log('Invalid response from rp_logout.');
-      return res.render('error', {
-        title: 'Internal error',
-        message:
-          'Logout was successfully handled.' +
-          ' However, there was an error while redirecting you to the correct endpoint.',
-        location: getRootLocation(),
-        locationMessage: 'Home',
-      });
-    }
-
-    return res.redirect(logoutResponse.data[LOGOUT_URL]);
-  });
-
-  return router;
 }
 
-const authRouter = oauthRouter();
-export { authRouter as oauthRouter };
+function setRoutes(app: Express, client: BaseClient, redirectUri: string): void {
+  // Initializing OAuth middleware.
+  app.use(oauthRouter(client, redirectUri, reduceRefreshDateSeconds));
+  // Authentication filter for API requests
+  app.use('/api', async (req: Request, resp: Response, next: NextFunction) => {
+    if (!isAuthenticated(req.session)) {
+      return next({ response: { status: 401 } });
+    } else {
+      const tokenSet = new TokenSet(req.session.tokenSet);
+      if (tokenSet.expired()) {
+        refreshPromises[req.session.id] ??= client.refresh(tokenSet).then((token) => {
+          reduceRefreshDateBy(token, reduceRefreshDateSeconds);
+          return token;
+        });
+        try {
+          req.session.tokenSet = await refreshPromises[req.session.id];
+          req.session.save((error) => {
+            if (error) {
+              console.log(`Error while saving tokenSet. Cause: ${error?.message}`);
+            }
+            delete refreshPromises[req.session.id];
+            next();
+          });
+        } catch (error) {
+          const err = error as errors.OPError | errors.RPError;
+          console.error(`Renewal of access_token did not work. Cause ${err.message}`);
+
+          delete refreshPromises[req.session.id];
+          removeSession(req);
+          resp.redirect(getRootLocation());
+        }
+      } else {
+        return next();
+      }
+    }
+  });
+}
+
+export { setupOAuth };

--- a/bridge/server/user/oauth.ts
+++ b/bridge/server/user/oauth.ts
@@ -6,8 +6,11 @@ import { BaseClient, errors, Issuer, TokenSet } from 'openid-client';
 const refreshPromises: { [sessionId: string]: Promise<TokenSet> } = {};
 const reduceRefreshDateSeconds = 10;
 
-async function setupOAuth(app: Express, discoveryEndpoint: string, clientId: string, clientUrl: string): Promise<void> {
-  const redirectUri = `${clientUrl}/oauth/redirect`;
+async function setupOAuth(app: Express, discoveryEndpoint: string, clientId: string, baseUrl: string): Promise<void> {
+  let prefix = getRootLocation();
+  baseUrl = baseUrl.endsWith('/') ? baseUrl.substring(0, baseUrl.length - 1) : baseUrl;
+  prefix = prefix.endsWith('/') ? prefix : `${prefix}/`;
+  const redirectUri = `${baseUrl}${prefix}oauth/redirect`;
   // Initialise session middleware
   app.use(sessionRouter(app));
   const client = await setupClient(discoveryEndpoint, clientId, redirectUri);

--- a/bridge/server/user/session.ts
+++ b/bridge/server/user/session.ts
@@ -79,11 +79,12 @@ function authenticateSession(req: Request, tokenSet: TokenSet): Promise<void> {
   return new Promise((resolve) => {
     // Regenerate session for the successful login
     req.session.regenerate(() => {
-      const userIdentifier = process.env.OAUTH_NAME_PROPERTY || 'name';
+      const userIdentifier = process.env.OAUTH_NAME_PROPERTY;
       const claims = tokenSet.claims();
       req.session.authenticated = true;
       req.session.tokenSet = tokenSet;
-      req.session.principal = (claims[userIdentifier] as string | undefined) || getUserIdentifier(claims);
+      req.session.principal =
+        (userIdentifier ? (claims[userIdentifier] as string | undefined) : undefined) || getUserIdentifier(claims);
 
       resolve();
     });

--- a/bridge/server/user/session.ts
+++ b/bridge/server/user/session.ts
@@ -91,7 +91,7 @@ function getUserIdentifier(claims: IdTokenClaims): string | undefined {
  * Returns the current principal if session is authenticated. Otherwise returns undefined
  */
 function getCurrentPrincipal(req: Request): string | undefined {
-  return req.session.principal;
+  return req.session?.principal;
 }
 
 /**

--- a/bridge/server/yarn.lock
+++ b/bridge/server/yarn.lock
@@ -3445,6 +3445,11 @@ jest@27.4.3:
     import-local "^3.0.2"
     jest-cli "^27.4.3"
 
+jose@^4.1.4:
+  version "4.3.7"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-4.3.7.tgz#5000e4a2d41ae411a5abdd11e6baf63fc2973a69"
+  integrity sha512-S7Xfsy8nN9Iw/AZxk+ZxEbd5ImIwJPM0TfAo8zI8FF+3lidQ2yiK4dqzsaPKSbZD0woNVSY0KCql6rlKc5V7ug==
+
 js-stringify@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/js-stringify/-/js-stringify-1.0.2.tgz#1736fddfd9724f28a3682adc6230ae7e4e9679db"
@@ -3822,6 +3827,11 @@ object-assign@^4.1.1:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
+object-hash@^2.0.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.2.0.tgz#5ad518581eefc443bd763472b8ff2e9c2c0d54a5"
+  integrity sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==
+
 object-inspect@^1.9.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.11.0.tgz#9dceb146cedd4148a0d9e51ab88d34cf509922b1"
@@ -3841,6 +3851,11 @@ object.assign@^4.1.0:
     define-properties "^1.1.3"
     has-symbols "^1.0.1"
     object-keys "^1.1.1"
+
+oidc-token-hash@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/oidc-token-hash/-/oidc-token-hash-5.0.1.tgz#ae6beec3ec20f0fd885e5400d175191d6e2f10c6"
+  integrity sha512-EvoOtz6FIEBzE+9q253HsLCVRiK/0doEJ2HCvvqMQb3dHZrP3WlJKYtJ55CRTw4jmYomzH4wkPuCj/I3ZvpKxQ==
 
 on-finished@~2.3.0:
   version "2.3.0"
@@ -3867,6 +3882,16 @@ onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+openid-client@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/openid-client/-/openid-client-5.1.0.tgz#e9a22574c0cf1ce64555b96a4670e33593cc276a"
+  integrity sha512-gTTNQ8SzfoWIeSeVkYGMDzaHHx06wRnJRYCyG1xrkGu9Xww7X4Uz4fFEJ19KQRee4xttb38GIcxACRxQVChegg==
+  dependencies:
+    jose "^4.1.4"
+    lru-cache "^6.0.0"
+    object-hash "^2.0.1"
+    oidc-token-hash "^5.0.1"
 
 optionator@^0.8.1:
   version "0.8.3"

--- a/bridge/shared/interfaces/end-session-data.ts
+++ b/bridge/shared/interfaces/end-session-data.ts
@@ -1,0 +1,9 @@
+export interface EndSessionParameters {
+  id_token_hint: string;
+  state: string;
+  post_logout_redirect_uri: string;
+}
+
+export interface EndSessionData extends EndSessionParameters {
+  end_session_endpoint: string;
+}

--- a/installer/manifests/keptn/charts/control-plane/templates/core.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/core.yaml
@@ -231,6 +231,19 @@ spec:
               value: "{{ .Values.bridge.oauth.enabled }}"
             - name: OAUTH_DISCOVERY
               value: "{{ .Values.bridge.oauth.discovery }}"
+            # Base URL e.g. https://example.com/
+            - name: OAUTH_BASE_URL
+              value: "{{ .Values.bridge.oauth.baseUrl }}"
+            - name: OAUTH_CLIENT_ID
+              value: "{{ .Values.bridge.oauth.clientID }}"
+            - name: OAUTH_CLIENT_SECRET
+              value: "{{ .Values.bridge.oauth.clientSecret }}"
+            # Token algorithm which is used for the ID token e.g. "RS256"
+            - name: OAUTH_ID_TOKEN_ALG
+              value: "{{ .Values.bridge.oauth.IDTokenAlg }}"
+            # User identifier property inside the ID token e.g. "name" or "email"
+            - name: OAUTH_NAME_PROPERTY
+              value: "{{ .Values.bridge.oauth.userIdentifier }}"
             - name: SECURE_COOKIE
               value: "{{ .Values.bridge.oauth.secureCookie }}"
             # Session cookie timeout in minutes

--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -69,6 +69,11 @@ bridge:
     secureCookie: false
     trustProxy: ""
     sessionTimeoutMin: ""
+    baseUrl: ""
+    clientID: ""
+    clientSecret: ""
+    IDTokenAlg: ""
+    userIdentifier: ""
 
 distributor:
   metadata:


### PR DESCRIPTION
Closes #6076
Closes #6077 

## This PR
- adds support to login via a custom OpenID provider

### How to test
The following environment variables have to be set
- `OAUTH_ENABLED`: true
- `OAUTH_BASE_URL`: e.g. http://localhost:3000 or http://myBridgeInstallation.com
- `OAUTH_DISCOVERY`: https://api.login.yahoo.com/.well-known/openid-configuration
- `OAUTH_CLIENT_ID`: myClientID
- `OAUTH_CLIENT_SECRET` (optional): myClientSecret
- `OAUTH_ID_TOKEN_ALG` (optional): myAlg (e.g. `ES256`). Default is `RS256`
- `OAUTH_NAME_PROPERTY` (optional): The property of the ID token that identifies the user (e.g. `username`). Default is `name`
![image](https://user-images.githubusercontent.com/11599148/145979592-cb5506ab-a908-4fea-9789-cdb79b5ca567.png)


Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>