### PR TITLE
chore: Add k8s resource stats to release notes

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -309,17 +309,17 @@ jobs:
           RESOURCE_MARKDOWN: resources.md
         run: |
           helm template ./dist/keptn-installer/keptn-*.tgz --dry-run > $HELM_TEMPLATE
-          cat "$HELM_TEMPLATE" | yq eval-all '[.spec.template.spec.containers.[] ]' -o=json
+          cat "$HELM_TEMPLATE" | yq eval-all '[.spec.template.spec.containers.[] | {"name":.name, "resources":.resources}]' -o=json
           
-          cat "$HELM_TEMPLATE" | yq eval-all '[.spec.template.spec.containers.[] | {"name":.name, "resources":.resources}]' -o=json | \
-          jq '[
-            .[] | {
-              name: .name, 
-              cpu_request: .resources.requests.cpu, 
-              cpu_limit: .resources.limits.cpu, 
-              mem_request: .resources.requests.memory, 
-              mem_limit: .resources.limits.memory
-            }
-          ] |
-          unique_by(.name)' > $RESOURCE_JSON
-          npx tablemark-cli@v2.0.0 $RESOURCE_JSON
+#          cat "$HELM_TEMPLATE" | yq eval-all '[.spec.template.spec.containers.[] | {"name":.name, "resources":.resources}]' -o=json | \
+#          jq '[
+#            .[] | {
+#              name: .name,
+#              cpu_request: .resources.requests.cpu,
+#              cpu_limit: .resources.limits.cpu,
+#              mem_request: .resources.requests.memory,
+#              mem_limit: .resources.limits.memory
+#            }
+#          ] |
+#          unique_by(.name)' > $RESOURCE_JSON
+#          npx tablemark-cli@v2.0.0 $RESOURCE_JSON

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -177,72 +177,72 @@ jobs:
   ############################################################################
   # Build Docker Images
   ############################################################################
-  docker_build:
-    needs: prepare
-    name: Docker Build
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix: ${{ fromJson(needs.prepare.outputs.BUILD_MATRIX) }}
-    env:
-      BRANCH: ${{ needs.prepare.outputs.branch }}
-      VERSION: ${{ needs.prepare.outputs.next-version }}
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v2.4.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.REGISTRY_USER }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: "ghcr.io"
-          username: "keptn-bot"
-          password: ${{ secrets.KEPTN_BOT_TOKEN }}
-
-      - name: Login to Quay.io
-        uses: docker/login-action@v1
-        with:
-          registry: "quay.io"
-          username: ${{ secrets.QUAY_USER }}
-          password: ${{ secrets.QUAY_TOKEN }}
-
-      - id: docker_build_image
-        name: "Docker Build keptn/${{ matrix.config.artifact }}"
-        uses: docker/build-push-action@v2
-        with:
-          context: ${{ matrix.config.working-dir }}
-          tags: |
-            keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
-            quay.io/keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
-            ghcr.io/keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
-          build-args: |
-            version=${{ env.VERSION }}
-          push: ${{ matrix.config.should-push-image }}
-          pull: true
-
-      - name: Write docker image digest to file
-        if: matrix.config.should-push-image
-        env:
-          IMAGE_DIGEST: ${{ steps.docker_build_image.outputs.digest }}
-          IMAGE_DIGEST_FILENAME: "./digest-${{ matrix.config.artifact }}.txt"
-        run: |
-          echo "${{ matrix.config.artifact }},$IMAGE_DIGEST" > "$IMAGE_DIGEST_FILENAME"
-
-      - name: Upload Digest file as artifact
-        if: matrix.config.should-push-image
-        uses: actions/upload-artifact@v2
-        env:
-          IMAGE_DIGEST_FILENAME: "./digest-${{ matrix.config.artifact }}.txt"
-        with:
-          name: image-digests
-          path: ${{ env.IMAGE_DIGEST_FILENAME }}
+#  docker_build:
+#    needs: prepare
+#    name: Docker Build
+#    runs-on: ubuntu-20.04
+#    strategy:
+#      matrix: ${{ fromJson(needs.prepare.outputs.BUILD_MATRIX) }}
+#    env:
+#      BRANCH: ${{ needs.prepare.outputs.branch }}
+#      VERSION: ${{ needs.prepare.outputs.next-version }}
+#    steps:
+#      - name: Checkout Code
+#        uses: actions/checkout@v2.4.0
+#
+#      - name: Set up Docker Buildx
+#        uses: docker/setup-buildx-action@v1
+#
+#      - name: Login to Docker Hub
+#        uses: docker/login-action@v1
+#        with:
+#          username: ${{ secrets.REGISTRY_USER }}
+#          password: ${{ secrets.REGISTRY_PASSWORD }}
+#
+#      - name: Login to GitHub Container Registry
+#        uses: docker/login-action@v1
+#        with:
+#          registry: "ghcr.io"
+#          username: "keptn-bot"
+#          password: ${{ secrets.KEPTN_BOT_TOKEN }}
+#
+#      - name: Login to Quay.io
+#        uses: docker/login-action@v1
+#        with:
+#          registry: "quay.io"
+#          username: ${{ secrets.QUAY_USER }}
+#          password: ${{ secrets.QUAY_TOKEN }}
+#
+#      - id: docker_build_image
+#        name: "Docker Build keptn/${{ matrix.config.artifact }}"
+#        uses: docker/build-push-action@v2
+#        with:
+#          context: ${{ matrix.config.working-dir }}
+#          tags: |
+#            keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
+#            quay.io/keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
+#            ghcr.io/keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
+#          build-args: |
+#            version=${{ env.VERSION }}
+#          push: ${{ matrix.config.should-push-image }}
+#          pull: true
+#
+#      - name: Write docker image digest to file
+#        if: matrix.config.should-push-image
+#        env:
+#          IMAGE_DIGEST: ${{ steps.docker_build_image.outputs.digest }}
+#          IMAGE_DIGEST_FILENAME: "./digest-${{ matrix.config.artifact }}.txt"
+#        run: |
+#          echo "${{ matrix.config.artifact }},$IMAGE_DIGEST" > "$IMAGE_DIGEST_FILENAME"
+#
+#      - name: Upload Digest file as artifact
+#        if: matrix.config.should-push-image
+#        uses: actions/upload-artifact@v2
+#        env:
+#          IMAGE_DIGEST_FILENAME: "./digest-${{ matrix.config.artifact }}.txt"
+#        with:
+#          name: image-digests
+#          path: ${{ env.IMAGE_DIGEST_FILENAME }}
 
   ############################################################################
   # Build Helm Charts (only relevant for build_everything)
@@ -260,13 +260,13 @@ jobs:
   ############################################################################
   # Build CLI
   ############################################################################
-  build-cli:
-    needs: prepare
-    uses: keptn/keptn/.github/workflows/build-cli.yml@master
-    with:
-      branch: ${{ needs.prepare.outputs.branch }}
-      version: ${{ needs.prepare.outputs.next-version }}
-      release: true
+#  build-cli:
+#    needs: prepare
+#    uses: keptn/keptn/.github/workflows/build-cli.yml@master
+#    with:
+#      branch: ${{ needs.prepare.outputs.branch }}
+#      version: ${{ needs.prepare.outputs.next-version }}
+#      release: true
 
   ############################################################################
   # Pre-Release
@@ -274,7 +274,8 @@ jobs:
   pre-release:
     name: "Pre-Release"
     runs-on: ubuntu-20.04
-    needs: [prepare, docker_build, build-helm-charts, build-cli]
+#    needs: [prepare, docker_build, build-helm-charts, build-cli]
+    needs: [prepare, build-helm-charts]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
@@ -283,131 +284,32 @@ jobs:
           path: keptn
           token: ${{ secrets.KEPTN_BOT_TOKEN }}
 
-      - name: Checkout helm-charts repo
-        uses: actions/checkout@v2
-        with:
-          repository: keptn/helm-charts
-          path: helm-charts
-          ref: gh-pages
-          token: ${{ secrets.KEPTN_BOT_TOKEN }}
-
       - name: Set up Node.js
         uses: actions/setup-node@v2.5.1
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Configure Git
+      - name: Get k8s resource stats
         env:
-          KEPTN_BOT_NAME: ${{ env.KEPTN_BOT_NAME }}
-          KEPTN_BOT_EMAIL: ${{ env.KEPTN_BOT_EMAIL }}
+          HELM_TEMPLATE: template.yml
+          RESOURCE_JSON: resources.json
+          RESOURCE_MARKDOWN: resources.md
         run: |
