### PR TITLE
test: Introduce gotestsum as test runner for all go based services

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -66,11 +66,6 @@ EXPOSE 8080
 # required for external tools to detect this as a go binary
 ENV GOTRACEBACK=all
 
-# KEEP THE FOLLOWING LINES COMMENTED OUT!!! (they will be included within the travis-ci build)
-#travis-uncomment ADD MANIFEST /
-#travis-uncomment COPY entrypoint.sh /
-#travis-uncomment ENTRYPOINT ["/entrypoint.sh"]
-
 RUN adduser -D nonroot -u 65532
 USER nonroot
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -22,8 +22,10 @@ RUN go mod download
 COPY . .
 
 FROM builder-base as builder-test
+ENV GOTESTSUM_FORMAT=testname
 
-CMD go test -coverprofile=coverage.txt -covermode=atomic -v ./handlers/... ./utils/... && mv ./coverage.txt /shared/coverage.txt
+RUN go get gotest.tools/gotestsum@v1.7.0
+CMD gotestsum --no-color=false -- -coverprofile=coverage.txt -covermode=atomic -v ./handlers/... ./utils/... && mv ./coverage.txt /shared/coverage.txt
 
 FROM builder-base as builder
 ARG version=develop
@@ -34,10 +36,8 @@ RUN if [ ! -z "$debugBuild" ]; then export BUILDFLAGS='-gcflags "all=-N -l"'; fi
 
 RUN sed -i "s/version: develop/version: ${version}/g" /go/src/github.com/keptn/keptn/api/swagger.yaml
 
-
 # Build the command inside the container.
-# (You may fetch or manage dependencies here,
-# either manually or with a tool like "godep".)
+# (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
 RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v cmd/api-server/main.go
 
 
@@ -50,7 +50,6 @@ LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \
     org.opencontainers.image.licenses="Apache-2.0" \
     org.opencontainers.image.version="${version}"
-
 
 # we need to install ca-certificates and libc6-compat for go programs to work properly
 RUN apk add --no-cache ca-certificates libc6-compat

--- a/approval-service/Dockerfile
+++ b/approval-service/Dockerfile
@@ -1,11 +1,10 @@
 # Use the official Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
-# https://hub.docker.com/_/golang
 FROM golang:1.16.13-alpine as builder-base
 
 WORKDIR /go/src/github.com/keptn/keptn/approval-service
 
-# Force the go compiler to use modules 
+# Force the go compiler to use modules
 ENV GO111MODULE=on
 ENV BUILDFLAGS=""
 ENV GOPROXY=https://proxy.golang.org
@@ -23,10 +22,13 @@ RUN go mod download
 COPY . .
 
 FROM builder-base as builder-test
+ENV GOTESTSUM_FORMAT=testname
 
-CMD go test -race -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
+RUN go get gotest.tools/gotestsum@v1.7.0
+CMD gotestsum --no-color=false -- -race -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
 
 FROM builder-base as builder
+ARG version=develop
 ARG debugBuild
 
 # set buildflags for debug build
@@ -36,8 +38,6 @@ RUN if [ ! -z "$debugBuild" ]; then export BUILDFLAGS='-gcflags "all=-N -l"'; fi
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
 RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o approval-service
 
-# Use a Docker multi-stage build to create a lean production image.
-# https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.15 as production
 ARG version=develop
 LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \

--- a/approval-service/Dockerfile
+++ b/approval-service/Dockerfile
@@ -59,11 +59,6 @@ EXPOSE 8080
 # required for external tools to detect this as a go binary
 ENV GOTRACEBACK=all
 
-# KEEP THE FOLLOWING LINES COMMENTED OUT!!! (they will be included within the travis-ci build)
-#travis-uncomment ADD MANIFEST /
-#travis-uncomment COPY entrypoint.sh /
-#travis-uncomment ENTRYPOINT ["/entrypoint.sh"]
-
 RUN adduser -D nonroot -u 65532
 USER nonroot
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,7 +13,7 @@ ignore:
   - "**/*.yaml"       # ignore all yaml files (Kubernetes manifests, etc...)
   - "**/*.yml"        # same as above
   - "**/*.md"         # ignore all markdown files, those are not relevant for building/testing
