### PR TITLE
fix(bridge): Fix style content security policy (#6750)

### DIFF
--- a/bridge/server/app.ts
+++ b/bridge/server/app.ts
@@ -105,7 +105,7 @@ async function init(): Promise<Express> {
           "'sha256-9Ts7nfXdJQSKqVPxtB4Jwhf9pXSA/krLvgk8JROkI6g='", // script to set base-href inside index.html
           `'sha256-1bE+yX7acJRNcaa95nVUmUtsD9IfSBgk5ofu7ClfR5Y='`, // script to set base-href inside common.pug
         ],
-        'style-src': [`'self`, `'unsafe-inline'`],
+        'style-src': [`'self'`, `'unsafe-inline'`],
         'upgrade-insecure-requests': null,
       },
     })

--- a/bridge/server/app.ts
+++ b/bridge/server/app.ts
@@ -105,6 +105,7 @@ async function init(): Promise<Express> {
           "'sha256-9Ts7nfXdJQSKqVPxtB4Jwhf9pXSA/krLvgk8JROkI6g='", // script to set base-href inside index.html
           `'sha256-1bE+yX7acJRNcaa95nVUmUtsD9IfSBgk5ofu7ClfR5Y='`, // script to set base-href inside common.pug
         ],
+        'style-src': [`'self`, `'unsafe-inline'`],
         'upgrade-insecure-requests': null,
       },
     })


### PR DESCRIPTION
Fixes #6750 
`style-src` `unsafe-inline` has to be used for Angular applications. https://github.com/angular/angular/issues/37631
Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>