### PR TITLE
test: Remove obsolete check of deployments

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -424,32 +424,6 @@ jobs:
           kubectl delete pod -n ${KEPTN_NAMESPACE} -lapp.kubernetes.io/name=helm-service
           sleep 15
 
-      - name: Verify Deployments of Keptn
-        run: |
-          source test/utils.sh
-          echo "Verifying that services and namespaces have been created"
-
-          # verify the deployments within the keptn namespace (for keptn control plane)
-          verify_deployment_in_namespace "api-gateway-nginx" ${KEPTN_NAMESPACE}
-          verify_deployment_in_namespace "api-service" ${KEPTN_NAMESPACE}
-          verify_deployment_in_namespace "bridge" ${KEPTN_NAMESPACE}
-          verify_deployment_in_namespace "configuration-service" ${KEPTN_NAMESPACE} TODO undo this change
-          verify_deployment_in_namespace "lighthouse-service" ${KEPTN_NAMESPACE}
-          verify_deployment_in_namespace "shipyard-controller" ${KEPTN_NAMESPACE}
-          verify_deployment_in_namespace "statistics-service" ${KEPTN_NAMESPACE}
-
-          # verify deployments for continuous delivery
-          if [[ "$RUN_CONTINUOUS_DELIVERY_TEST" == "true" ]]; then
-            verify_deployment_in_namespace "remediation-service" ${KEPTN_NAMESPACE}
-            verify_deployment_in_namespace "approval-service" ${KEPTN_NAMESPACE}
-            verify_deployment_in_namespace "helm-service" ${KEPTN_NAMESPACE}
-            verify_deployment_in_namespace "jmeter-service" ${KEPTN_NAMESPACE}
-          fi
-
-          # verify the datastore deployments
-          verify_deployment_in_namespace "mongo" ${KEPTN_NAMESPACE}
-          verify_deployment_in_namespace "mongodb-datastore" ${KEPTN_NAMESPACE}
-
       - name: Determine Keptn Endpoint
         id: determine_keptn_endpoint
         timeout-minutes: 5

--- a/test/utils.sh
+++ b/test/utils.sh
@@ -434,18 +434,6 @@ function wait_for_daemonset_in_namespace() {
   fi
 }
 
-function verify_deployment_in_namespace() {
-  DEPLOYMENT=$1; NAMESPACE=$2;
-
-  DEPLOYMENT_LIST=$(eval "kubectl get deployments -n ${NAMESPACE} | awk '/$DEPLOYMENT /'" | awk '{print $1}') # list of multiple deployments when starting with the same name
-  if [[ -z "$DEPLOYMENT_LIST" ]]; then
-    print_error "Could not find deployment ${DEPLOYMENT} in namespace ${NAMESPACE}"
-    exit 1
-  else
-    echo "Found deployment ${DEPLOYMENT} in namespace ${NAMESPACE}: ${DEPLOYMENT_LIST}"
-  fi
-}
-
 function verify_pod_in_namespace() {
   POD=$1; NAMESPACE=$2;
 

--- a/test/utils/install_istio.sh
+++ b/test/utils/install_istio.sh
@@ -15,6 +15,3 @@ istioctl x precheck
 istioctl install -y --verify
 
 verify_test_step $? "Failed to install Istio"
-
-# verify the pods within istio-system
-verify_deployment_in_namespace "istio-ingressgateway" "istio-system"


### PR DESCRIPTION
The checks performed in the step that has been removed with this PR are covered by helm. Therefore this step has become obsolete