### PR TITLE
fix(distributor): Added longer sleep for Nats down test in forwarder

### DIFF
--- a/distributor/pkg/forwarder/forwarder_test.go
+++ b/distributor/pkg/forwarder/forwarder_test.go
@@ -98,7 +98,7 @@ func Test_NATSDown(t *testing.T) {
 	svr.WaitForShutdown()
 
 	// wait until we exceed max reconnect time
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(5 * time.Second)
 
 	// restart embedded NATS cluster
 	svr, shutdownNats = runNATSServerOnPort(natsTestPort)


### PR DESCRIPTION

## This PR

reduce the chance of test failure