-  - "**/Dockerfile"   # ignore Dockerfiles, those are build with travis
+  - "**/Dockerfile"   # ignore Dockerfiles, those are build with GH Actions
   - "**/*.sh"         # ignore shell scripts
 
 comment:

--- a/configuration-service/Dockerfile
+++ b/configuration-service/Dockerfile
@@ -73,11 +73,6 @@ EXPOSE 8080
 # required for external tools to detect this as a go binary
 ENV GOTRACEBACK=all
 
-# KEEP THE FOLLOWING LINES COMMENTED OUT!!! (they will be included within the travis-ci build)
-#travis-uncomment ADD MANIFEST /
-#travis-uncomment COPY entrypoint.sh /
-#travis-uncomment ENTRYPOINT ["/entrypoint.sh"]
-
 RUN adduser -D nonroot -u 65532
 USER nonroot
 

--- a/configuration-service/Dockerfile
+++ b/configuration-service/Dockerfile
@@ -23,8 +23,10 @@ COPY . .
 
 FROM builder-base as builder-test
 ARG version=develop
+ENV GOTESTSUM_FORMAT=testname
 
-CMD go test -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
+RUN go get gotest.tools/gotestsum@v1.7.0
+CMD gotestsum --no-color=false -- -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
 
 FROM builder-base as builder
 

--- a/distributor/Dockerfile
+++ b/distributor/Dockerfile
@@ -55,12 +55,6 @@ COPY --from=builder /go/src/github.com/keptn/keptn/distributor/distributor /dist
 # required for external tools to detect this as a go binary
 ENV GOTRACEBACK=all
 
-
-# KEEP THE FOLLOWING LINES COMMENTED OUT!!! (they will be included within the travis-ci build)
-#travis-uncomment ADD MANIFEST /
-#travis-uncomment COPY entrypoint.sh /
-#travis-uncomment ENTRYPOINT ["/entrypoint.sh"]
-
 RUN adduser -D nonroot -u 65532
 USER nonroot
 

--- a/distributor/Dockerfile
+++ b/distributor/Dockerfile
@@ -1,6 +1,5 @@
 # Use the official Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
-# https://hub.docker.com/_/golang
 FROM golang:1.16.13-alpine as builder-base
 
 ARG debugBuild
@@ -13,8 +12,6 @@ ENV GOPROXY=https://proxy.golang.org
 
 RUN apk add --no-cache gcc libc-dev git
 
-# Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
-# in case of a change in the dependencies
 COPY go.mod go.sum ./
 
 # Download dependencies
@@ -24,8 +21,10 @@ RUN go mod download
 COPY . .
 
 FROM builder-base as builder-test
+ENV GOTESTSUM_FORMAT=testname
 
-CMD go test -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
+RUN go get gotest.tools/gotestsum@v1.7.0
+CMD gotestsum --no-color=false -- -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
 
 FROM builder-base as builder
 
@@ -38,8 +37,6 @@ RUN if [ ! -z "$debugBuild" ]; then export BUILDFLAGS='-gcflags "all=-N -l"'; fi
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o distributor ./cmd/
 
-# Use a Docker multi-stage build to create a lean production image.
-# https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.15 as production
 ARG version=develop
 LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \

--- a/helm-service/Dockerfile
+++ b/helm-service/Dockerfile
@@ -60,10 +60,5 @@ EXPOSE 8080
 # required for external tools to detect this as a go binary
 ENV GOTRACEBACK=all
 
-# KEEP THE FOLLOWING LINES COMMENTED OUT!!! (they will be included within the travis-ci build)
-#travis-uncomment ADD MANIFEST /
-#travis-uncomment COPY entrypoint.sh /
-#travis-uncomment ENTRYPOINT ["/entrypoint.sh"]
-
 # Run the web service on container startup.
 CMD ["/helm-service"]

