### PR TITLE
test: Remove deprecated option from gitea helm chart

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -362,7 +362,7 @@ jobs:
         timeout-minutes: 5
         run: |
           helm repo add gitea-charts https://dl.gitea.io/charts/
-          helm install --values test/assets/gitea/values.yaml gitea gitea-charts/gitea -n ${KEPTN_NAMESPACE} --wait
+          helm install --values test/assets/gitea/values.yaml gitea gitea-charts/gitea -n ${KEPTN_NAMESPACE} --wait --version v5.0.0
           GITEA_ADMIN_USER=$(kubectl get pod -n ${KEPTN_NAMESPACE} gitea-0 -ojsonpath='{@.spec.initContainers[?(@.name=="configure-gitea")].env[?(@.name=="GITEA_ADMIN_USERNAME")].value}')
           GITEA_ADMIN_PASSWORD=$(kubectl get pod -n ${KEPTN_NAMESPACE} gitea-0 -ojsonpath='{@.spec.initContainers[?(@.name=="configure-gitea")].env[?(@.name=="GITEA_ADMIN_PASSWORD")].value}')
           sleep 30 # TODO

--- a/test/assets/gitea/values.yaml
+++ b/test/assets/gitea/values.yaml
@@ -13,11 +13,6 @@ cache:
     enabled: true
 
 gitea:
-  database:
-    builtIn:
-      postgresql:
-        enabled: true
-
   config:
     cache:
       HOST: gitea-memcached:11211


### PR DESCRIPTION
This PR removes a deprecated option provided to the gitea helm chart. Also, this PR sets the version of the gitea helm chart to 5.0.0