### PR TITLE
test: Use API endpoint directly to delete project

### DIFF
--- a/test/go-tests/test_sequencequeue.go
+++ b/test/go-tests/test_sequencequeue.go
@@ -384,7 +384,8 @@ func Test_SequenceQueue_TriggerAndDeleteProject(t *testing.T) {
 	wg.Wait()
 
 	// after all sequences have been triggered, delete the project
-	_, err = ExecuteCommand(fmt.Sprintf("keptn delete project %s", projectName))
+	//_, err = ExecuteCommand(fmt.Sprintf("keptn delete project %s", projectName))
+	_, err = ApiDELETERequest("/controlPlane/v1/project/"+projectName, 3)
 
 	require.Nil(t, err)
 


### PR DESCRIPTION
With this PR, the project created during the `Test_SequenceQueue_TriggerAndDeleteProject` integration test is deleted via the API of the shipyard controller, instead of with the CLI. The reason for that is that during this test, 50 services are created within that project, which, using the CLI will be deleted one by one by the CLI before deleting the project itself. This unnecessarily slows down the test.