### PR TITLE
ci: Set minimum days of package stability to 3 for Renovate to auto-merge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,7 @@
   ],
   "addLabels": ["dependencies"],
   "cloneSubmodules": true,
+  "stabilityDays": 3,
   "timezone": "Europe/Vienna",
   "ignoreDeps": [
     "github.com/keptn/keptn/go-sdk"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,7 +10,6 @@
   ],
   "addLabels": ["dependencies"],
   "cloneSubmodules": true,
-  "stabilityDays": 7,
   "timezone": "Europe/Vienna",
   "ignoreDeps": [
     "github.com/keptn/keptn/go-sdk"


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- sets Renovates stability days setting to 3 to be faster with auto-merging patch dependencies
- this should prevent scenarios where a new package version is release for something but 7 days have not yet passed since the last versions so Keptn never gets the updates