### PR TITLE
ci: Push dev images to dev dockerhub registry, adjust helm charts

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -440,8 +440,8 @@ jobs:
         with:
           context: ${{ matrix.config.working-dir }}
           tags: |
-            keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
-            keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}.${{ env.DATETIME }}
+            keptndev/${{ matrix.config.artifact }}:${{ env.VERSION }}
+            keptndev/${{ matrix.config.artifact }}:${{ env.VERSION }}.${{ env.DATETIME }}
           build-args: |
             version=${{ env.VERSION }}
           push: ${{ matrix.config.should-push-image == 'true' && (( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository ) || ( github.event_name == 'push' )) && github.actor != 'renovate[bot]' && github.actor != 'dependabot[bot]' }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -347,7 +347,7 @@ jobs:
     name: Build Helm Charts
     needs: prepare_ci_run
     if: (needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (needs.prepare_ci_run.outputs.BUILD_INSTALLER == 'true')
-    uses: keptn/keptn/.github/workflows/build-helm-charts.yml@master
+    uses: keptn/keptn/.github/workflows/build-helm-charts.yml@ci/5629/push-dev-images-to-dev-registry
     with:
       branch: ${{ needs.prepare_ci_run.outputs.BRANCH }}
       version: ${{ needs.prepare_ci_run.outputs.VERSION }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -347,7 +347,7 @@ jobs:
     name: Build Helm Charts
     needs: prepare_ci_run
     if: (needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (needs.prepare_ci_run.outputs.BUILD_INSTALLER == 'true')
-    uses: keptn/keptn/.github/workflows/build-helm-charts.yml@ci/5629/push-dev-images-to-dev-registry
+    uses: keptn/keptn/.github/workflows/build-helm-charts.yml@master
     with:
       branch: ${{ needs.prepare_ci_run.outputs.BRANCH }}
       version: ${{ needs.prepare_ci_run.outputs.VERSION }}

--- a/.github/workflows/build-helm-charts.yml
+++ b/.github/workflows/build-helm-charts.yml
@@ -44,10 +44,10 @@ jobs:
         run: |
           if [[ "$RELEASE_BUILD" == "false" ]] && [[ $DATETIME != "" ]]; then
             # use VERSION.DATETIME for the image tag (e.g., nightly build)
-            ./gh-actions-scripts/build_helm_charts.sh "${VERSION}" "${VERSION}.${DATETIME}" "${KEPTN_SPEC_VERSION}"
+            ./gh-actions-scripts/build-helm-charts.sh "${VERSION}" "${VERSION}.${DATETIME}" "${KEPTN_SPEC_VERSION}" "keptndev"
           else
             # just use VERSION for the image tag
-            ./gh-actions-scripts/build_helm_charts.sh "${VERSION}" "${VERSION}" "${KEPTN_SPEC_VERSION}"
+            ./gh-actions-scripts/build-helm-charts.sh "${VERSION}" "${VERSION}" "${KEPTN_SPEC_VERSION}" "keptn"
           fi
 
       - name: Upload Helm Chart as an artifact

--- a/api/README.md
+++ b/api/README.md
@@ -7,7 +7,7 @@ The api component is a Keptn core component and allows the communication with Ke
 The api component is installed as a part of [Keptn](https://keptn.sh).
 
 ## Deploy in your Kubernetes cluster
-
+testytest
 To deploy the current version of the api component in your Keptn Kubernetes cluster, use the file `deploy/service.yaml` from this repository and apply it:
 
 ```console

--- a/api/README.md
+++ b/api/README.md
@@ -7,7 +7,7 @@ The api component is a Keptn core component and allows the communication with Ke
 The api component is installed as a part of [Keptn](https://keptn.sh).
 
 ## Deploy in your Kubernetes cluster
-testytest
+
 To deploy the current version of the api component in your Keptn Kubernetes cluster, use the file `deploy/service.yaml` from this repository and apply it:
 
 ```console

--- a/api/deploy/service.yaml
+++ b/api/deploy/service.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
         - name: api-service
-          image: keptn/api:latest
+          image: keptndev/api:latest
           ports:
             - containerPort: 8080
               protocol: TCP

--- a/api/skaffold.yaml
+++ b/api/skaffold.yaml
@@ -2,7 +2,7 @@ apiVersion: skaffold/v2beta25
 kind: Config
 build:
   artifacts:
-  - image: keptn/api
+  - image: keptndev/api
     docker:
       dockerfile: Dockerfile
       target: production

--- a/approval-service/deploy/service.yaml
+++ b/approval-service/deploy/service.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: keptn-default
       containers:
       - name: approval-service
-        image: keptn/approval-service:latest
+        image: keptndev/approval-service:latest
         ports:
         - containerPort: 8080
         resources:
@@ -45,7 +45,7 @@ spec:
         - name: DATASTORE
           value: 'http://mongodb-datastore:8080'
       - name: distributor
-        image: keptn/distributor:0.8.4
+        image: keptndev/distributor:0.8.4
         ports:
           - containerPort: 8081
         resources:

--- a/approval-service/skaffold.yaml
+++ b/approval-service/skaffold.yaml
@@ -4,7 +4,7 @@ build:
   local:
     useBuildkit: true
   artifacts:
-    - image: keptn/approval-service
+    - image: keptndev/approval-service
       docker:    # 	beta describes an artifact built from a Dockerfile.
         dockerfile: Dockerfile
         target: production

--- a/bridge/deploy/service.yaml
+++ b/bridge/deploy/service.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: keptn-default
       containers:
         - name: bridge
-          image: keptn/bridge2:latest
+          image: keptndev/bridge2:latest
           imagePullPolicy: Always
           env:
             - name: API_URL

--- a/bridge/skaffold.yaml
+++ b/bridge/skaffold.yaml
@@ -4,7 +4,7 @@ build:
   local:
     useBuildkit: true
   artifacts:
-    - image: keptn/bridge2
+    - image: keptndev/bridge2
       docker: # 	beta describes an artifact built from a Dockerfile.
         dockerfile: Dockerfile
         target: production

--- a/configuration-service/deploy/service.yaml
+++ b/configuration-service/deploy/service.yaml
@@ -45,7 +45,7 @@ spec:
             port: 8080
           initialDelaySeconds: 10
           periodSeconds: 5
-        image: keptn/configuration-service:latest
+        image: keptndev/configuration-service:latest
         env:
           - name: PREFIX_PATH
             value: ""

--- a/configuration-service/skaffold.yaml
+++ b/configuration-service/skaffold.yaml
@@ -4,7 +4,7 @@ build:
   local:
     useBuildkit: true
   artifacts:
-    - image: keptn/configuration-service
+    - image: keptndev/configuration-service
       docker:
         dockerfile: Dockerfile
         target: production

--- a/distributor/README.md
+++ b/distributor/README.md
@@ -128,7 +128,7 @@ spec:
     spec:
       containers:
         - name: distributor
-          image: keptn/distributor:latest
+          image: keptndev/distributor:latest
           ports:
             - containerPort: 8080
           resources:

--- a/distributor/deploy/distributor.yaml
+++ b/distributor/deploy/distributor.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: keptn-default
       containers:
       - name: distributor
-        image: keptn/distributor:latest
+        image: keptndev/distributor:latest
         ports:
         - containerPort: 8080
         resources:

--- a/distributor/skaffold.yaml
+++ b/distributor/skaffold.yaml
@@ -4,7 +4,7 @@ build:
   local:
     useBuildkit: true
   artifacts:
-    - image: keptn/distributor
+    - image: keptndev/distributor
       docker:    # 	beta describes an artifact built from a Dockerfile.
         dockerfile: Dockerfile
         target: production

--- a/docs/developer/debugging.md
+++ b/docs/developer/debugging.md
@@ -70,7 +70,7 @@ Most of our services should already have a working setup. But just in case the s
     kind: Config
     build:
       artifacts:
-        - image: keptn/some-go-service
+        - image: keptndev/some-go-service
           docker:    # 	beta describes an artifact built from a Dockerfile.
             dockerfile: Dockerfile
             buildArgs:

--- a/gh-actions-scripts/build-helm-charts.sh
+++ b/gh-actions-scripts/build-helm-charts.sh
@@ -6,7 +6,7 @@ IMAGE_TAG=$2
 KEPTN_SPEC_VERSION=$3
 DOCKER_ORG=$4
 
-if [ $# -ge 3 ]; then
+if [ $# -lt 3 ]; then
   echo "Usage: $0 VERSION IMAGE_TAG KEPTN_SPEC_VERSION"
   exit
 fi

--- a/gh-actions-scripts/build-helm-charts.sh
+++ b/gh-actions-scripts/build-helm-charts.sh
@@ -4,8 +4,9 @@
 VERSION=$1
 IMAGE_TAG=$2
 KEPTN_SPEC_VERSION=$3
+DOCKER_ORG=$4
 
-if [ $# -ne 3 ]; then
+if [ $# -ge 3 ]; then
   echo "Usage: $0 VERSION IMAGE_TAG KEPTN_SPEC_VERSION"
   exit
 fi
@@ -20,12 +21,18 @@ if [ -z "$IMAGE_TAG" ]; then
   IMAGE_TAG=$VERSION
 fi
 
+if [ -z "$DOCKER_ORG" ]; then
+  echo "No Docker organisation set, defaulting to keptn"
+  DOCKER_ORG='keptn'
+fi
+
 
 # replace "appVersion: latest" with "appVersion: $VERSION" in all Chart.yaml files
 find . -name Chart.yaml -exec sed -i -- "s/appVersion: latest/appVersion: ${IMAGE_TAG}/g" {} \;
 find . -name Chart.yaml -exec sed -i -- "s/version: latest/version: ${VERSION}/g" {} \;
 # replace "keptnSpecVersion: latest" with "keptnSpecVersion: $KEPTN_SPEC_VERSION" in all values.yaml files
 find . -name values.yaml -exec sed -i -- "s/keptnSpecVersion: latest/keptnSpecVersion: ${KEPTN_SPEC_VERSION}/g" {} \;
+find . -name values.yaml -exec sed -i -- "s/docker.io\/keptn\//docker.io\/${DOCKER_ORG}\//g" {} \;
 
 mkdir keptn-charts/
 

--- a/helm-service/skaffold.yaml
+++ b/helm-service/skaffold.yaml
@@ -4,7 +4,7 @@ build:
   local:
     useBuildkit: true
   artifacts:
-    - image: keptn/helm-service
+    - image: keptndev/helm-service
       docker:
         dockerfile: Dockerfile
         target: production
@@ -20,7 +20,7 @@ deploy:
         # upgradeOnChange: true
         # recreatePods: false # don't recreate all pods
         artifactOverrides:
-          image: keptn/helm-service
+          image: keptndev/helm-service
         overrides:
           distributor:
             image:

--- a/installer/manifests/keptn/charts/control-plane/Chart.yaml
+++ b/installer/manifests/keptn/charts/control-plane/Chart.yaml
@@ -13,7 +13,7 @@ description: A Helm chart for Kubernetes
 type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
+# to the chart and its templates, including the app version.testytest
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.1.0
 

--- a/installer/manifests/keptn/charts/control-plane/Chart.yaml
+++ b/installer/manifests/keptn/charts/control-plane/Chart.yaml
@@ -13,7 +13,7 @@ description: A Helm chart for Kubernetes
 type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.testytest
+# to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.1.0
 

--- a/jmeter-service/skaffold.yaml
+++ b/jmeter-service/skaffold.yaml
@@ -4,7 +4,7 @@ build:
   local:
     useBuildkit: true
   artifacts:
-    - image: keptn/jmeter-service
+    - image: keptndev/jmeter-service
       docker:
         dockerfile: Dockerfile
         target: production
@@ -20,7 +20,7 @@ deploy:
         # upgradeOnChange: true
         # recreatePods: false # don't recreate all pods
         artifactOverrides:
-          image: keptn/jmeter-service
+          image: keptndev/jmeter-service
         overrides:
           distributor:
             image:

--- a/lighthouse-service/deploy/service.yaml
+++ b/lighthouse-service/deploy/service.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: keptn-lighthouse-service
       containers:
         - name: lighthouse-service
-          image: keptn/lighthouse-service:latest
+          image: keptndev/lighthouse-service:latest
           livenessProbe:
             httpGet:
               path: /health

--- a/lighthouse-service/skaffold.yaml
+++ b/lighthouse-service/skaffold.yaml
@@ -4,7 +4,7 @@ build:
   local:
     useBuildkit: true
   artifacts:
-    - image: keptn/lighthouse-service
+    - image: keptndev/lighthouse-service
       docker:
         dockerfile: Dockerfile
         target: production

--- a/mongodb-datastore/deploy/mongodb-datastore.yaml
+++ b/mongodb-datastore/deploy/mongodb-datastore.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: keptn-default
       containers:
       - name: mongodb-datastore
-        image: keptn/mongodb-datastore:latest
+        image: keptndev/mongodb-datastore:latest
         ports:
         - containerPort: 8080
         resources:

--- a/mongodb-datastore/skaffold.yaml
+++ b/mongodb-datastore/skaffold.yaml
@@ -4,7 +4,7 @@ build:
   local:
     useBuildkit: true
   artifacts:
-    - image: keptn/mongodb-datastore
+    - image: keptndev/mongodb-datastore
       docker:    # 	beta describes an artifact built from a Dockerfile.
         dockerfile: Dockerfile
         target: production

--- a/remediation-service/deploy/service.yaml
+++ b/remediation-service/deploy/service.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: keptn-default
       containers:
       - name: remediation-service
-        image: keptn/remediation-service:latest
+        image: keptndev/remediation-service:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8080
@@ -47,7 +47,7 @@ spec:
           - name: ENVIRONMENT
             value: 'production'
       - name: distributor
-        image: keptn/distributor:0.8.4
+        image: keptndev/distributor:0.8.4
         imagePullPolicy: Always
         ports:
           - containerPort: 8080

--- a/remediation-service/skaffold.yaml
+++ b/remediation-service/skaffold.yaml
@@ -4,7 +4,7 @@ build:
   local:
     useBuildkit: true
   artifacts:
-    - image: keptn/remediation-service
+    - image: keptndev/remediation-service
       docker:    # 	beta describes an artifact built from a Dockerfile.
         dockerfile: Dockerfile
         target: production

--- a/resource-service/deploy/service.yaml
+++ b/resource-service/deploy/service.yaml
@@ -42,7 +42,7 @@ spec:
         #     port: 8080
         #   initialDelaySeconds: 10
         #   periodSeconds: 5
-        image: keptn/resource-service:latest
+        image: keptndev/resource-service:latest
         env:
           - name: PREFIX_PATH
             value: ""

--- a/resource-service/skaffold.yaml
+++ b/resource-service/skaffold.yaml
@@ -4,7 +4,7 @@ build:
   local:
     useBuildkit: true
   artifacts:
-    - image: keptn/resource-service
+    - image: keptndev/resource-service
       docker:
         dockerfile: Dockerfile
         target: production

--- a/secret-service/deploy/service.yaml
+++ b/secret-service/deploy/service.yaml
@@ -43,7 +43,7 @@ spec:
                 port: 8080
               initialDelaySeconds: 10
               periodSeconds: 5
-          image: keptn/secret-service:latest
+          image: keptndev/secret-service:latest
           ports:
             - containerPort: 8080
           resources:

--- a/secret-service/skaffold.yaml
+++ b/secret-service/skaffold.yaml
@@ -4,7 +4,7 @@ build:
   local:
     useBuildkit: true
   artifacts:
-    - image: keptn/secret-service
+    - image: keptndev/secret-service
       docker:
         dockerfile: Dockerfile
         target: production

--- a/shipyard-controller/deploy/service.yaml
+++ b/shipyard-controller/deploy/service.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: keptn-shipyard-controller
       containers:
       - name: shipyard-controller
-        image: keptn/shipyard-controller:latest
+        image: keptndev/shipyard-controller:latest
         env:
           - name: CONFIGURATION_SERVICE
             value: "http://configuration-service:8080"

--- a/shipyard-controller/skaffold.yaml
+++ b/shipyard-controller/skaffold.yaml
@@ -4,7 +4,7 @@ build:
   local:
     useBuildkit: true
   artifacts:
-    - image: keptn/shipyard-controller
+    - image: keptndev/shipyard-controller
       docker:
         dockerfile: Dockerfile
         target: production

--- a/statistics-service/deploy/service.yaml
+++ b/statistics-service/deploy/service.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: statistics-service
-          image: keptn/statistics-service:latest
+          image: keptndev/statistics-service:latest
           ports:
             - containerPort: 8080
           resources:
@@ -46,7 +46,7 @@ spec:
             - name: MONGODB_DATABASE
               value: 'keptn'
         - name: distributor
-          image: keptn/distributor:latest
+          image: keptndev/distributor:latest
           ports:
             - containerPort: 8080
           livenessProbe:

--- a/statistics-service/skaffold.yaml
+++ b/statistics-service/skaffold.yaml
@@ -4,7 +4,7 @@ build:
   local:
     useBuildkit: true
   artifacts:
-    - image: keptn/statistics-service
+    - image: keptndev/statistics-service
       docker:
         dockerfile: Dockerfile
         target: production

--- a/webhook-service/deploy/service.yaml
+++ b/webhook-service/deploy/service.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: keptn-webhook-service
       containers:
         - name: webhook-service
-          image: keptn/webhook-service:0.10.1-dev
+          image: keptndev/webhook-service:0.10.1-dev
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
@@ -45,7 +45,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
         - name: distributor
-          image: keptn/distributor:0.10.1-dev
+          image: keptndev/distributor:0.10.1-dev
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/webhook-service/skaffold.yaml
+++ b/webhook-service/skaffold.yaml
@@ -4,7 +4,7 @@ build:
   local:
     useBuildkit: true
   artifacts:
-    - image: keptn/webhook-service
+    - image: keptndev/webhook-service
       docker:
         dockerfile: Dockerfile
         target: production


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- pushes dev images to the new `keptndev` dockerhub organization
- adjusts the dev helm charts to make use of the new dockerhub organization
- updates all skaffold files to use the `keptndev` registry

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #5629
