### PR TITLE
chore: adapted CLI to newest state of `APISet` in go-utils

### DIFF
--- a/cli/cmd/add_resource.go
+++ b/cli/cmd/add_resource.go
@@ -77,7 +77,7 @@ keptn add-resource --project=keptn --service=keptn-control-plane --all-stages --
 			},
 		}
 
-		api, err := internal.APIProvider(endPoint.String(), apiToken, "x-token", endPoint.Scheme)
+		api, err := internal.APIProvider(endPoint.String(), apiToken)
 		if err != nil {
 			return err
 		}
@@ -108,7 +108,7 @@ keptn add-resource --project=keptn --service=keptn-control-plane --all-stages --
 			if addResourceCmdParams.AllStages != nil && *addResourceCmdParams.AllStages {
 				// Upload to all stages
 				// get stages
-				api, err := internal.APIProvider(endPoint.String(), apiToken, "x-token", endPoint.Scheme)
+				api, err := internal.APIProvider(endPoint.String(), apiToken)
 				if err != nil {
 					return err
 				}

--- a/cli/cmd/authenticator.go
+++ b/cli/cmd/authenticator.go
@@ -70,7 +70,7 @@ func (a *Authenticator) Auth(authenticatorOptions AuthenticatorOptions) error {
 		endpoint.Path = "/api"
 	}
 
-	api, err := internal.APIProvider(endpoint.String(), apiToken, "x-token", endpoint.Scheme)
+	api, err := internal.APIProvider(endpoint.String(), apiToken)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/configure_monitoring.go
+++ b/cli/cmd/configure_monitoring.go
@@ -88,7 +88,7 @@ keptn configure monitoring prometheus --project=PROJECTNAME --service=SERVICENAM
 				endPointErr)
 		}
 
-		api, err := internal.APIProvider(endPoint.String(), apiToken, "x-token", endPoint.Scheme)
+		api, err := internal.APIProvider(endPoint.String(), apiToken)
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/create_project.go
+++ b/cli/cmd/create_project.go
@@ -93,7 +93,7 @@ keptn create project PROJECTNAME --shipyard=FILEPATH --git-user=GIT_USER --git-t
 				endPointErr)
 		}
 
-		api, err := internal.APIProvider(endPoint.String(), apiToken, "x-token", endPoint.Scheme)
+		api, err := internal.APIProvider(endPoint.String(), apiToken)
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/create_service.go
+++ b/cli/cmd/create_service.go
@@ -61,7 +61,7 @@ var crServiceCmd = &cobra.Command{
 				endPointErr)
 		}
 
-		api, err := internal.APIProvider(endPoint.String(), apiToken, "x-token", endPoint.Scheme)
+		api, err := internal.APIProvider(endPoint.String(), apiToken)
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/delete_project.go
+++ b/cli/cmd/delete_project.go
@@ -63,7 +63,7 @@ var delProjectCmd = &cobra.Command{
 				endPointErr)
 		}
 
