### PR TITLE
test: use `T.TempDir()` to create temporary test directory in unit tests

### DIFF
--- a/cli/cmd/generate_docs_test.go
+++ b/cli/cmd/generate_docs_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -29,15 +28,10 @@ func TestGenerateDocs(t *testing.T) {
 	credentialmanager.MockAuthCreds = true
 
 	// create tempo directory
-	dname, err := ioutil.TempDir("", "docs_temp")
-	defer os.RemoveAll(dname)
-
-	if err != nil {
-		t.Errorf(unexpectedErrMsg, err)
-	}
+	dname := t.TempDir()
 
 	cmd := fmt.Sprintf("generate docs --dir=%s --mock", dname)
-	_, err = executeActionCommandC(cmd)
+	_, err := executeActionCommandC(cmd)
 
 	if err != nil {
 		t.Errorf(unexpectedErrMsg, err)

--- a/cli/cmd/generate_support_archive_test.go
+++ b/cli/cmd/generate_support_archive_test.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -33,15 +32,10 @@ func TestGenerateSupportArchive(t *testing.T) {
 	credentialmanager.MockAuthCreds = true
 
 	// create tempo directory
-	dname, err := ioutil.TempDir("", "docs_temp")
-	defer os.RemoveAll(dname)
-
-	if err != nil {
-		t.Errorf(unexpectedErrMsg, err)
-	}
+	dname := t.TempDir()
 
 	cmd := fmt.Sprintf("generate support-archive --dir=%s --mock", dname)
-	_, err = executeActionCommandC(cmd)
+	_, err := executeActionCommandC(cmd)
 
 	if err != nil {
 		t.Errorf(unexpectedErrMsg, err)

--- a/cli/cmd/set_config_test.go
+++ b/cli/cmd/set_config_test.go
@@ -28,17 +28,12 @@ const testConfig = `{"automatic_version_check":true,"last_version_check":"2020-0
 func TestSetAutomaticVersionCheckFalse(t *testing.T) {
 
 	configMng = config.NewCLIConfigManager("")
-	tmpDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Errorf("Unexpected error %v", err)
-	}
-
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	configMng.CLIConfigPath = filepath.Join(tmpDir, "config")
 	ioutil.WriteFile(configMng.CLIConfigPath, []byte(testConfig), 0644)
 
-	err = setConfigCmd.RunE(nil, []string{"automaticversioncheck", "false"})
+	err := setConfigCmd.RunE(nil, []string{"automaticversioncheck", "false"})
 	assert.Equal(t, err, nil, "Wrong error")
 
 	cliConfig, err := configMng.LoadCLIConfig()

--- a/cli/pkg/config/cli_config_test.go
+++ b/cli/pkg/config/cli_config_test.go
@@ -2,8 +2,6 @@ package config
 
 import (
 	"io/ioutil"
-	"log"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -24,14 +22,7 @@ func init() {
 
 func TestLoadNonExistingCLIConfig(t *testing.T) {
 	mng := NewCLIConfigManager("")
-	tmpDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	defer os.RemoveAll(tmpDir)
-
-	mng.CLIConfigPath = filepath.Join(tmpDir, "config")
+	mng.CLIConfigPath = filepath.Join(t.TempDir(), "config")
 
 	cliConfig, err := mng.LoadCLIConfig()
 	if err != nil {
@@ -47,18 +38,11 @@ func TestLoadNonExistingCLIConfig(t *testing.T) {
 
 func TestStoreCLIConfig(t *testing.T) {
 	mng := NewCLIConfigManager("")
-	tmpDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	defer os.RemoveAll(tmpDir)
-
-	mng.CLIConfigPath = filepath.Join(tmpDir, "config")
+	mng.CLIConfigPath = filepath.Join(t.TempDir(), "config")
 
 	cliConfig := CLIConfig{AutomaticVersionCheck: true, KubeContextCheck: true, LastVersionCheck: &testTime}
 
-	err = mng.StoreCLIConfig(cliConfig)
+	err := mng.StoreCLIConfig(cliConfig)
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
 	}
@@ -80,14 +64,7 @@ func TestStoreCLIConfig(t *testing.T) {
 
 func TestLoadCLIConfig(t *testing.T) {
 	mng := NewCLIConfigManager("")
-	tmpDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	defer os.RemoveAll(tmpDir)
-
-	mng.CLIConfigPath = filepath.Join(tmpDir, "config")
+	mng.CLIConfigPath = filepath.Join(t.TempDir(), "config")
 	ioutil.WriteFile(mng.CLIConfigPath, []byte(testConfig), 0644)
 
 	cliConfig, err := mng.LoadCLIConfig()

--- a/jmeter-service/jmeterUtils_test.go
+++ b/jmeter-service/jmeterUtils_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -16,7 +15,7 @@ import (
 )
 
 func Test_executeJMeter(t *testing.T) {
-	localTmpDir, _ := ioutil.TempDir("", "")
+	localTmpDir := t.TempDir()
 	var returnedStatus int
 	var returnedResources keptnapimodels.Resources
 
@@ -108,7 +107,7 @@ func Test_executeJMeter(t *testing.T) {
 					ResourceURI: &res,
 				})
 			}
-			tmpDir, _ := ioutil.TempDir("", "")
+			tmpDir := t.TempDir()
 			got, err := executeJMeter(tt.args.testInfo, tt.args.workload, tmpDir, tt.args.url, tt.args.LTN, tt.args.funcValidation)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("executeJMeter() error = %v, wantErr %v", err, tt.wantErr)

--- a/resource-service/common/files_test.go
+++ b/resource-service/common/files_test.go
@@ -1,27 +1,16 @@
 package common
 
 import (
-	"github.com/stretchr/testify/require"
-	"io/ioutil"
-	"os"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // base64 encoded tgz file containing file test.txt with content "test"
 const testTgzContent = "H4sIAOu80mEAA+2Vz0rDQBCHc84zeNgnSGf2b/ZQsFjFkxTRg+BltasGTAtJCjl46N2bZ5/SJ3ATrCW1iqCrlOx3mbAEMpvh+83E1MfWTG0xqGxZRV4AACUEiVTLusIbCEiQo+SCScYYAQqSiojUftrpsigrU7hWbu7nRWZmyZW5vrPFx/fGFyejs9PRweHleJ6bbEbOS1uUnUs6yHvdETAlt9l0iKBSppFzGruThTuhoEGCUKBiqkleZbkduhEhBUiFTkSqKUOJ8X9fIPAjGusHnr+x8n/pnh+e9x6bun/08gRruv6jUpRFRHjuq6Xn/rfzn3SWQFLVv7sI3P+QnH+V/3Qj/ymnEPL/L/hO/jPYkv+SKwUaZVgAO03rvxfr16z8X0af5b/Y8B85kxEBT/106Ln/zeiDwoFAINA/XgHzASEtABIAAA=="
 
 func TestFileSystem_WriteAndReadFile(t *testing.T) {
-	// create a tmp directory in test/tmp
-	err := ensureDirectoryExists("../test/tmp")
-	require.Nil(t, err)
-	dir, err := ioutil.TempDir("../test/tmp/", "project-")
-	require.Nil(t, err)
-	defer func(name string) {
-		err = os.RemoveAll(name)
-		if err != nil {
-			t.Logf("could not delete tmp directory: %v", err)
-		}
-	}(dir)
+	dir := t.TempDir()
 
 	fs := FileSystem{}
 
@@ -29,7 +18,7 @@ func TestFileSystem_WriteAndReadFile(t *testing.T) {
 
 	fileContent := "content"
 
-	err = fs.WriteFile(filePath, []byte(fileContent))
+	err := fs.WriteFile(filePath, []byte(fileContent))
 	require.Nil(t, err)
 
 	fileExists := fs.FileExists(filePath)
@@ -96,20 +85,13 @@ func TestIsHelmChartPath(t *testing.T) {
 
 func TestFileSystem_WriteHelmChart(t *testing.T) {
 	// create a tmp directory in test/tmp
-	dir, err := ioutil.TempDir("../test/tmp/", "project-")
-	require.Nil(t, err)
-	defer func(name string) {
-		err = os.RemoveAll(name)
-		if err != nil {
-			t.Logf("could not delete tmp directory: %v", err)
-		}
-	}(dir)
+	dir := t.TempDir()
 
 	fs := NewFileSystem(dir)
 
 	filePath := dir + "/my-file.tgz"
 
-	err = fs.WriteBase64EncodedFile(filePath, testTgzContent)
+	err := fs.WriteBase64EncodedFile(filePath, testTgzContent)
 	require.Nil(t, err)
 
 	err = fs.WriteHelmChart(filePath)


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

A small testing enhancement.

Use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

### Notes
<!-- any additional notes for this PR -->

Reference: https://pkg.go.dev/testing#T.TempDir

