### PR TITLE
build(deps): Move dependency alecthomas/jsonschema to invopop/jsonschema since source moved

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -3,12 +3,12 @@ module github.com/keptn/keptn/cli
 go 1.16
 
 require (
-	github.com/alecthomas/jsonschema v0.0.0-20220203024042-cc89723c9db0
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
 	github.com/cloudevents/sdk-go/v2 v2.8.0
 	github.com/docker/docker-credential-helpers v0.6.4
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-version v1.4.0
+	github.com/invopop/jsonschema v0.1.0
 	github.com/keptn/go-utils v0.13.1-0.20220221112829-908349438082
 	github.com/keptn/kubernetes-utils v0.13.0
 	github.com/mattn/go-shellwords v1.0.12

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -136,8 +136,6 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMx
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
-github.com/alecthomas/jsonschema v0.0.0-20220203024042-cc89723c9db0 h1:mK8XdNGiqF1l7iUvhPxNZo8butfcosaxe794sRRJn3U=
-github.com/alecthomas/jsonschema v0.0.0-20220203024042-cc89723c9db0/go.mod h1:/n6+1/DWPltRLWL/VKyUxg6tzsl5kHUCcraimt4vr60=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -743,6 +741,8 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
+github.com/invopop/jsonschema v0.1.0 h1:dw4iVnbNpnMSHNU0mjbKfIPVWzYRU3qszMWCoqwr8Gw=
+github.com/invopop/jsonschema v0.1.0/go.mod h1:O9uiLokuu0+MGFlyiaqtWxwqJm41/+8Nj0lD7A36YH0=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/cli/internal/cespec/genspec.go
+++ b/cli/internal/cespec/genspec.go
@@ -3,7 +3,7 @@ package cespec
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/alecthomas/jsonschema"
+	"github.com/invopop/jsonschema"
 	keptn "github.com/keptn/go-utils/pkg/lib"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 	"os"


### PR DESCRIPTION
The above mentioned dependency moved to a new repo, so our dependency import should also be updated to point to the new repo.