### PR TITLE
fix(shipyard-controller): Consider parallel stages when trying to set overall sequence state to finished

### DIFF
--- a/shipyard-controller/handler/sequencehooks/sequencestate.go
+++ b/shipyard-controller/handler/sequencehooks/sequencestate.go
@@ -235,6 +235,15 @@ func (smv *SequenceStateMaterializedView) updateOverallSequenceState(eventScope 
 		return
 	}
 
+	// if the sequence should be set to 'finished'  we need to ensure that all sequences in all stages are finished
+	if status == models.SequenceFinished {
+		for index := range state.Stages {
+			// if we still have an unfinished stage, we can not set the overall sequence state to 'finished'
+			if state.Stages[index].State == models.SequenceTriggeredState {
+				return
+			}
+		}
+	}
 	state.State = status
 	if err := smv.SequenceStateRepo.UpdateSequenceState(*state); err != nil {
 		log.Errorf("could not update sequence state: %s", err.Error())

--- a/shipyard-controller/handler/sequencehooks/sequencestate_test.go
+++ b/shipyard-controller/handler/sequencehooks/sequencestate_test.go
@@ -228,7 +228,16 @@ func TestSequenceStateMaterializedView_OnSequenceFinished(t *testing.T) {
 									Project:        "my-project",
 									Shkeptncontext: "my-context",
 									State:          "triggered",
-									Stages:         nil,
+									Stages: []models.SequenceStateStage{
+										{
+											Name:  "dev",
+											State: "succeeded",
+										},
+										{
+											Name:  "dev",
+											State: "succeeded",
+										},
+									},
 								},
 							},
 						}, nil
@@ -250,6 +259,51 @@ func TestSequenceStateMaterializedView_OnSequenceFinished(t *testing.T) {
 				},
 			},
 			expectUpdateToBeCalled: true,
