### PR TITLE
fix(cli): project without upstream is defined as project without `GitRemoteUri`

### DIFF
--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -257,7 +257,7 @@ func addWarningNonExistingProjectUpstream() error {
 	}
 
 	for _, project := range projects {
-		if project.GitRemoteURI == "" || project.GitToken == "" || project.GitUser == "" {
+		if project.GitRemoteURI == "" {
 			fmt.Printf("WARNING:  the project %s has no Git upstream configured. Please consider setting a Git upstream repository using:\n\n", project.ProjectName)
 			fmt.Printf("\tkeptn update project %s --git-user=GIT_USER --git-token=GIT_TOKEN --git-remote-url=GIT_REMOTE_URL\n\n", project.ProjectName)
 		}


### PR DESCRIPTION
Signed-off-by: odubajDT <ondrej.dubaj@dynatrace.com>


