### PR TITLE
fix(bridge): Display additional error information when creating a project

### DIFF
--- a/bridge/client/app/_components/ktb-project-settings/ktb-project-settings.component.ts
+++ b/bridge/client/app/_components/ktb-project-settings/ktb-project-settings.component.ts
@@ -220,8 +220,8 @@ export class KtbProjectSettingsComponent implements OnInit, OnDestroy, PendingCh
                 });
               });
             },
-            () => {
-              this.notificationsService.addNotification(NotificationType.ERROR, 'The project could not be created.');
+            (err) => {
+              this.notificationsService.addNotification(NotificationType.ERROR, `The project could not be created: ${err.error ?? "please, check the logs of configuration-service"}.`);
               this.isCreatingProjectInProgress = false;
             }
           );

--- a/bridge/client/app/_components/ktb-project-settings/ktb-project-settings.component.ts
+++ b/bridge/client/app/_components/ktb-project-settings/ktb-project-settings.component.ts
@@ -221,7 +221,10 @@ export class KtbProjectSettingsComponent implements OnInit, OnDestroy, PendingCh
               });
             },
             (err) => {
-              this.notificationsService.addNotification(NotificationType.ERROR, `The project could not be created: ${err.error ?? "please, check the logs of configuration-service"}.`);
+              this.notificationsService.addNotification(
+                NotificationType.ERROR,
+                `The project could not be created: ${err.error || 'please, check the logs of configuration-service'}.`
+              );
               this.isCreatingProjectInProgress = false;
             }
           );


### PR DESCRIPTION
Signed-off-by: Giovanni Liva <giovanni.liva@dynatrace.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR

- Adds to the error notification the information about the project-creation error

### Related Issues

Fixes #6615 
