### PR TITLE
feat: Add prometheus-service scope to secret-service

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/templates/secret-service.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/secret-service.yaml
@@ -27,6 +27,11 @@ data:
           keptn-dynatrace-svc-read:
             Permissions:
               - get
+      keptn-prometheus-service:
+        Capabilities:
+          keptn-prometheus-svc-read:
+            Permissions:
+              - get
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
## This PR

- Adds `keptn-prometheus-service` as a scope to secret-service, such that it also appears in Keptn Bridge

Part of https://github.com/keptn-contrib/prometheus-service/issues/274

