### PR TITLE
fix(bridge): Prevent spaces in URL

### DIFF
--- a/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.html
+++ b/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.html
@@ -28,7 +28,9 @@
         class="resize-vertical"
       ></textarea>
       <dt-error *ngIf="getFormControl('url').errors?.required">URL must not be empty</dt-error>
-      <dt-error *ngIf="getFormControl('url').errors?.url">URL must start with http(s)://</dt-error>
+      <dt-error *ngIf="getFormControl('url').errors?.url">
+        URL must start with http(s):// and must not contain spaces
+      </dt-error>
       <div dtSuffix uitestid="event-url">
         <ng-container
           [ngTemplateOutlet]="payloadButton"
@@ -163,7 +165,9 @@
     <dt-form-field uitestid="edit-webhook-field-proxy">
       <dt-label>Proxy</dt-label>
       <input formControlName="proxy" type="url" dtInput placeholder="Proxy" />
-      <dt-error *ngIf="getFormControl('proxy').errors?.url">URL must start with http(s)://</dt-error>
+      <dt-error *ngIf="getFormControl('proxy').errors?.url">
+        URL must start with http(s):// and must not contain spaces
+      </dt-error>
     </dt-form-field>
   </div>
   <div class="settings-section" fxLayout="row" fxLayoutAlign="start center">

--- a/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.html
+++ b/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.html
@@ -28,9 +28,8 @@
         class="resize-vertical"
       ></textarea>
       <dt-error *ngIf="getFormControl('url').errors?.required">URL must not be empty</dt-error>
-      <dt-error *ngIf="getFormControl('url').errors?.url">
-        URL must start with http(s):// and must not contain spaces
-      </dt-error>
+      <dt-error *ngIf="getFormControl('url').errors?.url"> URL must start with http(s):// </dt-error>
+      <dt-error *ngIf="getFormControl('url').errors?.space"> URL must not contain spaces </dt-error>
       <div dtSuffix uitestid="event-url">
         <ng-container
           [ngTemplateOutlet]="payloadButton"
@@ -165,9 +164,8 @@
     <dt-form-field uitestid="edit-webhook-field-proxy">
       <dt-label>Proxy</dt-label>
       <input formControlName="proxy" type="url" dtInput placeholder="Proxy" />
-      <dt-error *ngIf="getFormControl('proxy').errors?.url">
-        URL must start with http(s):// and must not contain spaces
-      </dt-error>
+      <dt-error *ngIf="getFormControl('proxy').errors?.url"> URL must start with http(s):// </dt-error>
+      <dt-error *ngIf="getFormControl('proxy').errors?.space"> URL must not contain spaces </dt-error>
     </dt-form-field>
   </div>
   <div class="settings-section" fxLayout="row" fxLayoutAlign="start center">

--- a/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.spec.ts
+++ b/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.spec.ts
@@ -83,15 +83,26 @@ describe('KtbWebhookSettingsComponent', () => {
     }
   });
 
