### PR TITLE
feat(distributor): Automatically determine DISTRIBUTOR_VERSION for uniform registration

### DIFF
--- a/distributor/Dockerfile
+++ b/distributor/Dockerfile
@@ -55,6 +55,8 @@ RUN apk add --no-cache ca-certificates libc6-compat
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /go/src/github.com/keptn/keptn/distributor/distributor /distributor
 
+ENV DISTRIBUTOR_VERSION=${version}
+
 # required for external tools to detect this as a go binary
 ENV GOTRACEBACK=all
 

--- a/distributor/README.md
+++ b/distributor/README.md
@@ -22,7 +22,6 @@ Thus, each service has its own distributor that is configured by the two environ
 - `DISABLE_REGISTRATION` - Disables automatic registration of the Keptn integration to the control plane. default = `false`
 - `REGISTRATION_INTERVAL` - Time duration between trying to re-register to the Keptn control plane. default =`10s`
 - `LOCATION` - Location the distributor is running on, e.g. "executionPlane-A". default = `""`
-- `DISTRIBUTOR_VERSION` - The software version of the distributor. default = `""`
 - `VERSION` - The version of the Keptn integration. default = `""`
 - `K8S_DEPLOYMENT_NAME` - Kubernetes deployment name of the Keptn integration. default = `""`
 - `K8S_POD_NAME` -  Kubernetes deployment name of the Keptn integration. default = `""`

--- a/distributor/pkg/config/envconfig.go
+++ b/distributor/pkg/config/envconfig.go
@@ -32,7 +32,7 @@ type EnvConfig struct {
 	DisableRegistration  bool     `envconfig:"DISABLE_REGISTRATION" default:"false"`
 	RegistrationInterval string   `envconfig:"REGISTRATION_INTERVAL" default:"10s"`
 	Location             string   `envconfig:"LOCATION" default:""`
-	DistributorVersion   string   `envconfig:"DISTRIBUTOR_VERSION" default:"0.9.0"` // TODO: set this automatically
+	DistributorVersion   string   `envconfig:"DISTRIBUTOR_VERSION" default:"0.9.0"` // Set in Dockerfile during build
 	Version              string   `envconfig:"VERSION" default:""`
 	K8sDeploymentName    string   `envconfig:"K8S_DEPLOYMENT_NAME" default:""`
 	K8sNamespace         string   `envconfig:"K8S_NAMESPACE" default:""`

--- a/helm-service/chart/templates/deployment.yaml
+++ b/helm-service/chart/templates/deployment.yaml
@@ -136,8 +136,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['app.kubernetes.io/version']
-            - name: DISTRIBUTOR_VERSION
-              value: {{ .Values.distributor.image.tag | default .Chart.AppVersion }}
             - name: LOCATION
               valueFrom:
                 fieldRef:

--- a/installer/manifests/keptn/Chart.lock
+++ b/installer/manifests/keptn/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: control-plane
+  repository: ""
+  version: 0.1.0
+- name: continuous-delivery
+  repository: ""
+  version: 0.1.0
+digest: sha256:f7746691659003114761bab211aef951277135f984ad5f69f483d3f1245b21ea
+generated: "2022-01-28T11:33:08.630951442+01:00"

--- a/installer/manifests/keptn/Chart.lock
+++ b/installer/manifests/keptn/Chart.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: control-plane
-  repository: ""
-  version: 0.1.0
-- name: continuous-delivery
-  repository: ""
-  version: 0.1.0
-digest: sha256:f7746691659003114761bab211aef951277135f984ad5f69f483d3f1245b21ea
-generated: "2022-01-28T11:33:08.630951442+01:00"

--- a/installer/manifests/keptn/charts/control-plane/templates/_helpers.tpl
+++ b/installer/manifests/keptn/charts/control-plane/templates/_helpers.tpl
@@ -97,12 +97,6 @@ lifecycle:
   valueFrom:
     fieldRef:
       fieldPath: metadata.labels['app.kubernetes.io/version']
-- name: DISTRIBUTOR_VERSION
-{{- if .Values.distributor.image.tag }}
-  value: {{ .Values.distributor.image.tag }}
-{{- else }}
-  value: {{ .Chart.AppVersion }}
-{{- end }}
 - name: LOCATION
   valueFrom:
    fieldRef:

--- a/jmeter-service/chart/templates/deployment.yaml
+++ b/jmeter-service/chart/templates/deployment.yaml
@@ -98,8 +98,6 @@ spec:
               value: "{{ .Values.distributor.projectFilter }}"
             - name: SERVICE_FILTER
               value: "{{ .Values.distributor.serviceFilter }}"
-            - name: DISTRIBUTOR_VERSION
-              value: {{ .Values.distributor.image.tag | default .Chart.AppVersion }}
             - name: VERSION
               valueFrom:
                 fieldRef:

--- a/test/go-tests/test_uniform.go
+++ b/test/go-tests/test_uniform.go
@@ -88,10 +88,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['app.kubernetes.io/version']
-            - name: DISTRIBUTOR_VERSION
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.labels['app.kubernetes.io/version']
             - name: LOCATION
               valueFrom:
                 fieldRef:

--- a/test/go-tests/test_uniform.go
+++ b/test/go-tests/test_uniform.go
@@ -88,6 +88,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['app.kubernetes.io/version']
+            - name: DISTRIBUTOR_VERSION
+              value: "0.1.2"
             - name: LOCATION
               valueFrom:
                 fieldRef:
@@ -465,7 +467,7 @@ func testUniformIntegration(t *testing.T, configureIntegrationFunc func(), clean
 	require.Equal(t, echoServiceName, fetchedEchoIntegration.MetaData.KubernetesMetaData.DeploymentName)
 	require.Equal(t, GetKeptnNameSpaceFromEnv(), fetchedEchoIntegration.MetaData.KubernetesMetaData.Namespace)
 	require.Equal(t, "control-plane", fetchedEchoIntegration.MetaData.Location)
-	require.Equal(t, "develop", fetchedEchoIntegration.MetaData.DistributorVersion)
+	require.Equal(t, "0.1.2", fetchedEchoIntegration.MetaData.DistributorVersion)
 	require.Equal(t, "develop", fetchedEchoIntegration.MetaData.IntegrationVersion)
 
 	// update the subscription to only receive "echo.triggered" events for a given project/stage/service combination


### PR DESCRIPTION
## This PR

- adds automatic detection of DISTRIBUTOR_VERSION for distributor
- Removes DISTRIBUTOR_VERSION from helm charts

### Notes

Slack discussion: https://keptn.slack.com/archives/CGS63H8G6/p1645091419610049

