### PR TITLE
fix(installer): Use previous fsGroup per default, provide option to execute init container (#6385)

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/templates/core.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/core.yaml
@@ -624,7 +624,21 @@ spec:
         helm.sh/chart: {{ include "control-plane.chart" . }}
     spec:
       securityContext:
-        fsGroup: {{ .Values.configurationService.fsGroup | default 1001 }}
+        fsGroup: {{ .Values.configurationService.fsGroup | default 65532 }}
+{{- if .Values.configurationService.initContainer }}
+      initContainers:
+        - name: change-user-init
+          image: {{ .Values.configurationService.image.repository }}:{{ .Values.configurationService.image.tag | default .Chart.AppVersion }}
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - mountPath: /data/config
+              name: configuration-volume
+          command:
+            - sh
+            - -c
+            - chown -R {{ .Values.configurationService.fsGroup | default 65532 }} /data/config
+{{- end }}
       containers:
         - name: configuration-service
           image: {{ .Values.configurationService.image.repository }}:{{ .Values.configurationService.image.tag | default .Chart.AppVersion }}
@@ -668,7 +682,7 @@ spec:
               name: configuration-volume
           securityContext:
             runAsNonRoot: true
-            runAsUser: {{ .Values.configurationService.fsGroup | default 1001 }}
+            runAsUser: {{ .Values.configurationService.fsGroup | default 65532 }}
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
       volumes:

--- a/installer/manifests/keptn/charts/control-plane/templates/core.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/core.yaml
@@ -624,7 +624,7 @@ spec:
         helm.sh/chart: {{ include "control-plane.chart" . }}
     spec:
       securityContext:
-        fsGroup: {{ .Values.configurationService.fsGroup | default 65532 }}
+        fsGroup: {{ .Values.configurationService.fsGroup | default 1001 }}
 {{- if .Values.configurationService.initContainer }}
       initContainers:
         - name: change-user-init
@@ -637,7 +637,7 @@ spec:
           command:
             - sh
             - -c
-            - chown -R {{ .Values.configurationService.fsGroup | default 65532 }} /data/config
+            - chown -R {{ .Values.configurationService.fsGroup | default 1001 }} /data/config
 {{- end }}
       containers:
         - name: configuration-service
@@ -682,7 +682,7 @@ spec:
               name: configuration-volume
           securityContext:
             runAsNonRoot: true
-            runAsUser: {{ .Values.configurationService.fsGroup | default 65532 }}
+            runAsUser: {{ .Values.configurationService.fsGroup | default 1001 }}
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
       volumes:

--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -101,6 +101,8 @@ configurationService:
   # storage and storageClass are the settings for the PVC used by the configuration-storage
   storage: 100Mi
   storageClass: null
+  fsGroup: 65532
+  initContainer: true
   env:
     GIT_KEPTN_USER: "keptn"
     GIT_KEPTN_EMAIL: "keptn@keptn.sh"

--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -101,7 +101,7 @@ configurationService:
   # storage and storageClass are the settings for the PVC used by the configuration-storage
   storage: 100Mi
   storageClass: null
-  fsGroup: 65532
+  fsGroup: 1001
   initContainer: true
   env:
     GIT_KEPTN_USER: "keptn"


### PR DESCRIPTION
Closes #6385 

The problem described in the linked issue occurs because the configuration service runs in a different `fsGroup` than it used to in previous versions - this was done because of compatibility issues on openshift installations.

Therefore, the fsGroup of the configuration has been set to the previous value, but can be changed via the `control-plane.configurationService.fsGroup` variable of the helm chart.

To ensure that project directories created with <0.11.3 and >0.11.3 have the same fsGroup, the initContainer that was removed in 0.11.3, can now be enabled or disabled with the value `control-plane.configurationService.initContainer`

