### PR TITLE
fix(bridge): Remove .event suffix from payload variables in webhook (#6396)

### DIFF
--- a/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.spec.ts
+++ b/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.spec.ts
@@ -404,7 +404,7 @@ describe('KtbWebhookSettingsComponent', () => {
                         keys: [
                           {
                             name: 'myCustomElement',
-                            path: '(index (index .event.data.myCustomData 0) 0).myCustomKey.myCustomElement',
+                            path: '(index (index .data.myCustomData 0) 0).myCustomKey.myCustomElement',
                           },
                         ],
                         name: 'myCustomKey',
@@ -418,7 +418,7 @@ describe('KtbWebhookSettingsComponent', () => {
                         keys: [
                           {
                             name: 'myCustomElement2',
-                            path: '(index (index .event.data.myCustomData 0) 1).myCustomKey2.myCustomElement2',
+                            path: '(index (index .data.myCustomData 0) 1).myCustomKey2.myCustomElement2',
                           },
                         ],
                         name: 'myCustomKey2',
@@ -434,18 +434,18 @@ describe('KtbWebhookSettingsComponent', () => {
           },
           {
             name: 'project',
-            path: '.event.data.project',
+            path: '.data.project',
           },
         ],
         name: 'data',
       },
       {
         name: 'id',
-        path: '.event.id',
+        path: '.id',
       },
       {
         name: 'keptnContext',
-        path: '.event.keptnContext',
+        path: '.keptnContext',
       },
     ]);
   });

--- a/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.ts
+++ b/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.ts
@@ -73,7 +73,7 @@ export class KtbWebhookSettingsComponent implements OnInit {
     this.eventDataSource = event ? this.setObject(event) : undefined;
   }
 
-  private setObject(data: Record<string, unknown>, path = '.event'): SelectTreeNode[] {
+  private setObject(data: Record<string, unknown>, path = ''): SelectTreeNode[] {
     const result: SelectTreeNode[] = [];
     for (const key of Object.keys(data)) {
       const newItem = this.generateNewTreeNode(data[key], key, `${path}.${key}`);

--- a/bridge/cypress/integration/uniform-integrations.spec.ts
+++ b/bridge/cypress/integration/uniform-integrations.spec.ts
@@ -90,7 +90,7 @@ describe('Integrations', () => {
     selectFirstItemOfVariableSelector();
     cy.byTestId(uniformPage.EDIT_WEBHOOK_FIELD_URL_ID)
       .find('textarea')
-      .should('have.value', 'https://example.com?secret={{.secret.SecretA.key1}}{{.event.data.project}}');
+      .should('have.value', 'https://example.com?secret={{.secret.SecretA.key1}}{{.data.project}}');
 
     // Payload: insert text, add secret and add event variable
     cy.byTestId(uniformPage.EDIT_WEBHOOK_PAYLOAD_ID).find('textarea').focus().type("{id: '123456789', secret: ");
@@ -101,7 +101,7 @@ describe('Integrations', () => {
     cy.byTestId(uniformPage.EDIT_WEBHOOK_PAYLOAD_ID).find('textarea').focus().type('}');
     cy.byTestId(uniformPage.EDIT_WEBHOOK_PAYLOAD_ID)
       .find('textarea')
-      .should('have.value', "{id: '123456789', secret: {{.secret.SecretA.key1}}{{.event.data.project}}}");
+      .should('have.value', "{id: '123456789', secret: {{.secret.SecretA.key1}}{{.data.project}}}");
 
     cy.byTestId('edit-webhook-field-proxy').find('input').focus().type('https://proxy.com');
 
@@ -118,7 +118,7 @@ describe('Integrations', () => {
     selectFirstItemOfVariableSelector();
     cy.byTestId(uniformPage.EDIT_WEBHOOK_FIELD_HEADER_VALUE_ID)
       .find('input')
-      .should('have.value', 'Bearer: {{.secret.SecretA.key1}}{{.event.data.project}}');
+      .should('have.value', 'Bearer: {{.secret.SecretA.key1}}{{.data.project}}');
 
     cy.byTestId(uniformPage.UPDATE_SUBSCRIPTION_BUTTON_ID).click();
     // It should redirect after successfully sending the subscription


### PR DESCRIPTION
Fixes #6396 

![image](https://user-images.githubusercontent.com/2674029/146742066-e26eb7bc-2fee-4572-8e9e-23e480e1ac95.png)

![image](https://user-images.githubusercontent.com/2674029/146741994-23f62de8-1440-4459-b245-eb256c2b58ad.png)
