### PR TITLE
feat(bridge): Read problem title from GET /sequence endpoint

### DIFF
--- a/bridge/client/app/_models/sequence.ts
+++ b/bridge/client/app/_models/sequence.ts
@@ -139,6 +139,10 @@ export class Sequence extends sq {
   }
 
   public isWaiting(): boolean {
+    if (this.isRemediation()) {
+      return false;
+    }
+
     const lastStageName = this.getLastStage();
     if (lastStageName && this.state === SequenceState.STARTED) {
       const lastStage = this.getStage(lastStageName);

--- a/bridge/server/fixtures/project-details-response.mock.ts
+++ b/bridge/server/fixtures/project-details-response.mock.ts
@@ -870,7 +870,7 @@ const projectDetailsResponse = {
           },
           openRemediations: [
             {
-              problemTitle: 'Response time degradation',
+              problemTitle: 'Failure rate increase',
               stages: [
                 {
                   name: 'production',
@@ -911,6 +911,7 @@ const projectDetailsResponse = {
             service: 'carts',
             project: 'sockshop',
             time: '2021-11-04T04:51:21.557Z',
+            problemTitle: 'Failure rate increase',
             shkeptncontext: '35383737-3630-4639-b037-353138323631',
             state: 'finished',
             stages: [

--- a/bridge/server/fixtures/sequence-response.mock.ts
+++ b/bridge/server/fixtures/sequence-response.mock.ts
@@ -345,6 +345,7 @@ const sequencesResponses = {
     states: [
       {
         name: 'remediation',
+        problemTitle: 'Failure rate increase',
         service: 'carts',
         project: 'sockshop',
         time: '2021-11-04T04:51:21.557Z',

--- a/bridge/server/services/data-service.ts
+++ b/bridge/server/services/data-service.ts
@@ -85,7 +85,7 @@ export class DataService {
     const cachedSequences: { [keptnContext: string]: Sequence | undefined } = {};
 
     if (includeRemediation) {
-      openRemediations = await this.getOpenRemediations(projectName, true, true);
+      openRemediations = await this.getOpenRemediations(projectName, true);
     }
 
     if (includeApproval) {
@@ -338,7 +338,6 @@ export class DataService {
 
   public async getOpenRemediations(
     projectName: string,
-    includeProblemTitle: boolean,
     includeActions: boolean,
     serviceName?: string
   ): Promise<Remediation[]> {
@@ -374,7 +373,7 @@ export class DataService {
     keptnContext: string
   ): Promise<void> {
     const response = await this.apiService.getTraces(
-      `${EventTypes.PREFIX}${stageName}.remediation.triggered`,
+      undefined,
       this.MAX_TRACE_PAGE_SIZE,
       projectName,
       stageName,
@@ -1008,7 +1007,7 @@ export class DataService {
   public async getServiceStates(projectName: string): Promise<ServiceState[]> {
     const projectResponse = await this.apiService.getProject(projectName);
     const project = Project.fromJSON(projectResponse.data);
-    const openRemediations = await this.getOpenRemediations(projectName, false, false);
+    const openRemediations = await this.getOpenRemediations(projectName, false);
     const serviceStates: ServiceState[] = [];
     for (const stage of project.stages) {
       for (const service of stage.services) {
@@ -1210,7 +1209,7 @@ export class DataService {
     openRemediations?: Remediation[]
   ): Promise<StageRemediationInformation> {
     if (!openRemediations) {
-      openRemediations = await this.getOpenRemediations(projectName, true, false, serviceName);
+      openRemediations = await this.getOpenRemediations(projectName, false, serviceName);
     }
     let remediationConfig: string | undefined;
     const openRemediationsForStage = openRemediations
@@ -1244,7 +1243,7 @@ export class DataService {
     includeConfig: boolean
   ): Promise<ServiceRemediationInformation> {
     const serviceRemediationInformation: ServiceRemediationInformation = { stages: [] };
-    const openRemediations = await this.getOpenRemediations(projectName, true, false, serviceName);
+    const openRemediations = await this.getOpenRemediations(projectName, false, serviceName);
     const stageRemediations = openRemediations.reduce((stagesAcc: { [key: string]: Sequence[] }, remediation) => {
       const stageName = remediation.stages[0].name;
       if (!stagesAcc[stageName]) {

--- a/bridge/shared/fixtures/open-remediations-response.mock.ts
+++ b/bridge/shared/fixtures/open-remediations-response.mock.ts
@@ -2,6 +2,7 @@ const openRemediationsResponseMock = {
   states: [
     {
       name: 'remediation',
+      problemTitle: 'Failure rate increase',
       service: 'carts',
       project: 'sockshop',
       time: '2021-11-04T04:51:21.557Z',


### PR DESCRIPTION
## This PR
- makes sure that the Bridge reads the problem title from GET /sequence endpoint and therefore it doesn't need to load the traces of the sequence anymore, only if also the actions are needed (e.g. environments screen)

### Related Issues
Fixes #4206 

### Note
A remediation should not end up in `waiting` state when the action is finished, but it is waiting for the evaluation task. Therefore the `isWaiting` check ignores now remediation sequences. This will be improved with #5526 