-          git config --global user.name "$KEPTN_BOT_NAME"
-          git config --global user.email "$KEPTN_BOT_EMAIL"
-
-      - name: Download Pre-Release Artifacts
-        uses: actions/download-artifact@v2
-        with:
-          path: ./dist
-
-      - name: Prepare GitHub Pre-Release Notes
-        working-directory: keptn
-        env:
-          SEMVER_TYPE: ${{ github.event.inputs.semver-type }}
-        run: |
-          if [[ ! -z "$SEMVER_TYPE" ]]; then
-            npx standard-version@^9.3.1 \
-              --prerelease "${{ env.PRERELEASE_KEYWORD }}" \
-              -i "${{ env.RELEASE_NOTES_FILE }}" \
-              --skip.commit \
-              --skip.tag \
-              --header "" \
-              --release-as "$SEMVER_TYPE"
-          else
-            npx standard-version@^9.3.1 \
-              --prerelease "${{ env.PRERELEASE_KEYWORD }}" \
-              -i "${{ env.RELEASE_NOTES_FILE }}" \
-              --skip.commit \
-              --skip.tag \
-              --header ""
-          fi
-
-      - name: Temporarily disable "include administrators" branch protection
-        uses: benjefferies/branch-protection-bot@76b8a9d745a68c6a6e9b4bf745d4b32ad805e9a1
-        with:
-          access_token: ${{ secrets.KEPTN_BOT_TOKEN }}
-          branch: ${{ needs.prepare.outputs.branch }}
-          enforce_admins: false
-
-      - name: Create pre-release package
-        id: create-release-package
-        working-directory: keptn
-        env:
-          SEMVER_TYPE: ${{ github.event.inputs.semver-type }}
-          GITHUB_TOKEN: ${{ secrets.KEPTN_BOT_TOKEN }}
-        run: |
-          echo "🚀 Creating release package now..."
-
-          if [[ ! -z "$SEMVER_TYPE" ]]; then
-            npx standard-version@^9.3.1 \
-              --release-as "$SEMVER_TYPE" \
-              --prerelease "${{ env.PRERELEASE_KEYWORD }}" \
-              --skip.commit \
-              --skip.changelog
-          else
-            npx standard-version@^9.3.1 \
-              --prerelease "${{ env.PRERELEASE_KEYWORD }}" \
-              --skip.commit \
-              --skip.changelog
-          fi
-
-          echo "::set-output name=tag-name::$(git describe --tags --abbrev=0)"
-
-          echo "⚡️ Pushing changes to remote repository..."
-          git push --follow-tags
-
-      - name: Enable "include administrators" branch protection
-        uses: benjefferies/branch-protection-bot@76b8a9d745a68c6a6e9b4bf745d4b32ad805e9a1
-        if: always() # Force to always run this step to ensure "include administrators" is always turned back on
-        with:
-          access_token: ${{ secrets.KEPTN_BOT_TOKEN }}
-          branch: ${{ needs.prepare.outputs.branch }}
-          enforce_admins: true
-
-      - name: Create GitHub Pre-Release
-        working-directory: keptn
-        env:
-          GITHUB_TOKEN: ${{ secrets.KEPTN_BOT_TOKEN }}
-          RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
-        run: |
-          gh release create "$RELEASE_TAG" --draft --prerelease --notes-file "${{ env.RELEASE_NOTES_FILE }}" --title "$RELEASE_TAG"
-
-      - name: Upload Release Assets
-        working-directory: keptn
-        env:
-          GITHUB_TOKEN: ${{ secrets.KEPTN_BOT_TOKEN }}
-          RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
-        run: |
-          gh release upload "$RELEASE_TAG" ../dist/keptn-installer/*.tgz
-          gh release upload "$RELEASE_TAG" ../dist/keptn-cli/*.tar.gz
-
-      - name: Upload helm charts
-        env:
-          ARTIFACTS: "./dist/keptn-installer/*.tgz"
-          RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
-        run: |
-          mv "$ARTIFACTS" ./helm-charts/packages
-          cd ./helm-charts
-          helm repo index ./ --url https://charts.keptn.sh/ --merge ./index.yaml
-          git add *.tgz
-          git add index.yaml
-          git commit --signoff -m "Keptn Release $RELEASE_TAG"
-          git push
-
-      - name: Attach docker image digests to release
-        env:
-          DIGEST_FILE: "digests.csv"
-          RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
-        run: |
-          cat ./dist/image-digests/digest-*.txt >> $DIGEST_FILE
-          
-          gh release upload "$RELEASE_TAG" "$DIGEST_FILE"
+          helm template ../dist/keptn-installer/keptn-*.tgz --dry-run > $HELM_TEMPLATE
+          cat $HELM_TEMPLATE | \
+          yq eval-all -o=json '
+            [
+              .spec.template.spec.containers.[] | 
+              {"name":.name, "resources":.resources}
+            ]' | \
+          jq '[
+            .[] | {
+              name: .name, 
+              cpu_request: .resources.requests.cpu, 
+              cpu_limit: .resources.limits.cpu, 
+              mem_request: .resources.requests.memory, 
+              mem_limit: .resources.limits.memory
+            }
+          ] |
+          unique_by(.name)' > $RESOURCE_JSON
+          npx tablemark-cli@v2.0.0 $RESOURCE_JSON

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -296,7 +296,7 @@ jobs:
         uses: actions/setup-node@v2.5.1
         with:
           node-version: ${{ env.NODE_VERSION }}
-      
+
       - name: Configure Git
         env:
           KEPTN_BOT_NAME: ${{ env.KEPTN_BOT_NAME }}
@@ -317,6 +317,7 @@ jobs:
         run: |
           ls -lah ./
           ls -lah ./dist
+          ls -lah ./dist/keptn-installer
           helm template ./dist/keptn-installer/keptn-*.tgz --dry-run > $HELM_TEMPLATE
           cat $HELM_TEMPLATE | \
           yq eval-all -o=json '

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -310,7 +310,10 @@ jobs:
         run: |
           helm template ./dist/keptn-installer/keptn-*.tgz --dry-run > $HELM_TEMPLATE
           cat $HELM_TEMPLATE | \
-          yq eval-all '[.spec.template.spec.containers.[] |  {"name":.name, "resources":.resources}]' -o=json | \
+          yq eval-all '[.spec.template.spec.containers.[] | {"name":.name, "resources":.resources}]' -o=json
+          
+          cat $HELM_TEMPLATE | \
+          yq eval-all '[.spec.template.spec.containers.[] | {"name":.name, "resources":.resources}]' -o=json | \
           jq '[
             .[] | {
               name: .name, 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -320,4 +320,4 @@ jobs:
             }
           ] |
           unique_by(.name)' > $RESOURCE_JSON
-          npx tablemark-cli@v2.0.0 $RESOURCE_JSON
+          npx tablemark-cli@v2.0.0 $RESOURCE_JSON -c "Name" -c "CPU Request" -c "CPU Limit" -c "RAM Request" -c "RAM Limit" > "$RESOURCE_MARKDOWN"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -284,6 +284,14 @@ jobs:
           path: keptn
           token: ${{ secrets.KEPTN_BOT_TOKEN }}
 
+      - name: Checkout helm-charts repo
+        uses: actions/checkout@v2
+        with:
+          repository: keptn/helm-charts
+          path: helm-charts
+          ref: gh-pages
+          token: ${{ secrets.KEPTN_BOT_TOKEN }}
+
       - name: Set up Node.js
         uses: actions/setup-node@v2.5.1
         with:
@@ -295,7 +303,7 @@ jobs:
           RESOURCE_JSON: resources.json
           RESOURCE_MARKDOWN: resources.md
         run: |
-          helm template ../dist/keptn-installer/keptn-*.tgz --dry-run > $HELM_TEMPLATE
+          helm template ./dist/keptn-installer/keptn-*.tgz --dry-run > $HELM_TEMPLATE
           cat $HELM_TEMPLATE | \
           yq eval-all -o=json '
             [

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -315,10 +315,8 @@ jobs:
           RESOURCE_JSON: resources.json
           RESOURCE_MARKDOWN: resources.md
         run: |
-          ls -lah ./
-          ls -lah ./dist
-          ls -lah ./dist/keptn-installer
           helm template ./dist/keptn-installer/keptn-*.tgz --dry-run > $HELM_TEMPLATE
+          cat $HELM_TEMPLATE
           cat $HELM_TEMPLATE | \
           yq eval-all -o=json '
             [

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -309,17 +309,15 @@ jobs:
           RESOURCE_MARKDOWN: resources.md
         run: |
           helm template ./dist/keptn-installer/keptn-*.tgz --dry-run > $HELM_TEMPLATE
-          yq eval-all '[.spec.template.spec.containers.[] | {"name":.name, "resources":.resources}]' "$HELM_TEMPLATE" -o=json
-          
-#          cat "$HELM_TEMPLATE" | yq eval-all '[.spec.template.spec.containers.[] | {"name":.name, "resources":.resources}]' -o=json | \
-#          jq '[
-#            .[] | {
-#              name: .name,
-#              cpu_request: .resources.requests.cpu,
-#              cpu_limit: .resources.limits.cpu,
-#              mem_request: .resources.requests.memory,
-#              mem_limit: .resources.limits.memory
-#            }
-#          ] |
-#          unique_by(.name)' > $RESOURCE_JSON
-#          npx tablemark-cli@v2.0.0 $RESOURCE_JSON
+          yq eval-all '[.spec.template.spec.containers.[] | {"name":.name, "resources":.resources}]' "$HELM_TEMPLATE" -o=json | \
+          jq '[
+            .[] | {
+              name: .name,
+              cpu_request: .resources.requests.cpu,
+              cpu_limit: .resources.limits.cpu,
+              mem_request: .resources.requests.memory,
+              mem_limit: .resources.limits.memory
+            }
+          ] |
+          unique_by(.name)' > $RESOURCE_JSON
+          npx tablemark-cli@v2.0.0 $RESOURCE_JSON

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -309,7 +309,7 @@ jobs:
           RESOURCE_MARKDOWN: resources.md
         run: |
           helm template ./dist/keptn-installer/keptn-*.tgz --dry-run > $HELM_TEMPLATE
-          cat "$HELM_TEMPLATE" | yq eval-all
+          cat "$HELM_TEMPLATE" | yq eval-all '[.spec.template.spec.containers.[] ]' -o=json
           
           cat "$HELM_TEMPLATE" | yq eval-all '[.spec.template.spec.containers.[] | {"name":.name, "resources":.resources}]' -o=json | \
           jq '[

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -177,72 +177,72 @@ jobs:
   ############################################################################
   # Build Docker Images
   ############################################################################
-#  docker_build:
-#    needs: prepare
-#    name: Docker Build
-#    runs-on: ubuntu-20.04
-#    strategy:
-#      matrix: ${{ fromJson(needs.prepare.outputs.BUILD_MATRIX) }}
-#    env:
-#      BRANCH: ${{ needs.prepare.outputs.branch }}
-#      VERSION: ${{ needs.prepare.outputs.next-version }}
-#    steps:
-#      - name: Checkout Code
-#        uses: actions/checkout@v2.4.0
-#
-#      - name: Set up Docker Buildx
-#        uses: docker/setup-buildx-action@v1
-#
-#      - name: Login to Docker Hub
-#        uses: docker/login-action@v1
-#        with:
-#          username: ${{ secrets.REGISTRY_USER }}
-#          password: ${{ secrets.REGISTRY_PASSWORD }}
-#
-#      - name: Login to GitHub Container Registry
-#        uses: docker/login-action@v1
-#        with:
-#          registry: "ghcr.io"
-#          username: "keptn-bot"
-#          password: ${{ secrets.KEPTN_BOT_TOKEN }}
-#
-#      - name: Login to Quay.io
-#        uses: docker/login-action@v1
-#        with:
-#          registry: "quay.io"
-#          username: ${{ secrets.QUAY_USER }}
-#          password: ${{ secrets.QUAY_TOKEN }}
-#
-#      - id: docker_build_image
-#        name: "Docker Build keptn/${{ matrix.config.artifact }}"
-#        uses: docker/build-push-action@v2
-#        with:
-#          context: ${{ matrix.config.working-dir }}
-#          tags: |
-#            keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
-#            quay.io/keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
-#            ghcr.io/keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
-#          build-args: |
-#            version=${{ env.VERSION }}
-#          push: ${{ matrix.config.should-push-image }}
-#          pull: true
-#
-#      - name: Write docker image digest to file
-#        if: matrix.config.should-push-image
-#        env:
-#          IMAGE_DIGEST: ${{ steps.docker_build_image.outputs.digest }}
-#          IMAGE_DIGEST_FILENAME: "./digest-${{ matrix.config.artifact }}.txt"
-#        run: |
-#          echo "${{ matrix.config.artifact }},$IMAGE_DIGEST" > "$IMAGE_DIGEST_FILENAME"
-#
-#      - name: Upload Digest file as artifact
-#        if: matrix.config.should-push-image
-#        uses: actions/upload-artifact@v2
-#        env:
-#          IMAGE_DIGEST_FILENAME: "./digest-${{ matrix.config.artifact }}.txt"
-#        with:
-#          name: image-digests
-#          path: ${{ env.IMAGE_DIGEST_FILENAME }}
+  docker_build:
+    needs: prepare
+    name: Docker Build
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix: ${{ fromJson(needs.prepare.outputs.BUILD_MATRIX) }}
+    env:
+      BRANCH: ${{ needs.prepare.outputs.branch }}
+      VERSION: ${{ needs.prepare.outputs.next-version }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2.4.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: "ghcr.io"
+          username: "keptn-bot"
+          password: ${{ secrets.KEPTN_BOT_TOKEN }}
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: "quay.io"
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
+      - id: docker_build_image
+        name: "Docker Build keptn/${{ matrix.config.artifact }}"
+        uses: docker/build-push-action@v2
+        with:
+          context: ${{ matrix.config.working-dir }}
+          tags: |
+            keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
+            quay.io/keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
+            ghcr.io/keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
+          build-args: |
+            version=${{ env.VERSION }}
+          push: false
+          pull: true
+
+      - name: Write docker image digest to file
+        if: matrix.config.should-push-image
+        env:
+          IMAGE_DIGEST: ${{ steps.docker_build_image.outputs.digest }}
+          IMAGE_DIGEST_FILENAME: "./digest-${{ matrix.config.artifact }}.txt"
+        run: |
+          echo "${{ matrix.config.artifact }},$IMAGE_DIGEST" > "$IMAGE_DIGEST_FILENAME"
+
+      - name: Upload Digest file as artifact
+        if: matrix.config.should-push-image
+        uses: actions/upload-artifact@v2
+        env:
+          IMAGE_DIGEST_FILENAME: "./digest-${{ matrix.config.artifact }}.txt"
+        with:
+          name: image-digests
+          path: ${{ env.IMAGE_DIGEST_FILENAME }}
 
   ############################################################################
   # Build Helm Charts (only relevant for build_everything)
@@ -260,13 +260,13 @@ jobs:
   ############################################################################
   # Build CLI
   ############################################################################
-#  build-cli:
-#    needs: prepare
-#    uses: keptn/keptn/.github/workflows/build-cli.yml@master
-#    with:
-#      branch: ${{ needs.prepare.outputs.branch }}
-#      version: ${{ needs.prepare.outputs.next-version }}
-#      release: true
+  build-cli:
+    needs: prepare
+    uses: keptn/keptn/.github/workflows/build-cli.yml@master
+    with:
+      branch: ${{ needs.prepare.outputs.branch }}
+      version: ${{ needs.prepare.outputs.next-version }}
+      release: true
 
   ############################################################################
   # Pre-Release
@@ -274,14 +274,21 @@ jobs:
   pre-release:
     name: "Pre-Release"
     runs-on: ubuntu-20.04
-#    needs: [prepare, docker_build, build-helm-charts, build-cli]
-    needs: [prepare, build-helm-charts]
+    needs: [prepare, docker_build, build-helm-charts, build-cli]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
           path: keptn
+          token: ${{ secrets.KEPTN_BOT_TOKEN }}
+
+      - name: Checkout helm-charts repo
+        uses: actions/checkout@v2
+        with:
+          repository: keptn/helm-charts
+          path: helm-charts
+          ref: gh-pages
           token: ${{ secrets.KEPTN_BOT_TOKEN }}
 
       - name: Set up Node.js
@@ -302,6 +309,70 @@ jobs:
         with:
           path: ./dist
 
+      - name: Prepare GitHub Pre-Release Notes
+        working-directory: keptn
+        env:
+          SEMVER_TYPE: ${{ github.event.inputs.semver-type }}
+        run: |
+          if [[ ! -z "$SEMVER_TYPE" ]]; then
+            npx standard-version@^9.3.1 \
+              --prerelease "${{ env.PRERELEASE_KEYWORD }}" \
+              -i "${{ env.RELEASE_NOTES_FILE }}" \
+              --skip.commit \
+              --skip.tag \
+              --header "" \
+              --release-as "$SEMVER_TYPE"
+          else
+            npx standard-version@^9.3.1 \
+              --prerelease "${{ env.PRERELEASE_KEYWORD }}" \
+              -i "${{ env.RELEASE_NOTES_FILE }}" \
+              --skip.commit \
+              --skip.tag \
+              --header ""
+          fi
+
+      - name: Temporarily disable "include administrators" branch protection
+        uses: benjefferies/branch-protection-bot@76b8a9d745a68c6a6e9b4bf745d4b32ad805e9a1
+        with:
+          access_token: ${{ secrets.KEPTN_BOT_TOKEN }}
+          branch: ${{ needs.prepare.outputs.branch }}
+          enforce_admins: false
+
+      - name: Create pre-release package
+        id: create-release-package
+        working-directory: keptn
+        env:
+          SEMVER_TYPE: ${{ github.event.inputs.semver-type }}
+          GITHUB_TOKEN: ${{ secrets.KEPTN_BOT_TOKEN }}
+        run: |
+          echo "🚀 Creating release package now..."
+
+          if [[ ! -z "$SEMVER_TYPE" ]]; then
+            npx standard-version@^9.3.1 \
+              --release-as "$SEMVER_TYPE" \
+              --prerelease "${{ env.PRERELEASE_KEYWORD }}" \
+              --skip.commit \
+              --skip.changelog
+          else
+            npx standard-version@^9.3.1 \
+              --prerelease "${{ env.PRERELEASE_KEYWORD }}" \
+              --skip.commit \
+              --skip.changelog
+          fi
+
+          echo "::set-output name=tag-name::$(git describe --tags --abbrev=0)"
+
+          echo "⚡️ Pushing changes to remote repository..."
+          git push --follow-tags
+
+      - name: Enable "include administrators" branch protection
+        uses: benjefferies/branch-protection-bot@76b8a9d745a68c6a6e9b4bf745d4b32ad805e9a1
+        if: always() # Force to always run this step to ensure "include administrators" is always turned back on
+        with:
+          access_token: ${{ secrets.KEPTN_BOT_TOKEN }}
+          branch: ${{ needs.prepare.outputs.branch }}
+          enforce_admins: true
+
       - name: Get k8s resource stats
         env:
           HELM_TEMPLATE: template.yml
@@ -309,7 +380,13 @@ jobs:
           RESOURCE_MARKDOWN: resources.md
         run: |
           helm template ./dist/keptn-installer/keptn-*.tgz --dry-run > $HELM_TEMPLATE
-          yq eval-all '[.spec.template.spec.containers.[] | {"name":.name, "resources":.resources}]' "$HELM_TEMPLATE" -o=json | \
+          yq eval-all '[
+            .spec.template.spec.containers.[] | 
+            {
+              "name":.name, 
+              "resources":.resources
+            }
+          ]' "$HELM_TEMPLATE" -o=json | \
           jq '[
             .[] | {
               name: .name,
@@ -321,3 +398,46 @@ jobs:
           ] |
           unique_by(.name)' > $RESOURCE_JSON
           npx tablemark-cli@v2.0.0 $RESOURCE_JSON -c "Name" -c "CPU Request" -c "CPU Limit" -c "RAM Request" -c "RAM Limit" > "$RESOURCE_MARKDOWN"
+          
+          echo "" >> ${{ env.RELEASE_NOTES_FILE }}
+          echo "### Resource Stats" >> ${{ env.RELEASE_NOTES_FILE }}
+          cat "$RESOURCE_MARKDOWN" >> ${{ env.RELEASE_NOTES_FILE }}
+
+      - name: Create GitHub Pre-Release
+        working-directory: keptn
+        env:
+          GITHUB_TOKEN: ${{ secrets.KEPTN_BOT_TOKEN }}
+          RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
+        run: |
+          gh release create "$RELEASE_TAG" --draft --prerelease --notes-file "${{ env.RELEASE_NOTES_FILE }}" --title "$RELEASE_TAG"
+
+      - name: Upload Release Assets
+        working-directory: keptn
+        env:
+          GITHUB_TOKEN: ${{ secrets.KEPTN_BOT_TOKEN }}
+          RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
+        run: |
+          gh release upload "$RELEASE_TAG" ../dist/keptn-installer/*.tgz
+          gh release upload "$RELEASE_TAG" ../dist/keptn-cli/*.tar.gz
+
+      - name: Upload helm charts
+        env:
+          ARTIFACTS: "./dist/keptn-installer/*.tgz"
+          RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
+        run: |
+          mv "$ARTIFACTS" ./helm-charts/packages
+          cd ./helm-charts
+          helm repo index ./ --url https://charts.keptn.sh/ --merge ./index.yaml
+          git add *.tgz
+          git add index.yaml
+          git commit --signoff -m "Keptn Release $RELEASE_TAG"
+          git push
+
+      - name: Attach docker image digests to release
+        env:
+          DIGEST_FILE: "digests.csv"
+          RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
+        run: |
+          cat ./dist/image-digests/digest-*.txt >> $DIGEST_FILE
+          
+          gh release upload "$RELEASE_TAG" "$DIGEST_FILE"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -296,6 +296,18 @@ jobs:
         uses: actions/setup-node@v2.5.1
         with:
           node-version: ${{ env.NODE_VERSION }}
+      
+      - name: Configure Git
+        env:
+          KEPTN_BOT_NAME: ${{ env.KEPTN_BOT_NAME }}
+          KEPTN_BOT_EMAIL: ${{ env.KEPTN_BOT_EMAIL }}
+        run: |
+          git config --global user.name "$KEPTN_BOT_NAME"
+          git config --global user.email "$KEPTN_BOT_EMAIL"
+      - name: Download Pre-Release Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: ./dist
 
       - name: Get k8s resource stats
         env:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -309,11 +309,9 @@ jobs:
           RESOURCE_MARKDOWN: resources.md
         run: |
           helm template ./dist/keptn-installer/keptn-*.tgz --dry-run > $HELM_TEMPLATE
-          cat "$HELM_TEMPLATE" | \
-          yq eval-all '[.spec.template.spec.containers.[] | {"name":.name, "resources":.resources}]' -o=json
+          cat "$HELM_TEMPLATE" | yq eval-all '[.spec.template.spec.containers.[] | {"name":.name, "resources":.resources}]' -o=json
           
-          cat "$HELM_TEMPLATE" | \
-          yq eval-all '[.spec.template.spec.containers.[] | {"name":.name, "resources":.resources}]' -o=json | \
+          cat "$HELM_TEMPLATE" | yq eval-all '[.spec.template.spec.containers.[] | {"name":.name, "resources":.resources}]' -o=json | \
           jq '[
             .[] | {
               name: .name, 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -190,59 +190,59 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2.4.0
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.REGISTRY_USER }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: "ghcr.io"
-          username: "keptn-bot"
-          password: ${{ secrets.KEPTN_BOT_TOKEN }}
-
-      - name: Login to Quay.io
-        uses: docker/login-action@v1
-        with:
-          registry: "quay.io"
-          username: ${{ secrets.QUAY_USER }}
-          password: ${{ secrets.QUAY_TOKEN }}
-
-      - id: docker_build_image
-        name: "Docker Build keptn/${{ matrix.config.artifact }}"
-        uses: docker/build-push-action@v2
-        with:
-          context: ${{ matrix.config.working-dir }}
-          tags: |
-            keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
-            quay.io/keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
-            ghcr.io/keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
-          build-args: |
-            version=${{ env.VERSION }}
-          push: ${{ matrix.config.should-push-image }}
-          pull: true
-
-      - name: Write docker image digest to file
-        if: matrix.config.should-push-image
-        env:
-          IMAGE_DIGEST: ${{ steps.docker_build_image.outputs.digest }}
-          IMAGE_DIGEST_FILENAME: "./digest-${{ matrix.config.artifact }}.txt"
-        run: |
-          echo "${{ matrix.config.artifact }},$IMAGE_DIGEST" > "$IMAGE_DIGEST_FILENAME"
-
-      - name: Upload Digest file as artifact
-        if: matrix.config.should-push-image
-        uses: actions/upload-artifact@v2
-        env:
-          IMAGE_DIGEST_FILENAME: "./digest-${{ matrix.config.artifact }}.txt"
-        with:
-          name: image-digests
-          path: ${{ env.IMAGE_DIGEST_FILENAME }}
+#      - name: Set up Docker Buildx
+#        uses: docker/setup-buildx-action@v1
+#
+#      - name: Login to Docker Hub
+#        uses: docker/login-action@v1
+#        with:
+#          username: ${{ secrets.REGISTRY_USER }}
+#          password: ${{ secrets.REGISTRY_PASSWORD }}
+#
+#      - name: Login to GitHub Container Registry
+#        uses: docker/login-action@v1
+#        with:
+#          registry: "ghcr.io"
+#          username: "keptn-bot"
+#          password: ${{ secrets.KEPTN_BOT_TOKEN }}
+#
+#      - name: Login to Quay.io
+#        uses: docker/login-action@v1
+#        with:
+#          registry: "quay.io"
+#          username: ${{ secrets.QUAY_USER }}
+#          password: ${{ secrets.QUAY_TOKEN }}
+#
+#      - id: docker_build_image
+#        name: "Docker Build keptn/${{ matrix.config.artifact }}"
+#        uses: docker/build-push-action@v2
+#        with:
+#          context: ${{ matrix.config.working-dir }}
+#          tags: |
+#            keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
+#            quay.io/keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
+#            ghcr.io/keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
+#          build-args: |
+#            version=${{ env.VERSION }}
+#          push: ${{ matrix.config.should-push-image }}
+#          pull: true
+#
+#      - name: Write docker image digest to file
+#        if: matrix.config.should-push-image
+#        env:
+#          IMAGE_DIGEST: ${{ steps.docker_build_image.outputs.digest }}
+#          IMAGE_DIGEST_FILENAME: "./digest-${{ matrix.config.artifact }}.txt"
+#        run: |
+#          echo "${{ matrix.config.artifact }},$IMAGE_DIGEST" > "$IMAGE_DIGEST_FILENAME"
+#
+#      - name: Upload Digest file as artifact
+#        if: matrix.config.should-push-image
+#        uses: actions/upload-artifact@v2
+#        env:
+#          IMAGE_DIGEST_FILENAME: "./digest-${{ matrix.config.artifact }}.txt"
+#        with:
+#          name: image-digests
+#          path: ${{ env.IMAGE_DIGEST_FILENAME }}
 
   ############################################################################
   # Build Helm Charts (only relevant for build_everything)
@@ -331,47 +331,47 @@ jobs:
               --header ""
           fi
 
-      - name: Temporarily disable "include administrators" branch protection
-        uses: benjefferies/branch-protection-bot@76b8a9d745a68c6a6e9b4bf745d4b32ad805e9a1
-        with:
-          access_token: ${{ secrets.KEPTN_BOT_TOKEN }}
-          branch: ${{ needs.prepare.outputs.branch }}
-          enforce_admins: false
-
-      - name: Create pre-release package
-        id: create-release-package
-        working-directory: keptn
-        env:
-          SEMVER_TYPE: ${{ github.event.inputs.semver-type }}
-          GITHUB_TOKEN: ${{ secrets.KEPTN_BOT_TOKEN }}
-        run: |
-          echo "🚀 Creating release package now..."
-
-          if [[ ! -z "$SEMVER_TYPE" ]]; then
-            npx standard-version@^9.3.1 \
-              --release-as "$SEMVER_TYPE" \
-              --prerelease "${{ env.PRERELEASE_KEYWORD }}" \
-              --skip.commit \
-              --skip.changelog
-          else
-            npx standard-version@^9.3.1 \
-              --prerelease "${{ env.PRERELEASE_KEYWORD }}" \
-              --skip.commit \
-              --skip.changelog
-          fi
-
-          echo "::set-output name=tag-name::$(git describe --tags --abbrev=0)"
-
-          echo "⚡️ Pushing changes to remote repository..."
-          git push --follow-tags
-
-      - name: Enable "include administrators" branch protection
-        uses: benjefferies/branch-protection-bot@76b8a9d745a68c6a6e9b4bf745d4b32ad805e9a1
-        if: always() # Force to always run this step to ensure "include administrators" is always turned back on
-        with:
-          access_token: ${{ secrets.KEPTN_BOT_TOKEN }}
-          branch: ${{ needs.prepare.outputs.branch }}
-          enforce_admins: true
+#      - name: Temporarily disable "include administrators" branch protection
+#        uses: benjefferies/branch-protection-bot@76b8a9d745a68c6a6e9b4bf745d4b32ad805e9a1
+#        with:
+#          access_token: ${{ secrets.KEPTN_BOT_TOKEN }}
+#          branch: ${{ needs.prepare.outputs.branch }}
+#          enforce_admins: false
+#
+#      - name: Create pre-release package
+#        id: create-release-package
+#        working-directory: keptn
+#        env:
+#          SEMVER_TYPE: ${{ github.event.inputs.semver-type }}
+#          GITHUB_TOKEN: ${{ secrets.KEPTN_BOT_TOKEN }}
+#        run: |
+#          echo "🚀 Creating release package now..."
+#
+#          if [[ ! -z "$SEMVER_TYPE" ]]; then
+#            npx standard-version@^9.3.1 \
+#              --release-as "$SEMVER_TYPE" \
+#              --prerelease "${{ env.PRERELEASE_KEYWORD }}" \
+#              --skip.commit \
+#              --skip.changelog
+#          else
+#            npx standard-version@^9.3.1 \
+#              --prerelease "${{ env.PRERELEASE_KEYWORD }}" \
+#              --skip.commit \
+#              --skip.changelog
+#          fi
+#
+#          echo "::set-output name=tag-name::$(git describe --tags --abbrev=0)"
+#
+#          echo "⚡️ Pushing changes to remote repository..."
+#          git push --follow-tags
+#
+#      - name: Enable "include administrators" branch protection
+#        uses: benjefferies/branch-protection-bot@76b8a9d745a68c6a6e9b4bf745d4b32ad805e9a1
+#        if: always() # Force to always run this step to ensure "include administrators" is always turned back on
+#        with:
+#          access_token: ${{ secrets.KEPTN_BOT_TOKEN }}
+#          branch: ${{ needs.prepare.outputs.branch }}
+#          enforce_admins: true
 
       - name: Get k8s resource stats
         working-directory: keptn
@@ -380,43 +380,45 @@ jobs:
           RESOURCE_JSON: resources.json
           RESOURCE_MARKDOWN: resources.md
           RELEASE_NOTES_FILE: ${{ env.RELEASE_NOTES_FILE }}
-        run: ./gh-actions-scripts/generate-k8s-resource-stats.sh
-
-      - name: Create GitHub Pre-Release
-        working-directory: keptn
-        env:
-          GITHUB_TOKEN: ${{ secrets.KEPTN_BOT_TOKEN }}
-          RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
         run: |
-          gh release create "$RELEASE_TAG" --draft --prerelease --notes-file "${{ env.RELEASE_NOTES_FILE }}" --title "$RELEASE_TAG"
+          ./gh-actions-scripts/generate-k8s-resource-stats.sh
+          cat "$RELEASE_NOTES_FILE"
 
-      - name: Upload Release Assets
-        working-directory: keptn
-        env:
-          GITHUB_TOKEN: ${{ secrets.KEPTN_BOT_TOKEN }}
-          RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
-        run: |
-          gh release upload "$RELEASE_TAG" ../dist/keptn-installer/*.tgz
-          gh release upload "$RELEASE_TAG" ../dist/keptn-cli/*.tar.gz
-
-      - name: Upload helm charts
-        env:
-          ARTIFACTS: "./dist/keptn-installer/*.tgz"
-          RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
-        run: |
-          mv "$ARTIFACTS" ./helm-charts/packages
-          cd ./helm-charts
-          helm repo index ./ --url https://charts.keptn.sh/ --merge ./index.yaml
-          git add *.tgz
-          git add index.yaml
-          git commit --signoff -m "Keptn Release $RELEASE_TAG"
-          git push
-
-      - name: Attach docker image digests to release
-        env:
-          DIGEST_FILE: "digests.csv"
-          RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
-        run: |
-          cat ./dist/image-digests/digest-*.txt >> $DIGEST_FILE
-          
-          gh release upload "$RELEASE_TAG" "$DIGEST_FILE"
+#      - name: Create GitHub Pre-Release
+#        working-directory: keptn
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.KEPTN_BOT_TOKEN }}
+#          RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
+#        run: |
+#          gh release create "$RELEASE_TAG" --draft --prerelease --notes-file "${{ env.RELEASE_NOTES_FILE }}" --title "$RELEASE_TAG"
+#
+#      - name: Upload Release Assets
+#        working-directory: keptn
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.KEPTN_BOT_TOKEN }}
+#          RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
+#        run: |
+#          gh release upload "$RELEASE_TAG" ../dist/keptn-installer/*.tgz
+#          gh release upload "$RELEASE_TAG" ../dist/keptn-cli/*.tar.gz
+#
+#      - name: Upload helm charts
+#        env:
+#          ARTIFACTS: "./dist/keptn-installer/*.tgz"
+#          RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
+#        run: |
+#          mv "$ARTIFACTS" ./helm-charts/packages
+#          cd ./helm-charts
+#          helm repo index ./ --url https://charts.keptn.sh/ --merge ./index.yaml
+#          git add *.tgz
+#          git add index.yaml
+#          git commit --signoff -m "Keptn Release $RELEASE_TAG"
+#          git push
+#
+#      - name: Attach docker image digests to release
+#        env:
+#          DIGEST_FILE: "digests.csv"
+#          RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
+#        run: |
+#          cat ./dist/image-digests/digest-*.txt >> $DIGEST_FILE
+#
+#          gh release upload "$RELEASE_TAG" "$DIGEST_FILE"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -374,34 +374,13 @@ jobs:
           enforce_admins: true
 
       - name: Get k8s resource stats
+        working-directory: keptn
         env:
           HELM_TEMPLATE: template.yml
           RESOURCE_JSON: resources.json
           RESOURCE_MARKDOWN: resources.md
-        run: |
-          helm template ./dist/keptn-installer/keptn-*.tgz --dry-run > $HELM_TEMPLATE
-          yq eval-all '[
-            .spec.template.spec.containers.[] | 
-            {
-              "name":.name, 
-              "resources":.resources
-            }
-          ]' "$HELM_TEMPLATE" -o=json | \
-          jq '[
-            .[] | {
-              name: .name,
-              cpu_request: .resources.requests.cpu,
-              cpu_limit: .resources.limits.cpu,
-              mem_request: .resources.requests.memory,
-              mem_limit: .resources.limits.memory
-            }
-          ] |
-          unique_by(.name)' > $RESOURCE_JSON
-          npx tablemark-cli@v2.0.0 $RESOURCE_JSON -c "Name" -c "CPU Request" -c "CPU Limit" -c "RAM Request" -c "RAM Limit" > "$RESOURCE_MARKDOWN"
-          
-          echo "" >> ${{ env.RELEASE_NOTES_FILE }}
-          echo "### Resource Stats" >> ${{ env.RELEASE_NOTES_FILE }}
-          cat "$RESOURCE_MARKDOWN" >> ${{ env.RELEASE_NOTES_FILE }}
+          RELEASE_NOTES_FILE: ${{ env.RELEASE_NOTES_FILE }}
+        run: ./gh-actions-scripts/generate-k8s-resource-stats.sh
 
       - name: Create GitHub Pre-Release
         working-directory: keptn

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -309,7 +309,7 @@ jobs:
           RESOURCE_MARKDOWN: resources.md
         run: |
           helm template ./dist/keptn-installer/keptn-*.tgz --dry-run > $HELM_TEMPLATE
-          cat "$HELM_TEMPLATE" | yq eval-all '[.spec.template.spec.containers.[] | {"name":.name, "resources":.resources}]' -o=json
+          cat "$HELM_TEMPLATE" | yq eval-all
           
           cat "$HELM_TEMPLATE" | yq eval-all '[.spec.template.spec.containers.[] | {"name":.name, "resources":.resources}]' -o=json | \
           jq '[

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -309,10 +309,10 @@ jobs:
           RESOURCE_MARKDOWN: resources.md
         run: |
           helm template ./dist/keptn-installer/keptn-*.tgz --dry-run > $HELM_TEMPLATE
-          cat $HELM_TEMPLATE | \
+          cat "$HELM_TEMPLATE" | \
           yq eval-all '[.spec.template.spec.containers.[] | {"name":.name, "resources":.resources}]' -o=json
           
-          cat $HELM_TEMPLATE | \
+          cat "$HELM_TEMPLATE" | \
           yq eval-all '[.spec.template.spec.containers.[] | {"name":.name, "resources":.resources}]' -o=json | \
           jq '[
             .[] | {

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -303,6 +303,8 @@ jobs:
           RESOURCE_JSON: resources.json
           RESOURCE_MARKDOWN: resources.md
         run: |
+          ls -lah ./
+          ls -lah ./dist
           helm template ./dist/keptn-installer/keptn-*.tgz --dry-run > $HELM_TEMPLATE
           cat $HELM_TEMPLATE | \
           yq eval-all -o=json '

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -284,14 +284,6 @@ jobs:
           path: keptn
           token: ${{ secrets.KEPTN_BOT_TOKEN }}
 
-      - name: Checkout helm-charts repo
-        uses: actions/checkout@v2
-        with:
-          repository: keptn/helm-charts
-          path: helm-charts
-          ref: gh-pages
-          token: ${{ secrets.KEPTN_BOT_TOKEN }}
-
       - name: Set up Node.js
         uses: actions/setup-node@v2.5.1
         with:
@@ -304,6 +296,7 @@ jobs:
         run: |
           git config --global user.name "$KEPTN_BOT_NAME"
           git config --global user.email "$KEPTN_BOT_EMAIL"
+
       - name: Download Pre-Release Artifacts
         uses: actions/download-artifact@v2
         with:
@@ -316,13 +309,8 @@ jobs:
           RESOURCE_MARKDOWN: resources.md
         run: |
           helm template ./dist/keptn-installer/keptn-*.tgz --dry-run > $HELM_TEMPLATE
-          cat $HELM_TEMPLATE
           cat $HELM_TEMPLATE | \
-          yq eval-all -o=json '
-            [
-              .spec.template.spec.containers.[] | 
-              {"name":.name, "resources":.resources}
-            ]' | \
+          yq eval-all -o=json '[.spec.template.spec.containers.[] |  {"name":.name, "resources":.resources}]' | \
           jq '[
             .[] | {
               name: .name, 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -224,7 +224,7 @@ jobs:
             ghcr.io/keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
           build-args: |
             version=${{ env.VERSION }}
-          push: false
+          push: ${{ matrix.config.should-push-image }}
           pull: true
 
       - name: Write docker image digest to file

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -310,7 +310,7 @@ jobs:
         run: |
           helm template ./dist/keptn-installer/keptn-*.tgz --dry-run > $HELM_TEMPLATE
           cat $HELM_TEMPLATE | \
-          yq eval-all -o=json '[.spec.template.spec.containers.[] |  {"name":.name, "resources":.resources}]' | \
+          yq eval-all '[.spec.template.spec.containers.[] |  {"name":.name, "resources":.resources}]' -o=json | \
           jq '[
             .[] | {
               name: .name, 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -190,59 +190,59 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2.4.0
 
-#      - name: Set up Docker Buildx
-#        uses: docker/setup-buildx-action@v1
-#
-#      - name: Login to Docker Hub
-#        uses: docker/login-action@v1
-#        with:
-#          username: ${{ secrets.REGISTRY_USER }}
-#          password: ${{ secrets.REGISTRY_PASSWORD }}
-#
-#      - name: Login to GitHub Container Registry
-#        uses: docker/login-action@v1
-#        with:
-#          registry: "ghcr.io"
-#          username: "keptn-bot"
-#          password: ${{ secrets.KEPTN_BOT_TOKEN }}
-#
-#      - name: Login to Quay.io
-#        uses: docker/login-action@v1
-#        with:
-#          registry: "quay.io"
-#          username: ${{ secrets.QUAY_USER }}
-#          password: ${{ secrets.QUAY_TOKEN }}
-#
-#      - id: docker_build_image
-#        name: "Docker Build keptn/${{ matrix.config.artifact }}"
-#        uses: docker/build-push-action@v2
-#        with:
-#          context: ${{ matrix.config.working-dir }}
-#          tags: |
-#            keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
-#            quay.io/keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
-#            ghcr.io/keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
-#          build-args: |
-#            version=${{ env.VERSION }}
-#          push: ${{ matrix.config.should-push-image }}
-#          pull: true
-#
-#      - name: Write docker image digest to file
-#        if: matrix.config.should-push-image
-#        env:
-#          IMAGE_DIGEST: ${{ steps.docker_build_image.outputs.digest }}
-#          IMAGE_DIGEST_FILENAME: "./digest-${{ matrix.config.artifact }}.txt"
-#        run: |
-#          echo "${{ matrix.config.artifact }},$IMAGE_DIGEST" > "$IMAGE_DIGEST_FILENAME"
-#
-#      - name: Upload Digest file as artifact
-#        if: matrix.config.should-push-image
-#        uses: actions/upload-artifact@v2
-#        env:
-#          IMAGE_DIGEST_FILENAME: "./digest-${{ matrix.config.artifact }}.txt"
-#        with:
-#          name: image-digests
-#          path: ${{ env.IMAGE_DIGEST_FILENAME }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: "ghcr.io"
+          username: "keptn-bot"
+          password: ${{ secrets.KEPTN_BOT_TOKEN }}
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: "quay.io"
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
+      - id: docker_build_image
+        name: "Docker Build keptn/${{ matrix.config.artifact }}"
+        uses: docker/build-push-action@v2
+        with:
+          context: ${{ matrix.config.working-dir }}
+          tags: |
+            keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
+            quay.io/keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
+            ghcr.io/keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
+          build-args: |
+            version=${{ env.VERSION }}
+          push: ${{ matrix.config.should-push-image }}
+          pull: true
+
+      - name: Write docker image digest to file
+        if: matrix.config.should-push-image
+        env:
+          IMAGE_DIGEST: ${{ steps.docker_build_image.outputs.digest }}
+          IMAGE_DIGEST_FILENAME: "./digest-${{ matrix.config.artifact }}.txt"
+        run: |
+          echo "${{ matrix.config.artifact }},$IMAGE_DIGEST" > "$IMAGE_DIGEST_FILENAME"
+
+      - name: Upload Digest file as artifact
+        if: matrix.config.should-push-image
+        uses: actions/upload-artifact@v2
+        env:
+          IMAGE_DIGEST_FILENAME: "./digest-${{ matrix.config.artifact }}.txt"
+        with:
+          name: image-digests
+          path: ${{ env.IMAGE_DIGEST_FILENAME }}
 
   ############################################################################
   # Build Helm Charts (only relevant for build_everything)
@@ -331,47 +331,47 @@ jobs:
               --header ""
           fi
 
-#      - name: Temporarily disable "include administrators" branch protection
-#        uses: benjefferies/branch-protection-bot@76b8a9d745a68c6a6e9b4bf745d4b32ad805e9a1
-#        with:
-#          access_token: ${{ secrets.KEPTN_BOT_TOKEN }}
-#          branch: ${{ needs.prepare.outputs.branch }}
-#          enforce_admins: false
-#
-#      - name: Create pre-release package
-#        id: create-release-package
-#        working-directory: keptn
-#        env:
-#          SEMVER_TYPE: ${{ github.event.inputs.semver-type }}
-#          GITHUB_TOKEN: ${{ secrets.KEPTN_BOT_TOKEN }}
-#        run: |
-#          echo "🚀 Creating release package now..."
-#
-#          if [[ ! -z "$SEMVER_TYPE" ]]; then
-#            npx standard-version@^9.3.1 \
-#              --release-as "$SEMVER_TYPE" \
-#              --prerelease "${{ env.PRERELEASE_KEYWORD }}" \
-#              --skip.commit \
-#              --skip.changelog
-#          else
-#            npx standard-version@^9.3.1 \
-#              --prerelease "${{ env.PRERELEASE_KEYWORD }}" \
-#              --skip.commit \
-#              --skip.changelog
-#          fi
-#
-#          echo "::set-output name=tag-name::$(git describe --tags --abbrev=0)"
-#
-#          echo "⚡️ Pushing changes to remote repository..."
-#          git push --follow-tags
-#
-#      - name: Enable "include administrators" branch protection
-#        uses: benjefferies/branch-protection-bot@76b8a9d745a68c6a6e9b4bf745d4b32ad805e9a1
-#        if: always() # Force to always run this step to ensure "include administrators" is always turned back on
-#        with:
-#          access_token: ${{ secrets.KEPTN_BOT_TOKEN }}
-#          branch: ${{ needs.prepare.outputs.branch }}
-#          enforce_admins: true
+      - name: Temporarily disable "include administrators" branch protection
+        uses: benjefferies/branch-protection-bot@76b8a9d745a68c6a6e9b4bf745d4b32ad805e9a1
+        with:
+          access_token: ${{ secrets.KEPTN_BOT_TOKEN }}
+          branch: ${{ needs.prepare.outputs.branch }}
+          enforce_admins: false
+
+      - name: Create pre-release package
+        id: create-release-package
+        working-directory: keptn
+        env:
+          SEMVER_TYPE: ${{ github.event.inputs.semver-type }}
+          GITHUB_TOKEN: ${{ secrets.KEPTN_BOT_TOKEN }}
+        run: |
+          echo "🚀 Creating release package now..."
+
+          if [[ ! -z "$SEMVER_TYPE" ]]; then
+            npx standard-version@^9.3.1 \
+              --release-as "$SEMVER_TYPE" \
+              --prerelease "${{ env.PRERELEASE_KEYWORD }}" \
+              --skip.commit \
+              --skip.changelog
+          else
+            npx standard-version@^9.3.1 \
+              --prerelease "${{ env.PRERELEASE_KEYWORD }}" \
+              --skip.commit \
+              --skip.changelog
+          fi
+
+          echo "::set-output name=tag-name::$(git describe --tags --abbrev=0)"
+
+          echo "⚡️ Pushing changes to remote repository..."
+          git push --follow-tags
+
+      - name: Enable "include administrators" branch protection
+        uses: benjefferies/branch-protection-bot@76b8a9d745a68c6a6e9b4bf745d4b32ad805e9a1
+        if: always() # Force to always run this step to ensure "include administrators" is always turned back on
+        with:
+          access_token: ${{ secrets.KEPTN_BOT_TOKEN }}
+          branch: ${{ needs.prepare.outputs.branch }}
+          enforce_admins: true
 
       - name: Get k8s resource stats
         working-directory: keptn
@@ -384,41 +384,41 @@ jobs:
           ./gh-actions-scripts/generate-k8s-resource-stats.sh
           cat "$RELEASE_NOTES_FILE"
 
-#      - name: Create GitHub Pre-Release
-#        working-directory: keptn
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.KEPTN_BOT_TOKEN }}
-#          RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
-#        run: |
-#          gh release create "$RELEASE_TAG" --draft --prerelease --notes-file "${{ env.RELEASE_NOTES_FILE }}" --title "$RELEASE_TAG"
-#
-#      - name: Upload Release Assets
-#        working-directory: keptn
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.KEPTN_BOT_TOKEN }}
-#          RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
-#        run: |
-#          gh release upload "$RELEASE_TAG" ../dist/keptn-installer/*.tgz
-#          gh release upload "$RELEASE_TAG" ../dist/keptn-cli/*.tar.gz
-#
-#      - name: Upload helm charts
-#        env:
-#          ARTIFACTS: "./dist/keptn-installer/*.tgz"
-#          RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
-#        run: |
-#          mv "$ARTIFACTS" ./helm-charts/packages
-#          cd ./helm-charts
-#          helm repo index ./ --url https://charts.keptn.sh/ --merge ./index.yaml
-#          git add *.tgz
-#          git add index.yaml
-#          git commit --signoff -m "Keptn Release $RELEASE_TAG"
-#          git push
-#
-#      - name: Attach docker image digests to release
-#        env:
-#          DIGEST_FILE: "digests.csv"
-#          RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
-#        run: |
-#          cat ./dist/image-digests/digest-*.txt >> $DIGEST_FILE
-#
-#          gh release upload "$RELEASE_TAG" "$DIGEST_FILE"
+      - name: Create GitHub Pre-Release
+        working-directory: keptn
+        env:
+          GITHUB_TOKEN: ${{ secrets.KEPTN_BOT_TOKEN }}
+          RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
+        run: |
+          gh release create "$RELEASE_TAG" --draft --prerelease --notes-file "${{ env.RELEASE_NOTES_FILE }}" --title "$RELEASE_TAG"
+
+      - name: Upload Release Assets
+        working-directory: keptn
+        env:
+          GITHUB_TOKEN: ${{ secrets.KEPTN_BOT_TOKEN }}
+          RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
+        run: |
+          gh release upload "$RELEASE_TAG" ../dist/keptn-installer/*.tgz
+          gh release upload "$RELEASE_TAG" ../dist/keptn-cli/*.tar.gz
+
+      - name: Upload helm charts
+        env:
+          ARTIFACTS: "./dist/keptn-installer/*.tgz"
+          RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
+        run: |
+          mv "$ARTIFACTS" ./helm-charts/packages
+          cd ./helm-charts
+          helm repo index ./ --url https://charts.keptn.sh/ --merge ./index.yaml
+          git add *.tgz
+          git add index.yaml
+          git commit --signoff -m "Keptn Release $RELEASE_TAG"
+          git push
+
+      - name: Attach docker image digests to release
+        env:
+          DIGEST_FILE: "digests.csv"
+          RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
+        run: |
+          cat ./dist/image-digests/digest-*.txt >> $DIGEST_FILE
+
+          gh release upload "$RELEASE_TAG" "$DIGEST_FILE"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -309,7 +309,7 @@ jobs:
           RESOURCE_MARKDOWN: resources.md
         run: |
           helm template ./dist/keptn-installer/keptn-*.tgz --dry-run > $HELM_TEMPLATE
-          cat "$HELM_TEMPLATE" | yq eval-all '[.spec.template.spec.containers.[] | {"name":.name, "resources":.resources}]' -o=json
+          yq eval-all '[.spec.template.spec.containers.[] | {"name":.name, "resources":.resources}]' "$HELM_TEMPLATE" -o=json
           
 #          cat "$HELM_TEMPLATE" | yq eval-all '[.spec.template.spec.containers.[] | {"name":.name, "resources":.resources}]' -o=json | \
 #          jq '[

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -369,6 +369,15 @@ jobs:
           branch: ${{ needs.prepare.outputs.branch }}
           enforce_admins: true
 
+      - name: Get k8s resource stats
+        working-directory: keptn
+        env:
+          HELM_TEMPLATE: template.yml
+          RESOURCE_JSON: resources.json
+          RESOURCE_MARKDOWN: resources.md
+          RELEASE_NOTES_FILE: ${{ env.RELEASE_NOTES_FILE }}
+        run: ./gh-actions-scripts/generate-k8s-resource-stats.sh
+
       - name: Create GitHub Release
         working-directory: keptn
         env:

--- a/gh-actions-scripts/generate-k8s-resource-stats.sh
+++ b/gh-actions-scripts/generate-k8s-resource-stats.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+helm template ../dist/keptn-installer/keptn-*.tgz --dry-run > "$HELM_TEMPLATE"
+yq eval-all '[
+  .spec.template.spec.containers.[] |
+  {
+    "name": .name,
+    "resources": .resources
+  }
+]' "$HELM_TEMPLATE" -o=json | \
+jq '[
+  .[] | {
+    name: .name,
+    cpu_request: .resources.requests.cpu,
+    cpu_limit: .resources.limits.cpu,
+    mem_request: .resources.requests.memory,
+    mem_limit: .resources.limits.memory
+  }
+] |
+unique_by(.name)' > "$RESOURCE_JSON"
+npx tablemark-cli@v2.0.0 "$RESOURCE_JSON" -c "Name" -c "CPU Request" -c "CPU Limit" -c "RAM Request" -c "RAM Limit" > "$RESOURCE_MARKDOWN"
+
+{
+  echo ""
+  echo "### Resource Stats"
+} >> "$RELEASE_NOTES_FILE"
+cat "$RESOURCE_MARKDOWN" >> "$RELEASE_NOTES_FILE"

--- a/gh-actions-scripts/generate-k8s-resource-stats.sh
+++ b/gh-actions-scripts/generate-k8s-resource-stats.sh
@@ -30,6 +30,9 @@ npx tablemark-cli@v2.0.0 "$RESOURCE_JSON" -c "Name" -c "CPU Request" -c "CPU Lim
 # Attach resource stats to release notes
 {
   echo ""
+  echo "<details>"
+  echo "<summary>Kubernetes Resource Data</summary>"
   echo "### Resource Stats"
+  cat "$RESOURCE_MARKDOWN"
+  echo "</details>"
 } >> "$RELEASE_NOTES_FILE"
-cat "$RESOURCE_MARKDOWN" >> "$RELEASE_NOTES_FILE"

--- a/gh-actions-scripts/generate-k8s-resource-stats.sh
+++ b/gh-actions-scripts/generate-k8s-resource-stats.sh
@@ -1,31 +1,34 @@
 #!/bin/bash
 
 # Print complete yaml of the keptn installer
-helm template ../dist/keptn-installer/keptn-*.tgz --dry-run > "$HELM_TEMPLATE"
+helm template ../dist/keptn-installer/keptn-*.tgz --dry-run --name-template=keptn > "$HELM_TEMPLATE"
 
 # yq: Extract container name and resource limits/requests for all resources
 # jq: Bring yq result into nice format that can be read by the tablemark-cli
-# unique_by: Remove duplicated distributor resource stats
 yq eval-all '[
-  .spec.template.spec.containers.[] |
-  {
-    "name": .name,
-    "resources": .resources
-  }
+{
+  "name": .metadata.name,
+  "container": .spec.template.spec.containers.[]
+} |
+{
+  "name": .name,
+  "container": .container.name,
+  "resources": .container.resources
+}
 ]' "$HELM_TEMPLATE" -o=json | \
 jq '[
-  .[] | {
+.[] | {
     name: .name,
+    container_name: .container,
     cpu_request: .resources.requests.cpu,
     cpu_limit: .resources.limits.cpu,
     mem_request: .resources.requests.memory,
     mem_limit: .resources.limits.memory
   }
-] |
-unique_by(.name)' > "$RESOURCE_JSON"
+]' > "$RESOURCE_JSON"
 
 # Generate markdown table from JSON
-npx tablemark-cli@v2.0.0 "$RESOURCE_JSON" -c "Name" -c "CPU Request" -c "CPU Limit" -c "RAM Request" -c "RAM Limit" > "$RESOURCE_MARKDOWN"
+npx tablemark-cli@v2.0.0 "$RESOURCE_JSON" -c "Name" -c "Container Name" -c "Image" -c "CPU Request" -c "CPU Limit" -c "RAM Request" -c "RAM Limit" > "$RESOURCE_MARKDOWN"
 
 # Attach resource stats to release notes
 {

--- a/gh-actions-scripts/generate-k8s-resource-stats.sh
+++ b/gh-actions-scripts/generate-k8s-resource-stats.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
+# Print complete yaml of the keptn installer
 helm template ../dist/keptn-installer/keptn-*.tgz --dry-run > "$HELM_TEMPLATE"
+
+# yq: Extract container name and resource limits/requests for all resources
+# jq: Bring yq result into nice format that can be read by the tablemark-cli
+# unique_by: Remove duplicated distributor resource stats
 yq eval-all '[
   .spec.template.spec.containers.[] |
   {
@@ -18,8 +23,11 @@ jq '[
   }
 ] |
 unique_by(.name)' > "$RESOURCE_JSON"
+
+# Generate markdown table from JSON
 npx tablemark-cli@v2.0.0 "$RESOURCE_JSON" -c "Name" -c "CPU Request" -c "CPU Limit" -c "RAM Request" -c "RAM Limit" > "$RESOURCE_MARKDOWN"
 
+# Attach resource stats to release notes
 {
   echo ""
   echo "### Resource Stats"

--- a/gh-actions-scripts/generate-k8s-resource-stats.sh
+++ b/gh-actions-scripts/generate-k8s-resource-stats.sh
@@ -13,6 +13,7 @@ yq eval-all '[
 {
   "name": .name,
   "container": .container.name,
+  "image": .container.image,
   "resources": .container.resources
 }
 ]' "$HELM_TEMPLATE" -o=json | \
@@ -23,19 +24,22 @@ jq '[
     cpu_request: .resources.requests.cpu,
     cpu_limit: .resources.limits.cpu,
     mem_request: .resources.requests.memory,
-    mem_limit: .resources.limits.memory
+    mem_limit: .resources.limits.memory,
+    image: .image
   }
 ]' > "$RESOURCE_JSON"
 
 # Generate markdown table from JSON
-npx tablemark-cli@v2.0.0 "$RESOURCE_JSON" -c "Name" -c "Container Name" -c "Image" -c "CPU Request" -c "CPU Limit" -c "RAM Request" -c "RAM Limit" > "$RESOURCE_MARKDOWN"
+npx tablemark-cli@v2.0.0 "$RESOURCE_JSON" -c "Name" -c "Container Name" -c "CPU Request" -c "CPU Limit" -c "RAM Request" -c "RAM Limit" -c "Image" > "$RESOURCE_MARKDOWN"
 
 # Attach resource stats to release notes
 {
   echo ""
   echo "<details>"
   echo "<summary>Kubernetes Resource Data</summary>"
+  echo ""
   echo "### Resource Stats"
+  echo ""
   cat "$RESOURCE_MARKDOWN"
   echo "</details>"
 } >> "$RELEASE_NOTES_FILE"


### PR DESCRIPTION
### This PR
- adds a new shell script to generate k8s resource consumption data from the Keptn Helm Chart
- doesn't use an actual installation for the gathering of data but rather parses the rendered helm chart to get the data
- attaches the resource data to (pre-)releases

Fixes #6178 

### Notes
Markdown result for the release notes can be checked here: https://github.com/keptn/keptn/runs/5018553305?check_suite_focus=true