### PR TITLE
ci: Disable manual triggers of the CI pipeline

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,6 @@ on:
     branches:
       - 'master'
       - '[0-9]+.[1-9][0-9]*.x'
-  workflow_dispatch: # run CI when triggered manually
 env:
   GO_VERSION: "^1.16"
   KUBE_CONSTRAINTS: ">= 1.14, <= 1.21"


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- disables the manual trigger of the CI pipeline since it is not supported

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #5815 
