### PR TITLE
ci: Minor pipeline improvements

### DIFF
--- a/.github/workflows/check-docker-image-digests.yml
+++ b/.github/workflows/check-docker-image-digests.yml
@@ -2,7 +2,7 @@ name: Check Docker Image Digests
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 5 * * 1-5'
+    - cron: '0 5 * * *'
 defaults:
   run:
     shell: bash

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -398,8 +398,6 @@ jobs:
           DIGEST_FILE: "digests.csv"
           RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
         run: |
-          for digest_file in ./dist/image-digests/digest-*.txt; do
-            cat "$digest_file" >> $DIGEST_FILE
-          done
+          cat ./dist/image-digests/digest-*.txt >> $DIGEST_FILE
           
           gh release upload "$RELEASE_TAG" "$DIGEST_FILE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -394,8 +394,6 @@ jobs:
           DIGEST_FILE: "digests.csv"
           RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
         run: |
-          for digest_file in ./dist/image-digests/digest-*.txt; do
-            cat "$digest_file" >> $DIGEST_FILE
-          done
+          cat ./dist/image-digests/digest-*.txt >> $DIGEST_FILE
           
           gh release upload "$RELEASE_TAG" "$DIGEST_FILE"


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- runs the docker digest check pipeline every night instead of just on workday nights
- simplifies some bash for loop to just wildcard expansions
