### PR TITLE
chore: promote @thschue to maintainers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -28,6 +28,7 @@ Moritz Wiesinger, @mowies, Dynatrace
 Anna Reale, @RealAnna, Dynatrace
 Ondrej Dubaj, @odubajDT, Dynatrace
 Oleg Nenashev, @oleg-nenashev, Dynatrace/CDF/Jenkins
+Thomas Schuetz, @thschue, Dynatrace
 
 # Approvers
 
@@ -42,4 +43,3 @@ Gilbert Tanner, @TannerGilbert, Dynatrace
 Kavindu Dodanduwa, @kavindu-dodan, Dynatrace
 Rob Jahn, @robertjahn, Dynatrace
 Suraj Banakar, @vadasambar, No Affiliation
-Thomas Schütz, @thschue, Dynatrace


### PR DESCRIPTION
FTR: https://github.com/keptn/community/issues/94

Signed-off-by: Thomas Schuetz <thomas.schuetz@dynatrace.com>

## This PR
- adds @thschue to MAINTAINERS
