### PR TITLE
fix(lighthouse-service): Modified criteria example in SLO (#6106)

### DIFF
--- a/lighthouse-service/README.md
+++ b/lighthouse-service/README.md
@@ -111,15 +111,17 @@ objectives:
   - sli: request_latency_p50
     # pass is optional
     # it defines the pass criteria for the SLI values
-    pass:        # pass if (relative change <= 10% OR absolute value is < 200)
+    pass:        # pass if (relative change <= 10% AND absolute value is < 200)
       # e.g.: If response time changes by more than 10%, it should still
-      #       be considered as a pass if it is less than 200 ms
+      #       be considered as a fail if it is less than 200 ms
       - criteria:
           - "<=+10%" # relative values require a prefixed sign (plus or minus)
-          - "<1000"   # absolute values only require a logical operator
+          - "<200"   # absolute values only require a logical operator
     warning:     # allow small relative changes, and response time has to be < 500 ms
-      - criteria:  # criteria connected by AND
-          - "<=800"
+      - criteria:  # criteria connected by OR 
+          - "<=500"
+      - criteria:   
+          - "<-+20%"
   - sli: error_rate
     weight: 2   # default weight: 1
     pass:       # do not allow any security vulnerabilities

--- a/lighthouse-service/README.md
+++ b/lighthouse-service/README.md
@@ -111,17 +111,15 @@ objectives:
   - sli: request_latency_p50
     # pass is optional
     # it defines the pass criteria for the SLI values
-    pass:        # pass if (relative change <= 10% AND absolute value is < 200)
+    pass:        # pass if (relative change <= 10% OR absolute value is < 200)
       # e.g.: If response time changes by more than 10%, it should still
-      #       be considered as a fail if it is less than 200 ms
+      #       be considered as a pass if it is less than 200 ms
       - criteria:
           - "<=+10%" # relative values require a prefixed sign (plus or minus)
           - "<200"   # absolute values only require a logical operator
     warning:     # allow small relative changes, and response time has to be < 500 ms
-      - criteria:  # criteria connected by OR 
-          - "<=500"
-      - criteria:   
-          - "<-+20%"
+      - criteria:  # criteria connected by AND 
+          - "<=500,<=+20%"
   - sli: error_rate
     weight: 2   # default weight: 1
     pass:       # do not allow any security vulnerabilities


### PR DESCRIPTION
Signed-off-by: RealAnna <anna.reale@dynatrace.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- when criteria are specified under a single criteria lighthouse verifies them with logical AND  ex "<10, >2"
- when multiple criteria are there it is enough for one to pass, aka logical OR  ex
      - "<10"
      -  ">2"  
as shown below putting two opposing condition in an AND will in fact result in a fail
![image](https://user-images.githubusercontent.com/89971034/146772653-d070d953-3678-450b-9bbd-3bb2dfd3c42e.png)


### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #6160 


