### PR TITLE
test: Introduce small delay between started and finished events

### DIFF
--- a/test/go-tests/test_sequencecontrol.go
+++ b/test/go-tests/test_sequencecontrol.go
@@ -332,6 +332,9 @@ func Test_SequenceControl_AbortPausedSequenceTaskPartiallyFinished(t *testing.T)
 	_, err = keptn.SendTaskStartedEvent(nil, source2)
 	require.Nil(t, err)
 
+	// simulate task execution time of 10s
+	<-time.After(10 * time.Second)
+
 	t.Logf("send one finished event with result 'fail'")
 	_, err = keptn.SendTaskFinishedEvent(&keptnv2.EventData{Result: keptnv2.ResultFailed, Status: keptnv2.StatusSucceeded}, source1)
 	require.Nil(t, err)

--- a/test/go-tests/test_utils.go
+++ b/test/go-tests/test_utils.go
@@ -3,6 +3,7 @@ package go_tests
 import (
 	"context"
 	b64 "encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -431,6 +432,8 @@ func VerifySequenceEndsUpInState(t *testing.T, projectName string, context *mode
 			return false
 		}
 		for _, state := range states.States {
+			m, _ := json.MarshalIndent(state, "", "  ")
+			t.Logf("%s", m)
 			if doesSequenceHaveOneOfTheDesiredStates(state, context, desiredStates) {
 				return true
 			}


### PR DESCRIPTION
This PR introduces a small delay between sending the two `started` and the `finished` events, to simulate the duration it takes a task executor to execute a task. Otherwise, if those three events are sent at roughly the same time, it might be the case that the finished event is being processed before the second started event, which will lead to a completion of the current task