### PR TITLE
ci: Remove unneeded pipelines and config files

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,8 +1,0 @@
-name: DCO
-on:
-  pull_request:
-jobs:
-  check:
-    uses: keptn/gh-automation/.github/workflows/dco.yml@v1
-    with:
-      exclude-emails: '49699333+dependabot[bot]@users.noreply.github.com'

--- a/.lift.toml
+++ b/.lift.toml
@@ -1,9 +1,0 @@
-# lift config reference: https://help.sonatype.com/lift/configuration-reference
-
-# A deny list of analyis tools to not be applied to the repository.
-# "Closure-Compiler", "ESLint", "JSHint" are focused on javascript stuff and often flagged generated code
-disableTools = ["Closure-Compiler", "ESLint", "JSHint"]
-
-# Any issue in the ignore list is never reported to the user
-# GoSec -> G306 - Expect WriteFile permissions to be 0600 or less
-ignoreRules = ["G306"]


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- removes the DCO pipeline. Since the DCO bot was not taken offline after all, we don't need a custom pipeline
- removes the now unneeded Sonatype Lift config file
