### PR TITLE
chore(distributor): cleanip of package structure

### DIFF
--- a/distributor/pkg/clientget/client.go
+++ b/distributor/pkg/clientget/client.go
@@ -1,4 +1,4 @@
-package client
+package clientget
 
 import (
 	"context"

--- a/distributor/pkg/clientget/client_test.go
+++ b/distributor/pkg/clientget/client_test.go
@@ -1,4 +1,4 @@
-package client
+package clientget
 
 import (
 	"fmt"

--- a/distributor/pkg/forwarder/forwarder.go
+++ b/distributor/pkg/forwarder/forwarder.go
@@ -1,4 +1,4 @@
-package events
+package forwarder
 
 import (
 	"context"
@@ -9,6 +9,7 @@ import (
 	api "github.com/keptn/go-utils/pkg/api/utils"
 	"github.com/keptn/go-utils/pkg/lib/v0_2_0"
 	"github.com/keptn/keptn/distributor/pkg/config"
+	"github.com/keptn/keptn/distributor/pkg/utils"
 	logger "github.com/sirupsen/logrus"
 	"io/ioutil"
 	"net/http"
@@ -26,7 +27,7 @@ type Forwarder struct {
 	env               config.EnvConfig
 }
 
-func NewForwarder(keptnEventAPI api.APIV1Interface, client *http.Client, env config.EnvConfig) *Forwarder {
+func New(keptnEventAPI api.APIV1Interface, client *http.Client, env config.EnvConfig) *Forwarder {
 	return &Forwarder{
 		EventChannel:      make(chan cloudevents.Event),
 		keptnEventAPI:     keptnEventAPI,
@@ -36,7 +37,7 @@ func NewForwarder(keptnEventAPI api.APIV1Interface, client *http.Client, env con
 	}
 }
 
-func (f *Forwarder) Start(executionContext *ExecutionContext) {
+func (f *Forwarder) Start(executionContext *utils.ExecutionContext) {
 	mux := http.NewServeMux()
 	mux.Handle("/health", http.HandlerFunc(api.HealthEndpointHandler))
 	mux.Handle(f.env.EventForwardingPath, http.HandlerFunc(f.handleEvent))
@@ -78,7 +79,7 @@ func (f *Forwarder) handleEvent(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	event, err := DecodeNATSMessage(body)
+	event, err := utils.DecodeNATSMessage(body)
 	if err != nil {
 		logger.Errorf("Failed to decode CloudEvent: %v", err)
 		rw.WriteHeader(http.StatusInternalServerError)

--- a/distributor/pkg/model/model.go
+++ b/distributor/pkg/model/model.go
@@ -1,4 +1,4 @@
-package events
+package model
 
 // AdditionalSubscriptionData is the data the distributor
 // will add as temporary data to the keptn events forwarded

--- a/distributor/pkg/natsconnection/nats_connection_handler.go
+++ b/distributor/pkg/natsconnection/nats_connection_handler.go
@@ -1,4 +1,4 @@
-package events
+package natsconnection
 
 import (
 	"errors"
@@ -11,11 +11,11 @@ import (
 )
 
 type NatsConnectionHandler struct {
+	MessageHandler func(m *nats.Msg)
 	natsConnection *nats.Conn
 	subscriptions  []*nats.Subscription
 	topics         []string
 	natsURL        string
-	messageHandler func(m *nats.Msg)
 	mux            sync.Mutex
 }
 
@@ -87,7 +87,7 @@ func (nch *NatsConnectionHandler) QueueSubscribeToTopics(topics []string, queueG
 
 		for _, topic := range nch.topics {
 			logger.Infof("Subscribing to topic '%s' with queue group '%s'", topic, queueGroup)
-			sub, err := nch.natsConnection.QueueSubscribe(topic, queueGroup, nch.messageHandler)
+			sub, err := nch.natsConnection.QueueSubscribe(topic, queueGroup, nch.MessageHandler)
 			if err != nil {
 				return errors.New("failed to subscribe to topic: " + err.Error())
 			}

--- a/distributor/pkg/poller/poller_test.go
+++ b/distributor/pkg/poller/poller_test.go
@@ -1,4 +1,4 @@
-package events
+package poller
 
 import (
 	"context"
@@ -10,6 +10,7 @@ import (
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 	keptnfake "github.com/keptn/go-utils/pkg/lib/v0_2_0/fake"
 	"github.com/keptn/keptn/distributor/pkg/config"
+	"github.com/keptn/keptn/distributor/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
@@ -86,10 +87,10 @@ func Test_PollAndForwardEvents1(t *testing.T) {
 	}
 	eventSender := keptnfake.EventSender{}
 	apiset, _ := keptnapi.New(server.URL)
-	poller := NewPoller(envConfig, apiset.ShipyardControlV1(), &eventSender)
+	poller := New(envConfig, apiset.ShipyardControlV1(), &eventSender)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	executionContext := NewExecutionContext(ctx, 1)
+	executionContext := utils.NewExecutionContext(ctx, 1)
 	poller.UpdateSubscriptions([]keptnmodels.EventSubscription{
 		{
 			ID:    "id1",
@@ -176,10 +177,10 @@ func Test_PollAndForwardEvents2(t *testing.T) {
 	eventSender := keptnfake.EventSender{}
 
 	apiset, _ := keptnapi.New(server.URL)
-	poller := NewPoller(envConfig, apiset.ShipyardControlV1(), &eventSender)
+	poller := New(envConfig, apiset.ShipyardControlV1(), &eventSender)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	executionContext := NewExecutionContext(ctx, 1)
+	executionContext := utils.NewExecutionContext(ctx, 1)
 
 	numSubscriptions := 100
 	subscriptions := []keptnmodels.EventSubscription{}

--- a/distributor/pkg/uniform/controlplane/controlplane.go
+++ b/distributor/pkg/uniform/controlplane/controlplane.go
@@ -24,7 +24,7 @@ type ControlPlane struct {
 	env            config.EnvConfig
 }
 
-func NewControlPlane(uniformHandler api.UniformV1Interface, connectionType config.ConnectionType, env config.EnvConfig) *ControlPlane {
+func New(uniformHandler api.UniformV1Interface, connectionType config.ConnectionType, env config.EnvConfig) *ControlPlane {
 	return &ControlPlane{
 		uniformHandler: uniformHandler,
 		connectionType: connectionType,

--- a/distributor/pkg/uniform/controlplane/controlplane_test.go
+++ b/distributor/pkg/uniform/controlplane/controlplane_test.go
@@ -66,7 +66,7 @@ func TestControlPlaneRegister(t *testing.T) {
 		PubSubTopic:        "t1,t2",
 	}
 
-	controlPlane := NewControlPlane(api.NewUniformHandler(server.URL), config.ConnectionTypeNATS, cfg)
+	controlPlane := New(api.NewUniformHandler(server.URL), config.ConnectionTypeNATS, cfg)
 	id, err := controlPlane.Register()
 	assert.Nil(t, err)
 	assert.Equal(t, "abcde", id)
@@ -83,7 +83,7 @@ func TestControlPlaneRegisterFails(t *testing.T) {
 	}))
 	defer server.Close()
 
-	controlPlane := NewControlPlane(api.NewUniformHandler(server.URL), config.ConnectionTypeNATS, config.EnvConfig{})
+	controlPlane := New(api.NewUniformHandler(server.URL), config.ConnectionTypeNATS, config.EnvConfig{})
 	id, err := controlPlane.Register()
 	assert.NotNil(t, err)
 	assert.Equal(t, "", id)
@@ -100,7 +100,7 @@ func TestControlPlaneUnregister(t *testing.T) {
 	}))
 	defer server.Close()
 
-	controlPlane := NewControlPlane(api.NewUniformHandler(server.URL), config.ConnectionTypeNATS, config.EnvConfig{})
+	controlPlane := New(api.NewUniformHandler(server.URL), config.ConnectionTypeNATS, config.EnvConfig{})
 	controlPlane.Register()
 	err := controlPlane.Unregister()
 	assert.Nil(t, err)
@@ -118,7 +118,7 @@ func TestControlPlaneUnregisterFails(t *testing.T) {
 	}))
 	defer server.Close()
 
-	controlPlane := NewControlPlane(api.NewUniformHandler(server.URL), config.ConnectionTypeNATS, config.EnvConfig{})
+	controlPlane := New(api.NewUniformHandler(server.URL), config.ConnectionTypeNATS, config.EnvConfig{})
 	controlPlane.Register()
 	err := controlPlane.Unregister()
 	assert.NotNil(t, err)
@@ -131,7 +131,7 @@ func TestControlPlaneUnregisterWithoutPreviousRegister(t *testing.T) {
 	}))
 	defer server.Close()
 
-	controlPlane := NewControlPlane(api.NewUniformHandler(server.URL), config.ConnectionTypeNATS, config.EnvConfig{})
+	controlPlane := New(api.NewUniformHandler(server.URL), config.ConnectionTypeNATS, config.EnvConfig{})
 	err := controlPlane.Unregister()
 	assert.NotNil(t, err)
 	assert.False(t, endpointInvoked)

--- a/distributor/pkg/uniform/log/uniformlog.go
+++ b/distributor/pkg/uniform/log/uniformlog.go
@@ -1,4 +1,4 @@
-package controlplane
+package log
 
 import (
 	"context"
@@ -20,7 +20,7 @@ type EventUniformLog struct {
 	logHandler    keptn.ILogHandler
 }
 
-func NewEventUniformLog(integrationID string, logHandler keptn.LogsV1Interface) *EventUniformLog {
+func New(integrationID string, logHandler keptn.LogsV1Interface) *EventUniformLog {
 	return &EventUniformLog{
 		IntegrationID: integrationID,
 		logHandler:    logHandler,
@@ -35,7 +35,7 @@ func (l *EventUniformLog) Start(ctx context.Context, eventChannel chan cloudeven
 			select {
 			case event := <-eventChannel:
 				logger.Debugf("Received event: %s", event.Context.GetType())
-				if err := l.OnEvent(event); err != nil {
+				if err := l.onEvent(event); err != nil {
 					logger.Errorf("Could not handle event: %v", err)
 				}
 			case <-ctx.Done():
@@ -46,7 +46,7 @@ func (l *EventUniformLog) Start(ctx context.Context, eventChannel chan cloudeven
 	}()
 }
 
-func (l *EventUniformLog) OnEvent(event cloudevents.Event) error {
+func (l *EventUniformLog) onEvent(event cloudevents.Event) error {
 	keptnEvent, err := keptnv2.ToKeptnEvent(event)
 	if err != nil {
 		return fmt.Errorf("could not decode CloudEvent to Keptn event: %w", err)

--- a/distributor/pkg/uniform/log/uniformlog_test.go
+++ b/distributor/pkg/uniform/log/uniformlog_test.go
@@ -1,4 +1,4 @@
-package controlplane
+package log
 
 import (
 	"context"
@@ -17,7 +17,7 @@ func TestEventUniformLog_LogEvent(t *testing.T) {
 	newEvent := event.New()
 	newEvent.SetType("random-event")
 
-	err := uniformLog.OnEvent(newEvent)
+	err := uniformLog.onEvent(newEvent)
 
 	require.Nil(t, err)
 	require.Empty(t, fakeLogHandler.LogCalls())
@@ -33,7 +33,7 @@ func TestEventUniformLog_LogEvent(t *testing.T) {
 	newEvent.SetExtension("triggeredid", "my-triggered-id")
 	newEvent.SetData(event.ApplicationJSON, logEventData)
 
-	err = uniformLog.OnEvent(newEvent)
+	err = uniformLog.onEvent(newEvent)
 
 	require.Nil(t, err)
 	require.NotEmpty(t, fakeLogHandler.LogCalls())
@@ -55,7 +55,7 @@ func TestEventUniformLog_LogEventInvalidPayload(t *testing.T) {
 	// send sh.keptn.log.error event with invalid payload -> should result in an error
 	newEvent.SetData(event.TextJSON, "invalid")
 
-	err := uniformLog.OnEvent(newEvent)
+	err := uniformLog.onEvent(newEvent)
 
 	require.NotNil(t, err)
 	require.Empty(t, fakeLogHandler.LogCalls())
@@ -75,7 +75,7 @@ func TestEventUniformLog_TaskFinishedWithErroredStatus(t *testing.T) {
 	}
 	newEvent.SetData(event.ApplicationJSON, finishedData)
 
-	err := uniformLog.OnEvent(newEvent)
+	err := uniformLog.onEvent(newEvent)
 
 	require.Nil(t, err)
 	require.Len(t, fakeLogHandler.LogCalls(), 1)
@@ -100,7 +100,7 @@ func TestEventUniformLog_TaskFinishedWithSucceedStatus(t *testing.T) {
 	}
 	newEvent.SetData(event.ApplicationJSON, finishedData)
 
-	err := uniformLog.OnEvent(newEvent)
+	err := uniformLog.onEvent(newEvent)
 
 	require.Nil(t, err)
 	require.Empty(t, fakeLogHandler.LogCalls())
@@ -119,7 +119,7 @@ func TestEventUniformLog_TaskFinishedWithSucceedStatusAndResultFail(t *testing.T
 	}
 	newEvent.SetData(event.ApplicationJSON, finishedData)
 
-	err := uniformLog.OnEvent(newEvent)
+	err := uniformLog.onEvent(newEvent)
 
 	require.Nil(t, err)
 	require.Empty(t, fakeLogHandler.LogCalls())
@@ -133,7 +133,7 @@ func TestEventUniformLog_TaskFinishedWithInvalidData(t *testing.T) {
 
 	newEvent.SetData(event.TextJSON, "invalid")
 
-	err := uniformLog.OnEvent(newEvent)
+	err := uniformLog.onEvent(newEvent)
 
 	require.NotNil(t, err)
 	require.Empty(t, fakeLogHandler.LogCalls())
@@ -151,7 +151,7 @@ func getTestUniformLogger() (*fakeapi.ILogHandlerMock, *EventUniformLog) {
 
 		},
 	}
-	uniformLog := NewEventUniformLog(
+	uniformLog := New(
 		"my-id",
 		fakeLogHandler,
 	)

--- a/distributor/pkg/uniform/watch/uniformwatch.go
+++ b/distributor/pkg/uniform/watch/uniformwatch.go
@@ -1,10 +1,10 @@
-package events
+package watch
 
 import (
 	"context"
 	"github.com/keptn/go-utils/pkg/api/models"
 	"github.com/keptn/go-utils/pkg/common/retry"
-	"github.com/keptn/keptn/distributor/pkg/lib/controlplane"
+	"github.com/keptn/keptn/distributor/pkg/uniform/controlplane"
 	logger "github.com/sirupsen/logrus"
 	"time"
 )
@@ -19,7 +19,7 @@ type UniformWatch struct {
 	pingInterval time.Duration
 }
 
-func NewUniformWatch(controlPlane controlplane.IControlPlane) *UniformWatch {
+func New(controlPlane controlplane.IControlPlane) *UniformWatch {
 	return &UniformWatch{
 		controlPlane: controlPlane,
 		pingInterval: 10 * time.Second,
@@ -69,11 +69,6 @@ func (sw *UniformWatch) RegisterListener(listener SubscriptionListener) {
 
 type SubscriptionListener interface {
 	UpdateSubscriptions([]models.EventSubscription)
-}
-
-func NewTestUniformWatch(subscriptions []models.EventSubscription) *TestUniformWatch {
-	t := &TestUniformWatch{subscriptions}
-	return t
 }
 
 type TestUniformWatch struct {

--- a/distributor/pkg/uniform/watch/uniformwatch_test.go
+++ b/distributor/pkg/uniform/watch/uniformwatch_test.go
@@ -1,4 +1,4 @@
-package events
+package watch
 
 import (
 	"context"
@@ -9,7 +9,7 @@ import (
 )
 
 func Test_UniformWatchReturnsRegistrationID(t *testing.T) {
-	uw := NewUniformWatch(&testControlPlane{})
+	uw := New(&testControlPlane{})
 	uw.RegisterListener(&testListener{})
 
 	id := uw.Start(context.TODO())
@@ -28,7 +28,7 @@ func Test_UniformWatchUpdatesListeners(t *testing.T) {
 	controlPlane := &testControlPlane{
 		integrationData: expectedUpdateData,
 	}
-	uw := NewUniformWatch(controlPlane)
+	uw := New(controlPlane)
 	uw.pingInterval = 100 * time.Millisecond
 	uw.RegisterListener(listener)
 	uw.Start(context.TODO())

--- a/distributor/pkg/utils/utils.go
+++ b/distributor/pkg/utils/utils.go
@@ -1,4 +1,4 @@
-package events
+package utils
 
 import (
 	"context"
@@ -203,15 +203,6 @@ func (c *Cache) containsSlice(key string, elements []string) bool {
 	return contains
 }
 
-// ToIDs takes a list of cloud events and returns a list of ids of the given cloud events
-func ToIDs(events []*keptnmodels.KeptnContextExtendedCE) []string {
-	ids := []string{}
-	for _, e := range events {
-		ids = append(ids, e.ID)
-	}
-	return ids
-}
-
 // Dedup removes duplicate elements from the given list of strings
 func Dedup(elements []string) []string {
 	result := make([]string, 0, len(elements))
@@ -223,4 +214,12 @@ func Dedup(elements []string) []string {
 		}
 	}
 	return result
+}
+
+func ToIds(events []*keptnmodels.KeptnContextExtendedCE) []string {
+	ids := []string{}
+	for _, e := range events {
+		ids = append(ids, e.ID)
+	}
+	return ids
 }

--- a/distributor/pkg/utils/utils_test.go
+++ b/distributor/pkg/utils/utils_test.go
@@ -1,4 +1,4 @@
-package events
+package utils
 
 import (
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -422,7 +422,7 @@ func Test_toIDs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := ToIDs(tt.args.events); !reflect.DeepEqual(got, tt.want) {
+			if got := ToIds(tt.args.events); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("ToIDs() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
The distributor code did not follow a clean package structure.
This PR tries to improve on this. Packages are now much smaller and semantically divided as much as possible:

![image](https://user-images.githubusercontent.com/72415058/156206400-e8f17473-de7b-4f49-b016-69c06daad2f4.png)
