### PR TITLE
fix(distributor): Include event filter for project, stage, service

### DIFF
--- a/distributor/pkg/lib/events/poller.go
+++ b/distributor/pkg/lib/events/poller.go
@@ -116,7 +116,7 @@ func (p *Poller) pollEventsForSubscription(subscription keptnmodels.EventSubscri
 // Per default, it only sets the event type of the subscription.
 // If exactly one project, stage or service is specified respectively, they are included in the filter.
 // However, this is only a (very) short term solution for the RBAC use case.
-// In the long term, we should just pass the subscription ID in the request, since the backend knows the required fiters associated with the subscription.
+// In the long term, we should just pass the subscription ID in the request, since the backend knows the required filters associated with the subscription.
 func getEventFilterForSubscription(subscription keptnmodels.EventSubscription) api.EventFilter {
 	eventFilter := api.EventFilter{
 		EventType: subscription.Event,

--- a/distributor/pkg/lib/events/poller.go
+++ b/distributor/pkg/lib/events/poller.go
@@ -72,9 +72,9 @@ func (p *Poller) doPollEvents() {
 }
 
 func (p *Poller) pollEventsForSubscription(subscription keptnmodels.EventSubscription) {
-	events, err := p.shipyardControlAPI.GetOpenTriggeredEvents(api.EventFilter{
-		EventType: subscription.Event,
-	})
+
+	eventFilter := getEventFilterForSubscription(subscription)
+	events, err := p.shipyardControlAPI.GetOpenTriggeredEvents(eventFilter)
 	if err != nil {
 		logger.Errorf("Could not retrieve events of type %s: %s", subscription.Event, err)
 		return
@@ -110,6 +110,29 @@ func (p *Poller) pollEventsForSubscription(subscription keptnmodels.EventSubscri
 
 	logger.Debugf("Cleaning up list of sent events for topic %s", subscription.Event)
 	p.ceCache.Keep(subscription.ID, ToIDs(events))
+}
+
+// getEventFilterForSubscription returns the event filter for the subscription
+// Per default, it only sets the event type of the subscription.
+// If exactly one project, stage or service is specified respectively, they are included in the filter.
+// However, this is only a (very) short term solution for the RBAC use case.
+// In the long term, we should just pass the subscription ID in the request, since the backend knows the required fiters associated with the subscription.
+func getEventFilterForSubscription(subscription keptnmodels.EventSubscription) api.EventFilter {
+	eventFilter := api.EventFilter{
+		EventType: subscription.Event,
+	}
+
+	if len(subscription.Filter.Projects) == 1 {
+		eventFilter.Project = subscription.Filter.Projects[0]
+	}
+	if len(subscription.Filter.Stages) == 1 {
+		eventFilter.Stage = subscription.Filter.Stages[0]
+	}
+	if len(subscription.Filter.Services) == 1 {
+		eventFilter.Service = subscription.Filter.Services[0]
+	}
+
+	return eventFilter
 }
 
 func (p *Poller) sendEvent(e keptnmodels.KeptnContextExtendedCE, subscription keptnmodels.EventSubscription) error {

--- a/distributor/pkg/lib/events/poller_test.go
+++ b/distributor/pkg/lib/events/poller_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -177,4 +178,99 @@ func Test_PollAndForwardEvents2(t *testing.T) {
 	}, time.Second*time.Duration(5), time.Second)
 	cancel()
 	executionContext.Wg.Wait()
+}
+
+func Test_getEventFilterForSubscription(t *testing.T) {
+	type args struct {
+		subscription keptnmodels.EventSubscription
+	}
+	tests := []struct {
+		name string
+		args args
+		want keptnapi.EventFilter
+	}{
+		{
+			name: "get default filter",
+			args: args{
+				subscription: keptnmodels.EventSubscription{
+					Event: "my-event",
+				},
+			},
+			want: keptnapi.EventFilter{
+				EventType: "my-event",
+			},
+		},
+		{
+			name: "multiple projects - get default filter",
+			args: args{
+				subscription: keptnmodels.EventSubscription{
+					Event: "my-event",
+					Filter: keptnmodels.EventSubscriptionFilter{
+						Projects: []string{"a", "b"},
+					},
+				},
+			},
+			want: keptnapi.EventFilter{
+				EventType: "my-event",
+			},
+		},
+		{
+			name: "one project",
+			args: args{
+				subscription: keptnmodels.EventSubscription{
+					Event: "my-event",
+					Filter: keptnmodels.EventSubscriptionFilter{
+						Projects: []string{"a"},
+					},
+				},
+			},
+			want: keptnapi.EventFilter{
+				EventType: "my-event",
+				Project:   "a",
+			},
+		},
+		{
+			name: "one project, one stage",
+			args: args{
+				subscription: keptnmodels.EventSubscription{
+					Event: "my-event",
+					Filter: keptnmodels.EventSubscriptionFilter{
+						Projects: []string{"a"},
+						Stages:   []string{"stage-a"},
+					},
+				},
+			},
+			want: keptnapi.EventFilter{
+				EventType: "my-event",
+				Project:   "a",
+				Stage:     "stage-a",
+			},
+		},
+		{
+			name: "one project, one stage, one service",
+			args: args{
+				subscription: keptnmodels.EventSubscription{
+					Event: "my-event",
+					Filter: keptnmodels.EventSubscriptionFilter{
+						Projects: []string{"a"},
+						Stages:   []string{"stage-a"},
+						Services: []string{"service-a"},
+					},
+				},
+			},
+			want: keptnapi.EventFilter{
+				EventType: "my-event",
+				Project:   "a",
+				Stage:     "stage-a",
+				Service:   "service-a",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getEventFilterForSubscription(tt.args.subscription); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getEventFilterForSubscription() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Closes #6964 

As discussed, we agreed to apply the filter properties only if one project/stage/service has been set for the subscription respectively. 
However, this is only a (very) short term solution for the RBAC use case.
In the long term, we should just pass the subscription ID in the request, since the backend knows the required filters associated with the subscription.