### PR TITLE
fix: ensure indicators are set in computeObjectives

### DIFF
--- a/lighthouse-service/event_handler/start_evaluation_handler.go
+++ b/lighthouse-service/event_handler/start_evaluation_handler.go
@@ -81,7 +81,7 @@ func (eh *StartEvaluationHandler) sendGetSliCloudEvent(ctx context.Context, kept
 	indicators := []string{}
 	var filters = []*keptnv2.SLIFilter{}
 
-	if err2, end := eh.computeObjectives(e, commitID, indicators, filters, evaluationStartTimestamp, evaluationEndTimestamp); end {
+	if err2, end := eh.computeObjectives(e, commitID, &indicators, filters, evaluationStartTimestamp, evaluationEndTimestamp); end {
 		return err2
 	}
 
@@ -123,12 +123,12 @@ func (eh *StartEvaluationHandler) sendGetSliCloudEvent(ctx context.Context, kept
 	return nil
 }
 
-func (eh *StartEvaluationHandler) computeObjectives(e *keptnv2.EvaluationTriggeredEventData, commitID string, indicators []string, filters []*keptnv2.SLIFilter, evaluationStartTimestamp string, evaluationEndTimestamp string) (error, bool) {
+func (eh *StartEvaluationHandler) computeObjectives(e *keptnv2.EvaluationTriggeredEventData, commitID string, indicators *[]string, filters []*keptnv2.SLIFilter, evaluationStartTimestamp string, evaluationEndTimestamp string) (error, bool) {
 	objectives, _, err := eh.SLOFileRetriever.GetSLOs(e.Project, e.Stage, e.Service, commitID)
 	if err == nil && objectives != nil {
 		logger.Info("SLO file found")
 		for _, objective := range objectives.Objectives {
-			indicators = append(indicators, objective.SLI)
+			*indicators = append(*indicators, objective.SLI)
 		}
 
 		if objectives.Filter != nil {

--- a/lighthouse-service/event_handler/start_evaluation_handler.go
+++ b/lighthouse-service/event_handler/start_evaluation_handler.go
@@ -81,7 +81,7 @@ func (eh *StartEvaluationHandler) sendGetSliCloudEvent(ctx context.Context, kept
 	indicators := []string{}
 	var filters = []*keptnv2.SLIFilter{}
 
-	if err2, end := eh.computeObjectives(e, commitID, &indicators, filters, evaluationStartTimestamp, evaluationEndTimestamp); end {
+	if err2, end := eh.computeObjectives(e, commitID, &indicators, &filters, evaluationStartTimestamp, evaluationEndTimestamp); end {
 		return err2
 	}
 
@@ -123,7 +123,7 @@ func (eh *StartEvaluationHandler) sendGetSliCloudEvent(ctx context.Context, kept
 	return nil
 }
 
-func (eh *StartEvaluationHandler) computeObjectives(e *keptnv2.EvaluationTriggeredEventData, commitID string, indicators *[]string, filters []*keptnv2.SLIFilter, evaluationStartTimestamp string, evaluationEndTimestamp string) (error, bool) {
+func (eh *StartEvaluationHandler) computeObjectives(e *keptnv2.EvaluationTriggeredEventData, commitID string, indicators *[]string, filters *[]*keptnv2.SLIFilter, evaluationStartTimestamp string, evaluationEndTimestamp string) (error, bool) {
 	objectives, _, err := eh.SLOFileRetriever.GetSLOs(e.Project, e.Stage, e.Service, commitID)
 	if err == nil && objectives != nil {
 		logger.Info("SLO file found")
@@ -137,7 +137,7 @@ func (eh *StartEvaluationHandler) computeObjectives(e *keptnv2.EvaluationTrigger
 					Key:   key,
 					Value: value,
 				}
-				filters = append(filters, filter)
+				*filters = append(*filters, filter)
 			}
 		}
 	} else if err != nil && err != ErrSLOFileNotFound {


### PR DESCRIPTION
## This PR

- Makes sure that the indicators array is passed as a pointer, so it can be modified within `computeObjects`

Fixes #6921 

## Proof

**Before:**
```json
{
  "data": {
    "deployment": "",
    "get-sli": {
      "end": "2022-02-18T18:26:38.691Z",
      "sliProvider": "prometheus",
      "start": "2022-02-18T18:21:38.691Z"
    },
    "project": "sockshop",
    "service": "carts",
    "stage": "staging"
  },
  "id": "43a46baa-ba2c-42c8-ac8a-49fa09208e40",
  "source": "lighthouse-service",
  "specversion": "1.0",
  "time": "2022-02-18T18:27:28.313Z",
  "type": "sh.keptn.event.get-sli.triggered",
  "shkeptncontext": "c4201612-585f-42c9-9e57-c0efbabac256",
  "shkeptnspecversion": "0.2.4"
}
```
![image](https://user-images.githubusercontent.com/56065213/154742595-a1b58257-10f4-483b-8c8c-c813bd653947.png)


**After:**
```json
{
  "data": {
    "deployment": "",
    "get-sli": {
      "end": "2022-02-18T18:30:13.263Z",
      "indicators": [
        "response_time_p95"
      ],
      "sliProvider": "prometheus",
      "start": "2022-02-18T18:25:13.263Z"
    },
    "project": "sockshop",
    "service": "carts",
    "stage": "staging"
  },
  "id": "5216d099-ace8-41a9-a531-b563c2f7532b",
  "source": "lighthouse-service",
  "specversion": "1.0",
  "time": "2022-02-18T18:30:16.535Z",
  "type": "sh.keptn.event.get-sli.triggered",
  "shkeptncontext": "97026244-dc3a-45af-ba7d-1b9a6019f957",
  "shkeptnspecversion": "0.2.4"
}
```
![image](https://user-images.githubusercontent.com/56065213/154742554-9a8b966f-643f-42d2-be6e-bd85de62cbda.png)
