### PR TITLE
ci: Fix intergation tests taking master artifacts from bot commits

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -147,7 +147,12 @@ jobs:
           REPO_SLUG: "keptn/keptn"
           BRANCH: ${{ steps.determine_branch.outputs.BRANCH }}
         run: |
-          RUN_ID=$(curl -sLH 'Accept: application/vnd.github.v3+json' -H "Authorization: token $GITHUB_TOKEN" "api.github.com/repos/$REPO_SLUG/actions/workflows/CI.yml/runs?branch=$BRANCH" | jq -c '[.workflow_runs[] | select( .conclusion == "success" )][0] | .id')
+          RUN_ID=$( \
+            curl -sL \
+              -H 'Accept: application/vnd.github.v3+json' \
+              -H "Authorization: token $GITHUB_TOKEN" \
+              "api.github.com/repos/$REPO_SLUG/actions/workflows/CI.yml/runs?branch=$BRANCH" | \
+            jq -c '[.workflow_runs[] | select( (.head_commit.author.name | endswith("[bot]") | not ) and ( .conclusion == "success" )][0] | .id')
           echo "::set-output name=RUN_ID::$RUN_ID"
 
       # download artifacts from the specified branch with event type push (e.g., push to master/release branch)

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -148,6 +148,7 @@ jobs:
           BRANCH: ${{ steps.determine_branch.outputs.BRANCH }}
         run: |
           RUN_ID=$(curl -sL -H 'Accept: application/vnd.github.v3+json' -H "Authorization: token $GITHUB_TOKEN" "api.github.com/repos/$REPO_SLUG/actions/workflows/CI.yml/runs?branch=$BRANCH" | jq '[.workflow_runs[] | select( (.head_commit.author.name | endswith("[bot]") | not ) and ( .conclusion == "success" ) )][0] | .id')
+          echo "Run ID that will be used to download artifacts from: $RUN_ID"
           echo "::set-output name=RUN_ID::$RUN_ID"
 
       # download artifacts from the specified branch with event type push (e.g., push to master/release branch)

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -147,7 +147,14 @@ jobs:
           REPO_SLUG: "keptn/keptn"
           BRANCH: ${{ steps.determine_branch.outputs.BRANCH }}
         run: |
-          RUN_ID=$(curl -sL -H 'Accept: application/vnd.github.v3+json' -H "Authorization: token $GITHUB_TOKEN" "api.github.com/repos/$REPO_SLUG/actions/workflows/CI.yml/runs?branch=$BRANCH" | jq '[.workflow_runs[] | select( (.head_commit.author.name | endswith("[bot]") | not ) and ( .conclusion == "success" ) )][0] | .id')
+          RUN_ID=$(\
+            curl -sL \
+              -H 'Accept: application/vnd.github.v3+json' \
+              -H "Authorization: token $GITHUB_TOKEN" \
+              "api.github.com/repos/$REPO_SLUG/actions/workflows/CI.yml/runs?branch=$BRANCH" | \
+            jq '[.workflow_runs[] | select( \
+              (.head_commit.author.name | endswith("[bot]") | not ) and ( .conclusion == "success" ) \
+            )][0] | .id')
           echo "Run ID that will be used to download artifacts from: $RUN_ID"
           echo "::set-output name=RUN_ID::$RUN_ID"
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -147,12 +147,7 @@ jobs:
           REPO_SLUG: "keptn/keptn"
           BRANCH: ${{ steps.determine_branch.outputs.BRANCH }}
         run: |
-          RUN_ID=$( \
-            curl -sL \
-              -H 'Accept: application/vnd.github.v3+json' \
-              -H "Authorization: token $GITHUB_TOKEN" \
-              "api.github.com/repos/$REPO_SLUG/actions/workflows/CI.yml/runs?branch=$BRANCH" | \
-            jq -c '[.workflow_runs[] | select( (.head_commit.author.name | endswith("[bot]") | not ) and ( .conclusion == "success" )][0] | .id')
+          RUN_ID=$(curl -sL -H 'Accept: application/vnd.github.v3+json' -H "Authorization: token $GITHUB_TOKEN" "api.github.com/repos/$REPO_SLUG/actions/workflows/CI.yml/runs?branch=$BRANCH" | jq '[.workflow_runs[] | select( (.head_commit.author.name | endswith("[bot]") | not ) and ( .conclusion == "success" ) )][0] | .id')
           echo "::set-output name=RUN_ID::$RUN_ID"
 
       # download artifacts from the specified branch with event type push (e.g., push to master/release branch)

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -152,8 +152,8 @@ jobs:
               -H 'Accept: application/vnd.github.v3+json' \
               -H "Authorization: token $GITHUB_TOKEN" \
               "api.github.com/repos/$REPO_SLUG/actions/workflows/CI.yml/runs?branch=$BRANCH" | \
-            jq '[.workflow_runs[] | select( \
-              (.head_commit.author.name | endswith("[bot]") | not ) and ( .conclusion == "success" ) \
+            jq '[.workflow_runs[] | select(
+              (.head_commit.author.name | endswith("[bot]") | not ) and ( .conclusion == "success" ) 
             )][0] | .id')
           echo "Run ID that will be used to download artifacts from: $RUN_ID"
           echo "::set-output name=RUN_ID::$RUN_ID"


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- enhances the `jq` command that filters the GH actions runs on master to find the latest successful build.
- Now, the filter takes bot builds into account, since those don't push any images which in turn makes the integration tests fail during keptn installation

Integration test run where the correct Run ID was extracted from previous master runs:
https://github.com/keptn/keptn/runs/4934107939?check_suite_focus=true#step:8:36