### PR TITLE
test: Fix missing image in k3d integration test setup

### DIFF
--- a/installer/airgapped/pull_and_retag_images.sh
+++ b/installer/airgapped/pull_and_retag_images.sh
@@ -16,7 +16,7 @@ fi
 
 IMAGES_CONTROL_PLANE_THIRD_PARTY=(
   "bitnami/mongodb:4.4.9-debian-10-r0"
-  "nats:2.7.3-alpine"
+  "nats:2.7.2-alpine"
   "natsio/nats-server-config-reloader:0.6.3"
   "natsio/prometheus-nats-exporter:0.9.1"
   "nginxinc/nginx-unprivileged:1.21.4-alpine"


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- fixes the k3d integration test setup by using the correct image version for nats (`nats:2.7.2-alpine`)

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Part of #7098