--- a/helm-service/Dockerfile
+++ b/helm-service/Dockerfile
@@ -23,8 +23,10 @@ RUN go mod download
 COPY . .
 
 FROM builder-base as builder-test
+ENV GOTESTSUM_FORMAT=testname
 
-CMD go test -race -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
+RUN go get gotest.tools/gotestsum@v1.7.0
+CMD gotestsum --no-color=false -- -race -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
 
 FROM builder-base as builder
 

--- a/jmeter-service/Dockerfile
+++ b/jmeter-service/Dockerfile
@@ -88,10 +88,5 @@ EXPOSE 8080
 # required for external tools to detect this as a go binary
 ENV GOTRACEBACK=all
 
-# KEEP THE FOLLOWING LINES COMMENTED OUT!!! (they will be included within the travis-ci build)
-#travis-uncomment ADD MANIFEST /
-#travis-uncomment COPY entrypoint.sh /
-#travis-uncomment ENTRYPOINT ["/entrypoint.sh"]
-
 # Run the web service on container startup.
 CMD ["/jmeter-service"]

--- a/jmeter-service/Dockerfile
+++ b/jmeter-service/Dockerfile
@@ -23,8 +23,10 @@ RUN go mod download
 COPY . .
 
 FROM builder-base as builder-test
+ENV GOTESTSUM_FORMAT=testname
 
-CMD go test -race -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
+RUN go get gotest.tools/gotestsum@v1.7.0
+CMD gotestsum --no-color=false -- -race -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
 
 FROM builder-base as builder
 

--- a/lighthouse-service/Dockerfile
+++ b/lighthouse-service/Dockerfile
@@ -23,8 +23,10 @@ RUN go mod download
 COPY . .
 
 FROM builder-base as builder-test
+ENV GOTESTSUM_FORMAT=testname
 
-CMD go test -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
+RUN go get gotest.tools/gotestsum@v1.7.0
+CMD gotestsum --no-color=false -- -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
 
 FROM builder-base as builder
 

--- a/lighthouse-service/Dockerfile
+++ b/lighthouse-service/Dockerfile
@@ -60,11 +60,6 @@ EXPOSE 8080
 # required for external tools to detect this as a go binary
 ENV GOTRACEBACK=all
 
-# KEEP THE FOLLOWING LINES COMMENTED OUT!!! (they will be included within the travis-ci build)
-#travis-uncomment ADD MANIFEST /
-#travis-uncomment COPY entrypoint.sh /
-#travis-uncomment ENTRYPOINT ["/entrypoint.sh"]
-
 RUN adduser -D nonroot -u 65532
 USER nonroot
 

--- a/mongodb-datastore/Dockerfile
+++ b/mongodb-datastore/Dockerfile
@@ -1,7 +1,6 @@
 # Use the official Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
-# https://hub.docker.com/_/golang
-FROM golang:1.16.13-alpine as builder-base
+FROM golang:1.16.13 as builder-base
 
 WORKDIR /go/src/github.com/keptn/keptn/mongodb-datastore
 
@@ -22,30 +21,7 @@ RUN go mod download
 # Copy local code to the container image.
 COPY . .
 
-FROM golang:1.16.13 as builder-test
-
-# install additional dependencies
-RUN apt-get install -y gcc libc-dev git
-
-# Force the go compiler to use modules
-ENV GO111MODULE=on
-ENV BUILDFLAGS=""
-ENV GOPROXY=https://proxy.golang.org
-
-# Pre-Req for gin-gonic/go-swagger: Install swag cli to generate swagger.yaml and swagger.json
-RUN go get -u github.com/swaggo/swag/cmd/swag@v1.7.0
-
-WORKDIR /go/src/github.com/keptn/keptn/shipyard-controller
-
-# Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
-# in case of a change in the dependencies
-COPY go.mod go.sum ./
-
-# Download dependencies
-RUN go mod download
-
-# Copy local code to the container image.
-COPY . .
+FROM builder-base as builder-test
 ENV GOTESTSUM_FORMAT=testname
 
 RUN go get gotest.tools/gotestsum@v1.7.0
