### PR TITLE
fix: Trim Incoming Keptn Context and Triggered ID via API

### DIFF
--- a/api/utils/event.go
+++ b/api/utils/event.go
@@ -1,9 +1,11 @@
 package utils
 
 import (
-	logger "github.com/sirupsen/logrus"
 	"os"
+	"strings"
 	"time"
+
+	logger "github.com/sirupsen/logrus"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/google/uuid"
@@ -36,7 +38,7 @@ func SendEvent(keptnContext, triggeredID, gitCommitID, eventType, source string,
 	ev.SetTime(time.Now().UTC())
 	ev.SetSource(source)
 	ev.SetDataContentType(cloudevents.ApplicationJSON)
-	ev.SetExtension("shkeptncontext", keptnContext)
+	ev.SetExtension("shkeptncontext", strings.TrimSpace(keptnContext))
 	ev.SetExtension("triggeredid", triggeredID)
 	ev.SetExtension("gitcommitid", gitCommitID)
 	ev.SetData(cloudevents.ApplicationJSON, data)

--- a/api/utils/event.go
+++ b/api/utils/event.go
@@ -39,7 +39,7 @@ func SendEvent(keptnContext, triggeredID, gitCommitID, eventType, source string,
 	ev.SetSource(source)
 	ev.SetDataContentType(cloudevents.ApplicationJSON)
 	ev.SetExtension("shkeptncontext", strings.TrimSpace(keptnContext))
-	ev.SetExtension("triggeredid", triggeredID)
+	ev.SetExtension("triggeredid", strings.TrimSpace(triggeredID))
 	ev.SetExtension("gitcommitid", gitCommitID)
 	ev.SetData(cloudevents.ApplicationJSON, data)
 


### PR DESCRIPTION

## fix: Trim Incoming Keptn Context and Triggered ID via API
Trims leading and trailing whitespace from keptnContext and triggeredID when event coming in via API

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #6828 

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
Does this need tests?

### How to test
Craft a JSON with:
```
{
  "shkeptncontext": " abc123... ",
  "triggeredid": " def234... "
}
```

Keptn should now trim that to:
```
{
  "shkeptncontext": "abc123...",
  "triggeredid": "def234..."
}
```

