### PR TITLE
fix(api): Trim spaces in cloudevents coming in via API

### DIFF
--- a/api/utils/event.go
+++ b/api/utils/event.go
@@ -1,13 +1,14 @@
 package utils
 
 import (
-	logger "github.com/sirupsen/logrus"
 	"os"
+	"strings"
 	"time"
+
+	logger "github.com/sirupsen/logrus"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/google/uuid"
-
 	keptnutils "github.com/keptn/go-utils/pkg/lib/keptn"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 )
@@ -36,8 +37,8 @@ func SendEvent(keptnContext, triggeredID, gitCommitID, eventType, source string,
 	ev.SetTime(time.Now().UTC())
 	ev.SetSource(source)
 	ev.SetDataContentType(cloudevents.ApplicationJSON)
-	ev.SetExtension("shkeptncontext", keptnContext)
-	ev.SetExtension("triggeredid", triggeredID)
+	ev.SetExtension("shkeptncontext", strings.TrimSpace(keptnContext))
+	ev.SetExtension("triggeredid", strings.TrimSpace(triggeredID))
 	ev.SetExtension("gitcommitid", gitCommitID)
 	ev.SetData(cloudevents.ApplicationJSON, data)
 


### PR DESCRIPTION
Signed-off-by: agardnerit <adam@agardner.net>

## This PR
Trims space for the `shkeptncontext` and `triggeredid` fields for cloudevents coming in via API. Improves usability.

### Related Issues
Fixes #6828

### Notes

### Follow-up Tasks

### How to test

