### PR TITLE
fix: ensure indicators are set in computeObjectives

### DIFF
--- a/lighthouse-service/event_handler/start_evaluation_handler.go
+++ b/lighthouse-service/event_handler/start_evaluation_handler.go
@@ -81,7 +81,7 @@ func (eh *StartEvaluationHandler) sendGetSliCloudEvent(ctx context.Context, kept
 	indicators := []string{}
 	var filters = []*keptnv2.SLIFilter{}
 
-	if err2, end := eh.computeObjectives(e, commitID, indicators, filters, evaluationStartTimestamp, evaluationEndTimestamp); end {
+	if err2, end := eh.computeObjectives(e, commitID, &indicators, filters, evaluationStartTimestamp, evaluationEndTimestamp); end {
 		return err2
 	}
 
@@ -123,12 +123,12 @@ func (eh *StartEvaluationHandler) sendGetSliCloudEvent(ctx context.Context, kept
 	return nil
 }
 
-func (eh *StartEvaluationHandler) computeObjectives(e *keptnv2.EvaluationTriggeredEventData, commitID string, indicators []string, filters []*keptnv2.SLIFilter, evaluationStartTimestamp string, evaluationEndTimestamp string) (error, bool) {
+func (eh *StartEvaluationHandler) computeObjectives(e *keptnv2.EvaluationTriggeredEventData, commitID string, indicators *[]string, filters []*keptnv2.SLIFilter, evaluationStartTimestamp string, evaluationEndTimestamp string) (error, bool) {
 	objectives, _, err := eh.SLOFileRetriever.GetSLOs(e.Project, e.Stage, e.Service, commitID)
 	if err == nil && objectives != nil {
 		logger.Info("SLO file found")
 		for _, objective := range objectives.Objectives {
-			indicators = append(indicators, objective.SLI)
+			*indicators = append(*indicators, objective.SLI)
 		}
 
 		if objectives.Filter != nil {

--- a/lighthouse-service/event_handler/start_evaluation_handler.go
+++ b/lighthouse-service/event_handler/start_evaluation_handler.go
@@ -81,7 +81,7 @@ func (eh *StartEvaluationHandler) sendGetSliCloudEvent(ctx context.Context, kept
 	indicators := []string{}
 	var filters = []*keptnv2.SLIFilter{}
 
-	if err2, end := eh.computeObjectives(e, commitID, &indicators, filters, evaluationStartTimestamp, evaluationEndTimestamp); end {
+	if err2, end := eh.computeObjectives(e, commitID, &indicators, &filters, evaluationStartTimestamp, evaluationEndTimestamp); end {
 		return err2
 	}
 
@@ -123,7 +123,7 @@ func (eh *StartEvaluationHandler) sendGetSliCloudEvent(ctx context.Context, kept
 	return nil
 }
 
-func (eh *StartEvaluationHandler) computeObjectives(e *keptnv2.EvaluationTriggeredEventData, commitID string, indicators *[]string, filters []*keptnv2.SLIFilter, evaluationStartTimestamp string, evaluationEndTimestamp string) (error, bool) {
+func (eh *StartEvaluationHandler) computeObjectives(e *keptnv2.EvaluationTriggeredEventData, commitID string, indicators *[]string, filters *[]*keptnv2.SLIFilter, evaluationStartTimestamp string, evaluationEndTimestamp string) (error, bool) {
 	objectives, _, err := eh.SLOFileRetriever.GetSLOs(e.Project, e.Stage, e.Service, commitID)
 	if err == nil && objectives != nil {
 		logger.Info("SLO file found")
@@ -137,7 +137,7 @@ func (eh *StartEvaluationHandler) computeObjectives(e *keptnv2.EvaluationTrigger
 					Key:   key,
 					Value: value,
 				}
-				filters = append(filters, filter)
+				*filters = append(*filters, filter)
 			}
 		}
 	} else if err != nil && err != ErrSLOFileNotFound {


### PR DESCRIPTION
## This PR

is a backport of https://github.com/keptn/keptn/pull/6922 (I hope I did it right...)

- Makes sure that the indicators array is passed as a pointer, so it can be modified within `computeObjects`

Fixes #6921 