### PR TITLE
ci: Only upload dev helm chart for non-fork PRs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -358,7 +358,7 @@ jobs:
   helm_charts_upload:
     name: Publish helm charts to dev repo
     needs: [prepare_ci_run, helm_charts_build]
-    if: ((needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (needs.prepare_ci_run.outputs.BUILD_INSTALLER == 'true')) && github.event.pull_request.head.repo.full_name == github.repository
+    if: ((needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (needs.prepare_ci_run.outputs.BUILD_INSTALLER == 'true')) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository))
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout helm-charts repo

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -358,7 +358,7 @@ jobs:
   helm_charts_upload:
     name: Publish helm charts to dev repo
     needs: [prepare_ci_run, helm_charts_build]
-    if: (needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (needs.prepare_ci_run.outputs.BUILD_INSTALLER == 'true')
+    if: ((needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (needs.prepare_ci_run.outputs.BUILD_INSTALLER == 'true')) && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout helm-charts repo


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- fixes a small issue where helm charts can not be uploaded from builds triggered by fork based PRs