### PR TITLE
feat: Added get options to fake keptn in go-sdk

### DIFF
--- a/go-sdk/pkg/sdk/keptn_fake.go
+++ b/go-sdk/pkg/sdk/keptn_fake.go
@@ -177,25 +177,25 @@ type StringResourceHandler struct {
 	ResourceContent string
 }
 
-func (s StringResourceHandler) GetServiceResource(project string, stage string, service string, resourceURI string) (*models.Resource, error) {
+func (s StringResourceHandler) GetServiceResource(project string, stage string, service string, resourceURI string, options ...api.GetOption) (*models.Resource, error) {
 	return &models.Resource{
-		Metadata:        nil,
+		Metadata:        &models.Version{Version: "CommitID"},
 		ResourceContent: s.ResourceContent,
 		ResourceURI:     nil,
 	}, nil
 }
 
-func (s StringResourceHandler) GetStageResource(project string, stage string, resourceURI string) (*models.Resource, error) {
+func (s StringResourceHandler) GetStageResource(project string, stage string, resourceURI string, options ...api.GetOption) (*models.Resource, error) {
 	return &models.Resource{
-		Metadata:        nil,
+		Metadata:        &models.Version{Version: "CommitID"},
 		ResourceContent: s.ResourceContent,
 		ResourceURI:     nil,
 	}, nil
 }
 
-func (s StringResourceHandler) GetProjectResource(project string, resourceURI string) (*models.Resource, error) {
+func (s StringResourceHandler) GetProjectResource(project string, resourceURI string, options ...api.GetOption) (*models.Resource, error) {
 	return &models.Resource{
-		Metadata:        nil,
+		Metadata:        &models.Version{Version: "CommitID"},
 		ResourceContent: s.ResourceContent,
 		ResourceURI:     nil,
 	}, nil

--- a/webhook-service/go.mod
+++ b/webhook-service/go.mod
@@ -4,8 +4,8 @@ go 1.16
 
 require (
 	github.com/cloudevents/sdk-go/v2 v2.8.0
-	github.com/keptn/go-utils v0.11.1-0.20220112143111-544c27052949
-	github.com/keptn/keptn/go-sdk v0.0.0-20211215141221-491a19a96c50
+	github.com/keptn/go-utils v0.11.1-0.20220118084854-b7470c0a2a7c
+	github.com/keptn/keptn/go-sdk v0.0.0-20220117144756-b73c1a3ed66a
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b

--- a/webhook-service/go.mod
+++ b/webhook-service/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/cloudevents/sdk-go/v2 v2.8.0
 	github.com/keptn/go-utils v0.11.1-0.20220118084854-b7470c0a2a7c
-	github.com/keptn/keptn/go-sdk v0.0.0-20220117144756-b73c1a3ed66a
+	github.com/keptn/keptn/go-sdk v0.0.0-20220202074141-65e36657d0f8
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b

--- a/webhook-service/go.sum
+++ b/webhook-service/go.sum
@@ -47,7 +47,6 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudevents/sdk-go/observability/opentelemetry/v2 v2.0.0-20211001212819-74757a691209 h1:pR23jlIJMXGMxljxP6QYytEsMQpPU2WT3Wjp1FWYOq0=
 github.com/cloudevents/sdk-go/observability/opentelemetry/v2 v2.0.0-20211001212819-74757a691209/go.mod h1:DmxtN+a7U9ktD8I0nTlI9CCrin/Tf7OdXxE3KBTjlOw=
 github.com/cloudevents/sdk-go/v2 v2.5.0/go.mod h1:nlXhgFkf0uTopxmRXalyMwS2LG70cRGPrxzmjJgSG0U=
-github.com/cloudevents/sdk-go/v2 v2.7.0/go.mod h1:GpCBmUj7DIRiDhVvsK5d6WCbgTWs8DxAWTRtAwQmIXs=
 github.com/cloudevents/sdk-go/v2 v2.8.0 h1:kmRaLbsafZmidZ0rZ6h7WOMqCkRMcVTLV5lxV/HKQ9Y=
 github.com/cloudevents/sdk-go/v2 v2.8.0/go.mod h1:GpCBmUj7DIRiDhVvsK5d6WCbgTWs8DxAWTRtAwQmIXs=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
@@ -165,8 +164,8 @@ github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa
 github.com/keptn/go-utils v0.11.1-0.20220117092643-ba5397b5d46f/go.mod h1:yJM7pnCUj23VHKa2az9eWUTAmLDv94f6DVHON9qV1kU=
 github.com/keptn/go-utils v0.11.1-0.20220118084854-b7470c0a2a7c h1:K2POShv4cf/AOSPHlah132D1La0ufF5QTvKUQaE6U4c=
 github.com/keptn/go-utils v0.11.1-0.20220118084854-b7470c0a2a7c/go.mod h1:yJM7pnCUj23VHKa2az9eWUTAmLDv94f6DVHON9qV1kU=
-github.com/keptn/keptn/go-sdk v0.0.0-20220117144756-b73c1a3ed66a h1:VTLIjKFx+u4j5fBFXGR+DKd6edQBXRGeHbBYVNCp/C0=
-github.com/keptn/keptn/go-sdk v0.0.0-20220117144756-b73c1a3ed66a/go.mod h1:vPAurkR5HC9eLaI9kxiEOsTd4bdfcyV+vOvBggIPkRw=
+github.com/keptn/keptn/go-sdk v0.0.0-20220202074141-65e36657d0f8 h1:30HyfIBJCNDiG3PvteaflREEtaM6A6EUQk+JbaafSYo=
+github.com/keptn/keptn/go-sdk v0.0.0-20220202074141-65e36657d0f8/go.mod h1:dlH8mDYSLylfU8pQnuJoWeb98t91ykaLwIR9QrenzHU=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/webhook-service/go.sum
+++ b/webhook-service/go.sum
@@ -47,6 +47,7 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudevents/sdk-go/observability/opentelemetry/v2 v2.0.0-20211001212819-74757a691209 h1:pR23jlIJMXGMxljxP6QYytEsMQpPU2WT3Wjp1FWYOq0=
 github.com/cloudevents/sdk-go/observability/opentelemetry/v2 v2.0.0-20211001212819-74757a691209/go.mod h1:DmxtN+a7U9ktD8I0nTlI9CCrin/Tf7OdXxE3KBTjlOw=
 github.com/cloudevents/sdk-go/v2 v2.5.0/go.mod h1:nlXhgFkf0uTopxmRXalyMwS2LG70cRGPrxzmjJgSG0U=
+github.com/cloudevents/sdk-go/v2 v2.7.0/go.mod h1:GpCBmUj7DIRiDhVvsK5d6WCbgTWs8DxAWTRtAwQmIXs=
 github.com/cloudevents/sdk-go/v2 v2.8.0 h1:kmRaLbsafZmidZ0rZ6h7WOMqCkRMcVTLV5lxV/HKQ9Y=
 github.com/cloudevents/sdk-go/v2 v2.8.0/go.mod h1:GpCBmUj7DIRiDhVvsK5d6WCbgTWs8DxAWTRtAwQmIXs=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
@@ -161,11 +162,11 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
-github.com/keptn/go-utils v0.11.1-0.20211215105940-5626bf92b8c6/go.mod h1:yJM7pnCUj23VHKa2az9eWUTAmLDv94f6DVHON9qV1kU=
-github.com/keptn/go-utils v0.11.1-0.20220112143111-544c27052949 h1:RPaapqPzdP0lyREsV0nh3HpcDW1Z4A8/D2FQZ2kDSGg=
-github.com/keptn/go-utils v0.11.1-0.20220112143111-544c27052949/go.mod h1:yJM7pnCUj23VHKa2az9eWUTAmLDv94f6DVHON9qV1kU=
-github.com/keptn/keptn/go-sdk v0.0.0-20211215141221-491a19a96c50 h1:3dTotOli68r2lIEWkppclvEt8YBQn6ctz7mlFi5eS3Q=
-github.com/keptn/keptn/go-sdk v0.0.0-20211215141221-491a19a96c50/go.mod h1:4ElHs+iaN7wZ7mA5Ico4/wBL0o0QMIClEtl30f1t90s=
+github.com/keptn/go-utils v0.11.1-0.20220117092643-ba5397b5d46f/go.mod h1:yJM7pnCUj23VHKa2az9eWUTAmLDv94f6DVHON9qV1kU=
+github.com/keptn/go-utils v0.11.1-0.20220118084854-b7470c0a2a7c h1:K2POShv4cf/AOSPHlah132D1La0ufF5QTvKUQaE6U4c=
+github.com/keptn/go-utils v0.11.1-0.20220118084854-b7470c0a2a7c/go.mod h1:yJM7pnCUj23VHKa2az9eWUTAmLDv94f6DVHON9qV1kU=
+github.com/keptn/keptn/go-sdk v0.0.0-20220117144756-b73c1a3ed66a h1:VTLIjKFx+u4j5fBFXGR+DKd6edQBXRGeHbBYVNCp/C0=
+github.com/keptn/keptn/go-sdk v0.0.0-20220117144756-b73c1a3ed66a/go.mod h1:vPAurkR5HC9eLaI9kxiEOsTd4bdfcyV+vOvBggIPkRw=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/webhook-service/lib/eventmod.go
+++ b/webhook-service/lib/eventmod.go
@@ -61,6 +61,10 @@ func (e *EventDataAdapter) Service() string {
 	return e.eventData.Service
 }
 
+func (e *EventDataAdapter) GitCommitID() string {
+	return e.event.Gitcommitid
+}
+
 func (e *EventDataAdapter) SubscriptionID() (string, error) {
 	distributorData := &DistributorData{}
 	if err := e.event.GetTemporaryData("distributor", distributorData); err != nil {


### PR DESCRIPTION
Signed-off-by: RealAnna <anna.reale@dynatrace.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- adds  commitid to webhook
BREAKING CHANGE:  in keptn sdk the keptn_fake interfaces have been updated to have api.GetOption in their signature (see [goutils change)](https://github.com/keptn/go-utils/pull/375/files#diff-245aca76b6ab2043d44c217312e1b9d487545aca0dd53418fb2106efacaec7b3)

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Closes #6349