-		api, err := internal.APIProvider(endPoint.String(), apiToken, "x-token", endPoint.Scheme)
+		api, err := internal.APIProvider(endPoint.String(), apiToken)
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/delete_service.go
+++ b/cli/cmd/delete_service.go
@@ -41,7 +41,7 @@ Furthermore, if Keptn is used for continuous delivery (i.e. services have been o
 
 		logging.PrintLog("Starting to delete service", logging.InfoLevel)
 
-		api, err := internal.APIProvider(endPoint.String(), apiToken, "x-token", endPoint.Scheme)
+		api, err := internal.APIProvider(endPoint.String(), apiToken)
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/generate_support_archive.go
+++ b/cli/cmd/generate_support_archive.go
@@ -543,7 +543,7 @@ func getProjects() *errorableProjectResult {
 	if err != nil {
 		return newErrorableProjectResult(nil, err)
 	}
-	api, err := internal.APIProvider(endPoint.String(), apiToken, "x-token", endPoint.Scheme)
+	api, err := internal.APIProvider(endPoint.String(), apiToken)
 	if err != nil {
 		return nil
 	}
@@ -569,7 +569,7 @@ func getKeptnMetadata() *errorableMetadataResult {
 	if err != nil {
 		return newErrorableMetadataResult(nil, err)
 	}
-	api, err := internal.APIProvider(endPoint.String(), apiToken, "x-token", endPoint.Scheme)
+	api, err := internal.APIProvider(endPoint.String(), apiToken)
 	if err != nil {
 		return nil
 	}

--- a/cli/cmd/get_event.go
+++ b/cli/cmd/get_event.go
@@ -88,7 +88,7 @@ func getEvent(eventStruct GetEventStruct, args []string) error {
 		EventType:     eventType,
 		NumberOfPages: *eventStruct.NumOfPages,
 	}
-	api, err := internal.APIProvider(endPoint.String(), apiToken, "x-token", endPoint.Scheme)
+	api, err := internal.APIProvider(endPoint.String(), apiToken)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/get_event_approvalTriggered.go
+++ b/cli/cmd/get_event_approvalTriggered.go
@@ -72,7 +72,7 @@ func getApprovalTriggeredEvents(approvalTriggered approvalTriggeredStruct) error
 			endPointErr)
 	}
 
-	api, err := internal.APIProvider(endPoint.String(), apiToken, "x-token", endPoint.Scheme)
+	api, err := internal.APIProvider(endPoint.String(), apiToken)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/get_event_evaluationFinished.go
+++ b/cli/cmd/get_event_evaluationFinished.go
@@ -57,7 +57,7 @@ var getEvaluationFinishedCmd = &cobra.Command{
 				endPointErr)
 		}
 
-		api, err := internal.APIProvider(endPoint.String(), apiToken, "x-token", endPoint.Scheme)
+		api, err := internal.APIProvider(endPoint.String(), apiToken)
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/get_projects.go
+++ b/cli/cmd/get_projects.go
@@ -94,7 +94,7 @@ keptn get project sockshop -output=json  # Returns project details in JSON forma
 				endPointErr)
 		}
 
-		api, err := internal.APIProvider(endPoint.String(), apiToken, "x-token", endPoint.Scheme)
+		api, err := internal.APIProvider(endPoint.String(), apiToken)
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/get_services.go
+++ b/cli/cmd/get_services.go
@@ -74,7 +74,7 @@ keptn get services carts --project=sockshop -o=json  # Get details of the carts 
 				endPointErr)
 		}
 
-		api, err := internal.APIProvider(endPoint.String(), apiToken, "x-token", endPoint.Scheme)
+		api, err := internal.APIProvider(endPoint.String(), apiToken)
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/get_stages.go
+++ b/cli/cmd/get_stages.go
@@ -67,7 +67,7 @@ staging        2020-04-06T14:37:45.210Z
 				endPointErr)
 		}
 
