### PR TITLE
ci: Fix digest checker pipeline

### DIFF
--- a/.github/workflows/check-docker-image-digests.yml
+++ b/.github/workflows/check-docker-image-digests.yml
@@ -14,4 +14,6 @@ jobs:
         uses: actions/checkout@v2.4.0
 
       - name: Check docker image digests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gh-actions-scripts/check-image-digests.sh

--- a/gh-actions-scripts/check-image-digests.sh
+++ b/gh-actions-scripts/check-image-digests.sh
@@ -9,9 +9,10 @@ for tag in "${tags[@]}"; do
   echo "Checking if release $tag has docker image digests attached..."
   if [[ "${release_assets[*]}" =~ $DIGEST_FILE ]]; then
     echo "Release $tag has docker image digests attached. Downloading digests file..."
-    gh release download --pattern="$DIGEST_FILE"
+    gh release download "$tag" --pattern="$DIGEST_FILE"
     echo "Digests from release:"
     cat "$DIGEST_FILE"
+    echo ""
 
     while IFS=, read -r artifact release_digest; do
       echo "Pulling docker image $artifact:$tag..."
@@ -30,4 +31,5 @@ for tag in "${tags[@]}"; do
     done < $DIGEST_FILE
     rm "$DIGEST_FILE"
   fi
+  echo ""
 done

--- a/gh-actions-scripts/check-image-digests.sh
+++ b/gh-actions-scripts/check-image-digests.sh
@@ -21,6 +21,8 @@ for tag in "${tags[@]}"; do
       echo "Checking image digest..."
       if [[ "$docker_digest" != "$release_digest" ]]; then
         echo "CAUTION: Docker image digest does not match released digest!"
+        echo "Digest from dockerhub: $docker_digest"
+        echo "Digest from release:   $release_digest"
         exit 1
       else
         echo "Image digest for $artifact:$tag matches released digest. Continuing..."

--- a/gh-actions-scripts/check-image-digests.sh
+++ b/gh-actions-scripts/check-image-digests.sh
@@ -31,5 +31,5 @@ for tag in "${tags[@]}"; do
     done < $DIGEST_FILE
     rm "$DIGEST_FILE"
   fi
-  echo ""
+  echo "============="
 done

--- a/gh-actions-scripts/check-image-digests.sh
+++ b/gh-actions-scripts/check-image-digests.sh
@@ -10,6 +10,8 @@ for tag in "${tags[@]}"; do
   if [[ "${release_assets[*]}" =~ $DIGEST_FILE ]]; then
     echo "Release $tag has docker image digests attached. Downloading digests file..."
     gh release download --pattern="$DIGEST_FILE"
+    echo "Digests from release:"
+    cat "$DIGEST_FILE"
 
     while IFS=, read -r artifact release_digest; do
       echo "Pulling docker image $artifact:$tag..."
@@ -24,5 +26,6 @@ for tag in "${tags[@]}"; do
         echo "Image digest for $artifact:$tag matches released digest. Continuing..."
       fi
     done < $DIGEST_FILE
+    rm "$DIGEST_FILE"
   fi
 done


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- adds the `GITHUB_TOKEN`  so that the `gh` CLI has access to the keptn github repo
- fixes the digest checker script (the digest file download always loaded the digests from the latest release)