### PR TITLE
feat(bridge): Use textarea for webhook url config and adapt styles (#5706)

### DIFF
--- a/bridge/client/app/_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component.html
+++ b/bridge/client/app/_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component.html
@@ -3,24 +3,26 @@
   <ng-container *ngIf="data$ | async as data; else loading">
     <h2>{{ editMode ? 'Edit' : 'Create' }} subscription</h2>
     <form [formGroup]="subscriptionForm">
-      <dt-form-field *ngIf="!isWebhookService" uitestid="edit-subscription-field-isGlobal">
-        <ng-container [ngTemplateOutlet]="data.subscription.hasFilter() ? showOverlay : isGlobalCheckbox">
-        </ng-container>
+      <div class="settings-section">
+        <dt-form-field *ngIf="!isWebhookService" uitestid="edit-subscription-field-isGlobal">
+          <ng-container [ngTemplateOutlet]="data.subscription.hasFilter() ? showOverlay : isGlobalCheckbox">
+          </ng-container>
 
-        <ng-template #showOverlay>
-          <div [dtOverlay]="projectFilterOverlay" class="checkbox-container">
-            <ng-container *ngTemplateOutlet="isGlobalCheckbox"></ng-container>
-          </div>
-          <ng-template #projectFilterOverlay>
-            It is not allowed to have filters for a subscription that is active for all projects
+          <ng-template #showOverlay>
+            <div [dtOverlay]="projectFilterOverlay" class="checkbox-container">
+              <ng-container *ngTemplateOutlet="isGlobalCheckbox"></ng-container>
+            </div>
+            <ng-template #projectFilterOverlay>
+              It is not allowed to have filters for a subscription that is active for all projects
+            </ng-template>
           </ng-template>
-        </ng-template>
-        <ng-template #isGlobalCheckbox>
-          <dt-checkbox formControlName="isGlobal" uitestid="ktb-modify-subscription-project-checkbox"
-            >Use for all projects</dt-checkbox
-          >
-        </ng-template>
-      </dt-form-field>
+          <ng-template #isGlobalCheckbox>
+            <dt-checkbox formControlName="isGlobal" uitestid="ktb-modify-subscription-project-checkbox"
+              >Use for all projects</dt-checkbox
+            >
+          </ng-template>
+        </dt-form-field>
+      </div>
       <div class="settings-section" fxLayout="row">
         <dt-form-field uitestid="edit-subscription-field-task" class="mr-2">
           <dt-label class="required">Task</dt-label>

--- a/bridge/client/app/_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component.html
+++ b/bridge/client/app/_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component.html
@@ -2,109 +2,106 @@
 <div class="container">
   <ng-container *ngIf="data$ | async as data; else loading">
     <h2>{{ editMode ? 'Edit' : 'Create' }} subscription</h2>
-    <form [formGroup]="subscriptionForm" fxLayout="row" fxLayoutAlign=" end">
-      <div fxLayout="column" fxLayoutGap="10px">
-        <dt-form-field *ngIf="!isWebhookService" uitestid="edit-subscription-field-isGlobal">
-          <ng-container [ngTemplateOutlet]="data.subscription.hasFilter() ? showOverlay : isGlobalCheckbox">
-          </ng-container>
+    <form [formGroup]="subscriptionForm">
+      <dt-form-field *ngIf="!isWebhookService" uitestid="edit-subscription-field-isGlobal">
+        <ng-container [ngTemplateOutlet]="data.subscription.hasFilter() ? showOverlay : isGlobalCheckbox">
+        </ng-container>
 
-          <ng-template #showOverlay>
-            <div [dtOverlay]="projectFilterOverlay" class="checkbox-container">
-              <ng-container *ngTemplateOutlet="isGlobalCheckbox"></ng-container>
-            </div>
-            <ng-template #projectFilterOverlay>
-              It is not allowed to have filters for a subscription that is active for all projects
-            </ng-template>
+        <ng-template #showOverlay>
+          <div [dtOverlay]="projectFilterOverlay" class="checkbox-container">
+            <ng-container *ngTemplateOutlet="isGlobalCheckbox"></ng-container>
+          </div>
+          <ng-template #projectFilterOverlay>
+            It is not allowed to have filters for a subscription that is active for all projects
           </ng-template>
-          <ng-template #isGlobalCheckbox>
-            <dt-checkbox formControlName="isGlobal" uitestid="ktb-modify-subscription-project-checkbox"
-              >Use for all projects</dt-checkbox
-            >
-          </ng-template>
+        </ng-template>
+        <ng-template #isGlobalCheckbox>
+          <dt-checkbox formControlName="isGlobal" uitestid="ktb-modify-subscription-project-checkbox"
+            >Use for all projects</dt-checkbox
+          >
+        </ng-template>
+      </dt-form-field>
+      <div class="settings-section" fxLayout="row">
+        <dt-form-field uitestid="edit-subscription-field-task" class="mr-2">
+          <dt-label class="required">Task</dt-label>
+          <dt-select
+            formControlName="taskPrefix"
+            class="mr-2 item"
+            placeholder="Choose your task"
+            aria-label="Choose your task"
+            (selectionChange)="selectedTaskChanged(data.project.projectName, data.subscription)"
+          >
+            <dt-option *ngFor="let task of data.taskNames" [value]="task" [textContent]="task"></dt-option>
+          </dt-select>
         </dt-form-field>
-        <div fxLayout="row" fxLayoutGap="5px">
-          <dt-form-field uitestid="edit-subscription-field-task">
-            <dt-label class="required">Task</dt-label>
-            <dt-select
-              formControlName="taskPrefix"
-              class="mr-2 item"
-              placeholder="Choose your task"
-              aria-label="Choose your task"
-              (selectionChange)="selectedTaskChanged(data.project.projectName, data.subscription)"
-            >
-              <dt-option *ngFor="let task of data.taskNames" [value]="task" [textContent]="task"></dt-option>
-            </dt-select>
-          </dt-form-field>
-          <dt-form-field uitestid="edit-subscription-field-suffix">
-            <dt-label class="required">Task suffix</dt-label>
-            <dt-select
-              formControlName="taskSuffix"
-              class="mr-2 item"
-              placeholder="Choose your task suffix"
-              aria-label="Choose your task suffix"
-              (selectionChange)="selectedTaskChanged(data.project.projectName, data.subscription)"
-            >
-              <dt-option
-                *ngFor="let suffix of suffixes"
-                [value]="suffix.value"
-                [textContent]="suffix.displayValue"
-              ></dt-option>
-            </dt-select>
-          </dt-form-field>
-        </div>
-        <div>
-          <label>Filter by stages and services</label>
-          <dt-filter-field
-            [dataSource]="_dataSource"
-            [filters]="
-              data.subscription.getFilter(_dataSource.isAutocomplete(_dataSource.data) ? _dataSource.data : undefined)
-            "
-            (filterChanges)="
-              data.subscription.filterChanged($event, data.project.projectName);
-              subscriptionFilterChanged(data.subscription, data.project.projectName)
-            "
-            class="mb-2"
-            aria-label="Filter by stage and service"
-            clearAllLabel="Clear all"
-            uitestid="edit-subscription-field-filterStageService"
-          ></dt-filter-field>
-          <dt-error *ngIf="data.subscription.filter.services?.length && !data.subscription.filter.stages?.length"
-            >If you add a service you must add a stage</dt-error
+        <dt-form-field uitestid="edit-subscription-field-suffix">
+          <dt-label class="required">Task suffix</dt-label>
+          <dt-select
+            formControlName="taskSuffix"
+            class="mr-2 item"
+            placeholder="Choose your task suffix"
+            aria-label="Choose your task suffix"
+            (selectionChange)="selectedTaskChanged(data.project.projectName, data.subscription)"
           >
-        </div>
-        <ktb-payload-viewer
-          [buttonTitle]="'Show example payload'"
-          [type]="getSelectedTask()"
-          [project]="data.project.projectName"
-          [stage]="data.subscription.getFirstStage()"
-          [service]="data.subscription.getFirstService()"
-        ></ktb-payload-viewer>
-        <ktb-webhook-settings
-          *ngIf="isWebhookService"
-          [(webhook)]="data.webhook"
-          [secrets]="data.webhookSecrets"
-          [eventPayload]="eventPayload"
-          [eventType]="taskSuffixControl.value"
-          (validityChanged)="webhookFormValidityChanged($event)"
-        ></ktb-webhook-settings>
-        <div fxLayout="row">
-          <button
-            class="mr-2"
-            uitestid="updateSubscriptionButton"
-            [disabled]="!isFormValid(data.subscription)"
-            (click)="updateSubscription(data.project.projectName, data.integrationId, data.subscription, data.webhook)"
-            dt-button
-          >
-            <dt-loading-spinner
-              *ngIf="updating"
-              aria-label="{{ editMode ? 'Updating' : 'Creating' }} subscription"
-            ></dt-loading-spinner>
-            {{ editMode ? 'Update' : 'Create' }} subscription
-          </button>
-          <button type="reset" dt-button variant="secondary" [routerLink]="editMode ? '../../../' : '../../'">
-            Cancel
-          </button>
-        </div>
+            <dt-option
+              *ngFor="let suffix of suffixes"
+              [value]="suffix.value"
+              [textContent]="suffix.displayValue"
+            ></dt-option>
+          </dt-select>
+        </dt-form-field>
+      </div>
+      <div class="settings-section">
+        <label>Filter by stages and services</label>
+        <dt-filter-field
+          [dataSource]="_dataSource"
+          [filters]="
+            data.subscription.getFilter(_dataSource.isAutocomplete(_dataSource.data) ? _dataSource.data : undefined)
+          "
+          (filterChanges)="
+            data.subscription.filterChanged($event, data.project.projectName);
+            subscriptionFilterChanged(data.subscription, data.project.projectName)
+          "
+          aria-label="Filter by stage and service"
+          clearAllLabel="Clear all"
+          uitestid="edit-subscription-field-filterStageService"
+        ></dt-filter-field>
+        <dt-error *ngIf="data.subscription.filter.services?.length && !data.subscription.filter.stages?.length"
+          >If you add a service you must add a stage</dt-error
+        >
+      </div>
+      <ktb-payload-viewer
+        [buttonTitle]="'Show example payload'"
+        [type]="getSelectedTask()"
+        [project]="data.project.projectName"
+        [stage]="data.subscription.getFirstStage()"
+        [service]="data.subscription.getFirstService()"
+      ></ktb-payload-viewer>
+      <ktb-webhook-settings
+        *ngIf="isWebhookService"
+        [(webhook)]="data.webhook"
+        [secrets]="data.webhookSecrets"
+        [eventPayload]="eventPayload"
+        [eventType]="taskSuffixControl.value"
+        (validityChanged)="webhookFormValidityChanged($event)"
+      ></ktb-webhook-settings>
+      <div>
+        <button
+          class="mr-2"
+          uitestid="updateSubscriptionButton"
+          [disabled]="!isFormValid(data.subscription)"
+          (click)="updateSubscription(data.project.projectName, data.integrationId, data.subscription, data.webhook)"
+          dt-button
+        >
+          <dt-loading-spinner
+            *ngIf="updating"
+            aria-label="{{ editMode ? 'Updating' : 'Creating' }} subscription"
+          ></dt-loading-spinner>
+          {{ editMode ? 'Update' : 'Create' }} subscription
+        </button>
+        <button type="reset" dt-button variant="secondary" [routerLink]="editMode ? '../../../' : '../../'">
+          Cancel
+        </button>
       </div>
     </form>
     <div class="mt-2 required-info">fields are required</div>

--- a/bridge/client/app/_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component.html
+++ b/bridge/client/app/_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component.html
@@ -23,7 +23,7 @@
           </ng-template>
         </dt-form-field>
       </div>
-      <div class="settings-section" fxLayout="row">
+      <div class="settings-section column-2" fxLayout="row">
         <dt-form-field uitestid="edit-subscription-field-task" class="mr-2">
           <dt-label class="required">Task</dt-label>
           <dt-select

--- a/bridge/client/app/_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component.scss
+++ b/bridge/client/app/_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component.scss
@@ -9,3 +9,7 @@
 .settings-section {
   margin-bottom: 2em;
 }
+
+.settings-section:first-of-type > .dt-form-field {
+  width: 50%;
+}

--- a/bridge/client/app/_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component.scss
+++ b/bridge/client/app/_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component.scss
@@ -5,3 +5,7 @@
 ::ng-deep .dt-form-field-disabled .dt-form-field-infix {
   height: 22px;
 }
+
+.settings-section {
+  margin-bottom: 2em;
+}

--- a/bridge/client/app/_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component.scss
+++ b/bridge/client/app/_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component.scss
@@ -13,3 +13,7 @@
 .settings-section:first-of-type > .dt-form-field {
   width: 50%;
 }
+
+form > div:last-of-type {
+  margin-top: 2em;
+}

--- a/bridge/client/app/_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component.scss
+++ b/bridge/client/app/_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component.scss
@@ -10,10 +10,6 @@
   margin-bottom: 2em;
 }
 
