### PR TITLE
test: Move installation of remote exec plane to beginning of tests

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -464,6 +464,27 @@ jobs:
         timeout-minutes: 1
         run: keptn status
 
+      - name: Install Remote Execution Plane
+        id: install_remote_execution_plane
+        if: env.REMOTE_EXECUTION_PLANE == 'true'
+        timeout-minutes: 5
+        env:
+          KEPTN_ENDPOINT: ${{ steps.authenticate_keptn_cli.outputs.KEPTN_ENDPOINT }}
+          HELM_SERVICE_HELM_CHART_NAME: ${{ steps.extract_helm_chart_name.outputs.HELM_SERVICE_HELM_CHART_NAME }}
+          JMETER_SERVICE_HELM_CHART_NAME: ${{ steps.extract_helm_chart_name.outputs.JMETER_SERVICE_HELM_CHART_NAME }}
+        run: |
+          KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n "$KEPTN_NAMESPACE" -o jsonpath='{.data.keptn-api-token}' | base64 --decode)
+          kubectl scale deployment/helm-service -n "${KEPTN_NAMESPACE}" --replicas=0
+          kubectl scale deployment/jmeter-service -n "${KEPTN_NAMESPACE}" --replicas=0
+
+          KEPTN_API_HOSTNAME=$(echo "${KEPTN_ENDPOINT}" | awk -F[/] '{print $3}')
+
+          helm install helm-service http://0.0.0.0:8000/"${HELM_SERVICE_HELM_CHART_NAME}" -n keptn-helm-service --set remoteControlPlane.enabled=true --set remoteControlPlane.api.protocol=http --set remoteControlPlane.api.hostname="${KEPTN_API_HOSTNAME}" --set remoteControlPlane.api.token="${KEPTN_API_TOKEN}" --create-namespace
+          helm install jmeter-service http://0.0.0.0:8000/"${JMETER_SERVICE_HELM_CHART_NAME}" -n keptn-jmeter-service --set remoteControlPlane.enabled=true --set remoteControlPlane.api.protocol=http --set remoteControlPlane.api.hostname="${KEPTN_API_HOSTNAME}" --set remoteControlPlane.api.token="${KEPTN_API_TOKEN}" --create-namespace
+
+          helm test jmeter-service -n keptn-jmeter-service
+          helm test helm-service -n keptn-helm-service
+
       - name: Update go-test dependencies
         id: update_go_test_dependencies
         continue-on-error: true
@@ -564,27 +585,6 @@ jobs:
         env:
           KEPTN_ENDPOINT: ${{ steps.authenticate_keptn_cli.outputs.KEPTN_ENDPOINT }}
         run: cd test/go-tests && go test -run CustomUserManagedEndpointsTest -v
-
-      - name: Install Remote Execution Plane
-        id: install_remote_execution_plane
-        if: env.REMOTE_EXECUTION_PLANE == 'true'
-        timeout-minutes: 5
-        env:
-          KEPTN_ENDPOINT: ${{ steps.authenticate_keptn_cli.outputs.KEPTN_ENDPOINT }}
-          HELM_SERVICE_HELM_CHART_NAME: ${{ steps.extract_helm_chart_name.outputs.HELM_SERVICE_HELM_CHART_NAME }}
-          JMETER_SERVICE_HELM_CHART_NAME: ${{ steps.extract_helm_chart_name.outputs.JMETER_SERVICE_HELM_CHART_NAME }}
-        run: |
-          KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n "$KEPTN_NAMESPACE" -o jsonpath='{.data.keptn-api-token}' | base64 --decode)
-          kubectl scale deployment/helm-service -n "${KEPTN_NAMESPACE}" --replicas=0
-          kubectl scale deployment/jmeter-service -n "${KEPTN_NAMESPACE}" --replicas=0
-
-          KEPTN_API_HOSTNAME=$(echo "${KEPTN_ENDPOINT}" | awk -F[/] '{print $3}')
-
-          helm install helm-service http://0.0.0.0:8000/"${HELM_SERVICE_HELM_CHART_NAME}" -n keptn-helm-service --set remoteControlPlane.enabled=true --set remoteControlPlane.api.protocol=http --set remoteControlPlane.api.hostname="${KEPTN_API_HOSTNAME}" --set remoteControlPlane.api.token="${KEPTN_API_TOKEN}" --create-namespace
-          helm install jmeter-service http://0.0.0.0:8000/"${JMETER_SERVICE_HELM_CHART_NAME}" -n keptn-jmeter-service --set remoteControlPlane.enabled=true --set remoteControlPlane.api.protocol=http --set remoteControlPlane.api.hostname="${KEPTN_API_HOSTNAME}" --set remoteControlPlane.api.token="${KEPTN_API_TOKEN}" --create-namespace
-
-          helm test jmeter-service -n keptn-jmeter-service
-          helm test helm-service -n keptn-helm-service
 
       - name: Test Continuous Delivery with parallel stages (with sockshop)
         id: test_continuous_delivery

--- a/test/go-tests/sequencestate_test.go
+++ b/test/go-tests/sequencestate_test.go
@@ -25,7 +25,7 @@ spec:
       sequences:
         - name: "delivery"
           tasks:
