### PR TITLE
ci: Fix resource cleanup in integration tests when resource arrays are empty

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -561,63 +561,63 @@ jobs:
 
           if [[ "${{ github.event_name }}" == 'schedule' && "${{ steps.test_aggregated.outcome }}" == 'failure' ]]; then
               for namespace in "${namespaces[@]}"; do
-                if [[ ! -z "${$namespace// }" ]]; then
+                if [[ ! -z "${namespace// }" ]]; then
                   echo "Annotating namespace $namespace with Janitor TTL of 3 days..."
                   kubectl annotate namespace "$namespace" janitor/ttl=3d
                 fi
               done
           
               for cr in "${clusterroles[@]}"; do
-                if [[ ! -z "${$cr// }" ]]; then
+                if [[ ! -z "${cr// }" ]]; then
                   echo "Annotating clusterrole $cr with Janitor TTL of 3 days..."
                   kubectl annotate clusterrole "$cr" janitor/ttl=3d
                 fi
               done
           
               for crb in "${clusterrolebindings[@]}"; do
-                if [[ ! -z "${$crb// }" ]]; then
+                if [[ ! -z "${crb// }" ]]; then
                   echo "Annotating clusterrolebinding $crb with Janitor TTL of 3 days..."
                   kubectl annotate clusterrolebinding "$crb" janitor/ttl=3d
                 fi
               done
           elif [[ "${{ github.event_name }}" == 'workflow_dispatch' && "${{ steps.test_aggregated.outcome }}" == 'failure' ]]; then
               for namespace in "${namespaces[@]}"; do
-                if [[ ! -z "${$namespace// }" ]]; then
+                if [[ ! -z "${namespace// }" ]]; then
                   echo "Annotating namespace $namespace with Janitor TTL of 6 hours..."
                   kubectl annotate namespace "$namespace" janitor/ttl=6h
                 fi
               done
           
               for cr in "${clusterroles[@]}"; do
-                if [[ ! -z "${$cr// }" ]]; then
+                if [[ ! -z "${cr// }" ]]; then
                   echo "Annotating clusterrole $cr with Janitor TTL of 3 days..."
                   kubectl annotate clusterrole "$cr" janitor/ttl=6h
                 fi
               done
           
               for crb in "${clusterrolebindings[@]}"; do
-                if [[ ! -z "${$crb// }" ]]; then
+                if [[ ! -z "${crb// }" ]]; then
                   echo "Annotating clusterrolebinding $crb with Janitor TTL of 3 days..."
                   kubectl annotate clusterrolebinding "$crb" janitor/ttl=6h
                 fi
               done
           else
               for namespace in "${namespaces[@]}"; do
-                if [[ ! -z "${$namespace// }" ]]; then
+                if [[ ! -z "${namespace// }" ]]; then
                   echo "Deleting namespace $namespace ..."
                   kubectl delete namespace "$namespace"
                 fi
               done
           
               for cr in "${clusterroles[@]}"; do
-                if [[ ! -z "${$cr// }" ]]; then
+                if [[ ! -z "${cr// }" ]]; then
                   echo "Deleting clusterrole $cr ..."
                   kubectl delete clusterrole "$cr"
                 fi
               done
           
               for crb in "${clusterrolebindings[@]}"; do
-                if [[ ! -z "${$crb// }" ]]; then
+                if [[ ! -z "${crb// }" ]]; then
                   echo "Deleting clusterrolebinding $crb ..."
                   kubectl delete clusterrolebindings "$crb"
                 fi

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -554,57 +554,94 @@ jobs:
       - name: Cleanup test namespace
         if: always() && env.CLOUD_PROVIDER == 'GKE'
         run: |
+          echo "Cleaning up test resources..."
           readarray -t namespaces <<< "$(kubectl get namespaces | awk '{ print $1 }' | grep ${{ env.KEPTN_NAMESPACE }})"
           readarray -t clusterroles <<< "$(kubectl get clusterroles | awk '{ print $1 }' | grep ${{ env.KEPTN_NAMESPACE }})"
           readarray -t clusterrolebindings <<< "$(kubectl get clusterrolebindings | awk '{ print $1 }' | grep ${{ env.KEPTN_NAMESPACE }})"
 
           if [[ "${{ github.event_name }}" == 'schedule' && "${{ steps.test_aggregated.outcome }}" == 'failure' ]]; then