-.settings-section:first-of-type > .dt-form-field {
-  width: 50%;
-}
-
 form > div:last-of-type {
   margin-top: 2em;
 }

--- a/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.html
+++ b/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.html
@@ -51,7 +51,7 @@
       </div>
     </dt-form-field>
   </div>
-  <div>
+  <div class="settings-section">
     <p>Custom headers</p>
     <button
       type="button"
@@ -69,13 +69,13 @@
   <div formArrayName="header" class="settings-section">
     <ng-container *ngFor="let headerGroup of headerControls; let i = index">
       <form [formGroup]="headerGroup">
-        <div class="mb-1" fxLayout="row" fxLayoutAlign="start end">
+        <div class="mb-2" fxLayout="row" fxLayoutAlign="start end">
           <dt-form-field class="mr-2" uitestid="edit-webhook-field-headerName">
             <dt-label class="required">Name</dt-label>
             <input formControlName="name" type="text" dtInput placeholder="e.g. Content-Type" autocomplete="false" />
             <dt-error>Must not be empty</dt-error>
           </dt-form-field>
-          <dt-form-field uitestid="edit-webhook-field-headerValue">
+          <dt-form-field class="mr-2" uitestid="edit-webhook-field-headerValue">
             <dt-label class="required">Value</dt-label>
             <input
               #headerInput

