### PR TITLE
fix: Avoid nil pointer access for undefined value in helm charts

### DIFF
--- a/helm-service/chart/templates/deployment.yaml
+++ b/helm-service/chart/templates/deployment.yaml
@@ -163,7 +163,7 @@ spec:
               {{- $apiValidateTls := .Values.remoteControlPlane.api.apiValidateTls | ternary "true" "false" }}
               value: "{{ $apiValidateTls }}"
             {{- end }}
-            {{- if .Values.distributor.config.queueGroup.enabled }}
+            {{- if (((.Values.distributor).config).queueGroup).enabled | default true }}
             - name: PUBSUB_GROUP
               valueFrom:
                 fieldRef:

--- a/jmeter-service/chart/templates/deployment.yaml
+++ b/jmeter-service/chart/templates/deployment.yaml
@@ -131,7 +131,7 @@ spec:
               {{- $apiValidateTls := .Values.remoteControlPlane.api.apiValidateTls | ternary "true" "false" }}
               value: "{{ $apiValidateTls }}"
             {{- end }}
-            {{- if .Values.distributor.config.queueGroup.enabled }}
+            {{- if (((.Values.distributor).config).queueGroup).enabled | default true }}
             - name: PUBSUB_GROUP
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
Backport of #6863