### PR TITLE
fix(distributor): Increase timout of http client to 30s

### DIFF
--- a/distributor/README.md
+++ b/distributor/README.md
@@ -7,6 +7,7 @@ Thus, each service has its own distributor that is configured by the two environ
 - `KEPTN_API_TOKEN` - Keptn API Token - needed when the distributor runs outside of the Keptn cluster. default = `""`
 - `API_PROXY_PORT` - Port on which the distributor will listen for incoming Keptn API requests by its execution plane service. default = `8081`.
 - `API_PROXY_PATH` - Path on which the distributor will listen for incoming Keptn API requests by its execution plane service. default = `/`.
+- `API_PROXY_HTTP_TIMEOUT` - Timeout value for the API Proxy's HTTP Client. default = `30`.
 - `HTTP_POLLING_INTERVAL` - Interval (in seconds) in which the distributor will check for new triggered events on the Keptn API. default = `10`
 - `EVENT_FORWARDING_PATH` - Path on which the distributor will listen for incoming events from its execution plane service. default = `/event`
 - `HTTP_SSL_VERIFY` - Determines whether the distributor should check the validity of SSL certificates when sending requests to a Keptn API endpoint via HTTPS. default = `true`

--- a/distributor/README.md
+++ b/distributor/README.md
@@ -7,7 +7,7 @@ Thus, each service has its own distributor that is configured by the two environ
 - `KEPTN_API_TOKEN` - Keptn API Token - needed when the distributor runs outside of the Keptn cluster. default = `""`
 - `API_PROXY_PORT` - Port on which the distributor will listen for incoming Keptn API requests by its execution plane service. default = `8081`.
 - `API_PROXY_PATH` - Path on which the distributor will listen for incoming Keptn API requests by its execution plane service. default = `/`.
-- `API_PROXY_HTTP_TIMEOUT` - Timeout value for the API Proxy's HTTP Client. default = `30`.
+- `API_PROXY_HTTP_TIMEOUT` - Timeout value (in seconds) for the API Proxy's HTTP Client. default = `30`.
 - `HTTP_POLLING_INTERVAL` - Interval (in seconds) in which the distributor will check for new triggered events on the Keptn API. default = `10`
 - `EVENT_FORWARDING_PATH` - Path on which the distributor will listen for incoming events from its execution plane service. default = `/event`
 - `HTTP_SSL_VERIFY` - Determines whether the distributor should check the validity of SSL certificates when sending requests to a Keptn API endpoint via HTTPS. default = `true`

--- a/distributor/pkg/config/const.go
+++ b/distributor/pkg/config/const.go
@@ -29,4 +29,5 @@ const (
 	DefaultShipyardControllerBaseURL = "http://shipyard-controller:8080"
 	DefaultEventsEndpoint            = DefaultShipyardControllerBaseURL + "/v1/event/triggered"
 	DefaultPollingInterval           = 10
+	DefaultAPIProxyHTTPTimeout       = 30
 )

--- a/distributor/pkg/config/envconfig.go
+++ b/distributor/pkg/config/envconfig.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/oauth2/clientcredentials"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -17,6 +18,7 @@ type EnvConfig struct {
 	KeptnAPIToken        string   `envconfig:"KEPTN_API_TOKEN" default:""`
 	APIProxyPort         int      `envconfig:"API_PROXY_PORT" default:"8081"`
 	APIProxyPath         string   `envconfig:"API_PROXY_PATH" default:"/"`
+	APIProxyHTTPTimeout  string   `envconfig:"API_PROXY_HTTP_TIMEOUT" default:"30"`
 	HTTPPollingInterval  string   `envconfig:"HTTP_POLLING_INTERVAL" default:"10"`
 	EventForwardingPath  string   `envconfig:"EVENT_FORWARDING_PATH" default:"/event"`
 	VerifySSL            bool     `envconfig:"HTTP_SSL_VERIFY" default:"true"`
@@ -172,7 +174,7 @@ func (env *EnvConfig) HTTPClient() *http.Client {
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: !env.VerifySSL}, //nolint:gosec
 		},
-		Timeout: 5 * time.Second,
+		Timeout: env.GetAPIProxyHTTPTimeout(),
 	}
 
 	if env.OAuthEnabled() {
@@ -185,6 +187,14 @@ func (env *EnvConfig) HTTPClient() *http.Client {
 		return conf.Client(context.WithValue(context.TODO(), oauth2.HTTPClient, c))
 	}
 	return c
+}
+
+func (env *EnvConfig) GetAPIProxyHTTPTimeout() time.Duration {
+	timeout, err := strconv.ParseInt(env.APIProxyHTTPTimeout, 10, 64)
+	if err != nil {
+		timeout = DefaultAPIProxyHTTPTimeout
+	}
+	return time.Duration(timeout) * time.Second
 }
 
 func queryEscapeConfigurationServiceURI(path string, value string) string {

--- a/distributor/pkg/config/envconfig_test.go
+++ b/distributor/pkg/config/envconfig_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
+	"time"
 )
 
 func Test_getProxyRequestURL(t *testing.T) {
@@ -314,5 +315,46 @@ func Test_OAuthEnabled(t *testing.T) {
 
 	for _, tc := range tests {
 		assert.Equal(t, tc.want, tc.input.OAuthEnabled())
+	}
+}
+
+func TestEnvConfig_GetAPIProxyHTTPTimeout(t *testing.T) {
+	type fields struct {
+		APIProxyHTTPTimeout string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   time.Duration
+	}{
+		{
+			name:   "Get default timeout",
+			fields: fields{},
+			want:   30 * time.Second,
+		},
+		{
+			name: "Get configured timeout",
+			fields: fields{
+				APIProxyHTTPTimeout: "5",
+			},
+			want: 5 * time.Second,
+		},
+		{
+			name: "Get default timeout if invalid value",
+			fields: fields{
+				APIProxyHTTPTimeout: "invalid",
+			},
+			want: 30 * time.Second,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := &EnvConfig{
+				APIProxyHTTPTimeout: tt.fields.APIProxyHTTPTimeout,
+			}
+			if got := env.GetAPIProxyHTTPTimeout(); got != tt.want {
+				t.Errorf("GetAPIProxyHTTPTimeout() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/distributor/pkg/lib/client/client.go
+++ b/distributor/pkg/lib/client/client.go
@@ -100,7 +100,7 @@ func (g *SimpleClientGetter) Get() (*http.Client, error) {
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: !g.envConfig.VerifySSL}, //nolint:gosec
 		},
-		Timeout: 30 * time.Second,
+		Timeout: g.envConfig.GetAPIProxyHTTPTimeout(),
 	}
 	return c, nil
 }

--- a/distributor/pkg/lib/client/client.go
+++ b/distributor/pkg/lib/client/client.go
@@ -100,7 +100,7 @@ func (g *SimpleClientGetter) Get() (*http.Client, error) {
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: !g.envConfig.VerifySSL}, //nolint:gosec
 		},
-		Timeout: 5 * time.Second,
+		Timeout: 30 * time.Second,
 	}
 	return c, nil
 }


### PR DESCRIPTION
Closes #6935

The timeout of 5s for the distributor's API Proxy was too low, which lead to the helm service running occasionally running into timeouts when trying to push the changes made to the helm chart of a service, when an external upstream repository was used.
This PR sets the default value for the timeout to 30s, and adds an environment variable to make this configurable as well