+  it('should be invalid URL if it contains spaces', () => {
+    const urlControl: AbstractControl = component.webhookConfigForm.get('url') as AbstractControl;
+    const urls = [
+      'http://my-jenkins-servcer.default.svc.cluster.local:8080/job/nodejs example app/build?token=',
+      'http://my-jenkins-servcer.com/job/nodejs example app/build?token=',
+    ];
+
+    for (const url of urls) {
+      urlControl.setValue(url);
+      expect(urlControl.valid).toEqual(false);
+    }
+  });
+
   it('should be valid URL when it starts with http(s)://', () => {
     const urlControl: AbstractControl = component.webhookConfigForm.get('url') as AbstractControl;
     const urls = [
       'https://keptn.sh',
       'http://keptn.sh',
       'http://www.keptn.sh',
-      'http://my-jenkins-servcer.default.svc.cluster.local:8080/job/nodejs example app/build?token=',
       'http://my-jenkins-servcer.default.svc.cluster.local:8080/job/nodejs%20example%20app/build?token=',
-      'http://my-jenkins-servcer.com/job/nodejs example app/build?token=',
     ];
 
     for (const url of urls) {

--- a/bridge/client/app/_utils/form.utils.ts
+++ b/bridge/client/app/_utils/form.utils.ts
@@ -9,7 +9,7 @@ export class FormUtils {
   }
 
   public static isUrlValidator(control: AbstractControl): { url: { value: boolean } } | null {
-    if (control.value && control.value.search(/^http(s?):\/\//) === -1) {
+    if (control.value && (control.value.search(/^http(s?):\/\//) === -1 || control.value.includes(' '))) {
       return { url: { value: true } };
     }
     return null;

--- a/bridge/client/app/_utils/form.utils.ts
+++ b/bridge/client/app/_utils/form.utils.ts
@@ -8,9 +8,15 @@ export class FormUtils {
     };
   }
 
-  public static isUrlValidator(control: AbstractControl): { url: { value: boolean } } | null {
-    if (control.value && (control.value.search(/^http(s?):\/\//) === -1 || control.value.includes(' '))) {
-      return { url: { value: true } };
+  public static isUrlValidator(
+    control: AbstractControl
+  ): { url: { value: boolean } } | { space: { value: boolean } } | null {
+    if (control.value) {
+      if (control.value.search(/^http(s?):\/\//) === -1) {
+        return { url: { value: true } };
+      } else if (control.value.includes(' ')) {
+        return { space: { value: true } };
+      }
     }
     return null;
   }

--- a/bridge/server/models/webhook-config-yaml.spec.ts
+++ b/bridge/server/models/webhook-config-yaml.spec.ts
@@ -1,0 +1,197 @@
+import { WebhookConfigYaml } from './webhook-config-yaml';
+import { WebhookConfig } from '../../shared/models/webhook-config';
+import { Webhook } from '../interfaces/webhook-config-yaml-result';
+
+describe('Test webhook-config-yaml', () => {
+  it('should parse request correctly', () => {
+    // given
+    const yamlConfig = getDefaultWebhookYaml();
+
+    // when
+    const result = yamlConfig.parsedRequest('myID') as WebhookConfig;
+
+    // then
+    const webhookConfig: WebhookConfig = Object.assign(new WebhookConfig(), {
+      url: 'http://keptn.sh/asdf asdf',
+      type: 'sh.keptn.event.deployment.started',
+      header: [
+        {
+          name: 'content-type',
+          value: 'application/json',
+        },
+      ],
+      proxy: 'http://keptn.sh/proxy',
+      payload: '{\n  "data": "myData"\n}',
+      method: 'GET',
+      secrets: [
+        {
+          name: 'mySecret',
+          secretRef: {
+            name: 'myName',
+            key: 'myKey',
+          },
+        },
+      ],
+      sendFinished: false,
+    });
+    expect(result).toEqual(webhookConfig);
+  });
+
+  it('should set sendFinished to the value specified', () => {
+    // given
+    const yamlConfigTrue = getDefaultWebhookYaml(true);
+    const yamlConfigFalse = getDefaultWebhookYaml(false);
+    const yamlConfigUndefined = getDefaultWebhookYaml();
+
+    // when
+    const webhookConfigTrue = yamlConfigTrue.parsedRequest('myID') as WebhookConfig;
+    const webhookConfigFalse = yamlConfigFalse.parsedRequest('myID') as WebhookConfig;
+    const webhookConfigUndefined = yamlConfigUndefined.parsedRequest('myID') as WebhookConfig;
+
+    // then
+    expect(webhookConfigTrue.sendFinished).toBe(true);
+    expect(webhookConfigFalse.sendFinished).toBe(false);
+    expect(webhookConfigUndefined.sendFinished).toBe(false);
+  });
+
+  it('should return undefined if subscriptionID does not exist', () => {
+    // given
+    const yamlConfig = getDefaultWebhookYaml(true);
+    // when
+    const webhookConfig = yamlConfig.parsedRequest('notExistingID');
+    // then
+    expect(webhookConfig).toBeUndefined();
+  });
+
+  it('should add another webhook', () => {
+    // given
+    const yamlConfig = getDefaultWebhookYaml(true);
+
+    // when
+    yamlConfig.addWebhook(
+      'sh.keptn.events.approval.triggered',
+      'curl http://keptn.sh --request GET',
+      'mySecondID',
+      [],
+      true
+    );
+
+    // then
+    expect(yamlConfig.spec.webhooks.length).toBe(2);
+    expect(yamlConfig.spec.webhooks[1]).toEqual({
+      type: 'sh.keptn.events.approval.triggered',
+      sendFinished: true,
+      subscriptionID: 'mySecondID',
+      requests: ['curl http://keptn.sh --request GET'],
+    } as Webhook);
+  });
+
+  it('should update an existing webhook', () => {
+    // given
+    const yamlConfig = getDefaultWebhookYaml(false);
+    expect(yamlConfig.spec.webhooks.length).toBe(1);
+
+    // when
+    yamlConfig.addWebhook(
+      'sh.keptn.events.approval.started',
+      'curl http://keptn.sh/second --request GET',
+      'myID',
+      [
+        {
+          name: 'mySecret',
+          secretRef: {
+            name: 'myName',
+            key: 'myKey',
+          },
+        },
+      ],
+      true
+    );
+
+    // then
+    expect(yamlConfig.spec.webhooks.length).toBe(1);
+    expect(yamlConfig.spec.webhooks[0]).toEqual({
+      type: 'sh.keptn.events.approval.started',
+      sendFinished: true,
+      envFrom: [
+        {
+          name: 'mySecret',
+          secretRef: {
+            name: 'myName',
+            key: 'myKey',
+          },
+        },
+      ],
+      subscriptionID: 'myID',
+      requests: ['curl http://keptn.sh/second --request GET'],
+    } as Webhook);
+  });
+
+  it('should update an existing webhook and remove secrets', () => {
+    // given
+    const yamlConfig = getDefaultWebhookYaml(false);
+
+    // when
+    yamlConfig.addWebhook(
+      'sh.keptn.events.approval.started',
+      'curl http://keptn.sh/second --request GET',
+      'myID',
+      [],
+      true
+    );
+
+    // then
+    expect(yamlConfig.spec.webhooks.length).toBe(1);
+    expect(yamlConfig.spec.webhooks[0]).toEqual({
+      type: 'sh.keptn.events.approval.started',
+      sendFinished: true,
+      subscriptionID: 'myID',
+      requests: ['curl http://keptn.sh/second --request GET'],
+    } as Webhook);
+  });
+
+  it('should remove webhooks', () => {
+    // given
+    const yamlConfig = getDefaultWebhookYaml(false);
+    expect(yamlConfig.spec.webhooks.length).toBe(1);
+    expect(yamlConfig.hasWebhooks()).toBe(true);
+
+    // when
+    yamlConfig.removeWebhook('myID');
+
+    // then
+    expect(yamlConfig.hasWebhooks()).toBe(false);
+    expect(yamlConfig.spec.webhooks.length).toBe(0);
+  });
+
+  function getDefaultWebhookYaml(sendFinished?: boolean): WebhookConfigYaml {
+    return WebhookConfigYaml.fromJSON({
+      kind: 'WebhookConfig',
+      apiVersion: 'webhookconfig.keptn.sh/v1alpha1',
+      spec: {
+        webhooks: [
+          {
+            subscriptionID: 'myID',
+            type: 'sh.keptn.event.deployment.started',
+            requests: [
+              `curl http://keptn.sh/asdf asdf --request GET --header 'content-type: application/json' --proxy http://keptn.sh/proxy --data '{"data": "myData"}'`,
+            ],
+            envFrom: [
+              {
+                name: 'mySecret',
+                secretRef: {
+                  name: 'myName',
+                  key: 'myKey',
+                },
+              },
+            ],
+            ...(sendFinished !== undefined && { sendFinished }),
+          },
+        ],
+      },
+      metadata: {
+        name: 'webhook-configuration',
+      },
+    });
+  }
+});

--- a/bridge/server/models/webhook-config-yaml.ts
+++ b/bridge/server/models/webhook-config-yaml.ts
@@ -1,7 +1,8 @@
 import Yaml from 'yaml';
 import { WebhookConfigMethod } from '../../shared/interfaces/webhook-config';
 import { WebhookConfig, WebhookSecret } from '../../shared/models/webhook-config';
-import { Webhook, WebhookConfigYamlResult } from './webhook-config-yaml-result';
+import { Webhook, WebhookConfigYamlResult } from '../interfaces/webhook-config-yaml-result';
+import { parseCurl } from '../utils/curl.utils';
 
 const order: { [key: string]: number } = {
   apiVersion: 0,
@@ -103,21 +104,23 @@ export class WebhookConfigYaml implements WebhookConfigYamlResult {
 
   public parsedRequest(subscriptionId: string): WebhookConfig | undefined {
     const webhook = this.getWebhook(subscriptionId);
-    const curl = webhook?.requests[0];
-    const secrets = webhook?.envFrom;
-
-    const parsedConfig = curl ? this.parseConfig(curl) : undefined;
-    if (parsedConfig) {
-      parsedConfig.secrets = secrets;
-      parsedConfig.sendFinished = webhook?.sendFinished ?? false;
+    if (webhook) {
+      const curl = webhook.requests[0];
+      if (curl) {
+        const parsedConfig = this.parseConfig(curl);
+        parsedConfig.secrets = webhook.envFrom;
+        parsedConfig.sendFinished = webhook.sendFinished ?? false;
+        parsedConfig.type = webhook.type;
+        return parsedConfig;
+      }
     }
-    return parsedConfig;
+    return undefined;
   }
 
   private parseConfig(curl: string): WebhookConfig {
     const config = new WebhookConfig();
-    const result = this.parseCurl(curl);
-    config.url = result._?.[0] ?? '';
+    const result = parseCurl(curl);
+    config.url = result._?.join(' ') ?? '';
     config.payload = this.formatJSON(result.data?.[0] ?? '');
     config.proxy = result.proxy?.[0] ?? '';
     config.method = (result.request?.[0] ?? '') as WebhookConfigMethod;
@@ -135,78 +138,6 @@ export class WebhookConfigYaml implements WebhookConfigYamlResult {
 
     config.header = headers;
     return config;
-  }
-
-  private parseCurl(curl: string): { [key: string]: string[] } {
-    const startCommand = 'curl ';
-    const result: { [key: string]: string[] } = {};
-    if (curl.startsWith(startCommand)) {
-      let i = startCommand.length;
-      while (i < curl.length) {
-        i = this.skipSpace(curl, i);
-        let command = '_';
-        if (curl[i] === '-') {
-          const commandInfo = this.getNextCommand(curl, i);
-          i = commandInfo.index + 1;
-          command = commandInfo.data;
-        }
-        i = this.skipSpace(curl, i);
-        if (i < curl.length) {
-          const commandData = this.getNextCommandData(curl, i);
-          i = commandData.index;
-          const data = result[command];
-          if (data) {
-            data.push(commandData.data);
-          } else {
-            result[command] = [commandData.data];
-          }
-          ++i;
-        }
-      }
-    }
-    return result;
-  }
-
-  private skipSpace(curl: string, index: number): number {
-    while (curl[index] === ' ') {
-      ++index;
-    }
-    return index;
-  }
-
-  private getNextCommandData(curl: string, i: number): { data: string; index: number } {
-    const startsWith = curl[i];
-    let data = '';
-    const startIndex = i;
-    if (startsWith === "'" || startsWith === '"') {
-      ++i;
-      while (i < curl.length && (curl[i] !== startsWith || (curl[i] === startsWith && curl[i - 1] === '\\'))) {
-        ++i;
-      }
-      data = curl.substring(startIndex + 1, i);
-    } else {
-      i = curl.indexOf(' ', startIndex);
-      if (i === -1) {
-        i = curl.length;
-      }
-      data = curl.substring(startIndex, i);
-    }
-    return {
-      data,
-      index: i,
-    };
-  }
-
-  private getNextCommand(curl: string, i: number): { data: string; index: number } {
-    let startCommandIndex = i + 1;
-    if (curl[i + 1] === '-') {
-      ++startCommandIndex;
-    }
-    i = curl.indexOf(' ', startCommandIndex);
-    return {
-      data: curl.substring(startCommandIndex, i),
-      index: i === -1 ? curl.length : i,
-    };
   }
 
   private formatJSON(data: string): string {

--- a/bridge/server/services/data-service.ts
+++ b/bridge/server/services/data-service.ts
@@ -14,7 +14,7 @@ import { Shipyard } from '../interfaces/shipyard';
 import { UniformRegistrationLocations } from '../../shared/interfaces/uniform-registration-locations';
 import { WebhookConfig, WebhookConfigFilter, WebhookSecret } from '../../shared/models/webhook-config';
 import { UniformRegistrationInfo } from '../../shared/interfaces/uniform-registration-info';
-import { WebhookConfigYaml } from '../interfaces/webhook-config-yaml';
+import { WebhookConfigYaml } from '../models/webhook-config-yaml';
 import { UniformSubscription, UniformSubscriptionFilter } from '../../shared/interfaces/uniform-subscription';
 import axios from 'axios';
 import { Resource } from '../../shared/interfaces/resource';
@@ -34,6 +34,7 @@ import { Remediation } from '../models/remediation';
 import { IStage } from '../../shared/interfaces/stage';
 import { ISequencesMetadata, SequenceMetadataDeployment } from '../../shared/interfaces/sequencesMetadata';
 import { SecretScope, SecretScopeDefault } from '../../shared/interfaces/secret-scope';
+import { generateWebhookConfigCurl } from '../utils/curl.utils';
 
 type TreeDirectory = ({ _: string[] } & { [key: string]: TreeDirectory }) | { _: string[] };
 type FlatSecret = { path: string; name: string; key: string; parsedPath: string };
@@ -839,7 +840,7 @@ export class DataService {
     }
 
     const secrets = await this.parseAndReplaceWebhookSecret(accessToken, webhookConfig);
-    const curl = this.generateWebhookConfigCurl(webhookConfig);
+    const curl = generateWebhookConfigCurl(webhookConfig);
 
     for (const project of currentFilters.projects) {
       for (const stage of currentFilters.stages) {
@@ -974,27 +975,6 @@ export class DataService {
       stages: webhookConfig.stages?.length ? webhookConfig.stages : [undefined],
       services: webhookConfig.services?.length ? webhookConfig.services : [undefined],
     };
-  }
-
-  private generateWebhookConfigCurl(webhookConfig: WebhookConfig): string {
-    let params = '';
-    for (const header of webhookConfig?.header || []) {
-      params += `--header '${header.name}: ${header.value}' `;
-    }
-    params += `--request ${webhookConfig.method} `;
-    if (webhookConfig.proxy) {
-      params += `--proxy ${webhookConfig.proxy} `;
-    }
-    if (webhookConfig.payload) {
-      let stringify = webhookConfig.payload;
-      try {
-        stringify = JSON.stringify(JSON.parse(webhookConfig.payload));
-      } catch {
-        stringify = stringify.replace(/\r\n|\n|\r/gm, '');
-      }
-      params += `--data '${stringify}' `;
-    }
-    return `curl ${params}${webhookConfig.url}`;
   }
 
   public async deleteSubscription(

--- a/bridge/server/utils/curl.utils.spec.ts
+++ b/bridge/server/utils/curl.utils.spec.ts
@@ -1,0 +1,109 @@
+import { WebhookConfig } from '../../shared/models/webhook-config';
+import { generateWebhookConfigCurl, parseCurl } from './curl.utils';
+
+describe('Test curl-parser', () => {
+  it('should generate webhook curl', () => {
+    const webhookConfig: WebhookConfig = Object.assign(new WebhookConfig(), {
+      url: 'http://keptn.sh/asdf asdf',
+      type: 'sh.keptn.event.deployment.started',
+      header: [
+        {
+          name: 'content-type',
+          value: 'application/json',
+        },
+        {
+          name: 'Authorization',
+          value: 'Bearer myToken',
+        },
+      ],
+      proxy: 'http://keptn.sh/proxy',
+      payload: '{\n  "data": "myData"\n}',
+      method: 'GET',
+      secrets: [
+        {
+          name: 'mySecret',
+          secretRef: {
+            name: 'myName',
+            key: 'myKey',
+          },
+        },
+      ],
+      sendFinished: false,
+    });
+    expect(generateWebhookConfigCurl(webhookConfig)).toBe(
+      `curl --header 'content-type: application/json' --header 'Authorization: Bearer myToken' --request GET --proxy http://keptn.sh/proxy --data '{"data":"myData"}' http://keptn.sh/asdf asdf`
+    );
+  });
+
+  it('should not add header if not provided', () => {
+    const webhookConfig: WebhookConfig = Object.assign(new WebhookConfig(), {
+      url: 'http://keptn.sh/asdf asdf',
+      type: 'sh.keptn.event.deployment.started',
+      proxy: 'http://keptn.sh/proxy',
+      payload: '{\n  "data": "myData"\n}',
+      method: 'GET',
+      secrets: [],
+      sendFinished: false,
+    });
+    expect(generateWebhookConfigCurl(webhookConfig)).toBe(
+      `curl --request GET --proxy http://keptn.sh/proxy --data '{"data":"myData"}' http://keptn.sh/asdf asdf`
+    );
+  });
+
+  it('should not add proxy if not provided', () => {
+    const webhookConfig: WebhookConfig = Object.assign(new WebhookConfig(), {
+      url: 'http://keptn.sh/asdf asdf',
+      type: 'sh.keptn.event.deployment.started',
+      proxy: '',
+      payload: '{\n  "data": "myData"\n}',
+      method: 'GET',
+      secrets: [],
+      sendFinished: false,
+    });
+    expect(generateWebhookConfigCurl(webhookConfig)).toBe(
+      `curl --request GET --data '{"data":"myData"}' http://keptn.sh/asdf asdf`
+    );
+  });
+
+  it('should not add data if not provided', () => {
+    const webhookConfig: WebhookConfig = Object.assign(new WebhookConfig(), {
+      url: 'http://keptn.sh/asdf',
+      type: 'sh.keptn.event.deployment.started',
+      proxy: '',
+      payload: '',
+      method: 'GET',
+      secrets: [],
+      sendFinished: false,
+    });
+    expect(generateWebhookConfigCurl(webhookConfig)).toBe(`curl --request GET http://keptn.sh/asdf`);
+  });
+
+  it('should remove new lines in payload', () => {
+    const webhookConfig: WebhookConfig = Object.assign(new WebhookConfig(), {
+      url: 'http://keptn.sh/asdf',
+      type: 'sh.keptn.event.deployment.started',
+      proxy: '',
+      payload: '\r\n<meta>myText</meta>\n<meta2>myOtherText</meta2>',
+      method: 'GET',
+      secrets: [],
+      sendFinished: false,
+    });
+    expect(generateWebhookConfigCurl(webhookConfig)).toBe(
+      `curl --request GET --data '<meta>myText</meta><meta2>myOtherText</meta2>' http://keptn.sh/asdf`
+    );
+  });
+
+  it('should parse curl correctly', () => {
+    expect(
+      parseCurl(
+        `curl http://keptn.sh/asdf asdf --request GET --header 'content-type: application/json' --header 'Authorization: Bearer myToken' --proxy http://keptn.sh/proxy --data '{"data": "myData"}'`
+      )
+    ).toEqual({
+      _: ['http://keptn.sh/asdf', 'asdf'],
+      request: ['GET'],
+      header: ['content-type: application/json', 'Authorization: Bearer myToken'],
+      proxy: ['http://keptn.sh/proxy'],
+      data: ['{"data": "myData"}'],
+    });
+  });
+});

--- a/bridge/server/utils/curl.utils.ts
+++ b/bridge/server/utils/curl.utils.ts
@@ -1,0 +1,96 @@
+import { WebhookConfig } from '../../shared/models/webhook-config';
+
+function generateWebhookConfigCurl(webhookConfig: WebhookConfig): string {
+  let params = '';
+  for (const header of webhookConfig?.header || []) {
+    params += `--header '${header.name}: ${header.value}' `;
+  }
+  params += `--request ${webhookConfig.method} `;
+  if (webhookConfig.proxy) {
+    params += `--proxy ${webhookConfig.proxy} `;
+  }
+  if (webhookConfig.payload) {
+    let stringify = webhookConfig.payload;
+    try {
+      stringify = JSON.stringify(JSON.parse(webhookConfig.payload));
+    } catch {
+      stringify = stringify.replace(/\r\n|\n|\r/gm, '');
+    }
+    params += `--data '${stringify}' `;
+  }
+  return `curl ${params}${webhookConfig.url}`;
+}
+
+function parseCurl(curl: string): { [key: string]: string[] } {
+  const startCommand = 'curl ';
+  const result: { [key: string]: string[] } = {};
+  if (curl.startsWith(startCommand)) {
+    let i = startCommand.length;
+    while (i < curl.length) {
+      i = skipSpace(curl, i);
+      let command = '_';
+      if (curl[i] === '-') {
+        const commandInfo = getNextCommand(curl, i);
+        i = commandInfo.index + 1;
+        command = commandInfo.data;
+      }
+      i = skipSpace(curl, i);
+      if (i < curl.length) {
+        const commandData = getNextCommandData(curl, i);
+        i = commandData.index;
+        const data = result[command];
+        if (data) {
+          data.push(commandData.data);
+        } else {
+          result[command] = [commandData.data];
+        }
+        ++i;
+      }
+    }
+  }
+  return result;
+}
+
+function skipSpace(curl: string, index: number): number {
+  while (curl[index] === ' ') {
+    ++index;
+  }
+  return index;
+}
+
+function getNextCommandData(curl: string, i: number): { data: string; index: number } {
+  const startsWith = curl[i];
+  let data = '';
+  const startIndex = i;
+  if (startsWith === "'" || startsWith === '"') {
+    ++i;
+    while (i < curl.length && (curl[i] !== startsWith || (curl[i] === startsWith && curl[i - 1] === '\\'))) {
+      ++i;
+    }
+    data = curl.substring(startIndex + 1, i);
+  } else {
+    i = curl.indexOf(' ', startIndex);
+    if (i === -1) {
+      i = curl.length;
+    }
+    data = curl.substring(startIndex, i);
+  }
+  return {
+    data,
+    index: i,
+  };
+}
+
+function getNextCommand(curl: string, i: number): { data: string; index: number } {
+  let startCommandIndex = i + 1;
+  if (curl[i + 1] === '-') {
+    ++startCommandIndex;
+  }
+  i = curl.indexOf(' ', startCommandIndex);
+  return {
+    data: curl.substring(startCommandIndex, i),
+    index: i === -1 ? curl.length : i,
+  };
+}
+
+export { parseCurl, generateWebhookConfigCurl };


### PR DESCRIPTION
Fixes #7000 
- The user is now not allowed to enter spaces for the URL (it has to be encoded)
- If the webhook.yaml contains spaces inside the URL, the full URL is now returned instead of the first part before the space

Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>