@@ -64,8 +40,6 @@ RUN sed -i "s/version: develop/version: ${version}/g" /go/src/github.com/keptn/k
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
 RUN cd cmd/mongodb-datastore-server && GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o mongodb-datastore
 
-# Use a Docker multi-stage build to create a lean production image.
-# https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.15 as production
 ARG version=develop
 LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \

--- a/mongodb-datastore/Dockerfile
+++ b/mongodb-datastore/Dockerfile
@@ -68,12 +68,6 @@ EXPOSE 8080
 # required for external tools to detect this as a go binary
 ENV GOTRACEBACK=all
 
-# KEEP THE FOLLOWING LINES COMMENTED OUT!!! (they will be included within the travis-ci build)
-#travis-uncomment ADD MANIFEST /
-#travis-uncomment COPY entrypoint.sh /
-#travis-uncomment ENTRYPOINT ["/entrypoint.sh"]
-
-
 RUN adduser -D nonroot -u 65532
 USER nonroot
 

--- a/mongodb-datastore/Dockerfile
+++ b/mongodb-datastore/Dockerfile
@@ -46,8 +46,10 @@ RUN go mod download
 
 # Copy local code to the container image.
 COPY . .
+ENV GOTESTSUM_FORMAT=testname
 
-CMD go test -race -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
+RUN go get gotest.tools/gotestsum@v1.7.0
+CMD gotestsum --no-color=false -- -race -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
 
 FROM builder-base as builder
 ARG version=develop

--- a/mongodb-datastore/Dockerfile
+++ b/mongodb-datastore/Dockerfile
@@ -9,7 +9,7 @@ ENV GO111MODULE=on
 ENV BUILDFLAGS=""
 ENV GOPROXY=https://proxy.golang.org
 
-RUN apk add --no-cache gcc libc-dev git
+RUN apt-get install -y gcc libc-dev git
 
 # Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
 # in case of a change in the dependencies

--- a/remediation-service/Dockerfile
+++ b/remediation-service/Dockerfile
@@ -23,8 +23,10 @@ RUN go mod download
 COPY . .
 
 FROM builder-base as builder-test
+ENV GOTESTSUM_FORMAT=testname
 
-CMD go test -race -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
+RUN go get gotest.tools/gotestsum@v1.7.0
+CMD gotestsum --no-color=false -- -race -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
 
 FROM builder-base as builder
 

--- a/remediation-service/Dockerfile
+++ b/remediation-service/Dockerfile
@@ -60,11 +60,6 @@ EXPOSE 8080
 # required for external tools to detect this as a go binary
 ENV GOTRACEBACK=all
 
-# KEEP THE FOLLOWING LINES COMMENTED OUT!!! (they will be included within the travis-ci build)
-#travis-uncomment ADD MANIFEST /
-#travis-uncomment COPY entrypoint.sh /
-#travis-uncomment ENTRYPOINT ["/entrypoint.sh"]
-
 RUN adduser -D nonroot -u 65532
 USER nonroot
 

--- a/resource-service/Dockerfile
+++ b/resource-service/Dockerfile
@@ -25,32 +25,11 @@ RUN go mod download
 # Copy local code to the container image.
 COPY . .
 
-FROM golang:1.16.13 as builder-test
+FROM builder-base as builder-test
+ENV GOTESTSUM_FORMAT=testname
 
-# install additional dependencies
-RUN apt-get install -y gcc libc-dev git
-
-# Force the go compiler to use modules
-ENV GO111MODULE=on
-ENV BUILDFLAGS=""
-ENV GOPROXY=https://proxy.golang.org
-
-# Pre-Req for gin-gonic/go-swagger: Install swag cli to generate swagger.yaml and swagger.json
-RUN go get -u github.com/swaggo/swag/cmd/swag@v1.7.0
-
-WORKDIR /go/src/github.com/keptn/keptn/resource-service
-
-# Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
-# in case of a change in the dependencies
-COPY go.mod go.sum ./
-
-# Download dependencies
-RUN go mod download
-
-# Copy local code to the container image.
-COPY . .
-
-CMD go test -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
+RUN go get gotest.tools/gotestsum@v1.7.0
+CMD gotestsum --no-color=false -- -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
 
 FROM builder-base as builder
 ARG version=develop