--- a/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.html
+++ b/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.html
@@ -1,7 +1,7 @@
 <h2>Webhook configuration</h2>
 <form class="mb-2" (input)="onWebhookFormChange()" [formGroup]="webhookConfigForm" id="webhook-config-form">
-  <div class="mb-1" fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="15px">
-    <dt-form-field fxFlex="160px" uitestid="edit-webhook-field-method">
+  <div class="settings-section" fxLayout="row" fxLayoutAlign="start stretch">
+    <dt-form-field uitestid="edit-webhook-field-method">
       <dt-label class="required">Request Method</dt-label>
       <dt-select
         (selectionChange)="onWebhookFormChange()"
@@ -14,10 +14,19 @@
       </dt-select>
       <dt-error *ngIf="getFormControl('method').errors?.required">Method must not be empty</dt-error>
     </dt-form-field>
-
-    <dt-form-field fxFlex="calc(100% - 175px)" uitestid="edit-webhook-field-url">
+  </div>
+  <div class="settings-section">
+    <dt-form-field class="text-area" fxFlex="calc(100% - 175px)" uitestid="edit-webhook-field-url">
       <dt-label class="required">URL</dt-label>
-      <input #urlInput formControlName="url" dtInput placeholder="URL" />
+      <textarea
+        #urlInput
+        formControlName="url"
+        placeholder="https://keptn.sh/"
+        dtInput
+        cols="60"
+        rows="1"
+        class="resize-vertical"
+      ></textarea>
       <dt-error *ngIf="getFormControl('url').errors?.required">URL must not be empty</dt-error>
       <dt-error *ngIf="getFormControl('url').errors?.url">URL must start with http(s)://</dt-error>
       <div dtSuffix uitestid="event-url">
