### PR TITLE
test(bridge): Fix UI test screenshots not being attached when UI tests fail

### DIFF
--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -1,9 +1,9 @@
 FROM cypress/browsers:node14.17.0-chrome91-ff89 as builder-test-ui
 WORKDIR /usr/src/app
-COPY package.json yarn.lock /usr/src/app/
+COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile
-COPY . /usr/src/app
-CMD yarn test:ui; mv ./dist/cypress/screenshots /shared/screenshots
+COPY ./ ./
+CMD ./cypress/run-tests.sh
 
 FROM node:14-alpine3.14 as builder-test-base
 WORKDIR /usr/src/app

--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /usr/src/app
 COPY package.json yarn.lock /usr/src/app/
 RUN yarn install --frozen-lockfile
 COPY . /usr/src/app
-CMD yarn test:ui && mv ./dist/cypress/screenshots /shared/screenshots
+CMD yarn test:ui; mv ./dist/cypress/screenshots /shared/screenshots
 
 FROM node:14-alpine3.14 as builder-test-base
 WORKDIR /usr/src/app

--- a/bridge/cypress/integration/notification.spec.ts
+++ b/bridge/cypress/integration/notification.spec.ts
@@ -55,6 +55,8 @@ describe('Test notifications', () => {
       .trigger('mouseleave')
       .wait(8200)
       .should('not.exist');
+
+    throw new Error('this is here for testing');
   });
 
   it('should test notification close', () => {

--- a/bridge/cypress/integration/notification.spec.ts
+++ b/bridge/cypress/integration/notification.spec.ts
@@ -55,8 +55,6 @@ describe('Test notifications', () => {
       .trigger('mouseleave')
       .wait(8200)
       .should('not.exist');
-
-    throw new Error('this is here for testing');
   });
 
   it('should test notification close', () => {

--- a/bridge/cypress/run-tests.sh
+++ b/bridge/cypress/run-tests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+yarn test:ui
+test_outcome=$?
+mv ./dist/cypress/screenshots /shared/screenshots
+
+if [[ $test_outcome -ne 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- fixes a bug where the UI test screenshots from the bridge were not attached to the pipeline runs if the tests failed. This should now be fixed by introducing a small runner shell script that takes care of moving the screenshots to the correct folder.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #6765

### Notes
Here is a CI run that had a failing UI test and still has screenshots attached: https://github.com/keptn/keptn/actions/runs/1811645354