### PR TITLE
ci: Add timeout to catch unexpected not found error

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -390,6 +390,7 @@ jobs:
           RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
         run: |
           gh release create "$RELEASE_TAG" --draft --prerelease --notes-file "${{ env.RELEASE_NOTES_FILE }}" --title "$RELEASE_TAG"
+          sleep 15
 
       - name: Upload Release Assets
         working-directory: keptn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -386,6 +386,7 @@ jobs:
           RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
         run: |
           gh release create "$RELEASE_TAG" --draft --notes-file "${{ env.RELEASE_NOTES_FILE }}" --title "$RELEASE_TAG"
+          sleep 15
 
       - name: Upload Release Assets
         working-directory: keptn


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- Adds a small sleep so that the GH API has time to store before we add files to the release that was just created
