### PR TITLE
fix(resource-service): Make sure to delete "/" prefix in resourcePath when resolving git commit id

### DIFF
--- a/resource-service/handler/project_resource_handler.go
+++ b/resource-service/handler/project_resource_handler.go
@@ -77,7 +77,6 @@ func (ph *ProjectResourceHandler) CreateProjectResources(c *gin.Context) {
 // @Accept  json
 // @Produce  json
 // @Param	projectName			path	string	true	"The name of the project"
-// @Param gitCommitID              query string false "The commit ID to be checked out"
 // @Param pageSize              query int false "The number of items to return"
 // @Param nextPageKey              query string false "Pointer to the next set of items"
 // @Success 200 {object} models.GetResourcesResponse

--- a/resource-service/handler/resource_manager.go
+++ b/resource-service/handler/resource_manager.go
@@ -164,7 +164,7 @@ func (p ResourceManager) readResource(gitContext *common_models.GitContext, para
 	if params.GitCommitID != "" && params.GitCommitID != "\"\"" {
 		// if commit ID is set, path needs to be relative to the project directory
 		configPath = strings.TrimPrefix(configPath, common.GetProjectConfigPath(params.ProjectName))
-		resourcePath := configPath + "/" + resourceName
+		resourcePath := strings.TrimPrefix(configPath+"/"+resourceName, "/")
 		fileContent, err = p.git.GetFileRevision(*gitContext, params.GitCommitID, resourcePath)
 		revision = params.GitCommitID
 	} else {

--- a/resource-service/handler/resource_manager.go
+++ b/resource-service/handler/resource_manager.go
@@ -164,6 +164,7 @@ func (p ResourceManager) readResource(gitContext *common_models.GitContext, para
 	if params.GitCommitID != "" && params.GitCommitID != "\"\"" {
 		// if commit ID is set, path needs to be relative to the project directory
 		configPath = strings.TrimPrefix(configPath, common.GetProjectConfigPath(params.ProjectName))
+		// resource path must not start with "/", otherwise git is not able to resolve the revision
 		resourcePath := strings.TrimPrefix(configPath+"/"+resourceName, "/")
 		fileContent, err = p.git.GetFileRevision(*gitContext, params.GitCommitID, resourcePath)
 		revision = params.GitCommitID

--- a/resource-service/handler/service_resource_handler.go
+++ b/resource-service/handler/service_resource_handler.go
@@ -83,7 +83,6 @@ func (ph *ServiceResourceHandler) CreateServiceResources(c *gin.Context) {
 // @Param	projectName					path	string	true	"The name of the project"
 // @Param	stageName					path	string	true	"The name of the stage"
 // @Param	serviceName					path	string	true	"The name of the service"
-// @Param gitCommitID              query string false "The commit ID to be checked out"
 // @Param pageSize              query int false "The number of items to return"
 // @Param nextPageKey              query string false "Pointer to the next set of items"
 // @Success 200 {object} models.GetResourcesResponse

--- a/resource-service/handler/stage_resource_handler.go
+++ b/resource-service/handler/stage_resource_handler.go
@@ -80,7 +80,6 @@ func (ph *StageResourceHandler) CreateStageResources(c *gin.Context) {
 // @Produce  json
 // @Param	projectName					path	string	true	"The name of the project"
 // @Param	stageName					path	string	true	"The name of the stage"
-// @Param gitCommitID              query string false "The commit ID to be checked out"
 // @Param pageSize              query int false "The number of items to return"
 // @Param nextPageKey              query string false "Pointer to the next set of items"
 // @Success 200 {object} models.GetResourcesResponse

--- a/test/go-tests/init_test.go
+++ b/test/go-tests/init_test.go
@@ -3,10 +3,11 @@ package go_tests
 import (
 	"errors"
 	"fmt"
-	"github.com/keptn/go-utils/pkg/common/retry"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/keptn/go-utils/pkg/common/retry"
 )
 
 func TestMain(m *testing.M) {

--- a/test/go-tests/k8s_utils.go
+++ b/test/go-tests/k8s_utils.go
@@ -5,14 +5,15 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
 	keptnkubeutils "github.com/keptn/kubernetes-utils/pkg"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
-	"net/http"
-	"strings"
-	"time"
 )
 
 func SetEnvVarsOfDeployment(deploymentName string, containerName string, envVars []v1.EnvVar) error {
@@ -199,4 +200,22 @@ func GetOOMEvents() (K8SEventArray, error) {
 		}
 	}
 	return oomEvents, err
+}
+
+func CompareServiceWithDeployment(service string, deployment string) (bool, error) {
+	api, err := keptnkubeutils.GetKubeAPI(false)
+	if err != nil {
+		return false, err
+	}
+
+	configService, err := api.Services(GetKeptnNameSpaceFromEnv()).Get(context.TODO(), service, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	if configService.Spec.Selector["app.kubernetes.io/name"] == deployment {
+		return true, nil
+	}
+
+	return false, nil
 }

--- a/test/go-tests/test_resourceservice.go
+++ b/test/go-tests/test_resourceservice.go
@@ -632,25 +632,13 @@ func Test_ResourceServiceGETCommitID(t *testing.T) {
 	require.Equal(t, resourceUri, *resource.ResourceURI)
 	require.Equal(t, resourceContent, resource.ResourceContent)
 
-	t.Logf("Checking all resources with commit ID")
-	resp, err = ApiGETRequest("/configuration-service/v1/project/"+projectName+"/stage/hardening/service/"+serviceName+"/resource?gitCommitID="+commitID, 3)
-	require.Nil(t, err)
-	require.Equal(t, 200, resp.Response().StatusCode)
-
-	t.Logf("Checking body of the received response")
-	resources := models.Resources{}
-	err = resp.ToJSON(&resources)
-	require.Nil(t, err)
-	require.Equal(t, float64(2), resources.TotalCount)
-	require.Nil(t, checkResourceInResponse(resources, resourceUriPath))
-
 	t.Logf("Checking all resources without commit ID")
 	resp, err = ApiGETRequest("/configuration-service/v1/project/"+projectName+"/stage/hardening/service/"+serviceName+"/resource", 3)
 	require.Nil(t, err)
 	require.Equal(t, 200, resp.Response().StatusCode)
 
 	t.Logf("Checking body of the received response")
-	resources = models.Resources{}
+	resources := models.Resources{}
 	err = resp.ToJSON(&resources)
 	require.Nil(t, err)
 	require.Equal(t, float64(2), resources.TotalCount)

--- a/test/go-tests/test_utils.go
+++ b/test/go-tests/test_utils.go
@@ -212,8 +212,11 @@ func CreateProject(projectName string, shipyardFilePath string, recreateIfAlread
 		}
 
 		// apply the k8s job for creating the git upstream
-		_, err = ExecuteCommand(fmt.Sprintf("keptn create project %s --shipyard=%s --git-remote-url=http://gitea-http:3000/%s/%s --git-user=%s --git-token=%s", newProjectName, shipyardFilePath, user, newProjectName, user, token))
+		out, err := ExecuteCommand(fmt.Sprintf("keptn create project %s --shipyard=%s --git-remote-url=http://gitea-http:3000/%s/%s --git-user=%s --git-token=%s", newProjectName, shipyardFilePath, user, newProjectName, user, token))
 
+		if !strings.Contains(out, "created successfully") {
+			return "", fmt.Errorf("unable to create project: %s", out)
+		}
 		if err == nil {
 			return newProjectName, nil
 		}

--- a/test/go-tests/testsuite_gke_test.go
+++ b/test/go-tests/testsuite_gke_test.go
@@ -30,6 +30,9 @@ func Test_GKE(t *testing.T) {
 	t.Run("Test_SequenceControl_AbortQueuedSequence", Test_SequenceControl_AbortQueuedSequence)
 	t.Run("Test_SequenceControl_PauseAndResume", Test_SequenceControl_PauseAndResume)
 	t.Run("Test_SequenceControl_PauseAndResume_2", Test_SequenceControl_PauseAndResume_2)
+	if res, err := CompareServiceWithDeployment("configuration-service", "resource-service"); err == nil && res {
+		t.Run("Test_ResourceServiceGETCommitID", Test_ResourceServiceGETCommitID)
+	}
 
 	// Platform-specific Tests
 	t.Run("Test_ResourceService", Test_ResourceServiceBasic)

--- a/test/go-tests/testsuite_k3s_test.go
+++ b/test/go-tests/testsuite_k3s_test.go
@@ -30,6 +30,9 @@ func Test_K3S(t *testing.T) {
 	t.Run("Test_SequenceControl_AbortQueuedSequence", Test_SequenceControl_AbortQueuedSequence)
 	t.Run("Test_SequenceControl_PauseAndResume", Test_SequenceControl_PauseAndResume)
 	t.Run("Test_SequenceControl_PauseAndResume_2", Test_SequenceControl_PauseAndResume_2)
+	if res, err := CompareServiceWithDeployment("configuration-service", "resource-service"); err == nil && res {
+		t.Run("Test_ResourceServiceGETCommitID", Test_ResourceServiceGETCommitID)
+	}
 
 	// Platform-specific Tests
 	t.Run("Test_QualityGates", Test_QualityGates)

--- a/test/go-tests/testsuite_openshift_test.go
+++ b/test/go-tests/testsuite_openshift_test.go
@@ -30,6 +30,9 @@ func Test_Openshift(t *testing.T) {
 	t.Run("Test_SequenceControl_AbortQueuedSequence", Test_SequenceControl_AbortQueuedSequence)
 	t.Run("Test_SequenceControl_PauseAndResume", Test_SequenceControl_PauseAndResume)
 	t.Run("Test_SequenceControl_PauseAndResume_2", Test_SequenceControl_PauseAndResume_2)
+	if res, err := CompareServiceWithDeployment("configuration-service", "resource-service"); err == nil && res {
+		t.Run("Test_ResourceServiceGETCommitID", Test_ResourceServiceGETCommitID)
+	}
 
 	// Platform-specific Tests
 }


### PR DESCRIPTION
Closes #6918

Note: the new integration test is not enabled, as it will fail with configuration-service, which is the default one, it works with resource-service