### PR TITLE
ci: Enable auto-merging of patch PRs by Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,8 @@
     "schedule:nonOfficeHours",
     ":semanticCommitTypeAll(build)",
     ":semanticCommitScope(deps)",
-    "group:monorepos"
+    "group:monorepos",
+    "autoMergePatch"
   ],
   "addLabels": ["dependencies"],
   "cloneSubmodules": true,


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- enables renovate patch update PRs to be auto-merged. This will be achieved by also installing the https://github.com/apps/renovate-approve GitHub Integration. that will auto-approve Renovate PRs that are ready for auto-merging

Related to #5825