### PR TITLE
feat(bridge): Allow to configure sendStarted flag for webhook config

### DIFF
--- a/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.html
+++ b/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.html
@@ -169,6 +169,27 @@
     </dt-form-field>
   </div>
   <div class="settings-section" fxLayout="row" fxLayoutAlign="start center">
+    <dt-form-field uitestid="edit-webhook-field-sendStarted" class="send-started-input">
+      <dt-label>Send started event</dt-label>
+      <dt-radio-group name="sendStarted" formControlName="sendStarted" (change)="onWebhookFormChange()">
+        <dt-radio-button value="true" class="mr-2"> automatically </dt-radio-button>
+        <dt-radio-button value="false"> by webhook receiver </dt-radio-button>
+      </dt-radio-group>
+    </dt-form-field>
+    <div [dtOverlay]="sendStartedOverlay" style="cursor: pointer" [dtOverlayConfig]="overlayConfig">
+      <dt-icon name="information" class="info mr-1"></dt-icon>
+    </div>
+    <ng-template #sendStartedOverlay>
+      <p>
+        If you subscribe your webhook to a task event of type triggered, the corresponding started and finished events
+        are sent automatically.
+        <br /><br />
+        To move the responsibility of sending the started event to the webhook receiver, select the option 'by webhook
+        receiver'.
+      </p>
+    </ng-template>
+  </div>
+  <div class="settings-section" fxLayout="row" fxLayoutAlign="start center">
     <dt-form-field uitestid="edit-webhook-field-sendFinished" class="send-finished-input">
       <dt-label>Send finished event</dt-label>
       <dt-radio-group name="sendFinished" formControlName="sendFinished" (change)="onWebhookFormChange()">
@@ -176,7 +197,7 @@
         <dt-radio-button value="false"> by webhook receiver </dt-radio-button>
       </dt-radio-group>
     </dt-form-field>
-    <div [dtOverlay]="sendFinishedOverlay" style="cursor: pointer" [dtOverlayConfig]="sendFinishedOverlayConfig">
+    <div [dtOverlay]="sendFinishedOverlay" style="cursor: pointer" [dtOverlayConfig]="overlayConfig">
       <dt-icon name="information" class="info mr-1"></dt-icon>
     </div>
     <ng-template #sendFinishedOverlay>

--- a/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.scss
+++ b/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.scss
@@ -16,8 +16,10 @@
   fill: var(--dt-theme-main-default-color);
 }
 
-.send-finished-input + .dt-overlay-trigger {
-  margin-top: 2.5em;
+.send-finished-input + .dt-overlay-trigger,
+.send-started-input + .dt-overlay-trigger {
+  margin-top: 2.7em;
+  margin-left: .3em;
 }
 
 ::ng-deep {

--- a/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.spec.ts
+++ b/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.spec.ts
@@ -288,51 +288,68 @@ describe('KtbWebhookSettingsComponent', () => {
       payload: 'payload',
       proxy: 'https://proxy.com',
       sendFinished: true,
+      sendStarted: true,
       type: '',
       url: 'https://example.com',
     });
   });
 
