### PR TITLE
ci: Automatically run go mod tidy after renovate updated a go dependency

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,9 @@
   "ignoreDeps": [
     "github.com/keptn/keptn/go-sdk"
   ],
+  "postUpdateOptions": [
+    "gomodTidy"
+  ],
   "packageRules": [
     {
       "matchManagers": ["npm"],


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- automatically runs `go mod tidy` after a go module was updated by Renovate