@@ -42,7 +51,7 @@
       </div>
     </dt-form-field>
   </div>
-  <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="15px">
+  <div>
     <p>Custom headers</p>
     <button
       type="button"
@@ -57,11 +66,11 @@
       Add custom header
     </button>
   </div>
-  <div formArrayName="header">
+  <div formArrayName="header" class="settings-section">
     <ng-container *ngFor="let headerGroup of headerControls; let i = index">
       <form [formGroup]="headerGroup">
-        <div class="mb-1" fxLayout="row" fxLayoutAlign="start end" fxLayoutGap="15px">
-          <dt-form-field uitestid="edit-webhook-field-headerName">
+        <div class="mb-1" fxLayout="row" fxLayoutAlign="start end">
+          <dt-form-field class="mr-2" uitestid="edit-webhook-field-headerName">
             <dt-label class="required">Name</dt-label>
             <input formControlName="name" type="text" dtInput placeholder="e.g. Content-Type" autocomplete="false" />
             <dt-error>Must not be empty</dt-error>
@@ -114,10 +123,17 @@
       </form>
     </ng-container>
   </div>
-  <div class="mb-1" fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="15px">
+  <div class="settings-section">
     <dt-form-field class="text-area" uitestid="edit-webhook-field-payload">
       <dt-label>Custom payload</dt-label>
