### PR TITLE
ci: Add pipeline to nightly check docker image digests

### DIFF
--- a/.github/workflows/check-docker-image-digests.yml
+++ b/.github/workflows/check-docker-image-digests.yml
@@ -1,0 +1,17 @@
+name: Check Docker Image Digests
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 5 * * 1-5'
+defaults:
+  run:
+    shell: bash
+jobs:
+  check:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2.4.0
+
+      - name: Check docker image digests
+        run: ./gh-actions-scripts/check-image-digests.sh

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -194,6 +194,20 @@ jobs:
           username: ${{ secrets.REGISTRY_USER }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: "ghcr.io"
+          username: "keptn-bot"
+          password: ${{ secrets.KEPTN_BOT_TOKEN }}
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: "quay.io"
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
       - id: docker_build_image
         name: "Docker Build keptn/${{ matrix.config.artifact }}"
         uses: docker/build-push-action@v2
@@ -201,6 +215,8 @@ jobs:
           context: ${{ matrix.config.working-dir }}
           tags: |
             keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
+            quay.io/keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
+            ghcr.io/keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
           build-args: |
             version=${{ env.VERSION }}
           push: ${{ matrix.config.should-push-image }}
@@ -382,44 +398,3 @@ jobs:
           done
           
           gh release upload "$RELEASE_TAG" "$DIGEST_FILE"
-  
-
-  ############################################################################
-  # Push Docker Images to alternative Registries
-  ############################################################################
-  repush_images:
-    needs: [prepare, pre-release]
-    name: Push Images to alternative Registries
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix: ${{ fromJson(needs.prepare.outputs.BUILD_MATRIX) }}
-    steps:
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.REGISTRY_USER }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: "ghcr.io"
-          username: "keptn-bot"
-          password: ${{ secrets.KEPTN_BOT_TOKEN }}
-
-      - name: Login to Quay.io
-        uses: docker/login-action@v1
-        with:
-          registry: "quay.io"
-          username: ${{ secrets.QUAY_USER }}
-          password: ${{ secrets.QUAY_TOKEN }}
-
-      - name: Push to alternative Registries
-        env:
-          VERSION: ${{ needs.prepare.outputs.next-version }}
-        uses: akhilerm/tag-push-action@v2.0.0
-        with:
-          src: docker.io/keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
-          dst: |
-            quay.io/keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
-            ghcr.io/keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -206,6 +206,23 @@ jobs:
           push: ${{ matrix.config.should-push-image }}
           pull: true
 
+      - name: Write docker image digest to file
+        if: matrix.config.should-push-image
+        env:
+          IMAGE_DIGEST: ${{ steps.docker_build_image.outputs.digest }}
+          IMAGE_DIGEST_FILENAME: "./digest-${{ matrix.config.artifact }}.txt"
+        run: |
+          echo "${{ matrix.config.artifact }},$IMAGE_DIGEST" > "$IMAGE_DIGEST_FILENAME"
+
+      - name: Upload Digest file as artifact
+        if: matrix.config.should-push-image
+        uses: actions/upload-artifact@v2
+        env:
+          IMAGE_DIGEST_FILENAME: "./digest-${{ matrix.config.artifact }}.txt"
+        with:
+          name: image-digests
+          path: ${{ env.IMAGE_DIGEST_FILENAME }}
+
   ############################################################################
   # Build Helm Charts (only relevant for build_everything)
   ############################################################################
@@ -354,6 +371,18 @@ jobs:
           echo ${GCLOUD_SERVICE_KEY} | base64 --decode > ~/gcloud-service-key.json
           gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
           gh-actions-scripts/upload_helm_chart_to_google_cloud.sh dist/keptn-installer/
+
+      - name: Attach docker image digests to release
+        env:
+          DIGEST_FILE: "digests.csv"
+          RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
+        run: |
+          for digest_file in ./dist/image-digests/digest-*.txt; do
+            cat "$digest_file" >> $DIGEST_FILE
+          done
+          
+          gh release upload "$RELEASE_TAG" "$DIGEST_FILE"
+  
 
   ############################################################################
   # Push Docker Images to alternative Registries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,6 +203,23 @@ jobs:
           push: ${{ matrix.config.should-push-image }}
           pull: true
 
+      - name: Write docker image digest to file
+        if: matrix.config.should-push-image
+        env:
+          IMAGE_DIGEST: ${{ steps.docker_build_image.outputs.digest }}
+          IMAGE_DIGEST_FILENAME: "./digest-${{ matrix.config.artifact }}.txt"
+        run: |
+          echo "${{ matrix.config.artifact }},$IMAGE_DIGEST" > "$IMAGE_DIGEST_FILENAME"
+
+      - name: Upload Digest file as artifact
+        if: matrix.config.should-push-image
+        uses: actions/upload-artifact@v2
+        env:
+          IMAGE_DIGEST_FILENAME: "./digest-${{ matrix.config.artifact }}.txt"
+        with:
+          name: image-digests
+          path: ${{ env.IMAGE_DIGEST_FILENAME }}
+
   ############################################################################
   # Build Helm Charts (only relevant for build_everything)
   ############################################################################
@@ -343,13 +360,24 @@ jobs:
           CLOUDSDK_COMPUTE_ZONE: "us-east1-b"
           CLOUDSDK_REGION: "us-east1"
         run: |