--- a/secret-service/Dockerfile
+++ b/secret-service/Dockerfile
@@ -26,8 +26,10 @@ RUN go mod download
 COPY . .
 
 FROM builder-base as builder-test
+ENV GOTESTSUM_FORMAT=testname
 
-CMD go test -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
+RUN go get gotest.tools/gotestsum@v1.7.0
+CMD gotestsum --no-color=false -- -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
 
 FROM builder-base as builder
 ARG version=develop

--- a/secret-service/Dockerfile
+++ b/secret-service/Dockerfile
@@ -80,11 +80,6 @@ EXPOSE 8080
 # required for external tools to detect this as a go binary
 ENV GOTRACEBACK=all
 
-# KEEP THE FOLLOWING LINES COMMENTED OUT!!! (they will be included within the travis-ci build)
-#travis-uncomment ADD MANIFEST /
-#travis-uncomment COPY entrypoint.sh /
-#travis-uncomment ENTRYPOINT ["/entrypoint.sh"]
-
 # Run the web service on container startup.
 ENV GIN_MODE=release
 

--- a/shipyard-controller/Dockerfile
+++ b/shipyard-controller/Dockerfile
@@ -1,9 +1,9 @@
 # Use the official Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
-FROM golang:1.16.13-alpine as builder-base
+FROM golang:1.16.13 as builder-base
 
 # install additional dependencies
-RUN apk add --no-cache gcc libc-dev git
+RUN apt-get install -y gcc libc-dev git
 
 # Force the go compiler to use modules
 ENV GO111MODULE=on

--- a/shipyard-controller/Dockerfile
+++ b/shipyard-controller/Dockerfile
@@ -80,11 +80,6 @@ EXPOSE 8080
 # required for external tools to detect this as a go binary
 ENV GOTRACEBACK=all
 
-# KEEP THE FOLLOWING LINES COMMENTED OUT!!! (they will be included within the travis-ci build)
-#travis-uncomment ADD MANIFEST /
-#travis-uncomment COPY entrypoint.sh /
-#travis-uncomment ENTRYPOINT ["/entrypoint.sh"]
-
 RUN adduser -D nonroot -u 65532
 USER nonroot
 

--- a/shipyard-controller/Dockerfile
+++ b/shipyard-controller/Dockerfile
@@ -25,32 +25,11 @@ RUN go mod download
 # Copy local code to the container image.
 COPY . .
 
-FROM golang:1.16.13 as builder-test
+FROM builder-base as builder-test
+ENV GOTESTSUM_FORMAT=testname
 
-# install additional dependencies
-RUN apt-get install -y gcc libc-dev git
-
-# Force the go compiler to use modules
-ENV GO111MODULE=on
-ENV BUILDFLAGS=""
-ENV GOPROXY=https://proxy.golang.org
-
-# Pre-Req for gin-gonic/go-swagger: Install swag cli to generate swagger.yaml and swagger.json
-RUN go get -u github.com/swaggo/swag/cmd/swag@v1.7.0
-
-WORKDIR /go/src/github.com/keptn/keptn/shipyard-controller
-
-# Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
-# in case of a change in the dependencies
-COPY go.mod go.sum ./
-
-# Download dependencies
-RUN go mod download
-
-# Copy local code to the container image.
-COPY . .
-
-CMD go test -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
+RUN go get gotest.tools/gotestsum@v1.7.0
+CMD gotestsum --no-color=false -- -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
 
 FROM builder-base as builder
 ARG version=develop

--- a/statistics-service/Dockerfile
+++ b/statistics-service/Dockerfile
@@ -1,9 +1,9 @@
 # Use the official Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
-FROM golang:1.16.13-alpine as builder-base
+FROM golang:1.16.13 as builder-base
 
 # install additional dependencies
