### PR TITLE
ci: Ignore keptn/go-sdk in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,9 @@
   "cloneSubmodules": true,
   "stabilityDays": 7,
   "timezone": "Europe/Vienna",
+  "ignoreDeps": [
+    "github.com/keptn/keptn/go-sdk"
+  ],
   "packageRules": [
     {
       "matchManagers": ["npm"],


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- adds `keptn/go-sdk` to the ignore list of Renovate since it will be updated in Dev PRs for now