-		api, err := internal.APIProvider(endPoint.String(), apiToken, "x-token", endPoint.Scheme)
+		api, err := internal.APIProvider(endPoint.String(), apiToken)
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/main_test.go
+++ b/cli/cmd/main_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestMain(m *testing.M) {
 	mocking = true
-	internal.APIProvider = func(baseURL string, authToken string, authHeader string, scheme string) (*apiutils.APISet, error) {
-		return apiutils.NewAPISet(baseURL, authToken, authHeader, &http.Client{}, scheme)
+	internal.APIProvider = func(baseURL string, authToken string) (*apiutils.APISet, error) {
+		return apiutils.New(baseURL, apiutils.WithAuthToken(authToken), apiutils.WithHTTPClient(&http.Client{}))
 	}
 	code := m.Run()
 	os.Exit(code)

--- a/cli/cmd/secret.go
+++ b/cli/cmd/secret.go
@@ -148,7 +148,7 @@ func NewSecretCmdHandler(cm credentialmanager.CredentialManagerInterface) (*Secr
 		return nil, fmt.Errorf("Error connecting to server: %s"+endPointErrorReasons,
 			endPointErr)
 	}
-	api, err := internal.APIProvider(endPoint.String(), apiToken, "x-token", endPoint.Scheme)
+	api, err := internal.APIProvider(endPoint.String(), apiToken)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/cmd/send_event.go
+++ b/cli/cmd/send_event.go
@@ -63,7 +63,7 @@ In addition, the payload of the CloudEvent needs to follow the Keptn spec (https
 				endPointErr)
 		}
 
-		api, err := internal.APIProvider(endPoint.String(), apiToken, "x-token", endPoint.Scheme)
+		api, err := internal.APIProvider(endPoint.String(), apiToken)
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/send_event_approvalFinished.go
+++ b/cli/cmd/send_event_approvalFinished.go
@@ -87,7 +87,7 @@ func sendApprovalFinishedEvent(sendApprovalFinishedOptions sendApprovalFinishedS
 	}
 
 	logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)
-	api, err := internal.APIProvider(endPoint.String(), apiToken, "x-token", endPoint.Scheme)
+	api, err := internal.APIProvider(endPoint.String(), apiToken)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/sequencecontrol.go
+++ b/cli/cmd/sequencecontrol.go
@@ -43,7 +43,7 @@ func controlSequence(sequenceState SequenceState, params sequenceControlStruct) 
 		return fmt.Errorf("Error connecting to server: %s"+endPointErrorReasons,
 			endPointErr)
 	}
-	api, err := internal.APIProvider(endPoint.String(), apiToken, "x-token", endPoint.Scheme)
+	api, err := internal.APIProvider(endPoint.String(), apiToken)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/trigger_delivery.go
+++ b/cli/cmd/trigger_delivery.go
@@ -88,7 +88,7 @@ func doTriggerDelivery(deliveryInputData deliveryStruct) error {
 			endPointErr)
 	}
 
-	api, err := internal.APIProvider(endPoint.String(), apiToken, "x-token", endPoint.Scheme)
+	api, err := internal.APIProvider(endPoint.String(), apiToken)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/trigger_evaluation.go
+++ b/cli/cmd/trigger_evaluation.go
@@ -104,7 +104,7 @@ func doTriggerEvaluation(triggerEvaluationData triggerEvaluationStruct) error {
 		return fmt.Errorf("Start and end time of evaluation time frame not set: %s", err.Error())
 	}
 
-	api, err := internal.APIProvider(endPoint.String(), apiToken, "x-token", endPoint.Scheme)
+	api, err := internal.APIProvider(endPoint.String(), apiToken)
 	if err != nil {
 		return err
 	}
@@ -134,7 +134,7 @@ func doTriggerEvaluation(triggerEvaluationData triggerEvaluationStruct) error {
 		}
 
 		if *triggerEvaluationData.Watch {
-			api, err := internal.APIProvider(endPoint.String(), apiToken, "x-token", endPoint.Scheme)
+			api, err := internal.APIProvider(endPoint.String(), apiToken)
 			if err != nil {
 				return err
 			}

--- a/cli/cmd/update_project.go
+++ b/cli/cmd/update_project.go
@@ -78,7 +78,7 @@ For more information about updating projects or upstream repositories, please go
 			project.GitRemoteURL = *updateProjectParams.RemoteURL
 		}
 
-		api, err := internal.APIProvider(endPoint.String(), apiToken, "x-token", endPoint.Scheme)
+		api, err := internal.APIProvider(endPoint.String(), apiToken)
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -253,7 +253,7 @@ func addWarningNonExistingProjectUpstream() error {
 		return errors.New(authErrorMsg)
 	}
 
