### PR TITLE
fix(bridge): load projects, also if version.json could not be loaded

### DIFF
--- a/bridge/client/app/_services/data.service.ts
+++ b/bridge/client/app/_services/data.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, forkJoin, from, Observable, of, Subject } from 'rxjs';
-import { map, mergeMap, switchMap, take, tap, toArray } from 'rxjs/operators';
+import { map, mergeMap, switchMap, take, tap, toArray, catchError } from 'rxjs/operators';
 import { Trace } from '../_models/trace';
 import { Stage } from '../_models/stage';
 import { Project } from '../_models/project';
@@ -247,7 +247,7 @@ export class DataService {
     this.apiService.getKeptnInfo().subscribe((bridgeInfo: KeptnInfoResult) => {
       forkJoin({
         availableVersions: bridgeInfo.enableVersionCheckFeature
-          ? this.apiService.getAvailableVersions()
+          ? this.apiService.getAvailableVersions().pipe(catchError((err) => of(undefined)))
           : of(undefined),
         versionCheckEnabled: of(this.apiService.isVersionCheckEnabled()),
         metadata: this.apiService.getMetadata(),

--- a/bridge/cypress/fixtures/bridgeInfoVersionCheck.mock.json
+++ b/bridge/cypress/fixtures/bridgeInfoVersionCheck.mock.json
@@ -1,0 +1,11 @@
+{
+  "bridgeVersion": "0.13.2",
+  "featureFlags": {},
+  "keptnInstallationType": "QUALITY_GATES,CONTINUOUS_OPERATIONS,CONTINUOUS_DELIVERY",
+  "apiUrl": "",
+  "apiToken": "",
+  "cliDownloadLink": "https://github.com/keptn/keptn/releases/tag/0.13.2",
+  "enableVersionCheckFeature": true,
+  "showApiToken": true,
+  "authType": "BASIC"
+}

--- a/bridge/cypress/integration/dashboard.spec.ts
+++ b/bridge/cypress/integration/dashboard.spec.ts
@@ -1,0 +1,33 @@
+import DashboardPage from '../support/pageobjects/DashboardPage';
+
+import * as projectsResponse from '../fixtures/projects.mock.json';
+
+describe('Bridge Dashboard', () => {
+  const dashboardPage = new DashboardPage();
+
+  beforeEach(() => {
+    cy.intercept('/api/v1/metadata', { fixture: 'metadata' });
+    cy.intercept('/api/controlPlane/v1/project?disableUpstreamSync=true&pageSize=50', { fixture: 'projects.mock' }).as(
+      'projects'
+    );
+    cy.intercept('/api/controlPlane/v1/sequence/sockshop?pageSize=5', { fixture: 'sequences.sockshop' }).as(
+      'sequences'
+    );
+    cy.intercept('/api/bridgeInfo', { fixture: 'bridgeInfo.mock' });
+  });
+
+  it('should load also if version.json is not available', () => {
+    cy.intercept('/api/bridgeInfo', { fixture: 'bridgeInfoVersionCheck.mock' }).as('bridgeInfo');
+    cy.intercept('/api/v1/metadata', { fixture: 'metadata' });
+    cy.intercept('/api/version.json', { statusCode: 500 }).as('version.json');
+
+    // versioncheck was accepted by user
+    localStorage.setItem('keptn_versioncheck', JSON.stringify({ enabled: true, time: 1647880061049 }));
+
+    dashboardPage.visitDashboard();
+    cy.visit('/');
+    cy.wait('@projects', { timeout: 15000 });
+    cy.wait('@sequences', { timeout: 15000 });
+    dashboardPage.assertProjects(projectsResponse.projects);
+  });
+});

--- a/bridge/cypress/integration/dashboard.spec.ts
+++ b/bridge/cypress/integration/dashboard.spec.ts
@@ -16,6 +16,11 @@ describe('Bridge Dashboard', () => {
     cy.intercept('/api/bridgeInfo', { fixture: 'bridgeInfo.mock' });
   });
 
+  it('should load and show projects', () => {
+    dashboardPage.visitDashboard();
+    dashboardPage.assertProjects(projectsResponse.projects);
+  });
+
   it('should load also if version.json is not available', () => {
     cy.intercept('/api/bridgeInfo', { fixture: 'bridgeInfoVersionCheck.mock' }).as('bridgeInfo');
     cy.intercept('/api/v1/metadata', { fixture: 'metadata' });

--- a/bridge/cypress/support/pageobjects/DashboardPage.ts
+++ b/bridge/cypress/support/pageobjects/DashboardPage.ts
@@ -1,0 +1,24 @@
+/// <reference types="cypress" />
+
+import { Project } from '../../../client/app/_models/project';
+
+class DashboardPage {
+  visitDashboard(): this {
+    cy.visit(`/`);
+    return this;
+  }
+
+  assertProjects(projects: Project[]): this {
+    cy.get('ktb-project-tile').should('have.length', projects.length);
+    projects.forEach((project, index) => {
+      cy.get('ktb-project-tile').eq(index).find('dt-tile-title').should('contain.text', project.projectName);
+      cy.get('ktb-project-tile')
+        .eq(index)
+        .byTestId('keptn-project-tile-numStagesServices')
+        .should('contain.text', `${project.stages.length} Stages, ${project.stages[0].services.length} Services `);
+    });
+    return this;
+  }
+}
+
+export default DashboardPage;


### PR DESCRIPTION
## This PR
- makes sure that the dashboard loads projects also if `version.json` could not be loaded

### Related Issues
Fixes #7120 

Reproduced issue:
![image](https://user-images.githubusercontent.com/6098219/159486457-9d38b6dc-6780-4107-8bba-93277bb5c5c7.png)

Fixed issue:
![image](https://user-images.githubusercontent.com/6098219/159486599-b8eadb6d-f5b9-4763-9684-883cf8aeeb22.png)
