### PR TITLE
test: Move Keptn CLI authentication to go tests (#6573)

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -585,7 +585,6 @@ jobs:
 
           test_outcomes=(
             "${{ steps.keptn_install.outcome }}"
-            "${{ steps.determine_keptn_endpoint.outcome }}"
           )
 
           for ((i=0; i<${#test_names[@]}; i++)); do

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -422,8 +422,8 @@ jobs:
           verify_deployment_in_namespace "mongo" ${KEPTN_NAMESPACE}
           verify_deployment_in_namespace "mongodb-datastore" ${KEPTN_NAMESPACE}
 
-      - name: Authenticate Keptn CLI with API
-        id: authenticate_keptn_cli
+      - name: Determine Keptn Endpoint
+        id: determine_keptn_endpoint
         timeout-minutes: 5
         run: |
           source test/utils.sh
@@ -446,19 +446,12 @@ jobs:
           echo "KEPTN_ENDPOINT=${KEPTN_ENDPOINT}"
           echo "##[set-output name=KEPTN_ENDPOINT;]$(echo ${KEPTN_ENDPOINT})"
 
-          auth_at_keptn $KEPTN_ENDPOINT $KEPTN_API_TOKEN
-          verify_test_step $? "Could not authenticate at Keptn API"
-
-      - name: Verify that Keptn CLI is authenticated using keptn status
-        timeout-minutes: 1
-        run: keptn status
-
       - name: Install Remote Execution Plane
         id: install_remote_execution_plane
         if: env.REMOTE_EXECUTION_PLANE == 'true'
         timeout-minutes: 5
         env:
-          KEPTN_ENDPOINT: ${{ steps.authenticate_keptn_cli.outputs.KEPTN_ENDPOINT }}
+          KEPTN_ENDPOINT: ${{ steps.determine_keptn_endpoint.outputs.KEPTN_ENDPOINT }}
           HELM_SERVICE_HELM_CHART_NAME: ${{ steps.extract_helm_chart_name.outputs.HELM_SERVICE_HELM_CHART_NAME }}
           JMETER_SERVICE_HELM_CHART_NAME: ${{ steps.extract_helm_chart_name.outputs.JMETER_SERVICE_HELM_CHART_NAME }}
         run: |
@@ -498,7 +491,8 @@ jobs:
         id: test_aggregated
         timeout-minutes: 60
         env:
-          KEPTN_ENDPOINT: ${{ steps.authenticate_keptn_cli.outputs.KEPTN_ENDPOINT }}
+          KEPTN_ENDPOINT: ${{ steps.determine_keptn_endpoint.outputs.KEPTN_ENDPOINT }}
+          DO_AUTH: "true"
           UNLEASH_SERVICE_VERSION: "release-0.3.2"
           GOTESTSUM_FORMAT: "testname"
           GOTESTSUM_JSONFILE: ${{ env.TEST_REPORT_FOLDER }}/tests-${{ env.TEST_REPORT_FILENAME_SUFFIX }}
@@ -591,7 +585,7 @@ jobs:
 
           test_outcomes=(
             "${{ steps.keptn_install.outcome }}"
-            "${{ steps.authenticate_keptn_cli.outcome }}"
+            "${{ steps.determine_keptn_endpoint.outcome }}"
           )
 
           for ((i=0; i<${#test_names[@]}; i++)); do

--- a/test/go-tests/init_test.go
+++ b/test/go-tests/init_test.go
@@ -3,6 +3,7 @@ package go_tests
 import (
 	"errors"
 	"fmt"
+	"github.com/keptn/go-utils/pkg/common/retry"
 	"os"
 	"strings"
 	"testing"
@@ -28,6 +29,11 @@ func TestMain(m *testing.M) {
 }
 
 func setup() error {
+	if _, doAuth := os.LookupEnv("DO_AUTH"); doAuth {
+		if err := authenticateKeptnCLI(); err != nil {
+			return err
+		}
+	}
 	// before executing the tests, we check whether the context of the Keptn CLI matches the one of the kubectl CLI
 	// i.e. The kubectl CLI should be connected to the cluster the Keptn CLI is currently authenticated against.
 	// this prevents unintended kubectl commands from being executed against a different cluster than the one containing the Keptn instance that should be tested
@@ -38,6 +44,26 @@ func setup() error {
 	if !match {
 		return errors.New("endpoint mismatch between CLI and kubectl detected")
 	}
+	return nil
+}
+
+func authenticateKeptnCLI() error {
+	apiToken, apiEndpoint, err := GetApiCredentials()
+	if err != nil {
+		return err
+	}
+
+	err = retry.Retry(func() error {
+		out, err := ExecuteCommand(fmt.Sprintf("keptn auth --endpoint=%s --api-token=%s", apiEndpoint, apiToken))
+		if err != nil {
+			return err
+		}
+		if !strings.Contains(out, "Successfully authenticated") {
+			return errors.New("authentication unsuccessful")
+		}
+		return nil
+	}, retry.NumberOfRetries(10))
+
 	return nil
 }
 

--- a/test/go-tests/testsuite_k3d_test.go
+++ b/test/go-tests/testsuite_k3d_test.go
@@ -5,9 +5,6 @@ import (
 )
 
 func Test_K3D(t *testing.T) {
-	// Common Tests
-	t.Run("Test_ResourceServiceBasic", Test_ResourceServiceBasic)
-
 	// Platform-specific Tests
 	t.Run("TestAirgappedImagesAreSetCorrectly", TestAirgappedImagesAreSetCorrectly)
 }


### PR DESCRIPTION
This PR removes the unintential execution of the configuration service integration test on K3D. Additionally, the keptn CLI authentication is moved to the go-tests. This should improve the stability especially on minishift where sometimes the keptn auth command fails on the first try due to the api server not being ready yet, and the retry mechanism written in bash was not functioning correctly (my guess is that the `authenticate_keptn_cli` step was failing as soon as `keptn auth` was returning an error code, without proceeding with the retry logic)