### PR TITLE
ci: Updates to integration test namespace cleanup

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -10,6 +10,11 @@ on:
         description: 'Take CI build artifacts from branch (e.g., master, release-x.y.z)'
         required: true
         default: 'master'
+      deleteOnFinish:
+        type: boolean
+        required: false
+        description: "Check this if you don't want the test namespaces to stay alive after the test run"
+        default: false
 env:
   META_KEPTN_VERSION: 0.13.2
   META_KEPTN_KEPTN_PROJECT: keptn
@@ -590,7 +595,7 @@ jobs:
                   kubectl annotate clusterrolebinding "$crb" janitor/ttl=3d
                 fi
               done
-          elif [[ "${{ github.event_name }}" == 'workflow_dispatch' && "${{ steps.test_aggregated.outcome }}" != 'success' ]]; then
+          elif [[ "${{ github.event_name }}" == 'workflow_dispatch' && "${{ steps.test_aggregated.outcome }}" != 'success' && "${{ github.event.inputs.deleteOnFinish }}" == 'false']]; then
               for namespace in "${namespaces[@]}"; do
                 if [[ ! -z "${namespace// }" ]]; then
                   echo "Annotating namespace $namespace with Janitor TTL of 3 hours..."

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -593,15 +593,15 @@ jobs:
           elif [[ "${{ github.event_name }}" == 'workflow_dispatch' && "${{ steps.test_aggregated.outcome }}" != 'success' ]]; then
               for namespace in "${namespaces[@]}"; do
                 if [[ ! -z "${namespace// }" ]]; then
-                  echo "Annotating namespace $namespace with Janitor TTL of 6 hours..."
-                  kubectl annotate namespace "$namespace" janitor/ttl=6h
+                  echo "Annotating namespace $namespace with Janitor TTL of 3 hours..."
+                  kubectl annotate namespace "$namespace" janitor/ttl=3h
                 fi
               done
           
               for crb in "${clusterrolebindings[@]}"; do
                 if [[ ! -z "${crb// }" ]]; then
-                  echo "Annotating clusterrolebinding $crb with Janitor TTL of 6 hours..."
-                  kubectl annotate clusterrolebinding "$crb" janitor/ttl=6h
+                  echo "Annotating clusterrolebinding $crb with Janitor TTL of 3 hours..."
+                  kubectl annotate clusterrolebinding "$crb" janitor/ttl=3h
                 fi
               done
           else


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- sets the TTL for manually triggered integration test runs that failed to 3h
- adds a checkbox to the box on GitHub Actions to force delete the test namespaces at the end of the run

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #7235 
