### PR TITLE
docs: Use K3d 5.3.0 in README for developing

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,18 +21,28 @@ Keptn runs on Kubernetes. To get started, you can follow our [Quickstart guide](
 
 ### Developing Keptn
 
-The easiest way to develop is to spin up a Kubernetes cluster locally by using [K3d](https://k3d.io) via the following commands:
+The easiest way to develop is to spin up a Kubernetes cluster locally by using [K3d](https://k3d.io) (requires `docker`) via the following commands:
 
 ```console
-curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v4.4.4 bash
-k3d cluster create mykeptn -p "8082:80@agent[0]" --k3s-server-arg '--no-deploy=traefik' --agents 1
+curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v5.3.0 bash
+k3d cluster create mykeptn -p "8082:80@loadbalancer" --k3s-arg "--no-deploy=traefik@server:*"
 ```
 
-Afterwards, install Keptn:
+Afterwards, install Keptn CLI:
 ```console
 curl -sL https://get.keptn.sh | bash
+```
+
+And install Keptn (Note: remove `--use-case=continuous-delivery` in case you don't want to install `helm-service` and `jmeter-service`):
+```console
 keptn install --use-case=continuous-delivery
 ```
+
+Please follow the instructions printed by the CLI to connect to your Keptn installation.
+
+### Installing Keptn from Master branch
+
+Note: This will install a potentially unstable version of Keptn.
 
 If you want to install the latest master version of Keptn onto your cluster you can do that by using the development helm charts repository located at https://charts-dev.keptn.sh .
 ```console


### PR DESCRIPTION
## This PR

- Updates README.md to use K3d 5.3.0 for developing.

Reason: I ran into problems using the K3d 4.x versions (which are no longer being updated, it seems) on Ubuntu 20.04:
```
keptn-mongo-56c8c56bd7-tbn7t             0/1     CrashLoopBackOff   2          78s
```
```
mongodb 15:05:00.70 
mongodb 15:05:00.71 Welcome to the Bitnami mongodb container
mongodb 15:05:00.71 Subscribe to project updates by watching https://github.com/bitnami/bitnami-docker-mongodb
mongodb 15:05:00.71 Submit issues and feature requests at https://github.com/bitnami/bitnami-docker-mongodb/issues
mongodb 15:05:00.71 
mongodb 15:05:00.71 INFO  ==> ** Starting MongoDB setup **
mongodb 15:05:00.73 INFO  ==> Validating settings in MONGODB_* env vars...
mkdir: cannot create directory '/bitnami/mongodb': Permission denied
```

Everything seems to work fine using K3d 5.3.0.
**Proof**: I have recorded a YouTube video demoing this for my personal YouTube channel: https://youtu.be/zVFLxaa2xkw