-            - name: "deployment"
+            - name: "delivery"
               properties:
                 deploymentstrategy: "direct"
             - name: "evaluation"
@@ -37,7 +37,7 @@ spec:
           triggeredOn:
             - event: "dev.delivery.finished"
           tasks:
-            - name: "deployment"
+            - name: "delivery"
               properties:
                 deploymentstrategy: "blue_green_service"
             - name: "evaluation"`
@@ -56,7 +56,7 @@ func Test_SequenceState(t *testing.T) {
 
 	source := "golang-test"
 
-	uniform := []string{"helm-service", "lighthouse-service"}
+	uniform := []string{"lighthouse-service"}
 
 	// scale down the services that are usually involved in the sequence defined in the shipyard above.
 	// this way we can control the events sent during this sequence and check whether the state is updated appropriately
@@ -154,7 +154,7 @@ func Test_SequenceState(t *testing.T) {
 			return false
 		}
 
-		if !IsEqual(t, keptnv2.GetTriggeredEventType(keptnv2.DeploymentTaskName), stage.LatestEvent.Type, "stage.LatestEvent.Type") {
+		if !IsEqual(t, keptnv2.GetTriggeredEventType("delivery"), stage.LatestEvent.Type, "stage.LatestEvent.Type") {
 			return false
 		}
 
@@ -162,11 +162,11 @@ func Test_SequenceState(t *testing.T) {
 	}, 10*time.Second, 2*time.Second)
 
 	// get deployment.triggered event
-	deploymentTriggeredEvent, err := GetLatestEventOfType(*context.KeptnContext, projectName, "dev", keptnv2.GetTriggeredEventType(keptnv2.DeploymentTaskName))
+	deliveryTriggeredEvent, err := GetLatestEventOfType(*context.KeptnContext, projectName, "dev", keptnv2.GetTriggeredEventType("delivery"))
 	require.Nil(t, err)
-	require.NotNil(t, deploymentTriggeredEvent)
+	require.NotNil(t, deliveryTriggeredEvent)
 
-	cloudEvent := keptnv2.ToCloudEvent(*deploymentTriggeredEvent)
+	cloudEvent := keptnv2.ToCloudEvent(*deliveryTriggeredEvent)
 
 	keptn, err := keptnv2.NewKeptn(&cloudEvent, keptncommon.KeptnOpts{EventSender: &APIEventSender{}})
 
@@ -199,7 +199,7 @@ func Test_SequenceState(t *testing.T) {
 
 		stage := state.Stages[0]
 
-		if stage.LatestEvent.Type != keptnv2.GetStartedEventType(keptnv2.DeploymentTaskName) {
+		if stage.LatestEvent.Type != keptnv2.GetStartedEventType("delivery") {
 			return false
 		}
 
@@ -288,19 +288,19 @@ func Test_SequenceState(t *testing.T) {
 
 		stagingStage := state.Stages[1]
 
-		if !IsEqual(t, keptnv2.GetTriggeredEventType(keptnv2.DeploymentTaskName), stagingStage.LatestEvent.Type, "stagingStage.LatestEvent.Type") {
+		if !IsEqual(t, keptnv2.GetTriggeredEventType("delivery"), stagingStage.LatestEvent.Type, "stagingStage.LatestEvent.Type") {
 			return false
 		}
 
 		return true
 	}, 10*time.Second, 2*time.Second)
 
-	deploymentTriggeredEvent, err = GetLatestEventOfType(*context.KeptnContext, projectName, "staging", keptnv2.GetTriggeredEventType(keptnv2.DeploymentTaskName))
+	deliveryTriggeredEvent, err = GetLatestEventOfType(*context.KeptnContext, projectName, "staging", keptnv2.GetTriggeredEventType("delivery"))
 
 	require.Nil(t, err)
-	require.NotNil(t, deploymentTriggeredEvent)
+	require.NotNil(t, deliveryTriggeredEvent)
 
-	cloudEvent = keptnv2.ToCloudEvent(*deploymentTriggeredEvent)
+	cloudEvent = keptnv2.ToCloudEvent(*deliveryTriggeredEvent)
 
 	keptn, err = keptnv2.NewKeptn(&cloudEvent, keptncommon.KeptnOpts{EventSender: &APIEventSender{}})
 	require.Nil(t, err)

--- a/test/go-tests/sequencestate_test.go
+++ b/test/go-tests/sequencestate_test.go
@@ -150,9 +150,6 @@ func Test_SequenceState(t *testing.T) {
 		if !IsEqual(t, "dev", stage.Name, "stage.Name") {
 			return false
 		}
-		if !IsEqual(t, "carts:test", stage.Image, "stage.Image") {
-			return false
-		}
 
 		if !IsEqual(t, keptnv2.GetTriggeredEventType("delivery"), stage.LatestEvent.Type, "stage.LatestEvent.Type") {
 			return false


### PR DESCRIPTION
Integration test run: https://github.com/keptn/keptn/actions/runs/1607320058

Note: the minishift error seems to have happened temporarily, as well as the graceful shutdown test on GKE 1.21 (this one is currently unstable on master). 