### PR TITLE
fix(configuration-service): Return 404 when token is invalid (#7121)

### DIFF
--- a/configuration-service/handlers/project.go
+++ b/configuration-service/handlers/project.go
@@ -1,11 +1,12 @@
 package handlers
 
 import (
-	logger "github.com/sirupsen/logrus"
 	"net/http"
 	"os"
 	"strings"
 	"time"
+
+	logger "github.com/sirupsen/logrus"
 
 	k8sutils "github.com/keptn/kubernetes-utils/pkg"
 
@@ -133,7 +134,7 @@ func PutProjectProjectNameHandlerFunc(params project.PutProjectProjectNameParams
 				}
 				if strings.Contains(err.Error(), "Authentication failed") || strings.Contains(err.Error(), common.WrongToken) || strings.Contains(err.Error(), common.GitError) {
 					logger.Error("Authentication error detected")
-					return project.NewPutProjectProjectNameBadRequest().WithPayload(&models.Error{Code: http.StatusFailedDependency, Message: swag.String(common.InvalidUpstreamTokenErrorMsg)})
+					return project.NewPutProjectProjectNameBadRequest().WithPayload(&models.Error{Code: http.StatusNotFound, Message: swag.String(common.RepositoryNotFoundErrorMsg)})
 				}
 
 				return project.NewPutProjectProjectNameDefault(http.StatusInternalServerError).WithPayload(&models.Error{Code: http.StatusInternalServerError, Message: swag.String(common.InternalErrorErrMsg)})

--- a/shipyard-controller/common/configurationstore.go
+++ b/shipyard-controller/common/configurationstore.go
@@ -2,9 +2,10 @@ package common
 
 import (
 	"errors"
+	"net/http"
+
 	keptnapimodels "github.com/keptn/go-utils/pkg/api/models"
 	keptnapi "github.com/keptn/go-utils/pkg/api/utils"
-	"net/http"
 )
 
 type configStoreErrType int

--- a/shipyard-controller/common/configurationstore_test.go
+++ b/shipyard-controller/common/configurationstore_test.go
@@ -52,6 +52,17 @@ func TestConfigurationStore(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 
+	t.Run("TestUpdateProject_APIReturnsStatusNotFoundError", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer ts.Close()
+
+		instance := NewGitConfigurationStore(ts.URL)
+		err := instance.UpdateProject(keptnapimodels.Project{})
+		assert.NotNil(t, err)
+	})
+
 	t.Run("TestDelete_Success", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 		defer ts.Close()


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- Return 404 when token is invalid

