### PR TITLE
chore(installer): Added metadata to keptn helm chart

### DIFF
--- a/installer/manifests/keptn/Chart.yaml
+++ b/installer/manifests/keptn/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: keptn
-description: Keptn - Cloud-native application life-cycle orchestration
+description: Cloud-native application life-cycle orchestration
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/installer/manifests/keptn/Chart.yaml
+++ b/installer/manifests/keptn/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: keptn
-description: A Helm chart for Kubernetes
+description: Keptn - Cloud-native application life-cycle orchestration
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -21,6 +21,22 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 appVersion: latest
+
+home: "https://keptn.sh"
+icon: "https://raw.githubusercontent.com/cncf/artwork/master/projects/keptn/icon/color/keptn-icon-color.svg"
+sources:
+  - "https://github.com/keptn/keptn"
+  - "https://github.com/keptn/helm-charts"
+annotations:
+  artifacthub.io/license: "Apache-2.0"
+  artifacthub.io/links: |
+    - name: support
+      url: https://github.com/keptn/keptn/issues
+keywords:
+  - cloud-native
+  - orchestration
+  - cd
+  - keptn
 
 dependencies:
   - name: control-plane


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- adds metadata to the keptn helm chart

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #5530

### Notes
The artifacthub repo was already switched to point to the github helm chart repository.
Adding an icon to the artifacthub repo is not possible without more effort. This would only be possible by having the unpackaged, but fully versioned chart in the https://github.com/keptn/helm-charts repo on master branch with a corresponding readme file.