### PR TITLE
ci: Fix release pipeline not uploading helm charts correctly

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -381,9 +381,7 @@ jobs:
           RESOURCE_JSON: resources.json
           RESOURCE_MARKDOWN: resources.md
           RELEASE_NOTES_FILE: ${{ env.RELEASE_NOTES_FILE }}
-        run: |
-          ./gh-actions-scripts/generate-k8s-resource-stats.sh
-          cat "$RELEASE_NOTES_FILE"
+        run: ./gh-actions-scripts/generate-k8s-resource-stats.sh
 
       - name: Create GitHub Pre-Release
         working-directory: keptn
@@ -404,10 +402,9 @@ jobs:
 
       - name: Upload helm charts
         env:
-          ARTIFACTS: "./dist/keptn-installer/*.tgz"
           RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
         run: |
-          mv "$ARTIFACTS" ./helm-charts/packages
+          mv "./dist/keptn-installer/*.tgz" ./helm-charts/packages
           cd ./helm-charts
           helm repo index ./ --url https://charts.keptn.sh/ --merge ./index.yaml
           git add *.tgz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -398,10 +398,9 @@ jobs:
 
       - name: Upload helm charts
         env:
-          ARTIFACTS: "./dist/keptn-installer/*.tgz"
           RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
         run: |
-          mv "$ARTIFACTS" ./helm-charts/packages
+          mv "./dist/keptn-installer/*.tgz" ./helm-charts/packages
           cd ./helm-charts
           helm repo index ./ --url https://charts.keptn.sh/ --merge ./index.yaml
           git add *.tgz


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- fixes a bug in the release and pre-release pipeline that prevented them from pushing the helm charts to our charts repository
