### PR TITLE
fix(bridge): Fix quick filter overflow

### DIFF
--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.scss
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.scss
@@ -30,7 +30,20 @@ ktb-event-item.focused {
   animation-delay: 0.5s;
 }
 
+/* Barista fix/feature on fixed height (adjust filter height to height of page) */
 dt-quick-filter dt-drawer {
   overflow-y: auto;
   overflow-x: hidden;
+  min-width: 230px;
+}
+
+.dt-quick-filter-detail {
+  dt-quick-filter-group {
+    height: calc(100% - 35px) !important;
+    padding: 0 !important;
+  }
+
+  dt-quick-filter-group .dt-quick-filter-group-items, cdk-virtual-scroll-viewport {
+    height: 100% !important;
+  }
 }


### PR DESCRIPTION
Fixes #6989 
The quick filter is not intended to have a pre-defined height. However, this is fixed/implemented now.

Before:
![image](https://user-images.githubusercontent.com/11599148/157030177-9922e691-1606-4de4-8f42-d11816f20f4c.png)

and if the width of the page was a little bit smaller then the second scrollbar disappeared:
![image](https://user-images.githubusercontent.com/11599148/157030302-ddb520eb-4be4-41f5-beb8-e2002598628f.png)


After:
![image](https://user-images.githubusercontent.com/11599148/157029902-d41b3081-9383-40f3-b45a-c81a4e5503d4.png)


Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>