-	api, err := internal.APIProvider(endPoint.String(), apiToken, "x-token", endPoint.Scheme)
+	api, err := internal.APIProvider(endPoint.String(), apiToken)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -181,7 +181,7 @@ func getKeptnServerVersion() (string, error) {
 	if endPointErr := CheckEndpointStatus(endPoint.String()); endPointErr != nil {
 		return "", fmt.Errorf("Error connecting to server: %s"+endPointErrorReasons, endPointErr)
 	}
-	api, err := internal.APIProvider(endPoint.String(), apiToken, "x-token", endPoint.Scheme)
+	api, err := internal.APIProvider(endPoint.String(), apiToken)
 	if err != nil {
 		return "", err
 	}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/docker/docker-credential-helpers v0.6.4
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-version v1.3.0
-	github.com/keptn/go-utils v0.11.1-0.20220113195527-4005d064f27c
+	github.com/keptn/go-utils v0.11.1-0.20220121133159-436bd5859179
 	github.com/keptn/kubernetes-utils v0.10.1-0.20211102080304-e59377afdc8b
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/mitchellh/mapstructure v1.4.3

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -773,8 +773,8 @@ github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8
 github.com/karrick/godirwalk v1.15.8 h1:7+rWAZPn9zuRxaIqqT8Ohs2Q2Ac0msBqwRdxNCr2VVs=
 github.com/karrick/godirwalk v1.15.8/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/keptn/go-utils v0.10.0/go.mod h1:ub4G0WZUckc3TizUoe5jKqfCOOLiH5pnf4M1SDCOT0M=
-github.com/keptn/go-utils v0.11.1-0.20220113195527-4005d064f27c h1:TZn9vf7ZuXd/TuhXtXbdkg+OPfM3C2+b4rDhd1BI9bY=
-github.com/keptn/go-utils v0.11.1-0.20220113195527-4005d064f27c/go.mod h1:yJM7pnCUj23VHKa2az9eWUTAmLDv94f6DVHON9qV1kU=
+github.com/keptn/go-utils v0.11.1-0.20220121133159-436bd5859179 h1:uK2eNwHCzZVhAykG6vRdcf3evebnmEcU90hCDXdd3hs=
+github.com/keptn/go-utils v0.11.1-0.20220121133159-436bd5859179/go.mod h1:yJM7pnCUj23VHKa2az9eWUTAmLDv94f6DVHON9qV1kU=
 github.com/keptn/kubernetes-utils v0.10.1-0.20211102080304-e59377afdc8b h1:L+1m9DuYPfQCEv82/u05jj7EgeeZ/8tDkwf4JoRzMbw=
 github.com/keptn/kubernetes-utils v0.10.1-0.20211102080304-e59377afdc8b/go.mod h1:vSj1n58CWHBrh4DzMhODGU1Z6BKYl9wEFzsg4XmuaJ0=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/cli/internal/api.go
+++ b/cli/internal/api.go
@@ -13,7 +13,7 @@ var PublicDiscovery = auth2.NewOauthDiscovery(&http.Client{})
 var APIProvider = getAPISet
 
 // getAPISet retrieves the ApiSet containing all Keptn client APIs
-func getAPISet(baseURL string, authToken string, authHeader string, scheme string) (*apiutils.APISet, error) {
+func getAPISet(baseURL string, authToken string) (*apiutils.APISet, error) {
 	var client *http.Client
 	var err error
 	tokenStore := auth2.NewLocalFileOauthStore()
@@ -24,5 +24,5 @@ func getAPISet(baseURL string, authToken string, authHeader string, scheme strin
 			return nil, err
 		}
 	}
-	return apiutils.NewAPISet(baseURL, authToken, authHeader, client, scheme)
+	return apiutils.New(baseURL, apiutils.WithAuthToken(authToken), apiutils.WithHTTPClient(client))
 }


### PR DESCRIPTION
This PR contains the code adaptations for CLI to be compatible with the newest codebase in `go-utils` see: https://github.com/keptn/go-utils/pull/378