-RUN apk add --no-cache gcc libc-dev git
+RUN apt-get install -y gcc libc-dev git
 
 # Force the go compiler to use modules
 ENV GO111MODULE=on

--- a/statistics-service/Dockerfile
+++ b/statistics-service/Dockerfile
@@ -80,11 +80,6 @@ EXPOSE 8080
 # required for external tools to detect this as a go binary
 ENV GOTRACEBACK=all
 
-# KEEP THE FOLLOWING LINES COMMENTED OUT!!! (they will be included within the travis-ci build)
-#travis-uncomment ADD MANIFEST /
-#travis-uncomment COPY entrypoint.sh /
-#travis-uncomment ENTRYPOINT ["/entrypoint.sh"]
-
 RUN adduser -D nonroot -u 65532
 USER nonroot
 

--- a/statistics-service/Dockerfile
+++ b/statistics-service/Dockerfile
@@ -25,32 +25,11 @@ RUN go mod download
 # Copy local code to the container image.
 COPY . .
 
-FROM golang:1.16.13 as builder-test
+FROM builder-base as builder-test
+ENV GOTESTSUM_FORMAT=testname
 
-# install additional dependencies
-RUN apt-get install -y gcc libc-dev git
-
-# Force the go compiler to use modules
-ENV GO111MODULE=on
-ENV BUILDFLAGS=""
-ENV GOPROXY=https://proxy.golang.org
-
-# Pre-Req for gin-gonic/go-swagger: Install swag cli to generate swagger.yaml and swagger.json
-RUN go get -u github.com/swaggo/swag/cmd/swag@v1.7.0
-
-WORKDIR /go/src/github.com/keptn/keptn/shipyard-controller
-
-# Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
-# in case of a change in the dependencies
-COPY go.mod go.sum ./
-
-# Download dependencies
-RUN go mod download
-
-# Copy local code to the container image.
-COPY . .
-
-CMD go test -race -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
+RUN go get gotest.tools/gotestsum@v1.7.0
+CMD gotestsum --no-color=false -- -race -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
 
 FROM builder-base as builder
 ARG version=develop

--- a/test/assets/mongodb-datastore_evaluation_triggered_template.json
+++ b/test/assets/mongodb-datastore_evaluation_triggered_template.json
@@ -1,7 +1,7 @@
 {
   "type": "sh.keptn.event.hardening.evaluation.triggered",
   "specversion": "1.0",
-  "source": "travis-ci",
+  "source": "github-actions",
   "contenttype": "application/json",
   "data": {
     "project": "$PROJECT",

--- a/webhook-service/Dockerfile
+++ b/webhook-service/Dockerfile
@@ -23,8 +23,10 @@ RUN go mod download
 COPY . .
 
 FROM builder-base as builder-test
+ENV GOTESTSUM_FORMAT=testname
 
-CMD go test -race -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
+RUN go get gotest.tools/gotestsum@v1.7.0
+CMD gotestsum --no-color=false -- -race -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
 
 FROM builder-base as builder
 

--- a/webhook-service/Dockerfile
+++ b/webhook-service/Dockerfile
@@ -60,11 +60,6 @@ EXPOSE 8080
 # required for external tools to detect this as a go binary
 ENV GOTRACEBACK=all
 
-# KEEP THE FOLLOWING LINES COMMENTED OUT!!! (they will be included within the travis-ci build)
-#travis-uncomment ADD MANIFEST /
-#travis-uncomment COPY entrypoint.sh /
-#travis-uncomment ENTRYPOINT ["/entrypoint.sh"]
-
 RUN adduser -D nonroot -u 65532
 USER nonroot
 


### PR DESCRIPTION
### This PR
- introduces `gotestsum` as the test runner for all go-based Keptn services
- simplifies some Dockerfiles where duplicate code was present (mongodb-datastore, resource-service, shipyard-controller, statistics-service)
- removes some unneeded comments from travis-ci times

Successful integration tests: https://github.com/keptn/keptn/actions/runs/1822968567

Fixes #5946 