### PR TITLE
chore(jmeter-service): Updated Dynatrace JMeter extension to 1.8.0

### DIFF
--- a/jmeter-service/Dockerfile
+++ b/jmeter-service/Dockerfile
@@ -54,8 +54,8 @@ ENV	JMETER_BIN	${JMETER_HOME}/bin
 ENV	JMETER_DOWNLOAD_URL  https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-${JMETER_VERSION}.tgz
 
 # Load additional extensions
-ARG DYNATRACE_EXTENSION_VERSION="1.3"
-ENV DYNATRACE_EXTENSION_URL https://github.com/dynatrace-oss/jmeter-dynatrace-plugin/releases/download/v${DYNATRACE_EXTENSION_VERSION}.snapshot/jmeter-dynatrace-plugin-${DYNATRACE_EXTENSION_VERSION}-SNAPSHOT.jar
+ARG DYNATRACE_EXTENSION_VERSION="1.8.0"
+ENV DYNATRACE_EXTENSION_URL https://github.com/dynatrace-oss/jmeter-dynatrace-plugin/releases/download/${DYNATRACE_EXTENSION_VERSION}/jmeter-dynatrace-plugin-${DYNATRACE_EXTENSION_VERSION}.jar
 
 # Install extra packages
 # See https://github.com/gliderlabs/docker-alpine/issues/136#issuecomment-272703023


### PR DESCRIPTION
## This PR
Updates the Dynatrace JMeter Extension that is installed into the jmeter-service from 1.3 to 1.8 (latest)

### Related Issues
Fixes #6877 

### How to test
No additional tests needed as this is just an update of a dependency