### PR TITLE
feat(cli): Added `--sso-scopes` flag to cli

### DIFF
--- a/cli/cmd/auth.go
+++ b/cli/cmd/auth.go
@@ -28,6 +28,7 @@ type authCmdParams struct {
 	ssoLogout            *bool
 	ssoDiscovery         *string
 	ssoClientID          *string
+	ssoScopes            *[]string
 	ssoClientSecret      *string
 }
 
@@ -105,6 +106,7 @@ keptn auth --skip-namespace-listing # To skip the listing of namespaces and use 
 				OauthDiscoveryURL: *authParams.ssoDiscovery,
 				OauthClientID:     *authParams.ssoClientID,
 				OauthClientSecret: *authParams.ssoClientSecret,
+				OauthScopes:       *authParams.ssoScopes,
 			}
 			if err := oauth.Auth(clientValues); err != nil {
 				return err
@@ -130,6 +132,7 @@ func init() {
 	authParams.ssoLogout = authCmd.Flags().Bool("sso-logout", false, "Disable single sign on access")
 	authParams.ssoDiscovery = authCmd.Flags().String("sso-discovery", "", "Well known discovery URL used for SSO")
 	authParams.ssoClientID = authCmd.Flags().String("sso-client-id", "", "Oauth Client ID used for SSO")
+	authParams.ssoScopes = authCmd.Flags().StringArray("sso-scopes", []string{}, "Oauth scopes used for SSO")
 	authParams.ssoClientSecret = authCmd.Flags().String("sso-client-secret", "", "Oauth Client Secret used for SSO")
 	authParams.secure = authCmd.Flags().BoolP("secure", "s", false, "To make http/https request to auto fetched endpoint while authentication")
 	authParams.skipNamespaceListing = authCmd.Flags().BoolP("skip-namespace-listing", "i", false, "To skip the listing of namespaces and use the namespace passed with \"--namespace\" flag (default namespace is 'keptn')")

--- a/cli/internal/auth/oauth.go
+++ b/cli/internal/auth/oauth.go
@@ -36,6 +36,10 @@ func NewOauthAuthenticator(discovery OauthLocationGetter, tokenStore OauthStore,
 
 // Auth tries to start the Oauth2 Authorization Code Flow
 func (a *OauthAuthenticator) Auth(clientValues OauthClientValues) error {
+	if err := clientValues.ValidateMandatoryFields(); err != nil {
+		return err
+	}
+
 	discoveryInfo, err := a.discovery.Discover(context.TODO(), clientValues.OauthDiscoveryURL)
 	if err != nil {
 		return fmt.Errorf("failed to perform OAuth Discovery using URL %s: %w: ", clientValues.OauthDiscoveryURL, err)
@@ -144,4 +148,11 @@ type OauthClientValues struct {
 	OauthClientID     string   `json:"oauth_client_id"`
 	OauthClientSecret string   `json:"oauth_client_secret"`
 	OauthScopes       []string `json:"oauth_scopes"`
+}
+
+func (v *OauthClientValues) ValidateMandatoryFields() error {
+	if v.OauthClientID == "" || v.OauthDiscoveryURL == "" {
+		return fmt.Errorf("client values invalid: client id and discovery URL must be set")
+	}
+	return nil
 }

--- a/cli/internal/auth/oauth.go
+++ b/cli/internal/auth/oauth.go
@@ -98,17 +98,6 @@ func (a *OauthAuthenticator) GetOauthClient(ctx context.Context) (*http.Client, 
 		return nil, fmt.Errorf("failed to get OAuth HTTP client: %w", err)
 	}
 
-	openIDScopePresent := false
-	for _, s := range oauthInfo.ClientValues.OauthScopes {
-		if s == "openid" {
-			openIDScopePresent = true
-			break
-		}
-	}
-	if !openIDScopePresent {
-		oauthInfo.ClientValues.OauthScopes = append(oauthInfo.ClientValues.OauthScopes, "openid")
-	}
-
 	config := &oauth2.Config{
 		ClientSecret: oauthInfo.ClientValues.OauthClientSecret,
 		ClientID:     oauthInfo.ClientValues.OauthClientID,

--- a/cli/internal/auth/oauth_test.go
+++ b/cli/internal/auth/oauth_test.go
@@ -9,12 +9,7 @@ import (
 	"testing"
 )
 
-func TestOauthAuthenticator_Auth(t *testing.T) {
-	discovery := &OauthDiscoveryMock{
-		discoverFn: func(ctx context.Context, discoveryURL string) (*OauthDiscoveryResult, error) {
-			return &OauthDiscoveryResult{}, nil
-		},
-	}
+func Test_Auth_DependenciesFail(t *testing.T) {
 
 	type fields struct {
 		discovery       OauthLocationGetter
@@ -38,7 +33,11 @@ func TestOauthAuthenticator_Auth(t *testing.T) {
 		},
 		{"Auth() - open browser fails",
 			fields{
-				discovery: discovery,
+				discovery: &OauthDiscoveryMock{
+					discoverFn: func(ctx context.Context, discoveryURL string) (*OauthDiscoveryResult, error) {
+						return &OauthDiscoveryResult{}, nil
+					},
+				},
 				browser: &BrowserMock{
 					openFn: func(string) error { return errors.New("browser open failed") },
 				},
@@ -51,7 +50,11 @@ func TestOauthAuthenticator_Auth(t *testing.T) {
 		},
 		{"Auth() - callback handler fails",
 			fields{
-				discovery: discovery,
+				discovery: &OauthDiscoveryMock{
+					discoverFn: func(ctx context.Context, discoveryURL string) (*OauthDiscoveryResult, error) {
+						return &OauthDiscoveryResult{}, nil
+					},
+				},
 				browser: &BrowserMock{
 					openFn: func(string) error { return nil },
 				},
@@ -69,7 +72,11 @@ func TestOauthAuthenticator_Auth(t *testing.T) {
 		},
 		{"Auth() - success",
 			fields{
-				discovery: discovery,
+				discovery: &OauthDiscoveryMock{
+					discoverFn: func(ctx context.Context, discoveryURL string) (*OauthDiscoveryResult, error) {
+						return &OauthDiscoveryResult{}, nil
+					},
+				},
 				browser: &BrowserMock{
 					openFn: func(string) error { return nil },
 				},
@@ -99,13 +106,76 @@ func TestOauthAuthenticator_Auth(t *testing.T) {
 	}
 }
 
-func TestOauthAuthenticator_GetOauthClient(t *testing.T) {
-	discovery := &OauthDiscoveryMock{
-		discoverFn: func(ctx context.Context, discoveryURL string) (*OauthDiscoveryResult, error) {
-			return &OauthDiscoveryResult{}, nil
-		},
+func Test_Auth_Scopes(t *testing.T) {
+	discovery := &OauthDiscoveryMock{}
+	tokenStore := &TokenStoreMock{}
+	browser := &BrowserMock{}
+	redirectHandler := &RedirectHandlerMock{}
+	authenticator := &OauthAuthenticator{
+		discovery:       discovery,
+		tokenStore:      tokenStore,
+		browser:         browser,
+		redirectHandler: redirectHandler,
 	}
+	t.Run("Auth - default openid scope is set", func(t *testing.T) {
+		redirectHandler.handleFn = func(b []byte, c *oauth2.Config, s string) (*oauth2.Token, error) {
+			assert.Equal(t, 1, len(c.Scopes))
+			assert.Equal(t, "openid", c.Scopes[0])
+			return nil, nil
+		}
+		authenticator.Auth(OauthClientValues{"http://well-known-discovery-url.com", "clientID", "", []string{}})
+	})
+	t.Run("Auth - scopes always contain default openid scope", func(t *testing.T) {
+		redirectHandler.handleFn = func(b []byte, c *oauth2.Config, s string) (*oauth2.Token, error) {
+			assert.Equal(t, 2, len(c.Scopes))
+			assert.Contains(t, c.Scopes, "openid")
+			assert.Contains(t, c.Scopes, "somescope")
+			return nil, nil
+		}
+		authenticator.Auth(OauthClientValues{"http://well-known-discovery-url.com", "clientID", "", []string{"somescope"}})
+	})
+}
 
+func Test_Auth_MissingOauthInfo(t *testing.T) {
+	discovery := &OauthDiscoveryMock{}
+	tokenStore := &TokenStoreMock{}
+	browser := &BrowserMock{}
+	redirectHandler := &RedirectHandlerMock{}
+	authenticator := &OauthAuthenticator{
+		discovery:       discovery,
+		tokenStore:      tokenStore,
+		browser:         browser,
+		redirectHandler: redirectHandler,
+	}
+	t.Run("Auth - client id set and client secret is optional", func(t *testing.T) {
+		{
+			redirectHandler.handleFn = func(b []byte, c *oauth2.Config, s string) (*oauth2.Token, error) {
+				assert.Equal(t, "clientID", c.ClientID)
+				assert.Equal(t, "", c.ClientSecret)
+				return nil, nil
+			}
+			authenticator.Auth(OauthClientValues{"http://well-known-discovery-url.com", "clientID", "", []string{}})
+		}
+	})
+	t.Run("Auth - client id and secret given", func(t *testing.T) {
+		{
+			redirectHandler.handleFn = func(b []byte, c *oauth2.Config, s string) (*oauth2.Token, error) {
+				assert.Equal(t, "clientID", c.ClientID)
+				assert.Equal(t, "clientSecret", c.ClientSecret)
+				return nil, nil
+			}
+			authenticator.Auth(OauthClientValues{"http://well-known-discovery-url.com", "clientID", "clientSecret", []string{}})
+		}
+	})
+	t.Run("Auth - client id missing", func(t *testing.T) {
+		{
+			err := authenticator.Auth(OauthClientValues{"http://well-known-discovery-url.com", "", "", []string{}})
+			assert.NotNil(t, err)
+		}
+	})
+}
+
+func Test_GetOauthClient(t *testing.T) {
 	type fields struct {
 		discovery  OauthLocationGetter
 		tokenStore OauthStore
@@ -123,7 +193,11 @@ func TestOauthAuthenticator_GetOauthClient(t *testing.T) {
 	}{
 		{"GetOauthClient - no persisted oauth info",
 			fields{
-				discovery: discovery,
+				discovery: &OauthDiscoveryMock{
+					discoverFn: func(ctx context.Context, discoveryURL string) (*OauthDiscoveryResult, error) {
+						return &OauthDiscoveryResult{}, nil
+					},
+				},
 				tokenStore: &TokenStoreMock{
 					getOauthInfoFn: func() (*OauthInfo, error) {
 						return nil, fmt.Errorf("not found")
@@ -137,7 +211,11 @@ func TestOauthAuthenticator_GetOauthClient(t *testing.T) {
 			assert.Error},
 		{"GetOauthClient - success",
 			fields{
-				discovery: discovery,
+				discovery: &OauthDiscoveryMock{
+					discoverFn: func(ctx context.Context, discoveryURL string) (*OauthDiscoveryResult, error) {
+						return &OauthDiscoveryResult{}, nil
+					},
+				},
 				tokenStore: &TokenStoreMock{
 					getOauthInfoFn: func() (*OauthInfo, error) {
 						return &OauthInfo{

--- a/cli/internal/auth/oauth_test.go
+++ b/cli/internal/auth/oauth_test.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/oauth2"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 )
 
@@ -96,7 +94,7 @@ func TestOauthAuthenticator_Auth(t *testing.T) {
 				browser:         tt.fields.browser,
 				redirectHandler: tt.fields.redirectHandler,
 			}
-			tt.wantErr(t, a.Auth(OauthClientValues{"http://well-known-discovery-url.com", "clientID", ""}), "Auth()")
+			tt.wantErr(t, a.Auth(OauthClientValues{"http://well-known-discovery-url.com", "clientID", "", []string{}}), "Auth()")
 		})
 	}
 }
@@ -171,22 +169,5 @@ func TestOauthAuthenticator_GetOauthClient(t *testing.T) {
 				return
 			}
 		})
-	}
-}
-
-func setupMockOAuthServer() (*httptest.Server, func()) {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/auth", func(w http.ResponseWriter, r *http.Request) {
-	})
-
-	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
-		w.Write([]byte("access_token=mocked-token&scope=user&token_type=bearer"))
-	})
-
-	server := httptest.NewServer(mux)
-
-	return server, func() {
-		server.Close()
 	}
 }


### PR DESCRIPTION
This PR adds the `--sso-scopes` flag to the CLI, supporting the use case of using custom scopes.
No matter what values the user passes, the scope "openid" will always be used.

closes #6707 
