### PR TITLE
fix: Fixed wrong nginx location for bridge urls

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/templates/api-gateway-nginx.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/api-gateway-nginx.yaml
@@ -77,7 +77,7 @@ data:
       proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    location ~* {{ .Values.prefixPath }}/bridge/.* {
+    location ~* {{ .Values.prefixPath }}/bridge {
       rewrite {{ .Values.prefixPath }}/bridge(/.*) $1 break;
       proxy_pass http://bridge:8080;
       proxy_http_version 1.1;


### PR DESCRIPTION
#6302 

This PR fixes the nginx location configuration for bridge so that it works without a trailing `/` after 