### PR TITLE
fix(installer): Remove unneeded helm chart values

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -133,11 +133,6 @@ webhookService:
     repository: docker.io/keptn/webhook-service
     tag: ""
 
-alpine:
-  image:
-    repository: docker.io/alpine
-    tag: "3.13"
-
 ingress:
   enabled: false
   annotations: {}


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- removes some unused values from the keptn installer helm chart
