### PR TITLE
fix(configuration-service): Ensure that git user and email are set before committing (#6645)

### DIFF
--- a/configuration-service/common/git.go
+++ b/configuration-service/common/git.go
@@ -110,8 +110,8 @@ func (g *Git) CheckoutBranch(project string, branch string, disableUpstreamSync 
 	projectConfigPath := config.ConfigDir + "/" + project
 
 	// first, ensure that we don't have any uncommitted changes
-	if _, err := g.Executor.ExecuteCommand("git", []string{"reset", "--hard"}, projectConfigPath); err != nil {
-		return fmt.Errorf("failed to reset branch '%s' in project '%s'", branch, project)
+	if err := g.Reset(project); err != nil {
+		return err
 	}
 	_, err := g.Executor.ExecuteCommand("git", []string{"checkout", branch}, projectConfigPath)
 	if err != nil {

--- a/configuration-service/common/git.go
+++ b/configuration-service/common/git.go
@@ -254,6 +254,10 @@ func (g *Git) pullUpstreamChanges(err error, repoURI string, projectConfigPath s
 
 // StageAndCommitAll stages all current changes and commits them to the current branch
 func (g *Git) StageAndCommitAll(project string, message string, withPull bool) error {
+	// ensure that the git user and email are set at this point
+	if err := ConfigureGitUser(project); err != nil {
+		return err
+	}
 	projectConfigPath := config.ConfigDir + "/" + project
 	_, err := g.Executor.ExecuteCommand("git", []string{"add", "."}, projectConfigPath)
 	if err != nil {

--- a/configuration-service/common/git.go
+++ b/configuration-service/common/git.go
@@ -108,6 +108,11 @@ func (g *Git) CloneRepo(project string, credentials common_models.GitCredentials
 // CheckoutBranch checks out the given branch
 func (g *Git) CheckoutBranch(project string, branch string, disableUpstreamSync bool) error {
 	projectConfigPath := config.ConfigDir + "/" + project
+
+	// first, ensure that we don't have any uncommitted changes
+	if _, err := g.Executor.ExecuteCommand("git", []string{"reset", "--hard"}, projectConfigPath); err != nil {
+		return fmt.Errorf("failed to reset branch '%s' in project '%s'", branch, project)
+	}
 	_, err := g.Executor.ExecuteCommand("git", []string{"checkout", branch}, projectConfigPath)
 	if err != nil {
 		return fmt.Errorf("failed to checkout requested branch '%s' in project '%s'", branch, project)

--- a/configuration-service/common/git_test.go
+++ b/configuration-service/common/git_test.go
@@ -263,14 +263,8 @@ func TestGit_setUpstreamsAndPush(t *testing.T) {
 							release-0.8.0 merges with remote release-0.8.0
 						  Local ref configured for 'git push':
 							release-0.8.0 pushes to release-0.8.0 (up to date)`, nil
-					} else if args[0] == "checkout" {
-						return "", nil
-					} else if args[0] == "push" {
-						return "", nil
-					} else if args[0] == "pull" {
-						return "", nil
 					}
-					return "", errors.New("unexpected command")
+					return "", nil
 				}},
 				CredentialReader: getDummyCredentialReader(),
 			},
@@ -292,6 +286,11 @@ func TestGit_setUpstreamsAndPush(t *testing.T) {
 				{
 					Command:   "git",
 					Args:      []string{"remote", "show", "origin"},
+					Directory: "./debug/config/my-project",
+				},
+				{
+					Command:   "git",
+					Args:      []string{"reset", "--hard"},
 					Directory: "./debug/config/my-project",
 				},
 				{
@@ -330,12 +329,10 @@ func TestGit_setUpstreamsAndPush(t *testing.T) {
 							release-0.8.0 pushes to release-0.8.0 (up to date)`, nil
 					} else if args[0] == "checkout" {
 						return "", nil
-					} else if args[0] == "push" {
-						return "", nil
 					} else if args[0] == "pull" {
 						return "", errors.New("oops")
 					}
-					return "", errors.New("unexpected command")
+					return "", nil
 				}},
 				CredentialReader: getDummyCredentialReader(),
 			},
@@ -357,6 +354,11 @@ func TestGit_setUpstreamsAndPush(t *testing.T) {
 				{
 					Command:   "git",
 					Args:      []string{"remote", "show", "origin"},
+					Directory: "./debug/config/my-project",
+				},
+				{
+					Command:   "git",
+					Args:      []string{"reset", "--hard"},
 					Directory: "./debug/config/my-project",
 				},
 				{
@@ -388,14 +390,10 @@ func TestGit_setUpstreamsAndPush(t *testing.T) {
 							release-0.8.0 merges with remote release-0.8.0
 						  Local ref configured for 'git push':
 							release-0.8.0 pushes to release-0.8.0 (up to date)`, nil
-					} else if args[0] == "checkout" {
-						return "", nil
-					} else if args[0] == "push" {
-						return "", nil
 					} else if args[0] == "pull" && args[1] == "-s" {
 						return "", errors.New("Couldn't find remote ref HEAD")
 					}
-					return "", errors.New("unexpected command")
+					return "", nil
 				}},
 				CredentialReader: getDummyCredentialReader(),
 			},
@@ -417,6 +415,11 @@ func TestGit_setUpstreamsAndPush(t *testing.T) {
 				{
 					Command:   "git",
 					Args:      []string{"remote", "show", "origin"},
+					Directory: "./debug/config/my-project",
+				},
+				{
+					Command:   "git",
+					Args:      []string{"reset", "--hard"},
 					Directory: "./debug/config/my-project",
 				},
 				{

--- a/configuration-service/handlers/project.go
+++ b/configuration-service/handlers/project.go
@@ -113,6 +113,12 @@ func PutProjectProjectNameHandlerFunc(params project.PutProjectProjectNameParams
 		common.LockProject(projectName)
 		defer common.UnlockProject(projectName)
 
+		err := common.ConfigureGitUser(params.Project.ProjectName)
+		if err != nil {
+			logger.WithError(err).Errorf("Could not configure git during creating project %s", params.Project.ProjectName)
+			return project.NewPostProjectDefault(http.StatusInternalServerError).WithPayload(&models.Error{Code: http.StatusInternalServerError, Message: swag.String("Could not configure git in project repo")})
+		}
+
 		gitCredentials, err := common.GetCredentials(projectName)
 		if err == nil && gitCredentials != nil {
 			logger.Infof("Storing Git credentials for project %s", projectName)


### PR DESCRIPTION
Closes #6645 
Closes #6651 

This PR ensure that the `git.user` and `git.email` config values are set before attempting to commit/push to a project's configuration repository.

Integration test run: https://github.com/keptn/keptn/runs/4896206083?check_suite_focus=true