### PR TITLE
fix(cli): Removed user check from create/update project and added simple tests

### DIFF
--- a/cli/cmd/create_project.go
+++ b/cli/cmd/create_project.go
@@ -40,6 +40,10 @@ const gitErrMsg = `Please specify a 'git-user' and 'git-remote-url' as flags for
 const gitMissingUpstream = `WARNING: Creating a project without Git upstream repository is not recommended and will not be supported in the future anymore.
 You can configure a Git upstream repository using: 
 
+keptn update project PROJECTNAME --git-remote-url=GIT_REMOTE_URL --git-token=GIT_TOKEN
+
+or (if your repository provider allows to use user and password)
+
 keptn update project PROJECTNAME --git-user=GIT_USER --git-remote-url=GIT_REMOTE_URL --git-token=GIT_TOKEN
 
 or (only for resource-service)
@@ -61,8 +65,9 @@ var crProjectCmd = &cobra.Command{
 The shipyard file describes the used stages. These stages are defined by name, as well as their task sequences.
 
 By executing the *create project* command, Keptn initializes an internal Git repository that is used to maintain all project-related resources. 
-To upstream this internal Git repository to a remote repository, the Git user (*--git-user*) and the remote URL (*--git-remote-url*) are required
-together with private key (*--git-private-key*) or access token (*--git-token*). For using proxy please specify proxy IP address together with port (*--git-proxy-url*) and
+To upstream this internal Git repository to a remote repository, the remote URL (*--git-remote-url*) is required
+together with private key (*--git-private-key*) or access token (*--git-token*). The Git user (*--git-user*) can be specified if the repository allows it. 
+For using proxy please specify proxy IP address together with port (*--git-proxy-url*) and
 used scheme (*--git-proxy-scheme=*) to connect to proxy. Please be aware that authentication with public/private key and via proxy is 
 supported only when using resource-service.
 
@@ -185,7 +190,7 @@ keptn create project PROJECTNAME --shipyard=FILEPATH --git-user=GIT_USER --git-r
 }
 
 func checkGitCredentials() error {
-	if *createProjectParams.GitUser == "" && *createProjectParams.GitToken == "" && *createProjectParams.RemoteURL == "" {
+	if *createProjectParams.GitToken == "" && *createProjectParams.RemoteURL == "" {
 		fmt.Println(gitMissingUpstream)
 		return nil
 	}

--- a/cli/cmd/create_project_test.go
+++ b/cli/cmd/create_project_test.go
@@ -66,8 +66,8 @@ func TestCreateProjectCmdWithGitMissingParam(t *testing.T) {
 	shipyardFilePath := "./shipyard.yaml"
 	defer testShipyard(t, shipyardFilePath, "")()
 
-	cmd := fmt.Sprintf("create project sockshop --shipyard=%s --git-user=%s --git-token=%s --mock",
-		shipyardFilePath, "user", "token")
+	cmd := fmt.Sprintf("create project sockshop --shipyard=%s --git-token=%s --mock",
+		shipyardFilePath, "token")
 	_, err := executeActionCommandC(cmd)
 
 	if !errorContains(err, gitErrMsg) {
@@ -75,7 +75,7 @@ func TestCreateProjectCmdWithGitMissingParam(t *testing.T) {
 	}
 }
 
-// TestCreateProjectCmdWithGitMissingParam tests a successful create project
+// TestCreateProjectCmdWithGit tests a successful create project
 // command with git upstream parameters
 func TestCreateProjectCmdWithGit(t *testing.T) {
 	credentialmanager.MockAuthCreds = true
@@ -85,6 +85,23 @@ func TestCreateProjectCmdWithGit(t *testing.T) {
 
 	cmd := fmt.Sprintf("create project sockshop --shipyard=%s --git-user=%s --git-token=%s --git-remote-url=%s --mock",
 		shipyardFilePath, "user", "token", "https://")
+	_, err := executeActionCommandC(cmd)
+
+	if err != nil {
+		t.Errorf(unexpectedErrMsg, err)
+	}
+}
+
+// TestCreateProjectCmdWithGit tests a successful create project
+// command with git upstream parameters without user
+func TestCreateProjectCmdWithoutGitUser(t *testing.T) {
+	credentialmanager.MockAuthCreds = true
+
+	shipyardFilePath := "./shipyard.yaml"
+	defer testShipyard(t, shipyardFilePath, "")()
+
+	cmd := fmt.Sprintf("create project sockshop --shipyard=%s --git-token=%s --git-remote-url=%s --mock",
+		shipyardFilePath, "token", "https://")
 	_, err := executeActionCommandC(cmd)
 
 	if err != nil {

--- a/cli/cmd/update_project.go
+++ b/cli/cmd/update_project.go
@@ -42,14 +42,18 @@ var upProjectCmd = &cobra.Command{
 Updating a shipyard file is not possible.
 
 By executing the update project command, Keptn will add the provided upstream repository to the existing internal Git repository that is used to maintain all project-related resources. 
-To upstream this internal Git repository to a remote repository, the Git user (--git-user) and the remote URL (*--git-remote-url*) are required
-together with private key (*--git-private-key*) or access token (*--git-token*). . For using proxy please specify proxy IP address together with port (*--git-proxy-url*) and
+To upstream this internal Git repository to a remote repository and the remote URL (*--git-remote-url*) are required
+together with private key (*--git-private-key*) or access token (*--git-token*). The Git user (--git-user) can be added if required. For using proxy please specify proxy IP address together with port (*--git-proxy-url*) and
 used scheme (*--git-proxy-scheme=*) to connect to proxy. Please be aware that authentication with public/private key and via proxy is 
 supported only when using resource-service.
 
 For more information about updating projects or upstream repositories, please go to [Manage Keptn](https://keptn.sh/docs/` + getReleaseDocsURL() + `/manage/)
 `,
-	Example: `keptn update project PROJECTNAME --git-user=GIT_USER --git-token=GIT_TOKEN --git-remote-url=GIT_REMOTE_URL
+	Example: `keptn update project PROJECTNAME --git-token=GIT_TOKEN --git-remote-url=GIT_REMOTE_URL
+
+or (if the git repo requires user)
+
+keptn update project PROJECTNAME --git-user=GIT_USER --git-token=GIT_TOKEN --git-remote-url=GIT_REMOTE_URL
 
 or (only for resource-service)
 
@@ -168,7 +172,6 @@ func init() {
 
 	updateProjectParams.GitUser = upProjectCmd.Flags().StringP("git-user", "u", "", "The git user of the upstream target")
 	updateProjectParams.GitToken = upProjectCmd.Flags().StringP("git-token", "t", "", "The git token of the git user")
-	upProjectCmd.MarkFlagRequired("git-user")
 	upProjectCmd.MarkFlagRequired("git-remote-url")
 
 	updateProjectParams.RemoteURL = upProjectCmd.Flags().StringP("git-remote-url", "r", "", "The remote url of the upstream target")

--- a/cli/cmd/update_project_test.go
+++ b/cli/cmd/update_project_test.go
@@ -18,7 +18,18 @@ func init() {
 func TestUpdateProjectCmd(t *testing.T) {
 	credentialmanager.MockAuthCreds = true
 
-	cmd := fmt.Sprintf("update project sockshop --git-token=token --git-user=user --git-remote-url=https://some.url --mock")
+	cmd := fmt.Sprintf("update project sockshop --git-token=token --git-remote-url=https://some.url --mock")
+	_, err := executeActionCommandC(cmd)
+	if err != nil {
+		t.Errorf(unexpectedErrMsg, err)
+	}
+}
+
+// TestUpdateProjectCmd tests the use of the update project command with a git user set up
+func TestUpdateProjectCmdWithUser(t *testing.T) {
+	credentialmanager.MockAuthCreds = true
+
+	cmd := fmt.Sprintf("update project sockshop --git-user=user --git-token=token --git-remote-url=https://some.url --mock")
 	_, err := executeActionCommandC(cmd)
 	if err != nil {
 		t.Errorf(unexpectedErrMsg, err)


### PR DESCRIPTION
Signed-off-by: RealAnna <anna.reale@dynatrace.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->
There have been issues on windows with 
`git push https://<USER>:<TOKEN>@github.com/<REPO>`
to help users and for consistency, we decided to remove mandatory User from create ad update commands so that we can fall back on the URL :
`git push https://<TOKEN>@github.com/<REPO>`


### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #7180 

### How to test
run a create command for a github repo without specifying the User
` keptn create project prova3 --shipyard=shipyard.yaml -t=$GIT_TOKEN -r=$GITHUB_REPO
`
