### PR TITLE
test: Verify content of get-sli.triggered event

### DIFF
--- a/test/go-tests/test_qualitygate.go
+++ b/test/go-tests/test_qualitygate.go
@@ -96,11 +96,12 @@ func Test_QualityGates(t *testing.T) {
 
 	source := "golang-test"
 
+	t.Logf("creating project %s", projectName)
 	projectName, err = CreateProject(projectName, shipyardFilePath, true)
 	require.Nil(t, err)
 
+	t.Log("deleting lighthouse configmap from previous test run")
 	_, _ = ExecuteCommand(fmt.Sprintf("kubectl delete configmap -n %s lighthouse-config-%s", GetKeptnNameSpaceFromEnv(), projectName))
-	t.Logf("creating project %s", projectName)
 
 	t.Logf("creating service %s", serviceName)
 	output, err := ExecuteCommand(fmt.Sprintf("keptn create service %s --project=%s", serviceName, projectName))

--- a/test/go-tests/test_qualitygate.go
+++ b/test/go-tests/test_qualitygate.go
@@ -96,15 +96,11 @@ func Test_QualityGates(t *testing.T) {
 
 	source := "golang-test"
 
-	resp, err := ExecuteCommand(fmt.Sprintf("kubectl get configmap -n %s lighthouse-config-%s", GetKeptnNameSpaceFromEnv(), projectName))
-	if !strings.Contains(resp, "not found") && err != nil {
-		_, err = ExecuteCommand(fmt.Sprintf("kubectl delete configmap -n %s lighthouse-config-%s", GetKeptnNameSpaceFromEnv(), projectName))
-		require.Nil(t, err)
-	}
-	t.Logf("creating project %s", projectName)
-
 	projectName, err = CreateProject(projectName, shipyardFilePath, true)
 	require.Nil(t, err)
+
+	_, _ = ExecuteCommand(fmt.Sprintf("kubectl delete configmap -n %s lighthouse-config-%s", GetKeptnNameSpaceFromEnv(), projectName))
+	t.Logf("creating project %s", projectName)
 
 	t.Logf("creating service %s", serviceName)
 	output, err := ExecuteCommand(fmt.Sprintf("keptn create service %s --project=%s", serviceName, projectName))
@@ -367,6 +363,9 @@ func performResourceServiceTest(t *testing.T, projectName string, serviceName st
 	require.Equal(t, "my-sli-provider", getSLIPayload.GetSLI.SLIProvider)
 	require.NotEmpty(t, getSLIPayload.GetSLI.Start)
 	require.NotEmpty(t, getSLIPayload.GetSLI.End)
+	require.Contains(t, getSLIPayload.GetSLI.Indicators, "response_time_p95")
+	require.Contains(t, getSLIPayload.GetSLI.Indicators, "throughput")
+	require.Contains(t, getSLIPayload.GetSLI.Indicators, "error_rate")
 
 	//SLI uses a different commitID
 	resp, err = ApiPOSTRequest("/v1/event", models.KeptnContextExtendedCE{


### PR DESCRIPTION
This PR extends the quality gates integration test by adding a check for the error that was reported in #6921