### PR TITLE
fix(bridge): When updating an all events subscription, keep sh.keptn.> format (#6628)

### DIFF
--- a/bridge/client/app/_components/ktb-markdown/ktb-markdown.component.ts
+++ b/bridge/client/app/_components/ktb-markdown/ktb-markdown.component.ts
@@ -1,4 +1,4 @@
-import { marked, Renderer } from 'marked';
+import marked, { Renderer } from 'marked';
 import DOMPurify from 'dompurify';
 import hljs from 'highlight.js';
 import {

--- a/bridge/client/app/_components/ktb-markdown/ktb-markdown.component.ts
+++ b/bridge/client/app/_components/ktb-markdown/ktb-markdown.component.ts
@@ -1,4 +1,4 @@
-import marked, { Renderer } from 'marked';
+import { marked, Renderer } from 'marked';
 import DOMPurify from 'dompurify';
 import hljs from 'highlight.js';
 import {

--- a/bridge/client/app/_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component.spec.ts
+++ b/bridge/client/app/_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component.spec.ts
@@ -258,6 +258,66 @@ describe('KtbModifyUniformSubscriptionComponent', () => {
     expect(subscription.filter.projects?.includes('sockshop')).toEqual(true);
   });
 
+  it('should update subscription for all keptn events with keptn.sh.>', () => {
+    // given
+    const dataService = TestBed.inject(DataService);
+    const spy = jest.spyOn(dataService, 'updateUniformSubscription');
+    const subscription = setSubscription(2, 0);
+    /* eslint-disable @typescript-eslint/ban-ts-comment */
+    // @ts-ignore //Ignore private property
+    component.taskControl.setValue('sh.keptn');
+    component.taskSuffixControl.setValue('>');
+    // @ts-ignore //Ignore private property
+    component.isGlobalControl.setValue(true);
+    component.editMode = true;
+    /* eslint-enable */
+
+    // when
+    component.updateSubscription('sockshop', UniformRegistrationsMock[2].id, subscription, undefined);
+
+    // then
+    expect(spy).toHaveBeenCalledWith(
+      'keptn-uniform-jmeter-service-ea9e7b21d21295570fd62adb04592065',
+      {
+        event: 'sh.keptn.>',
+        filter: { projects: [], services: ['carts'], stages: ['dev'] },
+        id: 'myJmeterSubscriptionId',
+        parameters: [],
+      },
+      undefined
+    );
+  });
+
+  it('should update subscription for approval keptn wildcard events with keptn.sh.event.approval.>', () => {
+    // given
+    const dataService = TestBed.inject(DataService);
+    const spy = jest.spyOn(dataService, 'updateUniformSubscription');
+    const subscription = setSubscription(2, 0);
+    /* eslint-disable @typescript-eslint/ban-ts-comment */
+    // @ts-ignore //Ignore private property
+    component.taskControl.setValue('deployment');
+    component.taskSuffixControl.setValue('>');
+    // @ts-ignore //Ignore private property
+    component.isGlobalControl.setValue(true);
+    component.editMode = true;
+    /* eslint-enable */
+
+    // when
+    component.updateSubscription('sockshop', UniformRegistrationsMock[2].id, subscription, undefined);
+
+    // then
+    expect(spy).toHaveBeenCalledWith(
+      'keptn-uniform-jmeter-service-ea9e7b21d21295570fd62adb04592065',
+      {
+        event: 'sh.keptn.event.deployment.>',
+        filter: { projects: [], services: ['carts'], stages: ['dev'] },
+        id: 'myJmeterSubscriptionId',
+        parameters: [],
+      },
+      undefined
+    );
+  });
+
   it('should update subscription and webhook', () => {
     // given
     const subscription = setSubscription(10, 0);

--- a/bridge/client/app/_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component.spec.ts
+++ b/bridge/client/app/_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component.spec.ts
@@ -260,8 +260,6 @@ describe('KtbModifyUniformSubscriptionComponent', () => {
 
   it('should update subscription for all keptn events with keptn.sh.>', () => {
     // given
-    const dataService = TestBed.inject(DataService);
-    const spy = jest.spyOn(dataService, 'updateUniformSubscription');
     const subscription = setSubscription(2, 0);
     /* eslint-disable @typescript-eslint/ban-ts-comment */
     // @ts-ignore //Ignore private property
@@ -276,22 +274,11 @@ describe('KtbModifyUniformSubscriptionComponent', () => {
     component.updateSubscription('sockshop', UniformRegistrationsMock[2].id, subscription, undefined);
 
     // then
-    expect(spy).toHaveBeenCalledWith(
-      'keptn-uniform-jmeter-service-ea9e7b21d21295570fd62adb04592065',
-      {
-        event: 'sh.keptn.>',
-        filter: { projects: [], services: ['carts'], stages: ['dev'] },
-        id: 'myJmeterSubscriptionId',
-        parameters: [],
-      },
-      undefined
-    );
+    expect(subscription.event).toEqual('sh.keptn.>');
   });
 
-  it('should update subscription for approval keptn wildcard events with keptn.sh.event.approval.>', () => {
+  it('should update subscription for deplyoment keptn wildcard events with keptn.sh.event.approval.>', () => {
     // given
-    const dataService = TestBed.inject(DataService);
-    const spy = jest.spyOn(dataService, 'updateUniformSubscription');
     const subscription = setSubscription(2, 0);
     /* eslint-disable @typescript-eslint/ban-ts-comment */
     // @ts-ignore //Ignore private property
@@ -306,16 +293,7 @@ describe('KtbModifyUniformSubscriptionComponent', () => {
     component.updateSubscription('sockshop', UniformRegistrationsMock[2].id, subscription, undefined);
 
     // then
-    expect(spy).toHaveBeenCalledWith(
-      'keptn-uniform-jmeter-service-ea9e7b21d21295570fd62adb04592065',
-      {
-        event: 'sh.keptn.event.deployment.>',
-        filter: { projects: [], services: ['carts'], stages: ['dev'] },
-        id: 'myJmeterSubscriptionId',
-        parameters: [],
-      },
-      undefined
-    );
+    expect(subscription.event).toEqual('sh.keptn.event.deployment.>');
   });
 
   it('should update subscription and webhook', () => {

--- a/bridge/client/app/_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component.ts
+++ b/bridge/client/app/_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component.ts
@@ -247,7 +247,12 @@ export class KtbModifyUniformSubscriptionComponent implements OnDestroy {
   ): void {
     this.updating = true;
     let update;
-    subscription.event = `${EventTypes.PREFIX}${this.taskControl.value}.${this.taskSuffixControl.value}`;
+
+    if (this.taskControl.value === EventTypes.PREFIX_SHORT && this.taskSuffixControl.value === '>') {
+      subscription.event = `${this.taskControl.value}.${this.taskSuffixControl.value}`;
+    } else {
+      subscription.event = `${EventTypes.PREFIX}${this.taskControl.value}.${this.taskSuffixControl.value}`;
+    }
     subscription.setIsGlobal(this.isGlobalControl.value, projectName);
 
     if (webhookConfig) {

--- a/bridge/shared/interfaces/event-types.ts
+++ b/bridge/shared/interfaces/event-types.ts
@@ -31,4 +31,5 @@ export enum EventTypes {
   ACTION_STARTED = 'sh.keptn.event.action.started',
   ACTION_FINISHED = 'sh.keptn.event.action.finished',
   PREFIX = 'sh.keptn.event.',
+  PREFIX_SHORT = 'sh.keptn',
 }


### PR DESCRIPTION
Fixes #6628 

Fix for the special case of updating an 'sh.keptn.*' subscription.
The additional prefix of 'sh.keptn.event' is now not added anymore and the format is preserved.
