### PR TITLE
ci: Remove dependency between unit tests and docker builds to speed up CI build time

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -364,7 +364,7 @@ jobs:
   ############################################################################
   docker_build:
     name: Docker Build
-    needs: [prepare_ci_run, unit-tests-microservices]
+    needs: [prepare_ci_run]
     runs-on: ubuntu-20.04
     if: needs.prepare_ci_run.outputs.BUILD_MATRIX_EMPTY == 'false'
     strategy:


### PR DESCRIPTION
### This PR
- Removes the dependency between unit tests and docker builds to speed up CI build time