### PR TITLE
ci: Ensure that build matrix runs as far as possible

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -182,6 +182,7 @@ jobs:
     name: Docker Build
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.prepare.outputs.BUILD_MATRIX) }}
     env:
       BRANCH: ${{ needs.prepare.outputs.branch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,6 +179,7 @@ jobs:
     name: Docker Build
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.prepare.outputs.BUILD_MATRIX) }}
     env:
       BRANCH: ${{ needs.prepare.outputs.branch }}


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- sets the build matrix in both release pipelines to `fail-fast: false`. This has the effect that even if one matrix job fails, the others continue running instead of being cancelled immediately.
