### PR TITLE
ci: Fix codecov reporting and monorepo setup

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -289,6 +289,13 @@ jobs:
           fail_ci_if_error: false
           flags: ${{ matrix.config.artifact }}
 
+      - name: Report test coverage for bridge-server
+        if: matrix.config.should-push-image == 'false' && matrix.config.artifact == 'bridge2' && matrix.config.docker-test-target == 'bridge-server-test'
+        uses: codecov/codecov-action@v2
+        with:
+          fail_ci_if_error: false
+          flags: bridge-server
+
       - name: Upload Test Screenshots
         if: always() && matrix.config.artifact == 'bridge2' && matrix.config.docker-test-target == 'builder-test-ui'
         uses: actions/upload-artifact@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -283,12 +283,10 @@ jobs:
           docker run --rm -v "$PWD/shared:/shared" $IMAGE_NAME
 
       - name: Report test coverage for ${{ matrix.config.artifact }}
-        if: ((needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (matrix.config.should-run == 'true'))
+        if: matrix.config.should-push-image == 'true'
         uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: false
-          verbose: true
-          move_coverage_to_trash: true
           flags: ${{ matrix.config.artifact }}
 
       - name: Upload Test Screenshots
@@ -328,8 +326,6 @@ jobs:
         uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: true
-          verbose: true
-          move_coverage_to_trash: true
           flags: cli
 
   ############################################################################

--- a/codecov.yml
+++ b/codecov.yml
@@ -25,69 +25,69 @@ github_checks:
 flags:
   api:
     paths:
-      - api/**/*
+      - api
     carryforward: true
   bridge2:
     paths:
-      - bridge/**/*
+      - bridge
     carryforward: true
   cli:
     paths:
-      - cli/**/*
+      - cli
     carryforward: true
   configuration-service:
     paths:
-      - configuration-service/**/*
+      - configuration-service
     carryforward: true
   resource-service:
     paths:
-      - resource-service/**/*
+      - resource-service
     carryforward: true
   distributor:
     paths:
-      - distributor/**/*
+      - distributor
     carryforward: true
   approval-service:
     paths:
-      - approval-service/**/*
+      - approval-service
     carryforward: true
   helm-service:
     paths:
-      - helm-service/**/*
+      - helm-service
     carryforward: true
   jmeter-service:
     paths:
-      - jmeter-service/**/*
+      - jmeter-service
     carryforward: true
   lighthouse-service:
     paths:
-      - lighthouse-service/**/*
+      - lighthouse-service
     carryforward: true
   mongodb-datastore:
     paths:
-      - mongodb-datastore/**/*
+      - mongodb-datastore
     carryforward: true
   openshift-route-service:
     paths:
-      - /platform-support/openshift-route-service/**/*
+      - /platform-support/openshift-route-service
     carryforward: true
   remediation-service:
     paths:
-      - remediation-service/**/*
+      - remediation-service
     carryforward: true
   shipyard-controller:
     paths:
-      - shipyard-controller/**/*
+      - shipyard-controller
     carryforward: true
   statistics-service:
     paths:
-      - statistics-service/**/*
+      - statistics-service
     carryforward: true
   webhook-service:
     paths:
-      - webhook-service/**/*
+      - webhook-service
     carryforward: true
   secret-service:
     paths:
-      - secret-service/**/*
+      - secret-service
     carryforward: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,16 +5,6 @@ coverage:
         # basic
         target: auto
         threshold: 2% # allow cov to drop by 2% (just in case)
-      microservices:
-        # basic
-        target: auto
-        threshold: 2% # allow cov to drop by 2% (just in case)
-      bridge:
-        target: auto
-        threshold: 2% # allow cov to drop by 2% (just in case)
-      cli:
-        target: auto
-        threshold: 2% # allow cov to drop by 2% (just in case)
     patch:
       default:
         threshold: 1% # allow patch
@@ -96,4 +86,8 @@ flags:
   webhook-service:
     paths:
       - webhook-service/*
+    carryforward: true
+  secret-service:
+    paths:
+      - secret-service/*
     carryforward: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -27,44 +27,41 @@ ignore:
   - "**/*.sh"         # ignore shell scripts
 
 comment:
-  layout: "diff, files"
-  show_carryforward_flags: true # see https://docs.codecov.io/docs/carryforward-flags
+  layout: "diff, files, flags"
 
 github_checks:
   annotations: false
 
 flags:
-  microservices:
-    carryforward: true # see https://docs.codecov.io/docs/carryforward-flags
   api:
-    carryforward: true # see https://docs.codecov.io/docs/carryforward-flags
-  bridge:
-    carryforward: true # see https://docs.codecov.io/docs/carryforward-flags
+    carryforward: true
+  bridge2:
+    carryforward: true
   cli:
-    carryforward: true # see https://docs.codecov.io/docs/carryforward-flags
+    carryforward: true
   configuration-service:
-    carryforward: true # see https://docs.codecov.io/docs/carryforward-flags
+    carryforward: true
   resource-service:
-    carryforward: true # see https://docs.codecov.io/docs/carryforward-flags
+    carryforward: true
   distributor:
-    carryforward: true # see https://docs.codecov.io/docs/carryforward-flags
+    carryforward: true
   approval-service:
-    carryforward: true # see https://docs.codecov.io/docs/carryforward-flags
+    carryforward: true
   helm-service:
-    carryforward: true # see https://docs.codecov.io/docs/carryforward-flags
+    carryforward: true
   jmeter-service:
-    carryforward: true # see https://docs.codecov.io/docs/carryforward-flags
+    carryforward: true
   lighthouse-service:
-    carryforward: true # see https://docs.codecov.io/docs/carryforward-flags
+    carryforward: true
   mongodb-datastore:
-    carryforward: true # see https://docs.codecov.io/docs/carryforward-flags
+    carryforward: true
   openshift-route-service:
-    carryforward: true # see https://docs.codecov.io/docs/carryforward-flags
+    carryforward: true
   remediation-service:
-    carryforward: true # see https://docs.codecov.io/docs/carryforward-flags
+    carryforward: true
   shipyard-controller:
-    carryforward: true # see https://docs.codecov.io/docs/carryforward-flags
+    carryforward: true
   statistics-service:
-    carryforward: true # see https://docs.codecov.io/docs/carryforward-flags
+    carryforward: true
   webhook-service:
-    carryforward: true # see https://docs.codecov.io/docs/carryforward-flags
+    carryforward: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -25,69 +25,69 @@ github_checks:
 flags:
   api:
     paths:
-      - api/*
+      - api/
     carryforward: true
   bridge2:
     paths:
-      - bridge/*
+      - bridge/
     carryforward: true
   cli:
     paths:
-      - cli/*
+      - cli/
     carryforward: true
   configuration-service:
     paths:
-      - configuration-service/*
+      - configuration-service/
     carryforward: true
   resource-service:
     paths:
-      - resource-service/*
+      - resource-service/
     carryforward: true
   distributor:
     paths:
-      - distributor/*
+      - distributor/
     carryforward: true
   approval-service:
     paths:
-      - approval-service/*
+      - approval-service/
     carryforward: true
   helm-service:
     paths:
-      - helm-service/*
+      - helm-service/
     carryforward: true
   jmeter-service:
     paths:
-      - jmeter-service/*
+      - jmeter-service/
     carryforward: true
   lighthouse-service:
     paths:
-      - lighthouse-service/*
+      - lighthouse-service/
     carryforward: true
   mongodb-datastore:
     paths:
-      - mongodb-datastore/*
+      - mongodb-datastore/
     carryforward: true
   openshift-route-service:
     paths:
-      - /platform-support/openshift-route-service/*
+      - /platform-support/openshift-route-service/
     carryforward: true
   remediation-service:
     paths:
-      - remediation-service/*
+      - remediation-service/
     carryforward: true
   shipyard-controller:
     paths:
-      - shipyard-controller/*
+      - shipyard-controller/
     carryforward: true
   statistics-service:
     paths:
-      - statistics-service/*
+      - statistics-service/
     carryforward: true
   webhook-service:
     paths:
-      - webhook-service/*
+      - webhook-service/
     carryforward: true
   secret-service:
     paths:
-      - secret-service/*
+      - secret-service/
     carryforward: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -25,7 +25,7 @@ github_checks:
 flags:
   api:
     paths:
-      - api
+      - api/
     carryforward: true
   bridge2:
     paths:
@@ -33,43 +33,43 @@ flags:
     carryforward: true
   bridge-server:
     paths:
-      - bridge/server
+      - bridge/server/
     carryforward: true
   cli:
     paths:
-      - cli
+      - cli/
     carryforward: true
   configuration-service:
     paths:
-      - configuration-service
+      - configuration-service/
     carryforward: true
   resource-service:
     paths:
-      - resource-service
+      - resource-service/
     carryforward: true
   distributor:
     paths:
-      - distributor
+      - distributor/
     carryforward: true
   approval-service:
     paths:
-      - approval-service
+      - approval-service/
     carryforward: true
   helm-service:
     paths:
-      - helm-service
+      - helm-service/
     carryforward: true
   jmeter-service:
     paths:
-      - jmeter-service
+      - jmeter-service/
     carryforward: true
   lighthouse-service:
     paths:
-      - lighthouse-service
+      - lighthouse-service/
     carryforward: true
   mongodb-datastore:
     paths:
-      - mongodb-datastore
+      - mongodb-datastore/
     carryforward: true
   openshift-route-service:
     paths:
@@ -77,21 +77,21 @@ flags:
     carryforward: true
   remediation-service:
     paths:
-      - remediation-service
+      - remediation-service/
     carryforward: true
   shipyard-controller:
     paths:
-      - shipyard-controller
+      - shipyard-controller/
     carryforward: true
   statistics-service:
     paths:
-      - statistics-service
+      - statistics-service/
     carryforward: true
   webhook-service:
     paths:
-      - webhook-service
+      - webhook-service/
     carryforward: true
   secret-service:
     paths:
-      - secret-service
+      - secret-service/
     carryforward: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -25,69 +25,69 @@ github_checks:
 flags:
   api:
     paths:
-      - api/
+      - api/**/*
     carryforward: true
   bridge2:
     paths:
-      - bridge/
+      - bridge/**/*
     carryforward: true
   cli:
     paths:
-      - cli/
+      - cli/**/*
     carryforward: true
   configuration-service:
     paths:
-      - configuration-service/
+      - configuration-service/**/*
     carryforward: true
   resource-service:
     paths:
-      - resource-service/
+      - resource-service/**/*
     carryforward: true
   distributor:
     paths:
-      - distributor/
+      - distributor/**/*
     carryforward: true
   approval-service:
     paths:
-      - approval-service/
+      - approval-service/**/*
     carryforward: true
   helm-service:
     paths:
-      - helm-service/
+      - helm-service/**/*
     carryforward: true
   jmeter-service:
     paths:
-      - jmeter-service/
+      - jmeter-service/**/*
     carryforward: true
   lighthouse-service:
     paths:
-      - lighthouse-service/
+      - lighthouse-service/**/*
     carryforward: true
   mongodb-datastore:
     paths:
-      - mongodb-datastore/
+      - mongodb-datastore/**/*
     carryforward: true
   openshift-route-service:
     paths:
-      - /platform-support/openshift-route-service/
+      - /platform-support/openshift-route-service/**/*
     carryforward: true
   remediation-service:
     paths:
-      - remediation-service/
+      - remediation-service/**/*
     carryforward: true
   shipyard-controller:
     paths:
-      - shipyard-controller/
+      - shipyard-controller/**/*
     carryforward: true
   statistics-service:
     paths:
-      - statistics-service/
+      - statistics-service/**/*
     carryforward: true
   webhook-service:
     paths:
-      - webhook-service/
+      - webhook-service/**/*
     carryforward: true
   secret-service:
     paths:
-      - secret-service/
+      - secret-service/**/*
     carryforward: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -30,6 +30,7 @@ flags:
   bridge2:
     paths:
       - bridge
+      - bridge/server
     carryforward: true
   cli:
     paths:

--- a/codecov.yml
+++ b/codecov.yml
@@ -34,34 +34,66 @@ github_checks:
 
 flags:
   api:
+    paths:
+      - api/*
     carryforward: true
   bridge2:
+    paths:
+      - bridge/*
     carryforward: true
   cli:
+    paths:
+      - cli/*
     carryforward: true
   configuration-service:
+    paths:
+      - configuration-service/*
     carryforward: true
   resource-service:
+    paths:
+      - resource-service/*
     carryforward: true
   distributor:
+    paths:
+      - distributor/*
     carryforward: true
   approval-service:
+    paths:
+      - approval-service/*
     carryforward: true
   helm-service:
+    paths:
+      - helm-service/*
     carryforward: true
   jmeter-service:
+    paths:
+      - jmeter-service/*
     carryforward: true
   lighthouse-service:
+    paths:
+      - lighthouse-service/*
     carryforward: true
   mongodb-datastore:
+    paths:
+      - mongodb-datastore/*
     carryforward: true
   openshift-route-service:
+    paths:
+      - /platform-support/openshift-route-service/*
     carryforward: true
   remediation-service:
+    paths:
+      - remediation-service/*
     carryforward: true
   shipyard-controller:
+    paths:
+      - shipyard-controller/*
     carryforward: true
   statistics-service:
+    paths:
+      - statistics-service/*
     carryforward: true
   webhook-service:
+    paths:
+      - webhook-service/*
     carryforward: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -29,7 +29,10 @@ flags:
     carryforward: true
   bridge2:
     paths:
-      - bridge
+      - bridge/
+    carryforward: true
+  bridge-server:
+    paths:
       - bridge/server
     carryforward: true
   cli:


### PR DESCRIPTION
### This PR
- adds paths to the different codecov flags that are used as identifiers for the monorepo sub-projects
- adds the `flags` report to the PR comment which shows coverage per keptn service
- removes verbose output from pipeline codecov upload step
- fixes a small bug where bridge coverage was uploaded multiple times

Fixes #6384 