### PR TITLE
ci: Only push docker images if not from a forked repo

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -400,5 +400,5 @@ jobs:
             keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}.${{ env.DATETIME }}
           build-args: |
             version=${{ env.VERSION }}
-          push: ${{ matrix.config.should-push-image && ( github.actor != 'renovate[bot]' && github.actor != 'dependabot[bot]' ) }}
+          push: ${{ matrix.config.should-push-image && github.actor != 'renovate[bot]' && github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
           pull: true


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- remove pushing of docker images for forked branches. This was not possible before anyways since the docker login step was not executed in those cases. But now, the docker build fails completely because pushing is not dependent on the fork/non-fork branch condition anymore. This was added back