-      <textarea #payloadInput class="resize-textarea" formControlName="payload" dtInput cols="60" rows="5"></textarea>
+      <textarea
+        #payloadInput
+        class="resize-vertical code"
+        formControlName="payload"
+        dtInput
+        cols="60"
+        rows="5"
+      ></textarea>
       <dt-error>Payload must not be empty</dt-error>
       <div dtSuffix uitestid="event-payload">
         <ng-container
@@ -141,14 +157,14 @@
       </div>
     </dt-form-field>
   </div>
-  <div class="mb-1" fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="15px">
+  <div class="settings-section">
     <dt-form-field uitestid="edit-webhook-field-proxy">
       <dt-label>Proxy</dt-label>
       <input formControlName="proxy" type="url" dtInput placeholder="Proxy" />
       <dt-error *ngIf="getFormControl('proxy').errors?.url">URL must start with http(s)://</dt-error>
     </dt-form-field>
   </div>
-  <div class="mb-1" fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="15px">
+  <div class="settings-section" fxLayout="row" fxLayoutAlign="start center">
     <dt-form-field uitestid="edit-webhook-field-sendFinished" class="send-finished-input">
       <dt-label>Send finished event</dt-label>
       <dt-radio-group name="sendFinished" formControlName="sendFinished" (change)="onWebhookFormChange()">

--- a/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.html
+++ b/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.html
@@ -69,7 +69,7 @@
   <div formArrayName="header" class="settings-section">
     <ng-container *ngFor="let headerGroup of headerControls; let i = index">
       <form [formGroup]="headerGroup">
-        <div class="mb-2" fxLayout="row" fxLayoutAlign="start end">
+        <div class="mb-3" fxLayout="row" fxLayoutAlign="start end">
           <dt-form-field class="mr-2" uitestid="edit-webhook-field-headerName">
             <dt-label class="required">Name</dt-label>
             <input formControlName="name" type="text" dtInput placeholder="e.g. Content-Type" autocomplete="false" />

--- a/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.scss
+++ b/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.scss
@@ -41,3 +41,7 @@
 h2 {
   margin-top: 2em;
 }
