### PR TITLE
test: Adapt sequence state assertions to waiting state

### DIFF
--- a/test/go-tests/test_sequencecontrol.go
+++ b/test/go-tests/test_sequencecontrol.go
@@ -332,6 +332,9 @@ func Test_SequenceControl_AbortPausedSequenceTaskPartiallyFinished(t *testing.T)
 	_, err = keptn.SendTaskStartedEvent(nil, source2)
 	require.Nil(t, err)
 
+	// simulate task execution time of 10s
+	<-time.After(10 * time.Second)
+
 	t.Logf("send one finished event with result 'fail'")
 	_, err = keptn.SendTaskFinishedEvent(&keptnv2.EventData{Result: keptnv2.ResultFailed, Status: keptnv2.StatusSucceeded}, source1)
 	require.Nil(t, err)
@@ -341,7 +344,7 @@ func Test_SequenceControl_AbortPausedSequenceTaskPartiallyFinished(t *testing.T)
 	secondContextID, _ := TriggerSequence(projectName, serviceName, stageName, sequencename, nil)
 
 	// verify that the second sequence gets the triggered status
-	VerifySequenceEndsUpInState(t, projectName, &models.EventContext{&secondContextID}, 2*time.Minute, []string{scmodels.SequenceTriggeredState})
+	VerifySequenceEndsUpInState(t, projectName, &models.EventContext{&secondContextID}, 2*time.Minute, []string{scmodels.SequenceWaitingState})
 
 	// pause the sequence
 	t.Log("pausing sequence")

--- a/test/go-tests/test_utils.go
+++ b/test/go-tests/test_utils.go
@@ -3,6 +3,7 @@ package go_tests
 import (
 	"context"
 	b64 "encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/keptn/go-utils/pkg/common/strutils"
@@ -471,7 +472,10 @@ func VerifySequenceEndsUpInState(t *testing.T, projectName string, context *mode
 		if err != nil {
 			return false
 		}
+
 		for _, state := range states.States {
+			m, _ := json.MarshalIndent(state, "", "  ")
+			t.Logf("%s", m)
 			if doesSequenceHaveOneOfTheDesiredStates(state, context, desiredStates) {
 				return true
 			}


### PR DESCRIPTION
The assertions regarding the sequence state did not take the `waiting` state that was introduced in 0.13.x into consideration. Also, this PR includes the fix made in https://github.com/keptn/keptn/pull/7172 

Integration test run: https://github.com/keptn/keptn/runs/5567767074?check_suite_focus=true