-  it('sendFinished should be enabled for triggered events and true by default', () => {
+  it('sendFinished and sendStarted should be enabled for triggered events and true by default', () => {
     // given
-    const checkbox = fixture.nativeElement.querySelector('[uitestid=edit-webhook-field-sendFinished] input');
+    const sendFinishedCheckbox = fixture.nativeElement.querySelector(
+      '[uitestid=edit-webhook-field-sendFinished] input'
+    );
+    const sendStartedCheckbox = fixture.nativeElement.querySelector('[uitestid=edit-webhook-field-sendStarted] input');
     component.eventType = 'triggered';
     fixture.detectChanges();
 
     // when
 
     // then
-    expect(checkbox.disabled).toEqual(false);
+    expect(sendFinishedCheckbox.disabled).toEqual(false);
+    expect(sendStartedCheckbox.disabled).toEqual(false);
     expect(component.getFormControl('sendFinished').value).toEqual('true');
+    expect(component.getFormControl('sendStarted').value).toEqual('true');
   });
 
-  it('sendFinished should be disabled for started events and null', () => {
+  it('sendFinished and sendStarted should be disabled for started events and null', () => {
     // given
-    const checkbox = fixture.nativeElement.querySelector('[uitestid=edit-webhook-field-sendFinished] input');
+    const sendFinishedCheckbox = fixture.nativeElement.querySelector(
+      '[uitestid=edit-webhook-field-sendFinished] input'
+    );
+    const sendStartedCheckbox = fixture.nativeElement.querySelector('[uitestid=edit-webhook-field-sendStarted] input');
     component.eventType = 'started';
     fixture.detectChanges();
 
     // when
 
     // then
-    expect(checkbox.disabled).toEqual(true);
+    expect(sendFinishedCheckbox.disabled).toEqual(true);
+    expect(sendStartedCheckbox.disabled).toEqual(true);
     expect(component.getFormControl('sendFinished').value).toEqual(null);
+    expect(component.getFormControl('sendStarted').value).toEqual(null);
   });
 
-  it('sendFinished should be disabled for finished events and null', () => {
+  it('sendFinished and sendStarted should be disabled for finished events and null', () => {
     // given
-    const checkbox = fixture.nativeElement.querySelector('[uitestid=edit-webhook-field-sendFinished] input');
+    const sendFinishedCheckbox = fixture.nativeElement.querySelector(
+      '[uitestid=edit-webhook-field-sendFinished] input'
+    );
+    const sendStartedCheckbox = fixture.nativeElement.querySelector('[uitestid=edit-webhook-field-sendStarted] input');
     component.eventType = 'finished';
     fixture.detectChanges();
 
     // when
 
     // then
-    expect(checkbox.disabled).toEqual(true);
+
+    expect(sendFinishedCheckbox.disabled).toEqual(true);
+    expect(sendStartedCheckbox.disabled).toEqual(true);
     expect(component.getFormControl('sendFinished').value).toEqual(null);
+    expect(component.getFormControl('sendStarted').value).toEqual(null);
   });
 
-  it('sendFinished should be set to true', () => {
+  it('sendFinished and sendStarted should be set to true', () => {
     // given
     component.eventType = 'triggered';
     component.webhook = {
@@ -341,6 +358,7 @@ describe('KtbWebhookSettingsComponent', () => {
       payload: 'payload',
       proxy: 'https://proxy.com',
       sendFinished: true,
+      sendStarted: true,
       filter: {
         projects: null,
         services: null,
@@ -354,9 +372,10 @@ describe('KtbWebhookSettingsComponent', () => {
 
     // then
     expect(component.getFormControl('sendFinished').value).toEqual('true');
+    expect(component.getFormControl('sendStarted').value).toEqual('true');
   });
 
-  it('sendFinished should be set to false', () => {
+  it('sendFinished and sendStarted should be set to false', () => {
     // given
     component.eventType = 'triggered';
     component.webhook = {
@@ -365,6 +384,7 @@ describe('KtbWebhookSettingsComponent', () => {
       payload: 'payload',
       proxy: 'https://proxy.com',
       sendFinished: false,
+      sendStarted: false,
       filter: {
         projects: null,
         services: null,
@@ -378,6 +398,7 @@ describe('KtbWebhookSettingsComponent', () => {
 
     // then
     expect(component.getFormControl('sendFinished').value).toEqual('false');
+    expect(component.getFormControl('sendStarted').value).toEqual('false');
   });
 
   it('should correctly set event payload', () => {

--- a/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.spec.ts
+++ b/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.spec.ts
@@ -294,62 +294,37 @@ describe('KtbWebhookSettingsComponent', () => {
     });
   });
 
-  it('sendFinished and sendStarted should be enabled for triggered events and true by default', () => {
+  it('should set sendFinished and sendStarted true by default for triggered events', () => {
     // given
-    const sendFinishedCheckbox = fixture.nativeElement.querySelector(
-      '[uitestid=edit-webhook-field-sendFinished] input'
-    );
-    const sendStartedCheckbox = fixture.nativeElement.querySelector('[uitestid=edit-webhook-field-sendStarted] input');
     component.eventType = 'triggered';
     fixture.detectChanges();
 
-    // when
-
     // then
-    expect(sendFinishedCheckbox.disabled).toEqual(false);
-    expect(sendStartedCheckbox.disabled).toEqual(false);
     expect(component.getFormControl('sendFinished').value).toEqual('true');
     expect(component.getFormControl('sendStarted').value).toEqual('true');
   });
 
-  it('sendFinished and sendStarted should be disabled for started events and null', () => {
+  it('should set sendFinished and sendStarted null when eventType started', () => {
     // given
-    const sendFinishedCheckbox = fixture.nativeElement.querySelector(
-      '[uitestid=edit-webhook-field-sendFinished] input'
-    );
-    const sendStartedCheckbox = fixture.nativeElement.querySelector('[uitestid=edit-webhook-field-sendStarted] input');
     component.eventType = 'started';
     fixture.detectChanges();
 
-    // when
-
     // then
-    expect(sendFinishedCheckbox.disabled).toEqual(true);
-    expect(sendStartedCheckbox.disabled).toEqual(true);
     expect(component.getFormControl('sendFinished').value).toEqual(null);
     expect(component.getFormControl('sendStarted').value).toEqual(null);
   });
 
-  it('sendFinished and sendStarted should be disabled for finished events and null', () => {
+  it('should set sendFinished and sendStarted null for finished events', () => {
     // given
-    const sendFinishedCheckbox = fixture.nativeElement.querySelector(
-      '[uitestid=edit-webhook-field-sendFinished] input'
-    );
-    const sendStartedCheckbox = fixture.nativeElement.querySelector('[uitestid=edit-webhook-field-sendStarted] input');
     component.eventType = 'finished';
     fixture.detectChanges();
 
-    // when
-
     // then
-
-    expect(sendFinishedCheckbox.disabled).toEqual(true);
-    expect(sendStartedCheckbox.disabled).toEqual(true);
     expect(component.getFormControl('sendFinished').value).toEqual(null);
     expect(component.getFormControl('sendStarted').value).toEqual(null);
   });
 
-  it('sendFinished and sendStarted should be set to true', () => {
+  it('should have sendFinished and sendStarted set to true', () => {
     // given
     component.eventType = 'triggered';
     component.webhook = {
@@ -375,7 +350,7 @@ describe('KtbWebhookSettingsComponent', () => {
     expect(component.getFormControl('sendStarted').value).toEqual('true');
   });
 
-  it('sendFinished and sendStarted should be set to false', () => {
+  it('should have sendFinished and sendStarted set to false', () => {
     // given
     component.eventType = 'triggered';
     component.webhook = {

--- a/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.ts
+++ b/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.ts
@@ -22,8 +22,8 @@ export class KtbWebhookSettingsComponent implements OnInit {
     payload: new FormControl('', [FormUtils.payloadSpecialCharValidator]),
     header: new FormArray([]),
     proxy: new FormControl('', [FormUtils.isUrlValidator]),
-    sendFinished: new FormControl('true', []),
-    sendStarted: new FormControl('true', []),
+    sendFinished: new FormControl('true'),
+    sendStarted: new FormControl('true'),
   });
   public webhookMethods: WebhookConfigMethod[] = ['GET', 'POST', 'PUT'];
   public secretDataSource: SelectTreeNode[] = [];

--- a/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.ts
+++ b/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.ts
@@ -163,12 +163,22 @@ export class KtbWebhookSettingsComponent implements OnInit {
 
   private setSendFinishedControl(): void {
     if (this._eventType !== 'triggered' && this._eventType !== '>') {
-      this.getFormControl('sendFinished').setValue(null);
-      this.getFormControl('sendFinished').disable();
+      this.disableFormControl('sendStarted');
+      this.disableFormControl('sendFinished');
     } else {
-      this.getFormControl('sendFinished').setValue(this._webhook.sendFinished.toString());
-      this.getFormControl('sendFinished').enable();
+      this.enableFormControl('sendStarted', this._webhook.sendStarted.toString());
+      this.enableFormControl('sendFinished', this._webhook.sendFinished.toString());
     }
+  }
+
+  private disableFormControl(controlName: ControlType): void {
+    this.getFormControl(controlName).setValue(null);
+    this.getFormControl(controlName).disable();
+  }
+
+  private enableFormControl(controlName: ControlType, initValue?: string): void {
+    this.getFormControl(controlName).setValue(initValue);
+    this.getFormControl(controlName).enable();
   }
 
   private mapSecret(secret: Secret): SelectTreeNode {

--- a/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.ts
+++ b/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.ts
@@ -7,7 +7,7 @@ import { DtOverlayConfig } from '@dynatrace/barista-components/overlay';
 import { Secret } from '../../_models/secret';
 import { SelectTreeNode } from '../ktb-tree-list-select/ktb-tree-list-select.component';
 
-type ControlType = 'method' | 'url' | 'payload' | 'proxy' | 'header' | 'sendFinished';
+type ControlType = 'method' | 'url' | 'payload' | 'proxy' | 'header' | 'sendFinished' | 'sendStarted';
 
 @Component({
   selector: 'ktb-webhook-settings',
@@ -23,10 +23,11 @@ export class KtbWebhookSettingsComponent implements OnInit {
     header: new FormArray([]),
     proxy: new FormControl('', [FormUtils.isUrlValidator]),
     sendFinished: new FormControl('true', []),
+    sendStarted: new FormControl('true', []),
   });
   public webhookMethods: WebhookConfigMethod[] = ['GET', 'POST', 'PUT'];
   public secretDataSource: SelectTreeNode[] = [];
-  public sendFinishedOverlayConfig: DtOverlayConfig = {
+  public overlayConfig: DtOverlayConfig = {
     pinnable: true,
     originY: 'center',
   };
@@ -134,6 +135,7 @@ export class KtbWebhookSettingsComponent implements OnInit {
     this._webhook.proxy = this.getFormControl('proxy').value;
     this._webhook.header = this.getFormControl('header').value;
     this._webhook.sendFinished = this.getFormControl('sendFinished').value === 'true';
+    this._webhook.sendStarted = this.getFormControl('sendStarted').value === 'true';
     this.webhookChange.emit(this._webhook);
   }
 

--- a/bridge/client/app/_services/api.service.mock.ts
+++ b/bridge/client/app/_services/api.service.mock.ts
@@ -359,6 +359,7 @@ export class ApiServiceMock extends ApiService {
       payload: '{"id":{{.id}}, "shkeptncontext": {{.shkeptncontext}}, "project": {{.data.project}}}',
       header: [],
       sendFinished: false,
+      sendStarted: false,
       proxy: '',
       filter: {
         projects: null,

--- a/bridge/cypress/integration/uniform-integrations.spec.ts
+++ b/bridge/cypress/integration/uniform-integrations.spec.ts
@@ -290,7 +290,15 @@ describe('Add webhook subscriptions', () => {
     cy.byTestId(uniformPage.EDIT_SUBSCRIPTION_FIELD_GLOBAL_ID).should('not.exist');
   });
 
-  it('should have sendFinished and sendStarted checkbox disabled', () => {
+  it('should have sendFinished and sendStarted checkbox disabled for started events', () => {
+    uniformPage
+      .setTaskPrefix('deployment')
+      .setTaskSuffix('started')
+      .assertIsSendStartedButtonsEnabled(false)
+      .assertIsSendFinishedButtonsEnabled(false);
+  });
+
+  it('should have sendFinished and sendStarted checkbox disabled for finished events', () => {
     uniformPage
       .setTaskPrefix('deployment')
       .setTaskSuffix('finished')
@@ -298,7 +306,7 @@ describe('Add webhook subscriptions', () => {
       .assertIsSendFinishedButtonsEnabled(false);
   });
 
-  it('should have sendFinished and sendStarted checkbox enabled and true by default', () => {
+  it('should have sendFinished and sendStarted checkbox enabled and true by default for triggered events', () => {
     uniformPage
       .setTaskPrefix('deployment')
       .setTaskSuffix('triggered')

--- a/bridge/cypress/integration/uniform-integrations.spec.ts
+++ b/bridge/cypress/integration/uniform-integrations.spec.ts
@@ -289,6 +289,24 @@ describe('Add webhook subscriptions', () => {
   it('should not show project checkbox', () => {
     cy.byTestId(uniformPage.EDIT_SUBSCRIPTION_FIELD_GLOBAL_ID).should('not.exist');
   });
+
+  it('should have sendFinished and sendStarted checkbox disabled', () => {
+    uniformPage
+      .setTaskPrefix('deployment')
+      .setTaskSuffix('finished')
+      .assertIsSendStartedButtonsEnabled(false)
+      .assertIsSendFinishedButtonsEnabled(false);
+  });
+
+  it('should have sendFinished and sendStarted checkbox enabled and true by default', () => {
+    uniformPage
+      .setTaskPrefix('deployment')
+      .setTaskSuffix('triggered')
+      .assertIsSendStartedButtonsEnabled(true)
+      .assertIsSendFinishedButtonsEnabled(true)
+      .assertIsSendStarted(true)
+      .assertIsSendFinished(true);
+  });
 });
 
 describe('Add control plane subscription default requests', () => {

--- a/bridge/cypress/integration/uniform-integrations.spec.ts
+++ b/bridge/cypress/integration/uniform-integrations.spec.ts
@@ -315,6 +315,114 @@ describe('Add webhook subscriptions', () => {
       .assertIsSendStarted(true)
       .assertIsSendFinished(true);
   });
+
+  it('should set sendFinished and sendStarted checkbox correctly onload to false', () => {
+    const subscriptionID = 'a0b7ea6b-01a7-4016-97ca-bc3251cd18ef';
+    const registrationID = '0f2d35875bbaa72b972157260a7bd4af4f2826df';
+
+    cy.intercept(`/api/controlPlane/v1/uniform/registration/${registrationID}/subscription/${subscriptionID}`, {
+      body: {
+        event: 'sh.keptn.event.deployment.triggered',
+        filter: {
+          projects: ['sockshop'],
+          services: [],
+          stages: [],
+        },
+        id: subscriptionID,
+      },
+    });
+    cy.intercept(`/api/uniform/registration/webhook-service/config/${subscriptionID}?projectName=sockshop`, {
+      body: {
+        type: '',
+        method: 'GET',
+        url: 'https://keptn.sh',
+        payload: '',
+        header: [],
+        sendStarted: false,
+        sendFinished: false,
+        proxy: '',
+      },
+    });
+
+    uniformPage
+      .visitEdit(registrationID, subscriptionID)
+      .assertIsSendStartedButtonsEnabled(true)
+      .assertIsSendFinishedButtonsEnabled(true)
+      .assertIsSendStarted(false)
+      .assertIsSendFinished(false);
+  });
+
+  it('should set sendFinished and sendStarted checkbox correctly onload to true', () => {
+    const subscriptionID = 'a0b7ea6b-01a7-4016-97ca-bc3251cd18ef';
+    const registrationID = '0f2d35875bbaa72b972157260a7bd4af4f2826df';
+
+    cy.intercept(`/api/controlPlane/v1/uniform/registration/${registrationID}/subscription/${subscriptionID}`, {
+      body: {
+        event: 'sh.keptn.event.deployment.triggered',
+        filter: {
+          projects: ['sockshop'],
+          services: [],
+          stages: [],
+        },
+        id: subscriptionID,
+      },
+    });
+    cy.intercept(`/api/uniform/registration/webhook-service/config/${subscriptionID}?projectName=sockshop`, {
+      body: {
+        type: '',
+        method: 'GET',
+        url: 'https://keptn.sh',
+        payload: '',
+        header: [],
+        sendStarted: true,
+        sendFinished: true,
+        proxy: '',
+      },
+    });
+
+    uniformPage
+      .visitEdit(registrationID, subscriptionID)
+      .assertIsSendStartedButtonsEnabled(true)
+      .assertIsSendFinishedButtonsEnabled(true)
+      .assertIsSendStarted(true)
+      .assertIsSendFinished(true);
+  });
+
+  it('should set sendFinished and sendStarted checkbox correctly onload to true/false', () => {
+    const subscriptionID = 'a0b7ea6b-01a7-4016-97ca-bc3251cd18ef';
+    const registrationID = '0f2d35875bbaa72b972157260a7bd4af4f2826df';
+
+    cy.intercept(`/api/controlPlane/v1/uniform/registration/${registrationID}/subscription/${subscriptionID}`, {
+      body: {
+        event: 'sh.keptn.event.deployment.triggered',
+        filter: {
+          projects: ['sockshop'],
+          services: [],
+          stages: [],
+        },
+        id: subscriptionID,
+      },
+    });
+    cy.intercept(`/api/uniform/registration/webhook-service/config/${subscriptionID}?projectName=sockshop`, {
+      body: {
+        type: '',
+        method: 'GET',
+        url: 'https://keptn.sh',
+        payload: '',
+        header: [],
+        sendStarted: true,
+        sendFinished: false,
+        proxy: '',
+      },
+    });
+
+    uniformPage
+      .visitEdit(registrationID, subscriptionID)
+      .assertIsSendStartedButtonsEnabled(true)
+      .assertIsSendFinishedButtonsEnabled(true)
+      .assertIsSendStarted(true)
+      .assertIsSendFinished(false);
+  });
 });
 
 describe('Add control plane subscription default requests', () => {

--- a/bridge/cypress/support/pageobjects/UniformPage.ts
+++ b/bridge/cypress/support/pageobjects/UniformPage.ts
@@ -60,7 +60,7 @@ class UniformPage {
   }
 
   public assertIsUpdateButtonEnabled(isEnabled: boolean): this {
-    cy.byTestId(this.UPDATE_SUBSCRIPTION_BUTTON_ID).should(isEnabled ? 'not.have.attr' : 'have.attr', 'disabled');
+    cy.byTestId(this.UPDATE_SUBSCRIPTION_BUTTON_ID).should(isEnabled ? 'be.enabled' : 'be.disabled');
     return this;
   }
 
@@ -68,11 +68,11 @@ class UniformPage {
     cy.byTestId(this.SEND_STARTED_BUTTONS)
       .find('input.dt-radio-input')
       .eq(0)
-      .should(isEnabled ? 'not.have.attr' : 'have.attr', 'disabled');
+      .should(isEnabled ? 'be.enabled' : 'be.disabled');
     cy.byTestId(this.SEND_STARTED_BUTTONS)
       .find('input.dt-radio-input')
       .eq(1)
-      .should(isEnabled ? 'not.have.attr' : 'have.attr', 'disabled');
+      .should(isEnabled ? 'be.enabled' : 'be.disabled');
     return this;
   }
 
@@ -92,11 +92,11 @@ class UniformPage {
     cy.byTestId(this.SEND_FINISHED_BUTTONS)
       .find('input.dt-radio-input')
       .eq(0)
-      .should(isEnabled ? 'not.have.attr' : 'have.attr', 'disabled');
+      .should(isEnabled ? 'be.enabled' : 'be.disabled');
     cy.byTestId(this.SEND_FINISHED_BUTTONS)
       .find('input.dt-radio-input')
       .eq(1)
-      .should(isEnabled ? 'not.have.attr' : 'have.attr', 'disabled');
+      .should(isEnabled ? 'be.enabled' : 'be.disabled');
     return this;
   }
 

--- a/bridge/cypress/support/pageobjects/UniformPage.ts
+++ b/bridge/cypress/support/pageobjects/UniformPage.ts
@@ -24,6 +24,8 @@ class UniformPage {
   EDIT_WEBHOOK_FILTER = 'edit-subscription-field-filterStageService';
   EDIT_WEBHOOK_METHOD = 'edit-webhook-field-method';
   EDIT_WEBHOOK_PROXY = 'edit-webhook-field-proxy';
+  SEND_FINISHED_BUTTONS = 'edit-webhook-field-sendFinished';
+  SEND_STARTED_BUTTONS = 'edit-webhook-field-sendStarted';
 
   public visit(project: string): this {
     cy.visit(`/project/${project}/settings/uniform/integrations`).wait('@metadata');
@@ -59,6 +61,54 @@ class UniformPage {
 
   public assertIsUpdateButtonEnabled(isEnabled: boolean): this {
     cy.byTestId(this.UPDATE_SUBSCRIPTION_BUTTON_ID).should(isEnabled ? 'not.have.attr' : 'have.attr', 'disabled');
+    return this;
+  }
+
+  public assertIsSendStartedButtonsEnabled(isEnabled: boolean): this {
+    cy.byTestId(this.SEND_STARTED_BUTTONS)
+      .find('input.dt-radio-input')
+      .eq(0)
+      .should(isEnabled ? 'not.have.attr' : 'have.attr', 'disabled');
+    cy.byTestId(this.SEND_STARTED_BUTTONS)
+      .find('input.dt-radio-input')
+      .eq(1)
+      .should(isEnabled ? 'not.have.attr' : 'have.attr', 'disabled');
+    return this;
+  }
+
+  public assertIsSendStarted(status: boolean): this {
+    cy.byTestId(this.SEND_STARTED_BUTTONS)
+      .find('input.dt-radio-input')
+      .eq(0)
+      .should(status ? 'be.checked' : 'not.be.checked');
+    cy.byTestId(this.SEND_STARTED_BUTTONS)
+      .find('input.dt-radio-input')
+      .eq(1)
+      .should(status ? 'not.be.checked' : 'be.checked');
+    return this;
+  }
+
+  public assertIsSendFinishedButtonsEnabled(isEnabled: boolean): this {
+    cy.byTestId(this.SEND_FINISHED_BUTTONS)
+      .find('input.dt-radio-input')
+      .eq(0)
+      .should(isEnabled ? 'not.have.attr' : 'have.attr', 'disabled');
+    cy.byTestId(this.SEND_FINISHED_BUTTONS)
+      .find('input.dt-radio-input')
+      .eq(1)
+      .should(isEnabled ? 'not.have.attr' : 'have.attr', 'disabled');
+    return this;
+  }
+
+  public assertIsSendFinished(status: boolean): this {
+    cy.byTestId(this.SEND_FINISHED_BUTTONS)
+      .find('input.dt-radio-input')
+      .eq(0)
+      .should(status ? 'be.checked' : 'not.be.checked');
+    cy.byTestId(this.SEND_FINISHED_BUTTONS)
+      .find('input.dt-radio-input')
+      .eq(1)
+      .should(status ? 'not.be.checked' : 'be.checked');
     return this;
   }
 

--- a/bridge/server/interfaces/webhook-config-yaml-result.ts
+++ b/bridge/server/interfaces/webhook-config-yaml-result.ts
@@ -3,6 +3,7 @@ import { WebhookSecret } from '../../shared/models/webhook-config';
 export type Webhook = {
   subscriptionID: string;
   sendFinished?: boolean;
+  sendStarted?: boolean;
   type: string; // type === event
   requests: string[];
   envFrom?: WebhookSecret[];

--- a/bridge/server/models/webhook-config-yaml.spec.ts
+++ b/bridge/server/models/webhook-config-yaml.spec.ts
@@ -23,6 +23,7 @@ const config = WebhookConfigYaml.fromJSON({
           },
         ],
         sendFinished: true,
+        sendStarted: true,
       },
     ],
   },
@@ -51,6 +52,7 @@ const configWithLongCurl = WebhookConfigYaml.fromJSON({
           },
         ],
         sendFinished: true,
+        sendStarted: true,
       },
     ],
   },
@@ -70,6 +72,7 @@ const configWithoutSecrets = WebhookConfigYaml.fromJSON({
           `curl http://keptn.sh/asdf asdf --request GET --header 'content-type: application/json' --header 'Authorization: myVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongHeader' --proxy http://keptn.sh/proxy --data '{"data": "myData"}'`,
         ],
         sendFinished: true,
+        sendStarted: true,
       },
     ],
   },
@@ -109,14 +112,15 @@ describe('Test webhook-config-yaml', () => {
         },
       ],
       sendFinished: false,
+      sendStarted: false,
     });
     expect(result).toEqual(webhookConfig);
   });
 
   it('should set sendFinished to the value specified', () => {
     // given
-    const yamlConfigTrue = getDefaultWebhookYaml(true);
-    const yamlConfigFalse = getDefaultWebhookYaml(false);
+    const yamlConfigTrue = getDefaultWebhookYaml(true, true);
+    const yamlConfigFalse = getDefaultWebhookYaml(false, false);
     const yamlConfigUndefined = getDefaultWebhookYaml();
 
     // when
@@ -128,6 +132,23 @@ describe('Test webhook-config-yaml', () => {
     expect(webhookConfigTrue.sendFinished).toBe(true);
     expect(webhookConfigFalse.sendFinished).toBe(false);
     expect(webhookConfigUndefined.sendFinished).toBe(false);
+  });
+
+  it('should set sendStarted to the value specified', () => {
+    // given
+    const yamlConfigTrue = getDefaultWebhookYaml(true, true);
+    const yamlConfigFalse = getDefaultWebhookYaml(false, false);
+    const yamlConfigUndefined = getDefaultWebhookYaml();
+
+    // when
+    const webhookConfigTrue = yamlConfigTrue.parsedRequest('myID') as WebhookConfig;
+    const webhookConfigFalse = yamlConfigFalse.parsedRequest('myID') as WebhookConfig;
+    const webhookConfigUndefined = yamlConfigUndefined.parsedRequest('myID') as WebhookConfig;
+
+    // then
+    expect(webhookConfigTrue.sendStarted).toBe(true);
+    expect(webhookConfigFalse.sendStarted).toBe(false);
+    expect(webhookConfigUndefined.sendStarted).toBe(true);
   });
 
   it('should return undefined if subscriptionID does not exist', () => {
@@ -149,6 +170,7 @@ describe('Test webhook-config-yaml', () => {
       'curl http://keptn.sh --request GET',
       'mySecondID',
       [],
+      true,
       true
     );
 
@@ -157,6 +179,7 @@ describe('Test webhook-config-yaml', () => {
     expect(yamlConfig.spec.webhooks[1]).toEqual({
       type: 'sh.keptn.events.approval.triggered',
       sendFinished: true,
+      sendStarted: true,
       subscriptionID: 'mySecondID',
       requests: ['curl http://keptn.sh --request GET'],
     } as Webhook);
@@ -181,6 +204,7 @@ describe('Test webhook-config-yaml', () => {
           },
         },
       ],
+      true,
       true
     );
 
@@ -189,6 +213,7 @@ describe('Test webhook-config-yaml', () => {
     expect(yamlConfig.spec.webhooks[0]).toEqual({
       type: 'sh.keptn.events.approval.started',
       sendFinished: true,
+      sendStarted: true,
       envFrom: [
         {
           name: 'mySecret',
@@ -213,6 +238,7 @@ describe('Test webhook-config-yaml', () => {
       'curl http://keptn.sh/second --request GET',
       'myID',
       [],
+      true,
       true
     );
 
@@ -221,6 +247,7 @@ describe('Test webhook-config-yaml', () => {
     expect(yamlConfig.spec.webhooks[0]).toEqual({
       type: 'sh.keptn.events.approval.started',
       sendFinished: true,
+      sendStarted: true,
       subscriptionID: 'myID',
       requests: ['curl http://keptn.sh/second --request GET'],
     } as Webhook);
@@ -261,6 +288,7 @@ spec:
             name: myName
             key: myKey
       sendFinished: true
+      sendStarted: true
 `);
   });
 
@@ -286,6 +314,7 @@ spec:
             name: myName
             key: myKey
       sendFinished: true
+      sendStarted: true
 `);
   });
 
@@ -306,10 +335,11 @@ spec:
         - >-
           curl http://keptn.sh/asdf asdf --request GET --header 'content-type: application/json' --header 'Authorization: myVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongHeader' --proxy http://keptn.sh/proxy --data '{"data": "myData"}'
       sendFinished: true
+      sendStarted: true
 `);
   });
 
-  function getDefaultWebhookYaml(sendFinished?: boolean): WebhookConfigYaml {
+  function getDefaultWebhookYaml(sendFinished?: boolean, sendStarted?: boolean): WebhookConfigYaml {
     return WebhookConfigYaml.fromJSON({
       kind: 'WebhookConfig',
       apiVersion: 'webhookconfig.keptn.sh/v1alpha1',
@@ -331,6 +361,7 @@ spec:
               },
             ],
             ...(sendFinished !== undefined && { sendFinished }),
+            ...(sendStarted !== undefined && { sendStarted }),
           },
         ],
       },

--- a/bridge/server/models/webhook-config-yaml.spec.ts
+++ b/bridge/server/models/webhook-config-yaml.spec.ts
@@ -148,7 +148,7 @@ describe('Test webhook-config-yaml', () => {
     // then
     expect(webhookConfigTrue.sendStarted).toBe(true);
     expect(webhookConfigFalse.sendStarted).toBe(false);
-    expect(webhookConfigUndefined.sendStarted).toBe(false);
+    expect(webhookConfigUndefined.sendStarted).toBe(true);
   });
 
   it('should return undefined if subscriptionID does not exist', () => {

--- a/bridge/server/models/webhook-config-yaml.spec.ts
+++ b/bridge/server/models/webhook-config-yaml.spec.ts
@@ -112,7 +112,7 @@ describe('Test webhook-config-yaml', () => {
         },
       ],
       sendFinished: false,
-      sendStarted: false,
+      sendStarted: true,
     });
     expect(result).toEqual(webhookConfig);
   });

--- a/bridge/server/models/webhook-config-yaml.spec.ts
+++ b/bridge/server/models/webhook-config-yaml.spec.ts
@@ -112,7 +112,7 @@ describe('Test webhook-config-yaml', () => {
         },
       ],
       sendFinished: false,
-      sendStarted: true,
+      sendStarted: false,
     });
     expect(result).toEqual(webhookConfig);
   });
@@ -148,7 +148,7 @@ describe('Test webhook-config-yaml', () => {
     // then
     expect(webhookConfigTrue.sendStarted).toBe(true);
     expect(webhookConfigFalse.sendStarted).toBe(false);
-    expect(webhookConfigUndefined.sendStarted).toBe(true);
+    expect(webhookConfigUndefined.sendStarted).toBe(false);
   });
 
   it('should return undefined if subscriptionID does not exist', () => {

--- a/bridge/server/models/webhook-config-yaml.ts
+++ b/bridge/server/models/webhook-config-yaml.ts
@@ -113,7 +113,7 @@ export class WebhookConfigYaml implements WebhookConfigYamlResult {
         const parsedConfig = this.parseConfig(curl);
         parsedConfig.secrets = webhook.envFrom;
         parsedConfig.sendFinished = webhook.sendFinished ?? false;
-        parsedConfig.sendStarted = webhook.sendStarted ?? false;
+        parsedConfig.sendStarted = webhook.sendStarted ?? true;
         parsedConfig.type = webhook.type;
         return parsedConfig;
       }

--- a/bridge/server/models/webhook-config-yaml.ts
+++ b/bridge/server/models/webhook-config-yaml.ts
@@ -66,7 +66,8 @@ export class WebhookConfigYaml implements WebhookConfigYamlResult {
     curl: string,
     subscriptionId: string,
     secrets: WebhookSecret[],
-    sendFinished: boolean
+    sendFinished: boolean,
+    sendStarted: boolean
   ): void {
     const webhook = this.getWebhook(subscriptionId);
     if (!webhook) {
@@ -76,12 +77,14 @@ export class WebhookConfigYaml implements WebhookConfigYamlResult {
         ...(secrets.length && { envFrom: secrets }),
         subscriptionID: subscriptionId,
         sendFinished: sendFinished,
+        sendStarted: sendStarted,
       });
     } else {
       // overwrite
       webhook.type = eventType;
       webhook.requests[0] = curl;
       webhook.sendFinished = sendFinished;
+      webhook.sendStarted = sendStarted;
       if (secrets.length) {
         webhook.envFrom = secrets;
       } else {
@@ -110,6 +113,7 @@ export class WebhookConfigYaml implements WebhookConfigYamlResult {
         const parsedConfig = this.parseConfig(curl);
         parsedConfig.secrets = webhook.envFrom;
         parsedConfig.sendFinished = webhook.sendFinished ?? false;
+        parsedConfig.sendStarted = webhook.sendStarted ?? true;
         parsedConfig.type = webhook.type;
         return parsedConfig;
       }

--- a/bridge/server/models/webhook-config-yaml.ts
+++ b/bridge/server/models/webhook-config-yaml.ts
@@ -113,7 +113,7 @@ export class WebhookConfigYaml implements WebhookConfigYamlResult {
         const parsedConfig = this.parseConfig(curl);
         parsedConfig.secrets = webhook.envFrom;
         parsedConfig.sendFinished = webhook.sendFinished ?? false;
-        parsedConfig.sendStarted = webhook.sendStarted ?? true;
+        parsedConfig.sendStarted = webhook.sendStarted ?? false;
         parsedConfig.type = webhook.type;
         return parsedConfig;
       }

--- a/bridge/server/services/data-service.ts
+++ b/bridge/server/services/data-service.ts
@@ -872,7 +872,8 @@ export class DataService {
             curl,
             subscriptionId,
             secrets,
-            webhookConfig.sendFinished
+            webhookConfig.sendFinished,
+            webhookConfig.sendStarted
           );
           await this.apiService.saveWebhookConfig(accessToken, previousWebhookConfig.toYAML(), project, stage, service);
         }

--- a/bridge/server/utils/curl.utils.spec.ts
+++ b/bridge/server/utils/curl.utils.spec.ts
@@ -29,6 +29,7 @@ describe('Test curl-parser', () => {
         },
       ],
       sendFinished: false,
+      sendStarted: false,
     });
     expect(generateWebhookConfigCurl(webhookConfig)).toBe(
       `curl --header 'content-type: application/json' --header 'Authorization: Bearer myToken' --request GET --proxy http://keptn.sh/proxy --data '{"data":"myData"}' http://keptn.sh/asdf asdf`
@@ -44,6 +45,7 @@ describe('Test curl-parser', () => {
       method: 'GET',
       secrets: [],
       sendFinished: false,
+      sendStarted: false,
     });
     expect(generateWebhookConfigCurl(webhookConfig)).toBe(
       `curl --request GET --proxy http://keptn.sh/proxy --data '{"data":"myData"}' http://keptn.sh/asdf asdf`
@@ -59,6 +61,7 @@ describe('Test curl-parser', () => {
       method: 'GET',
       secrets: [],
       sendFinished: false,
+      sendStarted: false,
     });
     expect(generateWebhookConfigCurl(webhookConfig)).toBe(
       `curl --request GET --data '{"data":"myData"}' http://keptn.sh/asdf asdf`
@@ -74,6 +77,7 @@ describe('Test curl-parser', () => {
       method: 'GET',
       secrets: [],
       sendFinished: false,
+      sendStarted: false,
     });
     expect(generateWebhookConfigCurl(webhookConfig)).toBe(`curl --request GET http://keptn.sh/asdf`);
   });
@@ -87,6 +91,7 @@ describe('Test curl-parser', () => {
       method: 'GET',
       secrets: [],
       sendFinished: false,
+      sendStarted: false,
     });
     expect(generateWebhookConfigCurl(webhookConfig)).toBe(
       `curl --request GET --data '<meta>myText</meta><meta2>myOtherText</meta2>' http://keptn.sh/asdf`

--- a/bridge/shared/interfaces/webhook-config.ts
+++ b/bridge/shared/interfaces/webhook-config.ts
@@ -17,4 +17,5 @@ export interface WebhookConfig {
   header: { name: string; value: string }[];
   proxy?: string;
   sendFinished: boolean;
+  sendStarted: boolean;
 }

--- a/bridge/shared/models/webhook-config.ts
+++ b/bridge/shared/models/webhook-config.ts
@@ -28,6 +28,7 @@ export class WebhookConfig implements wc {
   public proxy?: string;
   public secrets?: WebhookSecret[];
   public sendFinished: boolean;
+  public sendStarted: boolean;
 
   constructor() {
     this.type = '';
@@ -36,5 +37,6 @@ export class WebhookConfig implements wc {
     this.payload = '';
     this.header = [];
     this.sendFinished = true;
+    this.sendStarted = true;
   }
 }


### PR DESCRIPTION
## This PR
- allows the user to configure the sendStarted flag for a webhook configuration via Keptn Bridge

### Related Issues
Fixes #6059 

![image](https://user-images.githubusercontent.com/6098219/158765174-58f6eb7d-fba9-4aa2-9dd9-a87a754a5be3.png)
