### PR TITLE
feat(cli): Use `state` param during Oauth flow

### DIFF
--- a/cli/cmd/authenticator.go
+++ b/cli/cmd/authenticator.go
@@ -109,7 +109,7 @@ func (a *Authenticator) Auth(authenticatorOptions AuthenticatorOptions) error {
 
 	if !authenticated {
 		if authenticatorOptions.SSO {
-			fmt.Println("WARNING: You are using the SSO integration feature without a Keptn API Token. Please verify that your configuration allows it or use the --api-token flag")
+			fmt.Println("WARNING: You are using the SSO integration feature without a Keptn API Token. Please verify that your configuration allows it")
 		} else {
 			return fmt.Errorf(errMsg)
 		}

--- a/cli/internal/auth/mocks.go
+++ b/cli/internal/auth/mocks.go
@@ -32,12 +32,12 @@ func (h HTTPClientMock) Do(r *http.Request) (*http.Response, error) {
 // RedirectHandlerMock is a mocked implementation of TokenGetter
 // usable in tests
 type RedirectHandlerMock struct {
-	handleFn func([]byte, *oauth2.Config) (*oauth2.Token, error)
+	handleFn func([]byte, *oauth2.Config, string) (*oauth2.Token, error)
 }
 
-func (t RedirectHandlerMock) Handle(codeVerifier []byte, oauthConfig *oauth2.Config) (*oauth2.Token, error) {
+func (t RedirectHandlerMock) Handle(codeVerifier []byte, oauthConfig *oauth2.Config, state string) (*oauth2.Token, error) {
 	if t.handleFn != nil {
-		return t.handleFn(codeVerifier, oauthConfig)
+		return t.handleFn(codeVerifier, oauthConfig, state)
 	}
 	panic("handleFn of RedirectHandlerMock not set")
 }

--- a/cli/internal/auth/oauth_test.go
+++ b/cli/internal/auth/oauth_test.go
@@ -63,7 +63,7 @@ func TestOauthAuthenticator_Auth(t *testing.T) {
 					},
 				},
 				redirectHandler: RedirectHandlerMock{
-					handleFn: func(bytes []byte, config *oauth2.Config) (*oauth2.Token, error) {
+					handleFn: func(bytes []byte, config *oauth2.Config, state string) (*oauth2.Token, error) {
 						return nil, errors.New("callback handler failed")
 					},
 				},
@@ -81,7 +81,7 @@ func TestOauthAuthenticator_Auth(t *testing.T) {
 					},
 				},
 				redirectHandler: RedirectHandlerMock{
-					handleFn: func(bytes []byte, config *oauth2.Config) (*oauth2.Token, error) {
+					handleFn: func(bytes []byte, config *oauth2.Config, state string) (*oauth2.Token, error) {
 						return &oauth2.Token{}, nil
 					},
 				},

--- a/cli/internal/auth/state.go
+++ b/cli/internal/auth/state.go
@@ -1,0 +1,21 @@
+package auth
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"io"
+)
+
+// State generates a new pseudo random base64 encoded string of length n
+// to be used to avoid CSRF attacks. Note that n must be >=1
+func State(n int) (string, error) {
+	if n < 1 {
+		return "", fmt.Errorf("length must be at least one")
+	}
+	data := make([]byte, n)
+	if _, err := io.ReadFull(rand.Reader, data); err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(data), nil
+}

--- a/cli/internal/auth/state_test.go
+++ b/cli/internal/auth/state_test.go
@@ -1,0 +1,36 @@
+package auth
+
+import (
+	"encoding/base64"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestState(t *testing.T) {
+	t.Run("State - len 10", func(t *testing.T) {
+		state, err := State(10)
+		require.Nil(t, err)
+		decoded, err := base64.StdEncoding.DecodeString(state)
+		require.Nil(t, err)
+		assert.Equal(t, 10, len(decoded))
+	})
+	t.Run("State - len 1", func(t *testing.T) {
+		state, err := State(1)
+		require.Nil(t, err)
+		decoded, err := base64.StdEncoding.DecodeString(state)
+		require.Nil(t, err)
+		assert.Equal(t, 1, len(decoded))
+	})
+	t.Run("State - len 0", func(t *testing.T) {
+		state, err := State(0)
+		require.Equal(t, "", state)
+		require.NotNil(t, err)
+	})
+	t.Run("State - len -1", func(t *testing.T) {
+		state, err := State(-1)
+		require.Equal(t, "", state)
+		require.NotNil(t, err)
+	})
+
+}


### PR DESCRIPTION
This PR enhances the CLI SSO feature to make use of the OAuth `state` parameter to protect against CSRF attacks.

closes #6700 


Also, the PR contains a small adjustment to the message shown to the user when using sso without a specific api token.