### PR TITLE
fix: Fix container image OCI labels

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -43,8 +43,8 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v cmd/api-ser
 
 FROM alpine:3.15 as production
 ARG version=develop
-LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
-    org.opencontainers.image.url = "https://keptn.sh" \
+LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
+    org.opencontainers.image.url="https://keptn.sh" \
     org.opencontainers.image.title="Keptn API" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \

--- a/approval-service/Dockerfile
+++ b/approval-service/Dockerfile
@@ -40,8 +40,8 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o approval
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.15 as production
 ARG version=develop
-LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
-    org.opencontainers.image.url = "https://keptn.sh" \
+LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
+    org.opencontainers.image.url="https://keptn.sh" \
     org.opencontainers.image.title="Keptn Approval Service" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \

--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -59,8 +59,8 @@ RUN yarn build && \
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM node:14-alpine3.14 as production
 ARG version=develop
-LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
-    org.opencontainers.image.url = "https://keptn.sh" \
+LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
+    org.opencontainers.image.url="https://keptn.sh" \
     org.opencontainers.image.title="Keptn Bridge" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \

--- a/configuration-service/Dockerfile
+++ b/configuration-service/Dockerfile
@@ -41,8 +41,8 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 # Use a Docker multi-stage build to create a lean production image.
 FROM alpine:3.15 as production
 ARG version=develop
-LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
-    org.opencontainers.image.url = "https://keptn.sh" \
+LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
+    org.opencontainers.image.url="https://keptn.sh" \
     org.opencontainers.image.title="Keptn Configuration Service" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \

--- a/distributor/Dockerfile
+++ b/distributor/Dockerfile
@@ -42,8 +42,8 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS 
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.15 as production
 ARG version=develop
-LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
-    org.opencontainers.image.url = "https://keptn.sh" \
+LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
+    org.opencontainers.image.url="https://keptn.sh" \
     org.opencontainers.image.title="Keptn Distributor" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \

--- a/helm-service/Dockerfile
+++ b/helm-service/Dockerfile
@@ -39,8 +39,8 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.15 as production
 ARG version=develop
-LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
-    org.opencontainers.image.url = "https://keptn.sh" \
+LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
+    org.opencontainers.image.url="https://keptn.sh" \
     org.opencontainers.image.title="Keptn Helm Service" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \

--- a/jmeter-service/Dockerfile
+++ b/jmeter-service/Dockerfile
@@ -39,8 +39,8 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.15 as production
 ARG version=develop
-LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
-    org.opencontainers.image.url = "https://keptn.sh" \
+LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
+    org.opencontainers.image.url="https://keptn.sh" \
     org.opencontainers.image.title="Keptn JMeter Service" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \

--- a/lighthouse-service/Dockerfile
+++ b/lighthouse-service/Dockerfile
@@ -39,8 +39,8 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.15 as production
 ARG version=develop
-LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
-    org.opencontainers.image.url = "https://keptn.sh" \
+LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
+    org.opencontainers.image.url="https://keptn.sh" \
     org.opencontainers.image.title="Keptn Lighthouse Service" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \

--- a/mongodb-datastore/Dockerfile
+++ b/mongodb-datastore/Dockerfile
@@ -66,8 +66,8 @@ RUN cd cmd/mongodb-datastore-server && GOOS=linux go build -ldflags '-linkmode=e
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.15 as production
 ARG version=develop
-LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
-    org.opencontainers.image.url = "https://keptn.sh" \
+LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
+    org.opencontainers.image.url="https://keptn.sh" \
     org.opencontainers.image.title="Keptn MongoDB Datastore" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \

--- a/remediation-service/Dockerfile
+++ b/remediation-service/Dockerfile
@@ -39,8 +39,8 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.15 as production
 ARG version=develop
-LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
-    org.opencontainers.image.url = "https://keptn.sh" \
+LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
+    org.opencontainers.image.url="https://keptn.sh" \
     org.opencontainers.image.title="Keptn Remediation Service" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \

--- a/resource-service/Dockerfile
+++ b/resource-service/Dockerfile
@@ -74,8 +74,8 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 # Use a Docker multi-stage build to create a lean production image.
 FROM alpine:3.15 as production
 ARG version=develop
-LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
-    org.opencontainers.image.url = "https://keptn.sh" \
+LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
+    org.opencontainers.image.url="https://keptn.sh" \
     org.opencontainers.image.title="Keptn Resource Service" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \

--- a/secret-service/Dockerfile
+++ b/secret-service/Dockerfile
@@ -51,8 +51,8 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 # Use a Docker multi-stage build to create a lean production image.
 FROM alpine:3.15 as production
 ARG version=develop
-LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
-    org.opencontainers.image.url = "https://keptn.sh" \
+LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
+    org.opencontainers.image.url="https://keptn.sh" \
     org.opencontainers.image.title="Keptn Secret Service" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \

--- a/shipyard-controller/Dockerfile
+++ b/shipyard-controller/Dockerfile
@@ -74,8 +74,8 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 # Use a Docker multi-stage build to create a lean production image.
 FROM alpine:3.15 as production
 ARG version=develop
-LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
-    org.opencontainers.image.url = "https://keptn.sh" \
+LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
+    org.opencontainers.image.url="https://keptn.sh" \
     org.opencontainers.image.title="Keptn Shipyard Controller" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \

--- a/statistics-service/Dockerfile
+++ b/statistics-service/Dockerfile
@@ -75,8 +75,8 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 # Use a Docker multi-stage build to create a lean production image.
 FROM alpine:3.15 as production
 ARG version=develop
-LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
-    org.opencontainers.image.url = "https://keptn.sh" \
+LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
+    org.opencontainers.image.url="https://keptn.sh" \
     org.opencontainers.image.title="Keptn Statistics Service" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \

--- a/webhook-service/Dockerfile
+++ b/webhook-service/Dockerfile
@@ -39,8 +39,8 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.15 as production
 ARG version=develop
-LABEL org.opencontainers.image.source = "https://github.com/keptn/keptn" \
-    org.opencontainers.image.url = "https://keptn.sh" \
+LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
+    org.opencontainers.image.url="https://keptn.sh" \
     org.opencontainers.image.title="Keptn Webhook Service" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- fixes the OCI labels for all Keptn docker images
- The labels had some whitespace in between which meant that they were not interpreted correctly


Before:
<img width="1285" alt="Screenshot 2022-02-16 at 09 08 06" src="https://user-images.githubusercontent.com/6901203/154222166-43e38e4a-fb60-4625-9a9b-b6803e7b5dd2.png">

After:
<img width="584" alt="Screenshot 2022-02-16 at 09 08 28" src="https://user-images.githubusercontent.com/6901203/154222223-9ef71eb6-0ece-4445-add6-ddccaeef7038.png">