-            echo "Installing GCloud CLI"
-            export OS_TYPE="linux"
-            mkdir ~/downloads
-            ./test/utils/download_and_install_gcloud.sh
-            echo ${GCLOUD_SERVICE_KEY} | base64 --decode > ~/gcloud-service-key.json
-            gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
-            gh-actions-scripts/upload_helm_chart_to_google_cloud.sh dist/keptn-installer/
+          echo "Installing GCloud CLI"
+          export OS_TYPE="linux"
+          mkdir ~/downloads
+          ./test/utils/download_and_install_gcloud.sh
+          echo ${GCLOUD_SERVICE_KEY} | base64 --decode > ~/gcloud-service-key.json
+          gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
+          gh-actions-scripts/upload_helm_chart_to_google_cloud.sh dist/keptn-installer/
+
+      - name: Attach docker image digests to release
+        env:
+          DIGEST_FILE: "digests.csv"
+          RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
+        run: |
+          for digest_file in ./dist/image-digests/digest-*.txt; do
+            cat "$digest_file" >> $DIGEST_FILE
+          done
+          
+          gh release upload "$RELEASE_TAG" "$DIGEST_FILE"
 
   ############################################################################
   # Push Docker Images to alternative Registries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,6 +191,20 @@ jobs:
           username: ${{ secrets.REGISTRY_USER }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: "ghcr.io"
+          username: "keptn-bot"
+          password: ${{ secrets.KEPTN_BOT_TOKEN }}
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: "quay.io"
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
       - id: docker_build_image
         name: "Docker Build keptn/${{ matrix.config.artifact }}"
         uses: docker/build-push-action@v2
@@ -198,6 +212,8 @@ jobs:
           context: ${{ matrix.config.working-dir }}
           tags: |
             keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
+            quay.io/keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
+            ghcr.io/keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
           build-args: |
             version=${{ env.VERSION }}
           push: ${{ matrix.config.should-push-image }}
@@ -378,43 +394,3 @@ jobs:
           done
           
           gh release upload "$RELEASE_TAG" "$DIGEST_FILE"
-
-  ############################################################################
-  # Push Docker Images to alternative Registries
-  ############################################################################
-  repush_images:
-    needs: [prepare, release]
-    name: Push Images to alternative Registries
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix: ${{ fromJson(needs.prepare.outputs.BUILD_MATRIX) }}
-    steps:
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.REGISTRY_USER }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: "ghcr.io"
-          username: "keptn-bot"
-          password: ${{ secrets.KEPTN_BOT_TOKEN }}
-
-      - name: Login to Quay.io
-        uses: docker/login-action@v1
-        with:
-          registry: "quay.io"
-          username: ${{ secrets.QUAY_USER }}
-          password: ${{ secrets.QUAY_TOKEN }}
-
-      - name: Push to alternative Registries
-        env:
-          VERSION: ${{ needs.prepare.outputs.next-version }}
-        uses: akhilerm/tag-push-action@v2.0.0
-        with:
-          src: docker.io/keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
-          dst: |
-            quay.io/keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
-            ghcr.io/keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}

--- a/gh-actions-scripts/check-image-digests.sh
+++ b/gh-actions-scripts/check-image-digests.sh
@@ -13,7 +13,7 @@ for tag in "${tags[@]}"; do
 
     while IFS=, read -r artifact release_digest; do
       echo "Pulling docker image $artifact:$tag..."
-      docker pull "keptn/$artifact:$tag"
+      docker pull "keptn/$artifact:$tag" --quiet
       docker_digest=$(docker inspect "keptn/$artifact:$tag" | jq -r '.[0].RepoDigests[0]' | cut -d'@' -f2)
 
       echo "Checking image digest..."

--- a/gh-actions-scripts/check-image-digests.sh
+++ b/gh-actions-scripts/check-image-digests.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+DIGEST_FILE="digests.csv"
+
+readarray -t tags <<< "$(gh release list --limit 1000 | awk '{print $1}')"
+
+for tag in "${tags[@]}"; do
+  readarray -t release_assets <<< "$(gh release view "$tag" --json assets --jq ".assets[].name")"
+
+  echo "Checking if release $tag has docker image digests attached..."
+  if [[ "${release_assets[*]}" =~ $DIGEST_FILE ]]; then
+    echo "Release $tag has docker image digests attached. Downloading digests file..."
+    gh release download --pattern="$DIGEST_FILE"
+
+    while IFS=, read -r artifact release_digest; do
+      echo "Pulling docker image $artifact:$tag..."
+      docker pull "keptn/$artifact:$tag"
+      docker_digest=$(docker inspect "keptn/$artifact:$tag" | jq -r '.[0].RepoDigests[0]' | cut -d'@' -f2)
+
+      echo "Checking image digest..."
+      if [[ "$docker_digest" != "$release_digest" ]]; then
+        echo "CAUTION: Docker image digest does not match released digest!"
+        exit 1
+      else
+        echo "Image digest for $artifact:$tag matches released digest. Continuing..."
+      fi
+    done < $DIGEST_FILE
+  fi
+done


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- adds a new pipeline that checks the docker image digests from dockerhub against the digests that are attached to the releases of keptn
- adds the upload of a `digests.csv` file to the (pre)release pipeline
- streamlines image upload to quay.io and ghcr.io (now, the images are not first released and then copied to the other registries, instead, they are pushed directly at the same time to all 3 registries)

### Related Issues

Fixes #5738 
