### PR TITLE
fix(installer): External connection string not used while helm upgrade

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/templates/mongodb-credentials.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/mongodb-credentials.yaml
@@ -19,9 +19,6 @@
 {{- end -}}
 
 {{- $mongoExternalConnectionString := "" | b64enc | quote -}}
-{{- if .Values.mongo.external.connectionString -}}
-  {{- $mongoExternalConnectionString = .Values.mongo.external.connectionString | b64enc | quote -}}
-{{- end -}}
 
 {{- $mongosecret := (lookup "v1" "Secret" .Release.Namespace "mongodb-credentials") -}}
 
@@ -47,6 +44,10 @@
   {{- if index $mongosecret.data "external_connection_string" -}}
     {{- $mongoExternalConnectionString = index $mongosecret.data "external_connection_string" -}}
   {{- end -}}
+{{- end -}}
+
+{{- if .Values.mongo.external.connectionString -}}
+  {{- $mongoExternalConnectionString = .Values.mongo.external.connectionString | b64enc | quote -}}
 {{- end -}}
 
 ---


### PR DESCRIPTION
When upgrading keptn and setting a new external connection string it will use the existing one from the `mongodb-credentials`.
This PR just changes the order to use the provided value if there is one.