-            for namespace in "${namespaces[@]}"; do
-              echo "Annotating namespace $namespace with Janitor TTL of 3 days..."
-              kubectl annotate namespace "$namespace" janitor/ttl=3d
-            done
+            if [ ${#namespaces[@]} -ne 0 ]; then
+              for namespace in "${namespaces[@]}"; do
+                echo "Annotating namespace $namespace with Janitor TTL of 3 days..."
+                kubectl annotate namespace "$namespace" janitor/ttl=3d
+              done
+            else
+              echo "Didn't find any namespaces to clean up..."
+            fi
           
-            for cr in "${clusterroles[@]}"; do
-              echo "Annotating clusterrole $cr with Janitor TTL of 3 days..."
-              kubectl annotate clusterrole "$cr" janitor/ttl=3d
-            done
+            if [ ${#clusterroles[@]} -ne 0 ]; then
+              for cr in "${clusterroles[@]}"; do
+                echo "Annotating clusterrole $cr with Janitor TTL of 3 days..."
+                kubectl annotate clusterrole "$cr" janitor/ttl=3d
+              done
+            else
+              echo "Didn't find any clusterroles to clean up..."
+            fi
           
-            for crb in "${clusterrolebindings[@]}"; do
-              echo "Annotating clusterrolebinding $crb with Janitor TTL of 3 days..."
-              kubectl annotate clusterrolebinding "$crb" janitor/ttl=3d
-            done
+            if [ ${#clusterrolebindings[@]} -ne 0 ]; then
+              for crb in "${clusterrolebindings[@]}"; do
+                echo "Annotating clusterrolebinding $crb with Janitor TTL of 3 days..."
+                kubectl annotate clusterrolebinding "$crb" janitor/ttl=3d
+              done
+            else
+              echo "Didn't find any clusterrolebindings to clean up..."
+            fi
           elif [[ "${{ github.event_name }}" == 'workflow_dispatch' && "${{ steps.test_aggregated.outcome }}" == 'failure' ]]; then
-            for namespace in "${namespaces[@]}"; do
-              echo "Annotating namespace $namespace with Janitor TTL of 6 hours..."
-              kubectl annotate namespace "$namespace" janitor/ttl=6h
-            done
+            if [ ${#namespaces[@]} -ne 0 ]; then
+              for namespace in "${namespaces[@]}"; do
+                echo "Annotating namespace $namespace with Janitor TTL of 6 hours..."
+                kubectl annotate namespace "$namespace" janitor/ttl=6h
+              done
+            else
+              echo "Didn't find any namespaces to clean up..."
+            fi
           
-            for cr in "${clusterroles[@]}"; do
-              echo "Annotating clusterrole $cr with Janitor TTL of 3 days..."
-              kubectl annotate clusterrole "$cr" janitor/ttl=6h
-            done
+            if [ ${#clusterroles[@]} -ne 0 ]; then
+              for cr in "${clusterroles[@]}"; do
+                echo "Annotating clusterrole $cr with Janitor TTL of 3 days..."
+                kubectl annotate clusterrole "$cr" janitor/ttl=6h
+              done
+            else
+              echo "Didn't find any clusterroles to clean up..."
+            fi
           
-            for crb in "${clusterrolebindings[@]}"; do
-              echo "Annotating clusterrolebinding $crb with Janitor TTL of 3 days..."
-              kubectl annotate clusterrolebinding "$crb" janitor/ttl=6h
-            done
+            if [ ${#clusterrolebindings[@]} -ne 0 ]; then
+              for crb in "${clusterrolebindings[@]}"; do
+                echo "Annotating clusterrolebinding $crb with Janitor TTL of 3 days..."
+                kubectl annotate clusterrolebinding "$crb" janitor/ttl=6h
+              done
+            else
+              echo "Didn't find any clusterrolebindings to clean up..."
+            fi
           else
-            for namespace in "${namespaces[@]}"; do
-              echo "Deleting namespace $namespace ..."
-              kubectl delete namespace "$namespace"
-            done
+            if [ ${#namespaces[@]} -ne 0 ]; then
+              for namespace in "${namespaces[@]}"; do
+                echo "Deleting namespace $namespace ..."
+                kubectl delete namespace "$namespace"
+              done
+            else
+              echo "Didn't find any namespaces to clean up..."
+            fi
           
-            for cr in "${clusterroles[@]}"; do
-              echo "Deleting clusterrole $cr ..."
-              kubectl delete clusterrole "$cr"
-            done
+            if [ ${#clusterroles[@]} -ne 0 ]; then
+              for cr in "${clusterroles[@]}"; do
+                echo "Deleting clusterrole $cr ..."
+                kubectl delete clusterrole "$cr"
+              done
+            else
+              echo "Didn't find any clusterroles to clean up..."
+            fi
           
-            for crb in "${clusterrolebindings[@]}"; do
-              echo "Deleting clusterrolebinding $crb ..."
-              kubectl delete clusterrolebindings "$crb"
-            done
+            if [ ${#clusterrolebindings[@]} -ne 0 ]; then
+              for crb in "${clusterrolebindings[@]}"; do
+                echo "Deleting clusterrolebinding $crb ..."
+                kubectl delete clusterrolebindings "$crb"
+              done
+            else
+              echo "Didn't find any clusterrolebindings to clean up..."
+            fi
           fi
-
+          
       - name: Cleanup Minishift cluster
         if: env.CLOUD_PROVIDER == 'minishift-on-GHA'
         timeout-minutes: 3

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -560,86 +560,68 @@ jobs:
           readarray -t clusterrolebindings <<< "$(kubectl get clusterrolebindings | awk '{ print $1 }' | grep ${{ env.KEPTN_NAMESPACE }})"
 
           if [[ "${{ github.event_name }}" == 'schedule' && "${{ steps.test_aggregated.outcome }}" == 'failure' ]]; then
-            if [ ${#namespaces[@]} -ne 0 ]; then
               for namespace in "${namespaces[@]}"; do
-                echo "Annotating namespace $namespace with Janitor TTL of 3 days..."
-                kubectl annotate namespace "$namespace" janitor/ttl=3d
+                if [[ ! -z "${$namespace// }" ]]; then
+                  echo "Annotating namespace $namespace with Janitor TTL of 3 days..."
+                  kubectl annotate namespace "$namespace" janitor/ttl=3d
+                fi
               done
-            else
-              echo "Didn't find any namespaces to clean up..."
-            fi
           
-            if [ ${#clusterroles[@]} -ne 0 ]; then
               for cr in "${clusterroles[@]}"; do
-                echo "Annotating clusterrole $cr with Janitor TTL of 3 days..."
-                kubectl annotate clusterrole "$cr" janitor/ttl=3d
+                if [[ ! -z "${$cr// }" ]]; then
+                  echo "Annotating clusterrole $cr with Janitor TTL of 3 days..."
+                  kubectl annotate clusterrole "$cr" janitor/ttl=3d
+                fi
               done
-            else
-              echo "Didn't find any clusterroles to clean up..."
-            fi
           
-            if [ ${#clusterrolebindings[@]} -ne 0 ]; then
               for crb in "${clusterrolebindings[@]}"; do
-                echo "Annotating clusterrolebinding $crb with Janitor TTL of 3 days..."
-                kubectl annotate clusterrolebinding "$crb" janitor/ttl=3d
+                if [[ ! -z "${$crb// }" ]]; then
+                  echo "Annotating clusterrolebinding $crb with Janitor TTL of 3 days..."
+                  kubectl annotate clusterrolebinding "$crb" janitor/ttl=3d
+                fi
               done
-            else
-              echo "Didn't find any clusterrolebindings to clean up..."
-            fi
           elif [[ "${{ github.event_name }}" == 'workflow_dispatch' && "${{ steps.test_aggregated.outcome }}" == 'failure' ]]; then
-            if [ ${#namespaces[@]} -ne 0 ]; then
               for namespace in "${namespaces[@]}"; do
-                echo "Annotating namespace $namespace with Janitor TTL of 6 hours..."
-                kubectl annotate namespace "$namespace" janitor/ttl=6h
+                if [[ ! -z "${$namespace// }" ]]; then
+                  echo "Annotating namespace $namespace with Janitor TTL of 6 hours..."
+                  kubectl annotate namespace "$namespace" janitor/ttl=6h
+                fi
               done
-            else
-              echo "Didn't find any namespaces to clean up..."
-            fi
           
-            if [ ${#clusterroles[@]} -ne 0 ]; then
               for cr in "${clusterroles[@]}"; do
-                echo "Annotating clusterrole $cr with Janitor TTL of 3 days..."
-                kubectl annotate clusterrole "$cr" janitor/ttl=6h
+                if [[ ! -z "${$cr// }" ]]; then
+                  echo "Annotating clusterrole $cr with Janitor TTL of 3 days..."
+                  kubectl annotate clusterrole "$cr" janitor/ttl=6h
+                fi
               done
-            else
-              echo "Didn't find any clusterroles to clean up..."
-            fi
           
-            if [ ${#clusterrolebindings[@]} -ne 0 ]; then
               for crb in "${clusterrolebindings[@]}"; do
-                echo "Annotating clusterrolebinding $crb with Janitor TTL of 3 days..."
-                kubectl annotate clusterrolebinding "$crb" janitor/ttl=6h
+                if [[ ! -z "${$crb// }" ]]; then
+                  echo "Annotating clusterrolebinding $crb with Janitor TTL of 3 days..."
+                  kubectl annotate clusterrolebinding "$crb" janitor/ttl=6h
+                fi
               done
-            else
-              echo "Didn't find any clusterrolebindings to clean up..."
-            fi
           else
-            if [ ${#namespaces[@]} -ne 0 ]; then
               for namespace in "${namespaces[@]}"; do
-                echo "Deleting namespace $namespace ..."
-                kubectl delete namespace "$namespace"
+                if [[ ! -z "${$namespace// }" ]]; then
+                  echo "Deleting namespace $namespace ..."
+                  kubectl delete namespace "$namespace"
+                fi
               done
-            else
-              echo "Didn't find any namespaces to clean up..."
-            fi
           
-            if [ ${#clusterroles[@]} -ne 0 ]; then
               for cr in "${clusterroles[@]}"; do
-                echo "Deleting clusterrole $cr ..."
-                kubectl delete clusterrole "$cr"
+                if [[ ! -z "${$cr// }" ]]; then
+                  echo "Deleting clusterrole $cr ..."
+                  kubectl delete clusterrole "$cr"
+                fi
               done
-            else
-              echo "Didn't find any clusterroles to clean up..."
-            fi
           
-            if [ ${#clusterrolebindings[@]} -ne 0 ]; then
               for crb in "${clusterrolebindings[@]}"; do
-                echo "Deleting clusterrolebinding $crb ..."
-                kubectl delete clusterrolebindings "$crb"
+                if [[ ! -z "${$crb// }" ]]; then
+                  echo "Deleting clusterrolebinding $crb ..."
+                  kubectl delete clusterrolebindings "$crb"
+                fi
               done
-            else
-              echo "Didn't find any clusterrolebindings to clean up..."
-            fi
           fi
           
       - name: Cleanup Minishift cluster

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -346,7 +346,7 @@ jobs:
           SEMVER_TYPE: ${{ github.event.inputs.semver-type }}
           GITHUB_TOKEN: ${{ secrets.KEPTN_BOT_TOKEN }}
         run: |
-          echo "🚀 Creating release package now..."
+          echo "🚀 Creating pre-release package now..."
 
           if [[ ! -z "$SEMVER_TYPE" ]]; then
             npx standard-version@^9.3.1 \


### PR DESCRIPTION
### This PR
- fixes an issue where the pipeline run would fail when there were no resources found by `kubectl` during cleanup.
- The loop would still start iterating and then the `kubectl annotate` command would fail because no resource name is provided since the array is empty

Intergation test run where everything is red, but the cleanup worked: https://github.com/keptn/keptn/actions/runs/1887398297