+		},
+		{
+			name: "try to finish sequence - not all stages finished yet",
+			fields: SequenceStateMVTestFields{
+				SequenceStateRepo: &db_mock.SequenceStateRepoMock{
+					FindSequenceStatesFunc: func(filter models.StateFilter) (*models.SequenceStates, error) {
+						return &models.SequenceStates{
+							States: []models.SequenceState{
+								{
+									Name:           "my-sequence",
+									Service:        "my-service",
+									Project:        "my-project",
+									Shkeptncontext: "my-context",
+									State:          "triggered",
+									Stages: []models.SequenceStateStage{
+										{
+											Name:  "dev",
+											State: "succeeded",
+										},
+										{
+											Name:  "dev",
+											State: "triggered",
+										},
+									},
+								},
+							},
+						}, nil
+					},
+					UpdateSequenceStateFunc: func(state models.SequenceState) error {
+						return nil
+					},
+				},
+			},
+			args: args{
+				event: models.Event{
+					Data: keptnv2.EventData{
+						Project: "my-project",
+						Stage:   "my-stage",
+						Service: "my-service",
+					},
+					Shkeptncontext: "my-context",
+					Type:           common.Stringp("my-type"),
+				},
+			},
+			expectUpdateToBeCalled: false,
 		},
 		{
 			name: "invalid event scope - do not update",

--- a/test/go-tests/test_sequencestate.go
+++ b/test/go-tests/test_sequencestate.go
@@ -42,6 +42,32 @@ spec:
                 deploymentstrategy: "blue_green_service"
             - name: "evaluation"`
 
+const sequenceStateParallelStagesShipyard = `apiVersion: spec.keptn.sh/0.2.0
+kind: Shipyard
+metadata:
+  name: shipyard-parallel-stages
+spec:
+  stages:
+    - name: dev
+      sequences:
+        - name: delivery
+          tasks:
+            - name: delivery
+    - name: staging-2
+      sequences:
+        - name: delivery
+          triggeredOn:
+            - event: "dev.delivery.finished"
+          tasks:
+            - name: delivery
+    - name: staging-1
+      sequences:
+        - name: delivery
+          triggeredOn:
+            - event: "dev.delivery.finished"
+          tasks:
+            - name: delivery`
+
 func Test_SequenceState(t *testing.T) {
 	projectName := "state"
 	serviceName := "my-service"
@@ -345,6 +371,389 @@ func Test_SequenceState(t *testing.T) {
 
 		return true
 	}, 10*time.Second, 2*time.Second)
+}
+
+func Test_SequenceStateParallelStages(t *testing.T) {
+	projectName := "state-parallel-stages"
+	serviceName := "my-service"
+	sequenceStateShipyardFilePath, err := CreateTmpShipyardFile(sequenceStateParallelStagesShipyard)
+	require.Nil(t, err)
+	defer func() {
+		err := os.Remove(sequenceStateShipyardFilePath)
+		if err != nil {
+			t.Logf("Could not delete file: %s: %v", sequenceStateShipyardFilePath, err)
+		}
+	}()
+
+	source := "golang-test"
+
+	// check if the project 'state' is already available - if not, delete it before creating it again
+	// check if the project is already available - if not, delete it before creating it again
+	projectName, err = CreateProject(projectName, sequenceStateShipyardFilePath, true)
+	require.Nil(t, err)
+
+	output, err := ExecuteCommand(fmt.Sprintf("keptn create service %s --project=%s", serviceName, projectName))
+
+	require.Nil(t, err)
+	require.Contains(t, output, "created successfully")
+
+	states, resp, err := GetState(projectName)
+
+	// send a delivery.triggered event
+	eventType := keptnv2.GetTriggeredEventType("dev.delivery")
+
+	resp, err = ApiPOSTRequest("/v1/event", models.KeptnContextExtendedCE{
+		Contenttype: "application/json",
+		Data: keptnv2.DeploymentTriggeredEventData{
+			EventData: keptnv2.EventData{
+				Project: projectName,
+				Stage:   "dev",
+				Service: serviceName,
+			},
+			ConfigurationChange: keptnv2.ConfigurationChange{
+				Values: map[string]interface{}{"image": "carts:test"},
+			},
+		},
+		ID:                 uuid.NewString(),
+		Shkeptnspecversion: KeptnSpecVersion,
+		Source:             &source,
+		Specversion:        "1.0",
+		Type:               &eventType,
+	}, 3)
+	require.Nil(t, err)
+	body := resp.String()
+	require.Equal(t, http.StatusOK, resp.Response().StatusCode)
+	require.NotEmpty(t, body)
+
+	context := &models.EventContext{}
+	err = resp.ToJSON(context)
+	require.Nil(t, err)
+	require.NotNil(t, context.KeptnContext)
+
+	// verify state
+	require.Eventually(t, func() bool {
+		states, resp, err = GetState(projectName)
+		if err != nil {
+			return false
+		}
+		if !IsEqual(t, http.StatusOK, resp.Response().StatusCode, "resp.Response().StatusCode") {
+			return false
+		}
+		if !IsEqual(t, int64(1), states.TotalCount, "states.TotalCount") {
+			return false
+		}
+		if !IsEqual(t, 1, len(states.States), "len(states.States)") {
+			return false
+		}
+
+		state := states.States[0]
+
+		if !IsEqual(t, projectName, state.Project, "state.Project") {
+			return false
+		}
+		if !IsEqual(t, *context.KeptnContext, state.Shkeptncontext, "state.Shkeptncontext") {
+			return false
+		}
+		if !IsEqual(t, scmodels.SequenceStartedState, state.State, "state.State") {
+			return false
+		}
+
+		if !IsEqual(t, 1, len(state.Stages), "len(state.Stages)") {
+			return false
+		}
+
+		stage := state.Stages[0]
+
+		if !IsEqual(t, "dev", stage.Name, "stage.Name") {
+			return false
+		}
+
+		if !IsEqual(t, keptnv2.GetTriggeredEventType("delivery"), stage.LatestEvent.Type, "stage.LatestEvent.Type") {
+			return false
+		}
+
+		return true
+	}, 10*time.Second, 2*time.Second)
+
+	// get delivery.triggered event
+	deliveryTriggeredEvent, err := GetLatestEventOfType(*context.KeptnContext, projectName, "dev", keptnv2.GetTriggeredEventType("delivery"))
+	require.Nil(t, err)
+	require.NotNil(t, deliveryTriggeredEvent)
+
+	cloudEvent := keptnv2.ToCloudEvent(*deliveryTriggeredEvent)
+
+	keptn, err := keptnv2.NewKeptn(&cloudEvent, keptncommon.KeptnOpts{EventSender: &APIEventSender{}})
+
+	_, err = keptn.SendTaskStartedEvent(nil, source)
+	require.Nil(t, err)
+
+	// verify state
+	require.Eventually(t, func() bool {
+		states, resp, err = GetState(projectName)
+		if err != nil {
+			return false
+		}
+		if http.StatusOK != resp.Response().StatusCode {
+			return false
+		}
+		state := states.States[0]
+		if state.Project != projectName {
+			return false
+		}
+		if state.Shkeptncontext != *context.KeptnContext {
+			return false
+		}
+		if state.State != scmodels.SequenceStartedState {
+			return false
+		}
+
+		if len(state.Stages) != 1 {
+			return false
+		}
+
+		stage := state.Stages[0]
+
+		if stage.LatestEvent.Type != keptnv2.GetStartedEventType("delivery") {
+			return false
+		}
+
+		return true
+	}, 10*time.Second, 2*time.Second)
+
+	_, err = keptn.SendTaskFinishedEvent(&keptnv2.EventData{Result: keptnv2.ResultPass, Status: keptnv2.StatusSucceeded}, source)
+	require.Nil(t, err)
+
+	// now the sequences in staging-1 and staging-2 should have been triggered
+
+	require.Eventually(t, func() bool {
+		states, resp, err = GetState(projectName)
+		if err != nil {
+			return false
+		}
+		if http.StatusOK != resp.Response().StatusCode {
+			return false
+		}
+		state := states.States[0]
+		if state.Project != projectName {
+			return false
+		}
+		if state.Shkeptncontext != *context.KeptnContext {
+			return false
+		}
+		if state.State != scmodels.SequenceStartedState {
+			return false
+		}
+
+		if len(state.Stages) != 3 {
+			return false
+		}
+
+		staging1 := GetStageOfState(state, "staging-1")
+		staging2 := GetStageOfState(state, "staging-2")
+
+		if staging1.LatestEvent.Type != keptnv2.GetTriggeredEventType("delivery") {
+			return false
+		}
+		if staging2.LatestEvent.Type != keptnv2.GetTriggeredEventType("delivery") {
+			return false
+		}
+		return true
+	}, 30*time.Second, 2*time.Second)
+
+	// now, finish the sequence in staging-1, but not in staging-2
+
+	// get delivery.triggered event in staging-1
+	staging1TriggeredEvent, err := GetLatestEventOfType(*context.KeptnContext, projectName, "staging-1", keptnv2.GetTriggeredEventType("delivery"))
+	require.Nil(t, err)
+	require.NotNil(t, staging1TriggeredEvent)
+
+	cloudEvent = keptnv2.ToCloudEvent(*staging1TriggeredEvent)
+
+	keptn, err = keptnv2.NewKeptn(&cloudEvent, keptncommon.KeptnOpts{EventSender: &APIEventSender{}})
+	require.Nil(t, err)
+
+	// send started event
+	_, err = keptn.SendTaskStartedEvent(nil, source)
+	require.Nil(t, err)
+
+	require.Eventually(t, func() bool {
+		states, resp, err = GetState(projectName)
+		if err != nil {
+			return false
+		}
+		if http.StatusOK != resp.Response().StatusCode {
+			return false
+		}
+		state := states.States[0]
+		if state.Project != projectName {
+			return false
+		}
+		if state.Shkeptncontext != *context.KeptnContext {
+			return false
+		}
+		if state.State != scmodels.SequenceStartedState {
+			return false
+		}
+
+		if len(state.Stages) != 3 {
+			return false
+		}
+
+		staging1 := GetStageOfState(state, "staging-1")
+		staging2 := GetStageOfState(state, "staging-2")
+
+		if staging1.LatestEvent.Type != keptnv2.GetStartedEventType("delivery") {
+			return false
+		}
+		if staging2.LatestEvent.Type != keptnv2.GetTriggeredEventType("delivery") {
+			return false
+		}
+		return true
+	}, 30*time.Second, 2*time.Second)
+
+	// send finished event
+	_, err = keptn.SendTaskFinishedEvent(&keptnv2.EventData{
+		Status: keptnv2.StatusSucceeded,
+		Result: keptnv2.ResultPass,
+	}, source)
+	require.Nil(t, err)
+
+	// verify state
+	require.Eventually(t, func() bool {
+		states, resp, err = GetState(projectName)
+		if err != nil {
+			return false
+		}
+		if http.StatusOK != resp.Response().StatusCode {
+			return false
+		}
+		state := states.States[0]
+		if state.Project != projectName {
+			return false
+		}
+		if state.Shkeptncontext != *context.KeptnContext {
+			return false
+		}
+		if state.State != scmodels.SequenceStartedState {
+			return false
+		}
+
+		if len(state.Stages) != 3 {
+			return false
+		}
+
+		staging1 := GetStageOfState(state, "staging-1")
+		staging2 := GetStageOfState(state, "staging-2")
+
+		if staging1.LatestEvent.Type != keptnv2.GetFinishedEventType("staging-1.delivery") {
+			return false
+		}
+		if staging2.LatestEvent.Type != keptnv2.GetTriggeredEventType("delivery") {
+			return false
+		}
+		return true
+	}, 30*time.Second, 2*time.Second)
+
+	staging2TriggeredEvent, err := GetLatestEventOfType(*context.KeptnContext, projectName, "staging-2", keptnv2.GetTriggeredEventType("delivery"))
+	require.Nil(t, err)
+	require.NotNil(t, staging1TriggeredEvent)
+
+	cloudEvent = keptnv2.ToCloudEvent(*staging2TriggeredEvent)
+
+	keptn, err = keptnv2.NewKeptn(&cloudEvent, keptncommon.KeptnOpts{EventSender: &APIEventSender{}})
+	require.Nil(t, err)
+
+	// send started event
+	_, err = keptn.SendTaskStartedEvent(nil, source)
+	require.Nil(t, err)
+
+	// verify state - overall state should still not be set to finished
+	require.Eventually(t, func() bool {
+		states, resp, err = GetState(projectName)
+		if err != nil {
+			return false
+		}
+		if http.StatusOK != resp.Response().StatusCode {
+			return false
+		}
+		state := states.States[0]
+		if state.Project != projectName {
+			return false
+		}
+		if state.Shkeptncontext != *context.KeptnContext {
+			return false
+		}
+		if state.State != scmodels.SequenceStartedState {
+			return false
+		}
+
+		if len(state.Stages) != 3 {
+			return false
+		}
+
+		staging1 := GetStageOfState(state, "staging-1")
+		staging2 := GetStageOfState(state, "staging-2")
+
+		if staging1.LatestEvent.Type != keptnv2.GetFinishedEventType("staging-1.delivery") {
+			return false
+		}
+		if staging2.LatestEvent.Type != keptnv2.GetStartedEventType("delivery") {
+			return false
+		}
+		return true
+	}, 30*time.Second, 2*time.Second)
+
+	// now finish the sequence in staging-2
+	_, err = keptn.SendTaskFinishedEvent(&keptnv2.EventData{
+		Status: keptnv2.StatusSucceeded,
+		Result: keptnv2.ResultPass,
+	}, source)
+	require.Nil(t, err)
+
+	// verify state - now the overall state should be finished
+	require.Eventually(t, func() bool {
+		states, resp, err = GetState(projectName)
+		if err != nil {
+			return false
+		}
+		if http.StatusOK != resp.Response().StatusCode {
+			return false
+		}
+		state := states.States[0]
+		if state.Project != projectName {
+			return false
+		}
+		if state.Shkeptncontext != *context.KeptnContext {
+			return false
+		}
+		if state.State != scmodels.SequenceFinished {
+			return false
+		}
+
+		if len(state.Stages) != 3 {
+			return false
+		}
+
+		staging1 := GetStageOfState(state, "staging-1")
+		staging2 := GetStageOfState(state, "staging-2")
+
+		if staging1.LatestEvent.Type != keptnv2.GetFinishedEventType("staging-1.delivery") {
+			return false
+		}
+		if staging2.LatestEvent.Type != keptnv2.GetFinishedEventType("staging-2.delivery") {
+			return false
+		}
+		return true
+	}, 30*time.Second, 2*time.Second)
+}
+
+func GetStageOfState(state scmodels.SequenceState, stageName string) *scmodels.SequenceStateStage {
+	for index, stage := range state.Stages {
+		if stage.Name == stageName {
+			return &state.Stages[index]
+		}
+	}
+	return nil
 }
 
 func Test_SequenceState_CannotRetrieveShipyard(t *testing.T) {

--- a/test/go-tests/testsuite_gke_test.go
+++ b/test/go-tests/testsuite_gke_test.go
@@ -9,6 +9,7 @@ func Test_GKE(t *testing.T) {
 	t.Run("Test_LogIngestion", Test_LogIngestion)
 	t.Run("Test_LogForwarding", Test_LogForwarding)
 	t.Run("Test_SequenceState", Test_SequenceState)
+	t.Run("Test_SequenceStateParallelStages", Test_SequenceStateParallelStages)
 	t.Run("Test_SequenceState_RetrieveMultipleSequence", Test_SequenceState_RetrieveMultipleSequence)
 	t.Run("Test_SequenceState_SequenceNotFound", Test_SequenceState_SequenceNotFound)
 	t.Run("Test_SequenceState_InvalidShipyard", Test_SequenceState_InvalidShipyard)

--- a/test/go-tests/testsuite_k3s_test.go
+++ b/test/go-tests/testsuite_k3s_test.go
@@ -9,6 +9,7 @@ func Test_K3S(t *testing.T) {
 	t.Run("Test_LogIngestion", Test_LogIngestion)
 	t.Run("Test_LogForwarding", Test_LogForwarding)
 	t.Run("Test_SequenceState", Test_SequenceState)
+	t.Run("Test_SequenceStateParallelStages", Test_SequenceStateParallelStages)
 	t.Run("Test_SequenceState_RetrieveMultipleSequence", Test_SequenceState_RetrieveMultipleSequence)
 	t.Run("Test_SequenceState_SequenceNotFound", Test_SequenceState_SequenceNotFound)
 	t.Run("Test_SequenceState_InvalidShipyard", Test_SequenceState_InvalidShipyard)

--- a/test/go-tests/testsuite_openshift_test.go
+++ b/test/go-tests/testsuite_openshift_test.go
@@ -9,6 +9,7 @@ func Test_Openshift(t *testing.T) {
 	t.Run("Test_LogIngestion", Test_LogIngestion)
 	t.Run("Test_LogForwarding", Test_LogForwarding)
 	t.Run("Test_SequenceState", Test_SequenceState)
+	t.Run("Test_SequenceStateParallelStages", Test_SequenceStateParallelStages)
 	t.Run("Test_SequenceState_RetrieveMultipleSequence", Test_SequenceState_RetrieveMultipleSequence)
 	t.Run("Test_SequenceState_SequenceNotFound", Test_SequenceState_SequenceNotFound)
 	t.Run("Test_SequenceState_InvalidShipyard", Test_SequenceState_InvalidShipyard)


### PR DESCRIPTION
This PR fixes an issue where the overall state of a sequence was set to finished, even though the sequence might not have been finished in all stages. That error appears when there are parallel sequences executed in multiple stages, the completion of one of those sequences, whose completion should not trigger any further sequences leads to the overall state being set to finished.

Integration test run: https://github.com/keptn/keptn/runs/5655845742?check_suite_focus=true 
The GKE tests are marked red because there is an issue with cleaning up the cluster, but the test cases were passing