### PR TITLE
fix(cli): Set CLI context before attempting to check for K8s context change (#6449)

### DIFF
--- a/cli/pkg/credentialmanager/handler.go
+++ b/cli/pkg/credentialmanager/handler.go
@@ -156,6 +156,7 @@ func initChecks(autoApplyNewContext bool, cm CredentialManagerInterface) {
 	if err != nil {
 		log.Fatal(err)
 	}
+	keptnContext = cliConfig.CurrentContext
 	if cliConfig.KubeContextCheck && !GlobalCheckForContextChange {
 		getCurrentContextFromKubeConfig()
 		updatedCLIConfig, kubeConfig, err := checkForContextChange(cliConfigManager, autoApplyNewContext)
@@ -212,7 +213,6 @@ func checkForContextChange(cliConfigManager *config.CLIConfigManager, autoApplyN
 
 	if cliConfig.KubeContextCheck {
 		// Setting keptnContext from ~/.keptn/config file
-		keptnContext = cliConfig.CurrentContext
 		if kubeConfigFile.CurrentContext != "" && keptnContext != kubeConfigFile.CurrentContext {
 			fmt.Printf("Kube context has been changed to %s\n", kubeConfigFile.CurrentContext)
 			if keptnContext != "" {


### PR DESCRIPTION
Closes #6449 

**How to test:**

- Prerequisite: Authenticated Keptn CLI

1. Execute a Keptn command that uses the API, e.g. `keptn get project` - This should list the projects of the Keptn instance the CLI is connected to
2. Disable the context check: `keptn set config KubeContextCheck false`
3. Execute `keptn get project` again - this was failing previously, but should work now with the fix provided in this PR. 