### PR TITLE
fix(bridge): Validate start end date duration

### DIFF
--- a/bridge/client/app/_components/ktb-trigger-sequence/ktb-trigger-sequence.component.html
+++ b/bridge/client/app/_components/ktb-trigger-sequence/ktb-trigger-sequence.component.html
@@ -218,7 +218,7 @@
             dtSuffix
             variant="nested"
             [disabled]="!evaluationFormData.startDatetime"
-            (click)="evaluationFormData.startDatetime = undefined"
+            (click)="setStartDate(undefined)"
           >
             <dt-icon name="abort"></dt-icon>
           </button>
@@ -230,11 +230,11 @@
             uitestid="keptn-trigger-button-starttime"
             [timeEnabled]="true"
             [secondsEnabled]="true"
-            (selectedDateTime)="evaluationFormData.startDatetime = $event"
+            (selectedDateTime)="setStartDate($event)"
           >
             <dt-icon name="calendar"></dt-icon>
           </button>
-          <dt-hint>Has to be before End at</dt-hint>
+          <dt-hint>Has to be before end date</dt-hint>
         </dt-form-field>
         <dt-form-field class="overlay-origin">
           <dt-label class="required">End at</dt-label>
@@ -250,7 +250,7 @@
             dtSuffix
             variant="nested"
             [disabled]="!evaluationFormData.endDatetime"
-            (click)="evaluationFormData.endDatetime = undefined"
+            (click)="setEndDate(undefined)"
           >
             <dt-icon name="abort"></dt-icon>
           </button>
@@ -262,20 +262,24 @@
             uitestid="keptn-trigger-button-endtime"
             [timeEnabled]="true"
             [secondsEnabled]="true"
-            (selectedDateTime)="evaluationFormData.endDatetime = $event"
+            (selectedDateTime)="setEndDate($event)"
           >
             <dt-icon name="calendar"></dt-icon>
           </button>
-          <dt-hint>Has to be after Start at</dt-hint>
+          <dt-hint>Has to be after start date</dt-hint>
           <dt-error
             *ngIf="
               evaluationFormData.startDatetime &&
               evaluationFormData.endDatetime &&
-              !checkStartEndValidity(evaluationFormData.startDatetime, evaluationFormData.endDatetime)
+              (!isValidStartBeforeEnd || !isValidStartEndDuration)
             "
             uitestid="keptn-trigger-evaluation-date-error"
-            >Start date must be before end date.</dt-error
           >
+            <ng-container *ngIf="!isValidStartBeforeEnd">Start date must be before end date</ng-container>
+            <ng-container *ngIf="isValidStartBeforeEnd && !isValidStartEndDuration"
+              >The duration has to be minimum 1 minute</ng-container
+            >
+          </dt-error>
         </dt-form-field>
       </div>
 
@@ -297,8 +301,7 @@
         [ngTemplateOutletContext]="{
           isValid:
             (evaluationFormData.evaluationType === TRIGGER_EVALUATION_TIME.TIMEFRAME && isValidTimeframe) ||
-            (evaluationFormData.evaluationType === TRIGGER_EVALUATION_TIME.START_END &&
-              isValidStartEndTime(evaluationFormData.startDatetime, evaluationFormData.endDatetime))
+            (evaluationFormData.evaluationType === TRIGGER_EVALUATION_TIME.START_END && isValidStartEndTime())
         }"
       ></ng-container>
     </div>

