### PR TITLE
ci: Disable automerging for MongoDB and NATS Helm Charts

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -34,6 +34,10 @@
     {
       "matchManagers": ["dockerfile"],
       "addLabels": ["docker"]
+    },
+    {
+      "matchPackageNames": ["mongodb"],
+      "automerge": false
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -36,7 +36,7 @@
       "addLabels": ["docker"]
     },
     {
-      "matchPackageNames": ["mongodb"],
+      "matchPackageNames": ["mongodb", "nats"],
       "automerge": false
     }
   ]


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- disables auto-merging for the MongoDB and NATS helm chart since it would break the airgapped setup as soon as the underlying mongodb docker image tags are changed