### PR TITLE
fix(bridge): Add message that no events are available when sequence has no traces (#5985)

### DIFF
--- a/bridge/client/app/_components/ktb-markdown/ktb-markdown.component.ts
+++ b/bridge/client/app/_components/ktb-markdown/ktb-markdown.component.ts
@@ -1,4 +1,4 @@
-import { marked, Renderer } from 'marked';
+import marked, { Renderer } from 'marked';
 import DOMPurify from 'dompurify';
 import hljs from 'highlight.js';
 import {

--- a/bridge/client/app/_components/ktb-markdown/ktb-markdown.component.ts
+++ b/bridge/client/app/_components/ktb-markdown/ktb-markdown.component.ts
@@ -1,4 +1,4 @@
-import marked, { Renderer } from 'marked';
+import { marked, Renderer } from 'marked';
 import DOMPurify from 'dompurify';
 import hljs from 'highlight.js';
 import {

--- a/bridge/client/app/_components/ktb-sequence-tasks-list/ktb-sequence-tasks-list.component.html
+++ b/bridge/client/app/_components/ktb-sequence-tasks-list/ktb-sequence-tasks-list.component.html
@@ -1,4 +1,4 @@
-<div fxLayout="column" fxLayoutGap="15px" uitestid="keptn-sequence-tasks-list-tasks" *ngIf="stage">
+<div fxLayout="column" fxLayoutGap="15px" uitestid="keptn-sequence-tasks-list-tasks" *ngIf="stage; else noStage">
   <div
     #taskRef
     fxLayout="column"
@@ -15,3 +15,6 @@
     ></ktb-task-item>
   </div>
 </div>
+<ng-template #noStage>
+  <ktb-task-item [task]="tasks[0]" [isExpanded]="isFocusedTask(tasks[0])"></ktb-task-item>
+</ng-template>

--- a/bridge/client/app/_components/ktb-sequence-tasks-list/ktb-sequence-tasks-list.component.html
+++ b/bridge/client/app/_components/ktb-sequence-tasks-list/ktb-sequence-tasks-list.component.html
@@ -16,5 +16,5 @@
   </div>
 </div>
 <ng-template #noStage>
-  <ktb-task-item [task]="tasks[0]" [isExpanded]="isFocusedTask(tasks[0])"></ktb-task-item>
+  <ktb-task-item *ngIf="tasks[0]" [task]="tasks[0]" [isExpanded]="isFocusedTask(tasks[0])"></ktb-task-item>
 </ng-template>

--- a/bridge/client/app/_components/ktb-task-item/ktb-task-item.component.html
+++ b/bridge/client/app/_components/ktb-task-item/ktb-task-item.component.html
@@ -41,7 +41,9 @@
             [overlayDisabled]="true"
           ></ktb-evaluation-info>
         </div>
-        <div *ngIf="task.traces.length === 0" class="mt-2">No events are available for this sequence.</div>
+        <div *ngIf="task.traces.length === 0 && !isSubtask" class="mt-2">
+          No events are available for this sequence.
+        </div>
         <div *ngIf="task.data.canary">
           <p class="m-0 nobreak">
             <span class="bold">Action: </span><span [textContent]="task.data.canary.action"></span>
@@ -131,6 +133,7 @@
       *ngIf="subTask.isTriggered(); else taskLine"
       [task]="subTask"
       [latestDeployment]="latestDeployment"
+      [isSubtask]="true"
       (itemClicked)="onClick($event)"
       (click)="$event.stopPropagation(); onClick(subTask)"
     ></ktb-task-item>

--- a/bridge/client/app/_components/ktb-task-item/ktb-task-item.component.html
+++ b/bridge/client/app/_components/ktb-task-item/ktb-task-item.component.html
@@ -41,6 +41,7 @@
             [overlayDisabled]="true"
           ></ktb-evaluation-info>
         </div>
+        <div *ngIf="task.traces.length === 0" class="mt-2">No events for this sequence available.</div>
         <div *ngIf="task.data.canary">
           <p class="m-0 nobreak">
             <span class="bold">Action: </span><span [textContent]="task.data.canary.action"></span>

--- a/bridge/client/app/_components/ktb-task-item/ktb-task-item.component.html
+++ b/bridge/client/app/_components/ktb-task-item/ktb-task-item.component.html
@@ -41,7 +41,7 @@
             [overlayDisabled]="true"
           ></ktb-evaluation-info>
         </div>
-        <div *ngIf="task.traces.length === 0" class="mt-2">No events for this sequence available.</div>
+        <div *ngIf="task.traces.length === 0" class="mt-2">No events are available for this sequence.</div>
         <div *ngIf="task.data.canary">
           <p class="m-0 nobreak">
             <span class="bold">Action: </span><span [textContent]="task.data.canary.action"></span>

--- a/bridge/client/app/_components/ktb-task-item/ktb-task-item.component.ts
+++ b/bridge/client/app/_components/ktb-task-item/ktb-task-item.component.ts
@@ -35,6 +35,7 @@ export class KtbTaskItemComponent implements OnInit, OnDestroy {
   public project$: Observable<Project | undefined> = of(undefined);
   public _task?: Trace;
   @Input() public isExpanded = false;
+  @Input() public isSubtask = false;
 
   @ViewChild('taskPayloadDialog')
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Fixes #5985 

It was agreed on a minimal variant, as we only have the info if a sequence has traces or not. So we show the root event with the event payload button and a message that no events can be found. Any further implementation is not needed.

![image](https://user-images.githubusercontent.com/2674029/150974330-68ce243a-2cc1-404e-9c5b-e4cad3eadc38.png)
