### PR TITLE
fix(configuration-service): Adapt to different response from git CLI when upstream branch is not there yet

### DIFF
--- a/configuration-service/common/git_test.go
+++ b/configuration-service/common/git_test.go
@@ -439,6 +439,72 @@ func TestGit_setUpstreamsAndPush(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "push to upstream - unexpected error during pull, should continue",
+			fields: fields{
+				Executor: &common_mock.CommandExecutorMock{ExecuteCommandFunc: func(command string, args []string, directory string) (string, error) {
+					if args[0] == "for-each-ref" {
+						return "master", nil
+					} else if args[0] == "remote" {
+						return `* remote origin
+						  Fetch URL: https://my-repo.git
+						  Push  URL: https://my-repo.git
+						  HEAD branch: master
+						  Remote branch:
+							release-0.8.0 tracked
+						  Local branch configured for 'git pull':
+							release-0.8.0 merges with remote release-0.8.0
+						  Local ref configured for 'git push':
+							release-0.8.0 pushes to release-0.8.0 (up to date)`, nil
+					} else if args[0] == "pull" && args[1] == "-s" {
+						return "", errors.New("unexpected error")
+					}
+					return "", nil
+				}},
+				CredentialReader: getDummyCredentialReader(),
+			},
+			args: args{
+				project: "my-project",
+				repoURI: "https://my-repo.git",
+			},
+			wantErr: false,
+			expectedCommands: []struct {
+				Command   string
+				Args      []string
+				Directory string
+			}{
+				{
+					Command:   "git",
+					Args:      []string{"for-each-ref", "--format=%(refname:short)", "refs/heads/*"},
+					Directory: "./debug/config/my-project",
+				},
+				{
+					Command:   "git",
+					Args:      []string{"remote", "show", "origin"},
+					Directory: "./debug/config/my-project",
+				},
+				{
+					Command:   "git",
+					Args:      []string{"reset", "--hard"},
+					Directory: "./debug/config/my-project",
+				},
+				{
+					Command:   "git",
+					Args:      []string{"checkout", "master"},
+					Directory: "./debug/config/my-project",
+				},
+				{
+					Command:   "git",
+					Args:      []string{"pull", "-s", "recursive", "-X", "theirs", "https://my-repo.git"},
+					Directory: "./debug/config/my-project",
+				},
+				{
+					Command:   "git",
+					Args:      []string{"push", "--set-upstream", "https://my-repo.git", "master"},
+					Directory: "./debug/config/my-project",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/configuration-service/common/git_test.go
+++ b/configuration-service/common/git_test.go
@@ -311,69 +311,6 @@ func TestGit_setUpstreamsAndPush(t *testing.T) {
 			},
 		},
 		{
-			name: "push to upstream - error when pulling changes",
-			fields: fields{
-				Executor: &common_mock.CommandExecutorMock{ExecuteCommandFunc: func(command string, args []string, directory string) (string, error) {
-					if args[0] == "for-each-ref" {
-						return "master", nil
-					} else if args[0] == "remote" {
-						return `* remote origin
-						  Fetch URL: https://my-repo.git
-						  Push  URL: https://my-repo.git
-						  HEAD branch: master
-						  Remote branch:
-							release-0.8.0 tracked
-						  Local branch configured for 'git pull':
-							release-0.8.0 merges with remote release-0.8.0
-						  Local ref configured for 'git push':
-							release-0.8.0 pushes to release-0.8.0 (up to date)`, nil
-					} else if args[0] == "checkout" {
-						return "", nil
-					} else if args[0] == "pull" {
-						return "", errors.New("oops")
-					}
-					return "", nil
-				}},
-				CredentialReader: getDummyCredentialReader(),
-			},
-			args: args{
-				project: "my-project",
-				repoURI: "https://my-repo.git",
-			},
-			wantErr: true,
-			expectedCommands: []struct {
-				Command   string
-				Args      []string
-				Directory string
-			}{
-				{
-					Command:   "git",
-					Args:      []string{"for-each-ref", "--format=%(refname:short)", "refs/heads/*"},
-					Directory: "./debug/config/my-project",
-				},
-				{
-					Command:   "git",
-					Args:      []string{"remote", "show", "origin"},
-					Directory: "./debug/config/my-project",
-				},
-				{
-					Command:   "git",
-					Args:      []string{"reset", "--hard"},
-					Directory: "./debug/config/my-project",
-				},
-				{
-					Command:   "git",
-					Args:      []string{"checkout", "master"},
-					Directory: "./debug/config/my-project",
-				},
-				{
-					Command:   "git",
-					Args:      []string{"pull", "-s", "recursive", "-X", "theirs", "https://my-repo.git"},
-					Directory: "./debug/config/my-project",
-				},
-			},
-		},
-		{
 			name: "push to upstream - no remote ref HEAD found, should continue",
 			fields: fields{
 				Executor: &common_mock.CommandExecutorMock{ExecuteCommandFunc: func(command string, args []string, directory string) (string, error) {


### PR DESCRIPTION
Closes #6881
The problem was that instead of a `Couldn't find remote ref HEAD` when trying to pull from a branch that is not yet on the upstream we now get a `divergent branches` error message. Since we explicitly checked for the Couldn't find remote ref before proceeding with pushing the branch, setting the upstream failed at this point.

This PR changes the behavior of the configuration service to print a warning to the logs, if an unexpected output is returned by git in this case, but instead of aborting the process of setting the upstream immediately, it will try to push the branches. 

I tested the following scenarios (manually):


Installing keptn 0.10.0 -> Create a project without upstream -> Upgrading to Keptn 0.12.1 -> update the configuration service to the image built for this PR -> add an upstream on Github

Installing keptn 0.11.4 -> Create a project without upstream -> Upgrading to Keptn 0.12.1 -> update the configuration service to the image built for this PR -> add an upstream on Github