### PR TITLE
test(bridge): Fix flaky UI test

### DIFF
--- a/bridge/cypress/integration/environment.spec.ts
+++ b/bridge/cypress/integration/environment.spec.ts
@@ -19,22 +19,14 @@ describe('Environment Screen empty', () => {
   });
 });
 
-describe('Environment Screen', () => {
+describe('Environment Screen default requests', () => {
   const environmentPage = new EnvironmentPage();
   const project = 'sockshop';
   const stage = 'dev';
 
   beforeEach(() => {
     interceptEnvironmentScreen();
-    environmentPage.visit('sockshop');
-  });
-
-  it('should show evaluation history loading indicators', () => {
-    const service = 'carts';
-    cy.intercept(environmentPage.getEvaluationHistoryURL(project, stage, service, 6), {
-      delay: 10_000,
-    });
-    environmentPage.selectStage(stage).assertEvaluationHistoryLoadingCount(service, 5);
+    environmentPage.visit(project);
   });
 
   it('should not show evaluation history loading indicators', () => {
@@ -48,6 +40,32 @@ describe('Environment Screen', () => {
   it('should not show evaluation', () => {
     environmentPage.selectStage(stage).assertEvaluationInDetails('carts-db', '-');
   });
+});
+
+describe('Environment Screen dynamic requests', () => {
+  const environmentPage = new EnvironmentPage();
+  const project = 'sockshop';
+  const stage = 'dev';
+
+  beforeEach(() => {
+    interceptEnvironmentScreen();
+  });
+
+  it('should show evaluation history loading indicators', () => {
+    const service = 'carts';
+    cy.intercept(environmentPage.getEvaluationHistoryURL(project, stage, service, 6), {
+      delay: 10_000,
+    });
+    environmentPage.visit(project).selectStage(stage).assertEvaluationHistoryLoadingCount(service, 5);
+  });
+
+  it('should show evaluation history loading indicators', () => {
+    const service = 'carts';
+    cy.intercept(environmentPage.getEvaluationHistoryURL(project, stage, service, 6), {
+      delay: 10_000,
+    });
+    environmentPage.visit(project).selectStage(stage).assertEvaluationHistoryLoadingCount(service, 5);
+  });
 
   it('should show evaluations in history if sequence does not have an evaluation task', () => {
     const service = 'carts-db';
@@ -55,6 +73,7 @@ describe('Environment Screen', () => {
       fixture: 'get.environment.evaluation.history.carts-db.mock',
     });
     environmentPage
+      .visit(project)
       .selectStage(stage)
       .assertEvaluationHistoryLoadingCount(service, 0)
       .assertEvaluationHistoryCount(service, 5)
@@ -67,6 +86,7 @@ describe('Environment Screen', () => {
       fixture: 'get.environment.evaluation.history.limited.mock', // 3 events, including the current one
     });
     environmentPage
+      .visit(project)
       .selectStage(stage)
       .assertEvaluationHistoryCount(service, 2)
       .assertEvaluationInDetails(service, 0, 'success');
@@ -78,6 +98,7 @@ describe('Environment Screen', () => {
       fixture: 'get.environment.evaluation.history.mock',
     });
     environmentPage
+      .visit(project)
       .selectStage(stage)
       .assertEvaluationHistoryCount(service, 5)
       .assertEvaluationInDetails(service, 0, 'success');

--- a/bridge/cypress/support/intercept.ts
+++ b/bridge/cypress/support/intercept.ts
@@ -66,8 +66,7 @@ export function interceptProjectBoard(): void {
 }
 
 export function interceptIntegrations(): void {
-  cy.intercept('/api/v1/metadata', { fixture: 'metadata.mock' });
-  cy.intercept('/api/bridgeInfo', { fixture: 'bridgeInfo.mock' });
+  interceptMain();
   cy.intercept('/api/project/sockshop?approval=true&remediation=true', { fixture: 'project.mock' });
   cy.intercept('/api/hasUnreadUniformRegistrationLogs', { body: false });
   cy.intercept('/api/controlPlane/v1/project?disableUpstreamSync=true&pageSize=50', { fixture: 'projects.mock' });

--- a/bridge/cypress/support/intercept.ts
+++ b/bridge/cypress/support/intercept.ts
@@ -54,7 +54,7 @@ function getEvaluationUrls(project: string, service: string): string[] {
 }
 
 export function interceptMain(): void {
-  cy.intercept('/api/v1/metadata', { fixture: 'metadata.mock' });
+  cy.intercept('/api/v1/metadata', { fixture: 'metadata.mock' }).as('metadata');
   cy.intercept('/api/bridgeInfo', { fixture: 'bridgeInfo.mock' });
 }
 

--- a/bridge/cypress/support/pageobjects/EnvironmentPage.ts
+++ b/bridge/cypress/support/pageobjects/EnvironmentPage.ts
@@ -179,7 +179,7 @@ class EnvironmentPage {
   }
 
   public visit(project: string): this {
-    cy.visit(`/project/${project}`);
+    cy.visit(`/project/${project}`).wait('@metadata');
     return this;
   }
 

--- a/bridge/cypress/support/pageobjects/UniformPage.ts
+++ b/bridge/cypress/support/pageobjects/UniformPage.ts
@@ -25,13 +25,20 @@ class UniformPage {
   EDIT_WEBHOOK_METHOD = 'edit-webhook-field-method';
   EDIT_WEBHOOK_PROXY = 'edit-webhook-field-proxy';
 
+  public visit(project: string): this {
+    cy.visit(`/project/${project}/settings/uniform/integrations`).wait('@metadata');
+    return this;
+  }
+
   public visitAdd(integrationID: string): this {
-    cy.visit(`/project/sockshop/settings/uniform/integrations/${integrationID}/subscriptions/add`);
+    cy.visit(`/project/sockshop/settings/uniform/integrations/${integrationID}/subscriptions/add`).wait('@metadata');
     return this;
   }
 
   public visitEdit(integrationID: string, subscriptionId: string): this {
-    cy.visit(`/project/sockshop/settings/uniform/integrations/${integrationID}/subscriptions/${subscriptionId}/edit`);
+    cy.visit(
+      `/project/sockshop/settings/uniform/integrations/${integrationID}/subscriptions/${subscriptionId}/edit`
+    ).wait('@metadata');
     return this;
   }
 


### PR DESCRIPTION
Sometimes some UI tests fail because of an empty page. To prevent this, we will wait until the metadata endpoint is called after the page is visited. Could be that this still does not work because of a bug in Cypress https://github.com/keptn/keptn/issues/7107
Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>
