### PR TITLE
fix(configuration-service): Creating projects from empty upstream (#6398)

### DIFF
--- a/configuration-service/common/git.go
+++ b/configuration-service/common/git.go
@@ -97,7 +97,8 @@ func (g *Git) CloneRepo(project string, credentials common_models.GitCredentials
 	msg, err := g.Executor.ExecuteCommand("git", []string{"clone", uri, project}, config.ConfigDir)
 	const emptyRepoWarning = "warning: You appear to have cloned an empty repository."
 	if strings.Contains(msg, emptyRepoWarning) {
-		return false, fmt.Errorf("failed to clone empty git repository")
+		// if the repository is uninitialised, this is not an error, but it will have to be set up afterwards
+		return false, nil
 	} else if err != nil {
 		return false, fmt.Errorf("failed to reach git upstream")
 	}

--- a/configuration-service/common/git_test.go
+++ b/configuration-service/common/git_test.go
@@ -697,3 +697,86 @@ func Test_getGitKeptnEmail(t *testing.T) {
 		})
 	}
 }
+
+func TestGit_CloneRepo(t *testing.T) {
+	type fields struct {
+		Executor         *common_mock.CommandExecutorMock
+		CredentialReader CredentialReader
+	}
+	type args struct {
+		project     string
+		credentials common_models.GitCredentials
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "clone repo",
+			fields: fields{
+				Executor: &common_mock.CommandExecutorMock{
+					ExecuteCommandFunc: func(command string, args []string, directory string) (string, error) {
+						return "", nil
+					},
+				},
+				CredentialReader: getDummyCredentialReader(),
+			},
+			args: args{
+				project: "my-project",
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "clone empty",
+			fields: fields{
+				Executor: &common_mock.CommandExecutorMock{
+					ExecuteCommandFunc: func(command string, args []string, directory string) (string, error) {
+						return "warning: You appear to have cloned an empty repository.", nil
+					},
+				},
+				CredentialReader: getDummyCredentialReader(),
+			},
+			args: args{
+				project: "my-project",
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "error",
+			fields: fields{
+				Executor: &common_mock.CommandExecutorMock{
+					ExecuteCommandFunc: func(command string, args []string, directory string) (string, error) {
+						return "", errors.New("oops")
+					},
+				},
+				CredentialReader: getDummyCredentialReader(),
+			},
+			args: args{
+				project: "my-project",
+			},
+			want:    false,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &Git{
+				Executor:         tt.fields.Executor,
+				CredentialReader: tt.fields.CredentialReader,
+			}
+			got, err := g.CloneRepo(tt.args.project, tt.args.credentials)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CloneRepo() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("CloneRepo() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #6398 

How to test:

Create a project with an empty upstream repository.
