### PR TITLE
fix(bridge): Break words in project tile, to keep fix width

### DIFF
--- a/bridge/client/app/_components/ktb-project-tile/ktb-project-tile.component.scss
+++ b/bridge/client/app/_components/ktb-project-tile/ktb-project-tile.component.scss
@@ -5,6 +5,11 @@
   height: auto;
 }
 
+p {
+  word-break: break-word;
+  white-space: normal;
+}
+
 .error {
   color: $error-color;
 }


### PR DESCRIPTION
Signed-off-by: ermin.muratovic <ermin.muratovic@gmail.com>

## This PR
- makes sure that project tiles width stays fixed and long texts break correctly

Fixes #7200 

![image](https://user-images.githubusercontent.com/6098219/159240092-a6385451-551c-488a-b65d-9b1e9e157b8f.png)