+
+.settings-section:first-of-type .dt-form-field {
+  width: calc(50% - 0.2em);
+}

--- a/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.scss
+++ b/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.scss
@@ -20,7 +20,7 @@
 }
 
 ::ng-deep {
-  .dt-form-field.text-area {
+  .dt-form-field {
     .dt-form-field-suffix {
       align-items: start;
       position: absolute;
@@ -36,6 +36,10 @@
 
 .settings-section {
   margin-bottom: 2em;
+
+  &:last-of-type {
+    margin-bottom: 0;
+  }
 }
 
 h2 {

--- a/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.scss
+++ b/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.scss
@@ -3,6 +3,7 @@
 
 .resize-vertical {
   resize: vertical;
+  min-height: 33px;
 }
 
 .code {

--- a/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.scss
+++ b/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.scss
@@ -1,22 +1,11 @@
 @import '../../../variables';
 @import '~@dynatrace/barista-components/core/src/style/variables';
 
-#webhook-config-form {
-  > div:first-of-type {
-    min-width: calc(100% - 170px);
-
-    &.full-width {
-      min-width: 100%;
-    }
-
-    > div .dt-form-field {
-      width: 50%;
-    }
-  }
+.resize-vertical {
+  resize: vertical;
 }
 
-.resize-textarea {
-  resize: vertical;
+.code {
   font-family: monospace;
 }
 
@@ -35,11 +24,20 @@
     .dt-form-field-suffix {
       align-items: start;
       position: absolute;
-      right: 1px;
+      right: 0;
+      top: -10px;
     }
   }
 
   .dt-suffix:last-child:not(.dt-button) {
     margin-right: 0;
   }
+}
+
+.settings-section {
+  margin-bottom: 2em;
+}
+
+h2 {
+  margin-top: 2em;
 }

--- a/bridge/client/styles.scss
+++ b/bridge/client/styles.scss
@@ -456,6 +456,12 @@ pre.code {
   &.notification-open {
     padding-bottom: 100px;
   }
+
+  &.column-2 {
+    > dt-form-field {
+      width: 50%;
+    }
+  }
 }
 
 [fxFLex] {

--- a/bridge/cypress/integration/uniform-integrations.spec.ts
+++ b/bridge/cypress/integration/uniform-integrations.spec.ts
@@ -83,13 +83,13 @@ describe('Integrations', () => {
     cy.byTestId('edit-webhook-field-method').find('dt-select').focus().type('GET');
 
     // URL: insert text, add secret and add event variable
-    cy.byTestId(uniformPage.EDIT_WEBHOOK_FIELD_URL_ID).find('input').focus().type('https://example.com?secret=');
+    cy.byTestId(uniformPage.EDIT_WEBHOOK_FIELD_URL_ID).find('textarea').focus().type('https://example.com?secret=');
     cy.byTestId(uniformPage.EDIT_WEBHOOK_SECRET_SELECTOR_URL).find('button').click();
     selectFirstItemOfVariableSelector();
     cy.byTestId(uniformPage.EDIT_WEBHOOK_EVENT_SELECTOR_URL).find('button').click();
     selectFirstItemOfVariableSelector();
     cy.byTestId(uniformPage.EDIT_WEBHOOK_FIELD_URL_ID)
-      .find('input')
+      .find('textarea')
       .should('have.value', 'https://example.com?secret={{.secret.SecretA.key1}}{{.event.data.project}}');
 
     // Payload: insert text, add secret and add event variable


### PR DESCRIPTION
Closes #5706 

* Subscription and webhook forms are now a bit cleaner and more aligned
* Webhook URL is a textarea with standard row size 1 and can be expanded
* The buttons for payload and secret variables are now in the header of both textareas because it would otherwise overlap the content and the expand handle

![image](https://user-images.githubusercontent.com/2674029/145994524-d0dcb956-c942-4238-9008-aeba3adb2eff.png)
