### PR TITLE
fix(shipyard-controller): Make sure sequence queue is free again after aborting a sequence

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -515,7 +515,7 @@ jobs:
 
       - name: Integration Tests
         id: test_aggregated
-        timeout-minutes: 60
+        timeout-minutes: 100
         env:
           KEPTN_ENDPOINT: ${{ steps.determine_keptn_endpoint.outputs.KEPTN_ENDPOINT }}
           DO_AUTH: "true"
@@ -536,7 +536,7 @@ jobs:
             TESTSUITE="Test_K3D"
           fi
           
-          gotestsum --no-color=false -- -run "$TESTSUITE" -v -timeout 60m
+          gotestsum --no-color=false -- -run "$TESTSUITE" -v -timeout 100m
 
       - name: "------- TESTS END -------"
         run: echo "------- TESTS END -------"

--- a/shipyard-controller/db/mock/tasksequencerepo_mock.go
+++ b/shipyard-controller/db/mock/tasksequencerepo_mock.go
@@ -23,6 +23,9 @@ import (
 // 			DeleteTaskExecutionFunc: func(keptnContext string, project string, stage string, taskSequenceName string) error {
 // 				panic("mock out the DeleteTaskExecution method")
 // 			},
+// 			DeleteTaskExecutionsFunc: func(keptnContext string, project string, stage string) error {
+// 				panic("mock out the DeleteTaskExecutions method")
+// 			},
 // 			GetTaskExecutionsFunc: func(project string, filter models.TaskExecution) ([]models.TaskExecution, error) {
 // 				panic("mock out the GetTaskExecutions method")
 // 			},
@@ -41,6 +44,9 @@ type TaskSequenceRepoMock struct {
 
 	// DeleteTaskExecutionFunc mocks the DeleteTaskExecution method.
 	DeleteTaskExecutionFunc func(keptnContext string, project string, stage string, taskSequenceName string) error
+
+	// DeleteTaskExecutionsFunc mocks the DeleteTaskExecutions method.
+	DeleteTaskExecutionsFunc func(keptnContext string, project string, stage string) error
 
 	// GetTaskExecutionsFunc mocks the GetTaskExecutions method.
 	GetTaskExecutionsFunc func(project string, filter models.TaskExecution) ([]models.TaskExecution, error)
@@ -70,6 +76,15 @@ type TaskSequenceRepoMock struct {
 			// TaskSequenceName is the taskSequenceName argument value.
 			TaskSequenceName string
 		}
+		// DeleteTaskExecutions holds details about calls to the DeleteTaskExecutions method.
+		DeleteTaskExecutions []struct {
+			// KeptnContext is the keptnContext argument value.
+			KeptnContext string
+			// Project is the project argument value.
+			Project string
+			// Stage is the stage argument value.
+			Stage string
+		}
 		// GetTaskExecutions holds details about calls to the GetTaskExecutions method.
 		GetTaskExecutions []struct {
 			// Project is the project argument value.
@@ -78,10 +93,11 @@ type TaskSequenceRepoMock struct {
 			Filter models.TaskExecution
 		}
 	}
-	lockCreateTaskExecution sync.RWMutex
-	lockDeleteRepo          sync.RWMutex
-	lockDeleteTaskExecution sync.RWMutex
-	lockGetTaskExecutions   sync.RWMutex
+	lockCreateTaskExecution  sync.RWMutex
+	lockDeleteRepo           sync.RWMutex
+	lockDeleteTaskExecution  sync.RWMutex
+	lockDeleteTaskExecutions sync.RWMutex
+	lockGetTaskExecutions    sync.RWMutex
 }
 
 // CreateTaskExecution calls CreateTaskExecutionFunc.
@@ -190,6 +206,45 @@ func (mock *TaskSequenceRepoMock) DeleteTaskExecutionCalls() []struct {
 	mock.lockDeleteTaskExecution.RLock()
 	calls = mock.calls.DeleteTaskExecution
 	mock.lockDeleteTaskExecution.RUnlock()
+	return calls
+}
+
+// DeleteTaskExecutions calls DeleteTaskExecutionsFunc.
+func (mock *TaskSequenceRepoMock) DeleteTaskExecutions(keptnContext string, project string, stage string) error {
+	if mock.DeleteTaskExecutionsFunc == nil {
+		panic("TaskSequenceRepoMock.DeleteTaskExecutionsFunc: method is nil but TaskSequenceRepo.DeleteTaskExecutions was just called")
+	}
+	callInfo := struct {
+		KeptnContext string
+		Project      string
+		Stage        string
+	}{
+		KeptnContext: keptnContext,
+		Project:      project,
+		Stage:        stage,
+	}
+	mock.lockDeleteTaskExecutions.Lock()
+	mock.calls.DeleteTaskExecutions = append(mock.calls.DeleteTaskExecutions, callInfo)
+	mock.lockDeleteTaskExecutions.Unlock()
+	return mock.DeleteTaskExecutionsFunc(keptnContext, project, stage)
+}
+
+// DeleteTaskExecutionsCalls gets all the calls that were made to DeleteTaskExecutions.
+// Check the length with:
+//     len(mockedTaskSequenceRepo.DeleteTaskExecutionsCalls())
+func (mock *TaskSequenceRepoMock) DeleteTaskExecutionsCalls() []struct {
+	KeptnContext string
+	Project      string
+	Stage        string
+} {
+	var calls []struct {
+		KeptnContext string
+		Project      string
+		Stage        string
+	}
+	mock.lockDeleteTaskExecutions.RLock()
+	calls = mock.calls.DeleteTaskExecutions
+	mock.lockDeleteTaskExecutions.RUnlock()
 	return calls
 }
 

--- a/shipyard-controller/db/mongodb_task_sequence_repo.go
+++ b/shipyard-controller/db/mongodb_task_sequence_repo.go
@@ -88,7 +88,7 @@ func (mdbrepo *TaskSequenceMongoDBRepo) DeleteTaskExecution(keptnContext, projec
 	return nil
 }
 
-func (mdbrepo *TaskSequenceMongoDBRepo) DeleteTaskExecutions(keptnContext, project string) error {
+func (mdbrepo *TaskSequenceMongoDBRepo) DeleteTaskExecutions(keptnContext, project, stage string) error {
 	err := mdbrepo.DBConnection.EnsureDBConnection()
 	if err != nil {
 		return err
@@ -98,7 +98,12 @@ func (mdbrepo *TaskSequenceMongoDBRepo) DeleteTaskExecutions(keptnContext, proje
 
 	collection := mdbrepo.getTaskSequenceCollection(project)
 
-	_, err = collection.DeleteMany(ctx, bson.M{"keptnContext": keptnContext})
+	filter := bson.M{"keptnContext": keptnContext}
+	if stage != "" {
+		filter["stage"] = stage
+	}
+
+	_, err = collection.DeleteMany(ctx, filter)
 	if err != nil {
 		log.Errorf("Could not delete entries with context %s: %s", keptnContext, err.Error())
 		return err

--- a/shipyard-controller/db/mongodb_task_sequence_repo.go
+++ b/shipyard-controller/db/mongodb_task_sequence_repo.go
@@ -88,6 +88,24 @@ func (mdbrepo *TaskSequenceMongoDBRepo) DeleteTaskExecution(keptnContext, projec
 	return nil
 }
 
+func (mdbrepo *TaskSequenceMongoDBRepo) DeleteTaskExecutions(keptnContext, project string) error {
+	err := mdbrepo.DBConnection.EnsureDBConnection()
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	collection := mdbrepo.getTaskSequenceCollection(project)
+
+	_, err = collection.DeleteMany(ctx, bson.M{"keptnContext": keptnContext})
+	if err != nil {
+		log.Errorf("Could not delete entries with context %s: %s", keptnContext, err.Error())
+		return err
+	}
+	return nil
+}
+
 // DeleteTaskSequenceCollection godoc
 func (mdbrepo *TaskSequenceMongoDBRepo) DeleteRepo(project string) error {
 	err := mdbrepo.DBConnection.EnsureDBConnection()

--- a/shipyard-controller/db/mongodb_task_sequence_repo_test.go
+++ b/shipyard-controller/db/mongodb_task_sequence_repo_test.go
@@ -42,3 +42,39 @@ func Test_MongoDBTaskSequenceRepoInsertAndRetrieve(t *testing.T) {
 	require.Nil(t, err)
 	require.Len(t, sequences, 0)
 }
+
+func Test_MongoDBTaskSequenceRepoInsertAndRetrieveDeleteAll(t *testing.T) {
+	project := "my-project"
+	mdbrepo := NewTaskSequenceMongoDBRepo(GetMongoDBConnectionInstance())
+
+	err := mdbrepo.DeleteRepo(project)
+	require.Nil(t, err)
+
+	taskSequence := models.TaskExecution{
+		TaskSequenceName: "my-sequence",
+		TriggeredEventID: "my-triggered-id",
+		Task: models.Task{
+			Task: keptnv2.Task{
+				Name: "my-task",
+			},
+		},
+		Stage:        "my-stage",
+		Service:      "my-service",
+		KeptnContext: "my-context",
+	}
+
+	err = mdbrepo.CreateTaskExecution(project, taskSequence)
+	require.Nil(t, err)
+
+	sequences, err := mdbrepo.GetTaskExecutions(project, taskSequence)
+	require.Nil(t, err)
+	require.Len(t, sequences, 1)
+	require.Equal(t, taskSequence, sequences[0])
+
+	err = mdbrepo.DeleteTaskExecution("my-context", project, "my-stage", "my-sequence")
+	require.Nil(t, err)
+
+	sequences, err = mdbrepo.GetTaskExecutions(project, models.TaskExecution{TaskSequenceName: "my-sequence"})
+	require.Nil(t, err)
+	require.Len(t, sequences, 0)
+}

--- a/shipyard-controller/db/mongodb_task_sequence_repo_test.go
+++ b/shipyard-controller/db/mongodb_task_sequence_repo_test.go
@@ -43,14 +43,14 @@ func Test_MongoDBTaskSequenceRepoInsertAndRetrieve(t *testing.T) {
 	require.Len(t, sequences, 0)
 }
 
-func Test_MongoDBTaskSequenceRepoInsertAndRetrieveDeleteAll(t *testing.T) {
+func Test_MongoDBTaskSequenceRepoInsertAndRetrieveDeleteAllInAllStages(t *testing.T) {
 	project := "my-project"
 	mdbrepo := NewTaskSequenceMongoDBRepo(GetMongoDBConnectionInstance())
 
 	err := mdbrepo.DeleteRepo(project)
 	require.Nil(t, err)
 
-	taskSequence := models.TaskExecution{
+	taskSequence1 := models.TaskExecution{
 		TaskSequenceName: "my-sequence",
 		TriggeredEventID: "my-triggered-id",
 		Task: models.Task{
@@ -63,18 +63,102 @@ func Test_MongoDBTaskSequenceRepoInsertAndRetrieveDeleteAll(t *testing.T) {
 		KeptnContext: "my-context",
 	}
 
-	err = mdbrepo.CreateTaskExecution(project, taskSequence)
+	taskSequence2 := models.TaskExecution{
+		TaskSequenceName: "my-sequence",
+		TriggeredEventID: "my-triggered-id",
+		Task: models.Task{
+			Task: keptnv2.Task{
+				Name: "my-task",
+			},
+		},
+		Stage:        "my-stage-2",
+		Service:      "my-service",
+		KeptnContext: "my-context",
+	}
+
+	err = mdbrepo.CreateTaskExecution(project, taskSequence1)
 	require.Nil(t, err)
 
-	sequences, err := mdbrepo.GetTaskExecutions(project, taskSequence)
+	err = mdbrepo.CreateTaskExecution(project, taskSequence2)
+	require.Nil(t, err)
+
+	sequences, err := mdbrepo.GetTaskExecutions(project, taskSequence1)
 	require.Nil(t, err)
 	require.Len(t, sequences, 1)
-	require.Equal(t, taskSequence, sequences[0])
+	require.Equal(t, taskSequence1, sequences[0])
 
-	err = mdbrepo.DeleteTaskExecution("my-context", project, "my-stage", "my-sequence")
+	// delete all task executions for the given context
+	err = mdbrepo.DeleteTaskExecutions("my-context", project, "")
 	require.Nil(t, err)
 
-	sequences, err = mdbrepo.GetTaskExecutions(project, models.TaskExecution{TaskSequenceName: "my-sequence"})
+	sequences, err = mdbrepo.GetTaskExecutions(project, models.TaskExecution{KeptnContext: "my-context"})
 	require.Nil(t, err)
 	require.Len(t, sequences, 0)
+}
+
+func Test_MongoDBTaskSequenceRepoInsertAndRetrieveDeleteAll(t *testing.T) {
+	project := "my-project"
+	mdbrepo := NewTaskSequenceMongoDBRepo(GetMongoDBConnectionInstance())
+
+	err := mdbrepo.DeleteRepo(project)
+	require.Nil(t, err)
+
+	taskSequence1 := models.TaskExecution{
+		TaskSequenceName: "my-sequence",
+		TriggeredEventID: "my-triggered-id",
+		Task: models.Task{
+			Task: keptnv2.Task{
+				Name: "my-task",
+			},
+		},
+		Stage:        "my-stage",
+		Service:      "my-service",
+		KeptnContext: "my-context",
+	}
+
+	taskSequence2 := models.TaskExecution{
+		TaskSequenceName: "my-sequence",
+		TriggeredEventID: "my-triggered-id",
+		Task: models.Task{
+			Task: keptnv2.Task{
+				Name: "my-task",
+			},
+		},
+		Stage:        "my-stage-2",
+		Service:      "my-service",
+		KeptnContext: "my-context",
+	}
+
+	taskSequence3 := models.TaskExecution{
+		TaskSequenceName: "my-sequence",
+		TriggeredEventID: "my-triggered-id",
+		Task: models.Task{
+			Task: keptnv2.Task{
+				Name: "my-task",
+			},
+		},
+		Stage:        "my-stage-2",
+		Service:      "my-service",
+		KeptnContext: "my-context",
+	}
+
+	err = mdbrepo.CreateTaskExecution(project, taskSequence1)
+	require.Nil(t, err)
+
+	err = mdbrepo.CreateTaskExecution(project, taskSequence2)
+	require.Nil(t, err)
+
+	err = mdbrepo.CreateTaskExecution(project, taskSequence3)
+	require.Nil(t, err)
+
+	// delete all task executions for the given context
+	err = mdbrepo.DeleteTaskExecutions("my-context", project, "my-stage-2")
+	require.Nil(t, err)
+
+	sequences, err := mdbrepo.GetTaskExecutions(project, models.TaskExecution{KeptnContext: "my-context"})
+	require.Nil(t, err)
+	require.Len(t, sequences, 1)
+
+	// the task execution in my-stage should still be there
+	require.Equal(t, "my-stage", sequences[0].Stage)
 }

--- a/shipyard-controller/db/repos.go
+++ b/shipyard-controller/db/repos.go
@@ -35,7 +35,7 @@ type TaskSequenceRepo interface {
 	CreateTaskExecution(project string, taskExecution models.TaskExecution) error
 	DeleteTaskExecution(keptnContext, project, stage, taskSequenceName string) error
 	// DeleteTaskExecutions deletes all open task executions of a keptnContext
-	DeleteTaskExecutions(keptnContext, project string) error
+	DeleteTaskExecutions(keptnContext, project, stage string) error
 	DeleteRepo(project string) error
 }
 

--- a/shipyard-controller/db/repos.go
+++ b/shipyard-controller/db/repos.go
@@ -34,6 +34,8 @@ type TaskSequenceRepo interface {
 	GetTaskExecutions(project string, filter models.TaskExecution) ([]models.TaskExecution, error)
 	CreateTaskExecution(project string, taskExecution models.TaskExecution) error
 	DeleteTaskExecution(keptnContext, project, stage, taskSequenceName string) error
+	// DeleteTaskExecutions deletes all open task executions of a keptnContext
+	DeleteTaskExecutions(keptnContext, project string) error
 	DeleteRepo(project string) error
 }
 

--- a/shipyard-controller/handler/eventdispatcher.go
+++ b/shipyard-controller/handler/eventdispatcher.go
@@ -85,16 +85,16 @@ func (e *EventDispatcher) Add(event models.DispatcherEvent, skipQueue bool) erro
 	})
 }
 
-func (e *EventDispatcher) OnSequenceAborted(event models.Event) {
-	e.cleanupQueueOfSequence(event)
+func (e *EventDispatcher) OnSequenceAborted(eventScope models.EventScope) {
+	e.cleanupQueueOfSequence(eventScope)
 }
 
 func (e *EventDispatcher) OnSequenceFinished(event models.Event) {
-	e.cleanupQueueOfSequence(event)
+	e.cleanupQueueOfSequence(models.EventScope{KeptnContext: event.Shkeptncontext})
 }
 
 func (e *EventDispatcher) OnSequenceTimeout(event models.Event) {
-	e.cleanupQueueOfSequence(event)
+	e.cleanupQueueOfSequence(models.EventScope{KeptnContext: event.Shkeptncontext})
 }
 
 func (e *EventDispatcher) OnSequencePaused(pause models.EventScope) {
@@ -247,16 +247,16 @@ func (e *EventDispatcher) isCurrentEventOverrulingOtherEvent(lastTaskOfSequence 
 	return false
 }
 
-func (e *EventDispatcher) cleanupQueueOfSequence(event models.Event) {
+func (e *EventDispatcher) cleanupQueueOfSequence(eventScope models.EventScope) {
 	err := e.eventQueueRepo.DeleteEventQueueStates(models.EventQueueSequenceState{Scope: models.EventScope{
-		KeptnContext: event.Shkeptncontext,
+		KeptnContext: eventScope.KeptnContext,
 	}})
 	if err != nil {
-		log.WithError(err).Errorf("could not clear event queue states for context %s", event.Shkeptncontext)
+		log.WithError(err).Errorf("could not clear event queue states for context %s", eventScope.KeptnContext)
 	}
-	err = e.eventQueueRepo.DeleteQueuedEvents(models.EventScope{KeptnContext: event.Shkeptncontext})
+	err = e.eventQueueRepo.DeleteQueuedEvents(models.EventScope{KeptnContext: eventScope.KeptnContext})
 	if err != nil {
-		log.WithError(err).Errorf("could not clear event queue for context %s", event.Shkeptncontext)
+		log.WithError(err).Errorf("could not clear event queue for context %s", eventScope.KeptnContext)
 	}
 }
 

--- a/shipyard-controller/handler/sequencehooks/fake/sequenceaborted.go
+++ b/shipyard-controller/handler/sequencehooks/fake/sequenceaborted.go
@@ -14,7 +14,7 @@ import (
 //
 // 		// make and configure a mocked sequencehooks.ISequenceAbortedHook
 // 		mockedISequenceAbortedHook := &ISequenceAbortedHookMock{
-// 			OnSequenceAbortedFunc: func(event models.Event)  {
+// 			OnSequenceAbortedFunc: func(event models.EventScope)  {
 // 				panic("mock out the OnSequenceAborted method")
 // 			},
 // 		}
@@ -25,26 +25,26 @@ import (
 // 	}
 type ISequenceAbortedHookMock struct {
 	// OnSequenceAbortedFunc mocks the OnSequenceAborted method.
-	OnSequenceAbortedFunc func(event models.Event)
+	OnSequenceAbortedFunc func(event models.EventScope)
 
 	// calls tracks calls to the methods.
 	calls struct {
 		// OnSequenceAborted holds details about calls to the OnSequenceAborted method.
 		OnSequenceAborted []struct {
 			// Event is the event argument value.
-			Event models.Event
+			Event models.EventScope
 		}
 	}
 	lockOnSequenceAborted sync.RWMutex
 }
 
 // OnSequenceAborted calls OnSequenceAbortedFunc.
-func (mock *ISequenceAbortedHookMock) OnSequenceAborted(event models.Event) {
+func (mock *ISequenceAbortedHookMock) OnSequenceAborted(event models.EventScope) {
 	if mock.OnSequenceAbortedFunc == nil {
 		panic("ISequenceAbortedHookMock.OnSequenceAbortedFunc: method is nil but ISequenceAbortedHook.OnSequenceAborted was just called")
 	}
 	callInfo := struct {
-		Event models.Event
+		Event models.EventScope
 	}{
 		Event: event,
 	}
@@ -58,10 +58,10 @@ func (mock *ISequenceAbortedHookMock) OnSequenceAborted(event models.Event) {
 // Check the length with:
 //     len(mockedISequenceAbortedHook.OnSequenceAbortedCalls())
 func (mock *ISequenceAbortedHookMock) OnSequenceAbortedCalls() []struct {
-	Event models.Event
+	Event models.EventScope
 } {
 	var calls []struct {
-		Event models.Event
+		Event models.EventScope
 	}
 	mock.lockOnSequenceAborted.RLock()
 	calls = mock.calls.OnSequenceAborted

--- a/shipyard-controller/handler/sequencehooks/hooks.go
+++ b/shipyard-controller/handler/sequencehooks/hooks.go
@@ -38,9 +38,10 @@ type ISubSequenceFinishedHook interface {
 type ISequenceFinishedHook interface {
 	OnSequenceFinished(event models.Event)
 }
+
 //go:generate moq -pkg fake -skip-ensure -out ./fake/sequenceaborted.go . ISequenceAbortedHook
 type ISequenceAbortedHook interface {
-	OnSequenceAborted(event models.Event)
+	OnSequenceAborted(event models.EventScope)
 }
 
 //go:generate moq -pkg fake -skip-ensure -out ./fake/sequencetimeout.go . ISequenceTimeoutHook

--- a/shipyard-controller/handler/sequencehooks/sequencestate.go
+++ b/shipyard-controller/handler/sequencehooks/sequencestate.go
@@ -157,15 +157,10 @@ func (smv *SequenceStateMaterializedView) OnSequenceFinished(event models.Event)
 	smv.updateOverallSequenceState(*eventScope, models.SequenceFinished)
 }
 
-func (smv *SequenceStateMaterializedView) OnSequenceAborted(event models.Event) {
+func (smv *SequenceStateMaterializedView) OnSequenceAborted(eventScope models.EventScope) {
 	smv.mutex.Lock()
 	defer smv.mutex.Unlock()
-	eventScope, err := models.NewEventScope(event)
-	if err != nil {
-		log.WithError(err).Errorf(eventScopeErrorMessage)
-		return
-	}
-	smv.updateOverallSequenceState(*eventScope, models.SequenceAborted)
+	smv.updateOverallSequenceState(eventScope, models.SequenceAborted)
 }
 
 func (smv *SequenceStateMaterializedView) OnSequenceTimeout(event models.Event) {

--- a/shipyard-controller/handler/shipyardcontroller.go
+++ b/shipyard-controller/handler/shipyardcontroller.go
@@ -344,6 +344,10 @@ func (sc *shipyardController) wasTaskTriggered(eventScope models.EventScope) (bo
 }
 
 func (sc *shipyardController) cancelSequence(cancel models.SequenceControl) error {
+	sc.onSequenceAborted(models.EventScope{
+		KeptnContext: cancel.KeptnContext,
+		EventData:    keptnv2.EventData{Project: cancel.Project, Stage: cancel.Stage},
+	})
 	taskExecutions, err := sc.taskSequenceRepo.GetTaskExecutions(cancel.Project,
 		models.TaskExecution{
 			KeptnContext: cancel.KeptnContext,
@@ -355,6 +359,12 @@ func (sc *shipyardController) cancelSequence(cancel models.SequenceControl) erro
 	if len(taskExecutions) == 0 {
 		log.Infof("no active task execution for context %s found. Trying to remove it from the queue", cancel.KeptnContext)
 		return sc.cancelQueuedSequence(cancel)
+	}
+
+	err = sc.taskSequenceRepo.DeleteTaskExecutions(cancel.KeptnContext, cancel.Project)
+	if err != nil {
+		// log the error, but continue with the rest
+		log.Errorf("Could not delete open task executions for sequence %s in proect %s: %v", cancel.KeptnContext, cancel.Project, err)
 	}
 
 	// delete all open .triggered events for the task sequence
@@ -385,7 +395,6 @@ func (sc *shipyardController) cancelSequence(cancel models.SequenceControl) erro
 }
 
 func (sc *shipyardController) forceTaskSequenceCompletion(sequenceTriggeredEvent models.Event, taskSequenceName string) error {
-	sc.onSequenceAborted(sequenceTriggeredEvent)
 	scope, err := models.NewEventScope(sequenceTriggeredEvent)
 	if err != nil {
 		return err
@@ -413,14 +422,24 @@ func (sc *shipyardController) cancelQueuedSequence(cancel models.SequenceControl
 		log.WithError(err).Errorf("could not remove sequence %s from sequence queue", cancel.KeptnContext)
 	}
 
+	// theoretically, we should not have any open task executions at this point, but call the delete function anyway,
+	// just to be 100% sure no entries of this collection are blocking any new sequences
+	err = sc.taskSequenceRepo.DeleteTaskExecutions(cancel.KeptnContext, cancel.Project)
+	if err != nil {
+		// log the error, but continue with the rest
+		log.Errorf("Could not delete open task executions for sequence %s in proect %s: %v", cancel.KeptnContext, cancel.Project, err)
+	}
+
 	events, err := sc.eventRepo.GetEvents(
 		cancel.Project,
 		common.EventFilter{KeptnContext: &cancel.KeptnContext, Stage: &cancel.Stage},
 		common.TriggeredEvent,
 	)
 	if err != nil {
+		// if the sequence.triggered event is not available anymore, we cannot send a referencing .finished event
 		if err == db.ErrNoEventFound {
-			return ErrSequenceNotFound
+			log.Infof("No sequence.triggered event for sequence %s available anymore.", cancel.KeptnContext)
+			return nil
 		}
 		return err
 	} else if len(events) == 0 {
@@ -429,7 +448,9 @@ func (sc *shipyardController) cancelQueuedSequence(cancel models.SequenceControl
 	// the first event of the context should be a task sequence event that contains the sequence name
 	sequenceTriggeredEvent := events[0]
 	if !keptnv2.IsSequenceEventType(*sequenceTriggeredEvent.Type) {
-		return ErrSequenceNotFound
+		// if the sequence.triggered event is not available anymore, we cannot send a referencing .finished event
+		log.Infof("No sequence.triggered event for sequence %s available anymore.", cancel.KeptnContext)
+		return nil
 	}
 	_, sequenceName, _, err := keptnv2.ParseSequenceEventType(*sequenceTriggeredEvent.Type)
 	if err != nil {
@@ -672,11 +693,6 @@ func (sc *shipyardController) triggerNextTaskSequences(eventScope models.EventSc
 }
 
 func (sc *shipyardController) completeTaskSequence(eventScope models.EventScope, taskSequenceName, triggeredID string) error {
-	err := sc.taskSequenceRepo.DeleteTaskExecution(eventScope.KeptnContext, eventScope.Project, eventScope.Stage, taskSequenceName)
-	if err != nil {
-		return err
-	}
-
 	log.Infof("Deleting all task.finished events of task sequence %s with context %s", taskSequenceName, eventScope.KeptnContext)
 	if err := sc.eventRepo.DeleteAllFinishedEvents(eventScope); err != nil {
 		return err

--- a/shipyard-controller/handler/shipyardcontroller.go
+++ b/shipyard-controller/handler/shipyardcontroller.go
@@ -361,7 +361,7 @@ func (sc *shipyardController) cancelSequence(cancel models.SequenceControl) erro
 		return sc.cancelQueuedSequence(cancel)
 	}
 
-	err = sc.taskSequenceRepo.DeleteTaskExecutions(cancel.KeptnContext, cancel.Project)
+	err = sc.taskSequenceRepo.DeleteTaskExecutions(cancel.KeptnContext, cancel.Project, cancel.Stage)
 	if err != nil {
 		// log the error, but continue with the rest
 		log.Errorf("Could not delete open task executions for sequence %s in proect %s: %v", cancel.KeptnContext, cancel.Project, err)
@@ -424,7 +424,7 @@ func (sc *shipyardController) cancelQueuedSequence(cancel models.SequenceControl
 
 	// theoretically, we should not have any open task executions at this point, but call the delete function anyway,
 	// just to be 100% sure no entries of this collection are blocking any new sequences
-	err = sc.taskSequenceRepo.DeleteTaskExecutions(cancel.KeptnContext, cancel.Project)
+	err = sc.taskSequenceRepo.DeleteTaskExecutions(cancel.KeptnContext, cancel.Project, cancel.Stage)
 	if err != nil {
 		// log the error, but continue with the rest
 		log.Errorf("Could not delete open task executions for sequence %s in proect %s: %v", cancel.KeptnContext, cancel.Project, err)

--- a/shipyard-controller/handler/shipyardcontroller.go
+++ b/shipyard-controller/handler/shipyardcontroller.go
@@ -693,6 +693,10 @@ func (sc *shipyardController) triggerNextTaskSequences(eventScope models.EventSc
 }
 
 func (sc *shipyardController) completeTaskSequence(eventScope models.EventScope, taskSequenceName, triggeredID string) error {
+	err := sc.taskSequenceRepo.DeleteTaskExecution(eventScope.KeptnContext, eventScope.Project, eventScope.Stage, taskSequenceName)
+	if err != nil {
+		return err
+	}
 	log.Infof("Deleting all task.finished events of task sequence %s with context %s", taskSequenceName, eventScope.KeptnContext)
 	if err := sc.eventRepo.DeleteAllFinishedEvents(eventScope); err != nil {
 		return err

--- a/shipyard-controller/handler/shipyardcontroller_component_test.go
+++ b/shipyard-controller/handler/shipyardcontroller_component_test.go
@@ -932,25 +932,35 @@ func Test_shipyardController_CancelSequence(t *testing.T) {
 		Type:           common.Stringp(keptnv2.GetTriggeredEventType(keptnv2.DeploymentTaskName)),
 	}, common.TriggeredEvent)
 
-	taskSequenceMapping := models.TaskExecution{
+	taskExecution := models.TaskExecution{
 		TaskSequenceName: "delivery",
 		TriggeredEventID: "my-deployment-triggered-id",
 		Task:             models.Task{},
 		Stage:            "my-stage",
 		KeptnContext:     "my-keptn-context-id",
 	}
-	sc.taskSequenceRepo.CreateTaskExecution("my-project", taskSequenceMapping)
+	err := sc.taskSequenceRepo.CreateTaskExecution("my-project", taskExecution)
+	require.Nil(t, err)
+
+	// also insert another task execution - this should then also be deleted
+	taskExecution.Stage = "my-other-stage"
+	err = sc.taskSequenceRepo.CreateTaskExecution("my-project", taskExecution)
+	require.Nil(t, err)
 
 	// invoke the CancelSequence function
-	err := sc.cancelSequence(models.SequenceControl{
+	err = sc.cancelSequence(models.SequenceControl{
 		KeptnContext: "my-keptn-context-id",
 		Project:      "my-project",
-		Stage:        "my-stage",
 	})
 
 	require.Nil(t, err)
 	require.Len(t, fakeSequenceFinishedHook.OnSequenceFinishedCalls(), 0)
 	require.Len(t, fakeSequenceAbortedHook.OnSequenceAbortedCalls(), 1)
+
+	// verify that no open task executions for this context are left in the collection
+	executions, err := sc.taskSequenceRepo.GetTaskExecutions("my-project", models.TaskExecution{KeptnContext: "my-keptn-context-id"})
+	require.Nil(t, err)
+	require.Empty(t, executions)
 }
 
 func Test_shipyardController_CancelQueuedSequence(t *testing.T) {
@@ -992,6 +1002,11 @@ func Test_shipyardController_CancelQueuedSequence(t *testing.T) {
 	require.Nil(t, err)
 	require.Len(t, fakeSequenceFinishedHook.OnSequenceFinishedCalls(), 0)
 	require.Len(t, fakeSequenceAbortedHook.OnSequenceAbortedCalls(), 1)
+
+	// verify that no open task executions for this context are left in the collection
+	executions, err := sc.taskSequenceRepo.GetTaskExecutions("my-project", models.TaskExecution{KeptnContext: "my-keptn-context-id"})
+	require.Nil(t, err)
+	require.Empty(t, executions)
 }
 
 func Test_shipyardController_CancelQueuedSequence_RemoveFromQueueFails(t *testing.T) {
@@ -1033,6 +1048,11 @@ func Test_shipyardController_CancelQueuedSequence_RemoveFromQueueFails(t *testin
 	require.Nil(t, err)
 	require.Len(t, fakeSequenceFinishedHook.OnSequenceFinishedCalls(), 0)
 	require.Len(t, fakeSequenceAbortedHook.OnSequenceAbortedCalls(), 1)
+
+	// verify that no open task executions for this context are left in the collection
+	executions, err := sc.taskSequenceRepo.GetTaskExecutions("my-project", models.TaskExecution{KeptnContext: "my-keptn-context-id"})
+	require.Nil(t, err)
+	require.Empty(t, executions)
 }
 
 func Test_shipyardController_CancelQueuedSequence_NoTriggeredEventAvailable(t *testing.T) {
@@ -1062,6 +1082,11 @@ func Test_shipyardController_CancelQueuedSequence_NoTriggeredEventAvailable(t *t
 	require.Nil(t, err)
 	require.Len(t, fakeSequenceFinishedHook.OnSequenceFinishedCalls(), 0)
 	require.Len(t, fakeSequenceAbortedHook.OnSequenceAbortedCalls(), 1)
+
+	// verify that no open task executions for this context are left in the collection
+	executions, err := sc.taskSequenceRepo.GetTaskExecutions("my-project", models.TaskExecution{KeptnContext: "my-keptn-context-id"})
+	require.Nil(t, err)
+	require.Empty(t, executions)
 }
 
 func Test_SequenceForUnavailableStage(t *testing.T) {

--- a/shipyard-controller/handler/shipyardcontroller_hooks.go
+++ b/shipyard-controller/handler/shipyardcontroller_hooks.go
@@ -91,9 +91,9 @@ func (sc *shipyardController) onSequenceFinished(event models.Event) {
 	}
 }
 
-func (sc *shipyardController) onSequenceAborted(event models.Event) {
+func (sc *shipyardController) onSequenceAborted(eventScope models.EventScope) {
 	for _, hook := range sc.sequenceAbortedHooks {
-		hook.OnSequenceAborted(event)
+		hook.OnSequenceAborted(eventScope)
 	}
 }
 

--- a/test/go-tests/test_sequencecontrol.go
+++ b/test/go-tests/test_sequencecontrol.go
@@ -336,6 +336,9 @@ func Test_SequenceControl_AbortPausedSequenceTaskPartiallyFinished(t *testing.T)
 	_, err = keptn.SendTaskFinishedEvent(&keptnv2.EventData{Result: keptnv2.ResultFailed, Status: keptnv2.StatusSucceeded}, source1)
 	require.Nil(t, err)
 
+	// wait a couple of seconds - it's very unlikely that a sequence is manually paused right at the same time as an event is sent back
+	<-time.After(5 * time.Second)
+
 	// pause the sequence
 	t.Log("pausing sequence")
 	resp, err := ApiPOSTRequest(fmt.Sprintf("/controlPlane/v1/sequence/%s/%s/control", projectName, keptnContextID), scmodels.SequenceControlCommand{

--- a/test/go-tests/test_sequencecontrol.go
+++ b/test/go-tests/test_sequencecontrol.go
@@ -56,6 +56,33 @@ spec:
           tasks:
             - name: "task2"`
 
+const shipyardWithParallelStages = `--- 
+apiVersion: spec.keptn.sh/0.2.3
+kind: Shipyard
+metadata: 
+  name: shipyard-echo-service
+spec: 
+  stages: 
+    - name: dev
+      sequences: 
+        - name: mysequence
+          tasks: 
+            - name: task1
+    - name: prod-a
+      sequences: 
+        - name: mysequence
+          tasks: 
+            - name: task2
+          triggeredOn: 
+            - event: "dev.mysequence.finished"
+    - name: prod-b
+      sequences: 
+        - name: mysequence
+          tasks: 
+            - name: task2
+          triggeredOn: 
+            - event: "dev.mysequence.finished"`
+
 func Test_SequenceControl_Abort(t *testing.T) {
 	projectName := "sequence-abort"
 	serviceName := "myservice"
@@ -347,6 +374,102 @@ func Test_SequenceControl_AbortPausedSequenceTaskPartiallyFinished(t *testing.T)
 		return true
 	}, 1*time.Minute, 10*time.Second)
 
+}
+
+func Test_SequenceControl_AbortPausedSequenceMultipleStages(t *testing.T) {
+	projectName := "sequence-abort5"
+	serviceName := "myservice"
+	stageName := "dev"
+	sequencename := "mysequence"
+	source := "golang-test"
+
+	shipyardFilePath, err := CreateTmpShipyardFile(shipyardWithParallelStages)
+	require.Nil(t, err)
+	defer os.Remove(shipyardFilePath)
+
+	t.Logf("creating project %s", projectName)
+	projectName, err = CreateProject(projectName, shipyardFilePath, true)
+	require.Nil(t, err)
+
+	t.Logf("creating service %s", serviceName)
+	output, err := ExecuteCommand(fmt.Sprintf("keptn create service %s --project=%s", serviceName, projectName))
+
+	require.Nil(t, err)
+	require.Contains(t, output, "created successfully")
+
+	t.Logf("triggering sequence %s in stage %s", sequencename, stageName)
+	keptnContextID, _ := TriggerSequence(projectName, serviceName, stageName, sequencename, nil)
+
+	// verify state
+	VerifySequenceEndsUpInState(t, projectName, &models.EventContext{&keptnContextID}, 2*time.Minute, []string{scmodels.SequenceStartedState})
+
+	taskTriggeredEvent, err := GetLatestEventOfType(keptnContextID, projectName, stageName, keptnv2.GetTriggeredEventType("task1"))
+	require.Nil(t, err)
+	require.NotNil(t, taskTriggeredEvent)
+
+	cloudEvent := keptnv2.ToCloudEvent(*taskTriggeredEvent)
+
+	keptn, err := keptnv2.NewKeptn(&cloudEvent, keptncommon.KeptnOpts{EventSender: &APIEventSender{}})
+	require.Nil(t, err)
+	require.NotNil(t, keptn)
+
+	t.Log("sending task started event")
+	_, err = keptn.SendTaskStartedEvent(nil, source)
+	require.Nil(t, err)
+	t.Log("sending task finished event")
+	_, err = keptn.SendTaskFinishedEvent(&keptnv2.EventData{Result: keptnv2.ResultPass, Status: keptnv2.StatusSucceeded}, source)
+	require.Nil(t, err)
+
+	// wait until sequences in prod-a and prod-b have been started (by retrieving the triggered events of the first task in each stage)
+	parallelStagesAreTriggered := func(keptnContextID string) {
+		require.Eventually(t, func() bool {
+			taskTriggeredEventA, err := GetLatestEventOfType(keptnContextID, projectName, "prod-a", keptnv2.GetTriggeredEventType("task2"))
+			if err != nil || taskTriggeredEventA == nil {
+				return false
+			}
+			taskTriggeredEventB, err := GetLatestEventOfType(keptnContextID, projectName, "prod-b", keptnv2.GetTriggeredEventType("task2"))
+			if err != nil || taskTriggeredEventB == nil {
+				return false
+			}
+			return true
+		}, 1*time.Minute, 10*time.Second)
+	}
+
+	parallelStagesAreTriggered(keptnContextID)
+
+	// now trigger another sequence and finish its execution in the first stage
+	secondContextID, _ := TriggerSequence(projectName, serviceName, stageName, sequencename, nil)
+
+	taskTriggeredEvent, err = GetLatestEventOfType(secondContextID, projectName, stageName, keptnv2.GetTriggeredEventType("task1"))
+	require.Nil(t, err)
+	require.NotNil(t, taskTriggeredEvent)
+
+	cloudEvent = keptnv2.ToCloudEvent(*taskTriggeredEvent)
+
+	keptn, err = keptnv2.NewKeptn(&cloudEvent, keptncommon.KeptnOpts{EventSender: &APIEventSender{}})
+	require.Nil(t, err)
+	require.NotNil(t, keptn)
+
+	t.Log("sending task started event")
+	_, err = keptn.SendTaskStartedEvent(nil, source)
+	require.Nil(t, err)
+	t.Log("sending task finished event")
+	_, err = keptn.SendTaskFinishedEvent(&keptnv2.EventData{Result: keptnv2.ResultPass, Status: keptnv2.StatusSucceeded}, source)
+	require.Nil(t, err)
+
+	// now abort the first sequence
+	t.Log("aborting first sequence")
+	resp, err := ApiPOSTRequest(fmt.Sprintf("/controlPlane/v1/sequence/%s/%s/control", projectName, keptnContextID), scmodels.SequenceControlCommand{
+		State: scmodels.AbortSequence,
+		Stage: "",
+	}, 3)
+	require.Nil(t, err)
+	require.Equal(t, http.StatusOK, resp.Response().StatusCode)
+
+	VerifySequenceEndsUpInState(t, projectName, &models.EventContext{&keptnContextID}, 2*time.Minute, []string{scmodels.SequenceAborted})
+
+	// now that the first sequence is aborted, the other sequence should start in prod-a and prod-b
+	parallelStagesAreTriggered(secondContextID)
 }
 
 func Test_SequenceControl_PauseAndResume(t *testing.T) {

--- a/test/go-tests/test_sequencecontrol.go
+++ b/test/go-tests/test_sequencecontrol.go
@@ -665,7 +665,12 @@ func Test_SequenceControl_PauseAndResume_2(t *testing.T) {
 
 	VerifySequenceEndsUpInState(t, projectName, &models.EventContext{&keptnContextID}, 2*time.Minute, []string{scmodels.SequenceStartedState})
 
-	task2TriggeredEvent, err := GetLatestEventOfType(keptnContextID, projectName, "prod", keptnv2.GetTriggeredEventType("task2"))
-	require.Nil(t, err)
-	require.NotNil(t, task2TriggeredEvent)
+	require.Eventually(t, func() bool {
+		task2TriggeredEvent, err := GetLatestEventOfType(keptnContextID, projectName, "prod", keptnv2.GetTriggeredEventType("task2"))
+		if err != nil || task2TriggeredEvent == nil {
+			return false
+		}
+		return true
+	}, 30*time.Second, 5*time.Second)
+
 }

--- a/test/go-tests/test_sequencecontrol.go
+++ b/test/go-tests/test_sequencecontrol.go
@@ -401,11 +401,15 @@ func Test_SequenceControl_AbortPausedSequenceMultipleStages(t *testing.T) {
 	keptnContextID, _ := TriggerSequence(projectName, serviceName, stageName, sequencename, nil)
 
 	// verify state
-	VerifySequenceEndsUpInState(t, projectName, &models.EventContext{&keptnContextID}, 2*time.Minute, []string{scmodels.SequenceStartedState})
 
-	taskTriggeredEvent, err := GetLatestEventOfType(keptnContextID, projectName, stageName, keptnv2.GetTriggeredEventType("task1"))
-	require.Nil(t, err)
-	require.NotNil(t, taskTriggeredEvent)
+	var taskTriggeredEvent *models.KeptnContextExtendedCE
+	require.Eventually(t, func() bool {
+		taskTriggeredEvent, err = GetLatestEventOfType(keptnContextID, projectName, stageName, keptnv2.GetTriggeredEventType("task1"))
+		if err != nil || taskTriggeredEvent == nil {
+			return false
+		}
+		return true
+	}, 1*time.Minute, 10*time.Second)
 
 	cloudEvent := keptnv2.ToCloudEvent(*taskTriggeredEvent)
 
@@ -440,9 +444,13 @@ func Test_SequenceControl_AbortPausedSequenceMultipleStages(t *testing.T) {
 	// now trigger another sequence and finish its execution in the first stage
 	secondContextID, _ := TriggerSequence(projectName, serviceName, stageName, sequencename, nil)
 
-	taskTriggeredEvent, err = GetLatestEventOfType(secondContextID, projectName, stageName, keptnv2.GetTriggeredEventType("task1"))
-	require.Nil(t, err)
-	require.NotNil(t, taskTriggeredEvent)
+	require.Eventually(t, func() bool {
+		taskTriggeredEvent, err = GetLatestEventOfType(secondContextID, projectName, stageName, keptnv2.GetTriggeredEventType("task1"))
+		if err != nil || taskTriggeredEvent == nil {
+			return false
+		}
+		return true
+	}, 1*time.Minute, 10*time.Second)
 
 	cloudEvent = keptnv2.ToCloudEvent(*taskTriggeredEvent)
 

--- a/test/go-tests/testsuite_gke_test.go
+++ b/test/go-tests/testsuite_gke_test.go
@@ -27,6 +27,8 @@ func Test_GKE(t *testing.T) {
 	t.Run("Test_SequenceTimeoutDelayedTask", Test_SequenceTimeoutDelayedTask)
 	t.Run("Test_SequenceControl_Abort", Test_SequenceControl_Abort)
 	t.Run("Test_SequenceControl_AbortQueuedSequence", Test_SequenceControl_AbortQueuedSequence)
+	t.Run("Test_SequenceControl_AbortPausedSequence", Test_SequenceControl_AbortPausedSequence)
+	t.Run("Test_SequenceControl_AbortPausedSequenceTaskPartiallyFinished", Test_SequenceControl_AbortPausedSequenceTaskPartiallyFinished)
 	t.Run("Test_SequenceControl_PauseAndResume", Test_SequenceControl_PauseAndResume)
 	t.Run("Test_SequenceControl_PauseAndResume_2", Test_SequenceControl_PauseAndResume_2)
 

--- a/test/go-tests/testsuite_gke_test.go
+++ b/test/go-tests/testsuite_gke_test.go
@@ -29,6 +29,7 @@ func Test_GKE(t *testing.T) {
 	t.Run("Test_SequenceControl_AbortQueuedSequence", Test_SequenceControl_AbortQueuedSequence)
 	t.Run("Test_SequenceControl_AbortPausedSequence", Test_SequenceControl_AbortPausedSequence)
 	t.Run("Test_SequenceControl_AbortPausedSequenceTaskPartiallyFinished", Test_SequenceControl_AbortPausedSequenceTaskPartiallyFinished)
+	t.Run("Test_SequenceControl_AbortPausedSequenceMultipleStages", Test_SequenceControl_AbortPausedSequenceMultipleStages)
 	t.Run("Test_SequenceControl_PauseAndResume", Test_SequenceControl_PauseAndResume)
 	t.Run("Test_SequenceControl_PauseAndResume_2", Test_SequenceControl_PauseAndResume_2)
 

--- a/test/go-tests/testsuite_k3s_test.go
+++ b/test/go-tests/testsuite_k3s_test.go
@@ -29,6 +29,7 @@ func Test_K3S(t *testing.T) {
 	t.Run("Test_SequenceControl_AbortQueuedSequence", Test_SequenceControl_AbortQueuedSequence)
 	t.Run("Test_SequenceControl_AbortPausedSequence", Test_SequenceControl_AbortPausedSequence)
 	t.Run("Test_SequenceControl_AbortPausedSequenceTaskPartiallyFinished", Test_SequenceControl_AbortPausedSequenceTaskPartiallyFinished)
+	t.Run("Test_SequenceControl_AbortPausedSequenceMultipleStages", Test_SequenceControl_AbortPausedSequenceMultipleStages)
 	t.Run("Test_SequenceControl_PauseAndResume", Test_SequenceControl_PauseAndResume)
 	t.Run("Test_SequenceControl_PauseAndResume_2", Test_SequenceControl_PauseAndResume_2)
 

--- a/test/go-tests/testsuite_k3s_test.go
+++ b/test/go-tests/testsuite_k3s_test.go
@@ -27,6 +27,8 @@ func Test_K3S(t *testing.T) {
 	t.Run("Test_SequenceTimeoutDelayedTask", Test_SequenceTimeoutDelayedTask)
 	t.Run("Test_SequenceControl_Abort", Test_SequenceControl_Abort)
 	t.Run("Test_SequenceControl_AbortQueuedSequence", Test_SequenceControl_AbortQueuedSequence)
+	t.Run("Test_SequenceControl_AbortPausedSequence", Test_SequenceControl_AbortPausedSequence)
+	t.Run("Test_SequenceControl_AbortPausedSequenceTaskPartiallyFinished", Test_SequenceControl_AbortPausedSequenceTaskPartiallyFinished)
 	t.Run("Test_SequenceControl_PauseAndResume", Test_SequenceControl_PauseAndResume)
 	t.Run("Test_SequenceControl_PauseAndResume_2", Test_SequenceControl_PauseAndResume_2)
 

--- a/test/go-tests/testsuite_openshift_test.go
+++ b/test/go-tests/testsuite_openshift_test.go
@@ -29,6 +29,7 @@ func Test_Openshift(t *testing.T) {
 	t.Run("Test_SequenceControl_AbortQueuedSequence", Test_SequenceControl_AbortQueuedSequence)
 	t.Run("Test_SequenceControl_AbortPausedSequence", Test_SequenceControl_AbortPausedSequence)
 	t.Run("Test_SequenceControl_AbortPausedSequenceTaskPartiallyFinished", Test_SequenceControl_AbortPausedSequenceTaskPartiallyFinished)
+	t.Run("Test_SequenceControl_AbortPausedSequenceMultipleStages", Test_SequenceControl_AbortPausedSequenceMultipleStages)
 	t.Run("Test_SequenceControl_PauseAndResume", Test_SequenceControl_PauseAndResume)
 	t.Run("Test_SequenceControl_PauseAndResume_2", Test_SequenceControl_PauseAndResume_2)
 

--- a/test/go-tests/testsuite_openshift_test.go
+++ b/test/go-tests/testsuite_openshift_test.go
@@ -27,6 +27,8 @@ func Test_Openshift(t *testing.T) {
 	t.Run("Test_SequenceTimeoutDelayedTask", Test_SequenceTimeoutDelayedTask)
 	t.Run("Test_SequenceControl_Abort", Test_SequenceControl_Abort)
 	t.Run("Test_SequenceControl_AbortQueuedSequence", Test_SequenceControl_AbortQueuedSequence)
+	t.Run("Test_SequenceControl_AbortPausedSequence", Test_SequenceControl_AbortPausedSequence)
+	t.Run("Test_SequenceControl_AbortPausedSequenceTaskPartiallyFinished", Test_SequenceControl_AbortPausedSequenceTaskPartiallyFinished)
 	t.Run("Test_SequenceControl_PauseAndResume", Test_SequenceControl_PauseAndResume)
 	t.Run("Test_SequenceControl_PauseAndResume_2", Test_SequenceControl_PauseAndResume_2)
 


### PR DESCRIPTION
Backport for #7116 
This PR makes sure that the sequence queue is freed up for new sequences when a sequence is cancelled, even if there might be an error with retrieving certain entries from the database (e.g. the original sequence.triggered event)

Also, additional test cases for queueing/pausing/aborting sequences have been added

Integration test run: https://github.com/keptn/keptn/runs/5496316358?check_suite_focus=true

Note: the failing minishift test seems to be unrelated to the changes made in this PR

New integration test run: https://github.com/keptn/keptn/runs/5507244019?check_suite_focus=true 