--- a/bridge/client/app/_components/ktb-trigger-sequence/ktb-trigger-sequence.component.spec.ts
+++ b/bridge/client/app/_components/ktb-trigger-sequence/ktb-trigger-sequence.component.spec.ts
@@ -71,14 +71,34 @@ describe('KtbTriggerSequenceComponent', () => {
     const end = moment().date(1).month(1).year(2021);
 
     // when, then
-    expect(component.isValidStartEndTime(undefined, undefined)).toEqual(false);
-    expect(component.isValidStartEndTime(undefined, end.toISOString())).toEqual(false);
-    expect(component.isValidStartEndTime(start.toISOString(), undefined)).toEqual(false);
-    expect(component.isValidStartEndTime(start.toISOString(), end.toISOString())).toEqual(false);
+    component.setStartDate(undefined);
+    component.setEndDate(undefined);
+    expect(component.isValidStartEndTime()).toEqual(false);
+    component.setStartDate(undefined);
+    component.setEndDate(end.toISOString());
+    expect(component.isValidStartEndTime()).toEqual(false);
+    component.setStartDate(start.toISOString());
+    component.setEndDate(undefined);
+    expect(component.isValidStartEndTime()).toEqual(false);
 
-    // given
+    component.setStartDate(start.toISOString());
+    component.setEndDate(end.toISOString());
+    expect(component.isValidStartBeforeEnd).toEqual(false);
+    expect(component.isValidStartEndTime()).toEqual(false);
+
+    start.hours(12).minutes(0).seconds(0);
+    end.hours(12).minutes(0).seconds(5);
+    component.setStartDate(start.toISOString());
+    component.setEndDate(end.toISOString());
+    expect(component.isValidStartEndDuration).toEqual(false);
+    expect(component.isValidStartEndTime()).toEqual(false);
+
     end.date(3).month(1).year(2021);
-    expect(component.isValidStartEndTime(start.toISOString(), end.toISOString())).toEqual(true);
+    component.setStartDate(start.toISOString());
+    component.setEndDate(end.toISOString());
+    expect(component.isValidStartEndDuration).toEqual(true);
+    expect(component.isValidStartBeforeEnd).toEqual(true);
+    expect(component.isValidStartEndTime()).toEqual(true);
   });
 
   it('should return an combined and cleaned string for image and tag', () => {

--- a/bridge/client/app/_components/ktb-trigger-sequence/ktb-trigger-sequence.component.ts
+++ b/bridge/client/app/_components/ktb-trigger-sequence/ktb-trigger-sequence.component.ts
@@ -55,6 +55,8 @@ export class KtbTriggerSequenceComponent implements OnInit, OnDestroy {
   public isLoading = false;
   public isQualityGatesOnly = false;
   public isValidTimeframe = true;
+  public isValidStartBeforeEnd = true;
+  public isValidStartEndDuration = true;
   private _services: string[] = [];
   private unsubscribe$: Subject<void> = new Subject<void>();
 
@@ -126,8 +128,13 @@ export class KtbTriggerSequenceComponent implements OnInit, OnDestroy {
     return input !== undefined && input.trim() !== '';
   }
 
-  public isValidStartEndTime(start: string | undefined, end: string | undefined): boolean {
-    return start !== undefined && end !== undefined && this.checkStartEndValidity(start, end);
+  public isValidStartEndTime(): boolean {
+    return (
+      this.evaluationFormData.startDatetime !== undefined &&
+      this.evaluationFormData.endDatetime !== undefined &&
+      this.isValidStartBeforeEnd &&
+      this.isValidStartEndDuration
+    );
   }
 
   public isValidJSON(jsonString: string | undefined): boolean {
@@ -137,10 +144,27 @@ export class KtbTriggerSequenceComponent implements OnInit, OnDestroy {
     return AppUtils.isValidJson(jsonString);
   }
 
-  public checkStartEndValidity(start: string | undefined, end: string | undefined): boolean {
-    const startMoment = moment(start);
-    const endMoment = moment(end);
-    return startMoment.isBefore(endMoment);
+  private validateStartEndDate(): void {
+    if (this.evaluationFormData.startDatetime && this.evaluationFormData.endDatetime) {
+      const start = moment(this.evaluationFormData.startDatetime);
+      const end = moment(this.evaluationFormData.endDatetime);
+
+      this.isValidStartBeforeEnd = start.isBefore(end);
+      this.isValidStartEndDuration = moment.duration(end.diff(start)).asMinutes() >= 1;
+    } else {
+      this.isValidStartBeforeEnd = true;
+      this.isValidStartEndDuration = true;
+    }
+  }
+
+  public setStartDate(start: string | undefined): void {
+    this.evaluationFormData.startDatetime = start;
+    this.validateStartEndDate();
+  }
+
+  public setEndDate(end: string | undefined): void {
+    this.evaluationFormData.endDatetime = end;
+    this.validateStartEndDate();
   }
 
   public setTimeframe(timeframe: Timeframe): void {


### PR DESCRIPTION
Fixes #7118 

It now checks, if the duration between start and end date is greater or equal than 1 minute.
I also refactored it to have a cleaner html file, without the long calls of the validation methods.