### PR TITLE
fix(bridge): Add latestEvaluationTrace to every stage

### DIFF
--- a/bridge/server/services/data-service.ts
+++ b/bridge/server/services/data-service.ts
@@ -319,14 +319,13 @@ export class DataService {
     service.latestSequence = latestSequence ? Sequence.fromJSON(latestSequence) : undefined;
     service.latestSequence?.reduceToStage(options.stageName);
 
-    if (!cachedSequence && service.latestSequence) {
-      const stage = service.latestSequence.stages.find((seq) => seq.name === options.stageName);
-      if (stage) {
-        stage.latestEvaluationTrace = stageInformation.evaluations.find(
-          (t) => t.data.service === service.latestSequence?.service
-        );
-      }
+    const stage = service.latestSequence?.stages.find((seq) => seq.name === options.stageName);
+    if (stage) {
+      stage.latestEvaluationTrace = stageInformation.evaluations.find(
+        (t) => t.data.service === service.latestSequence?.service
+      );
     }
+
     const deployment = stageDeployments.find((t) => t.data.service === service.serviceName);
     if (deployment) {
       service.deploymentInformation = {

--- a/bridge/server/services/data-service.ts
+++ b/bridge/server/services/data-service.ts
@@ -320,7 +320,7 @@ export class DataService {
     service.latestSequence?.reduceToStage(options.stageName);
 
     const stage = service.latestSequence?.stages.find((seq) => seq.name === options.stageName);
-    if (stage) {
+    if (stage && !stage.latestEvaluationTrace) {
       stage.latestEvaluationTrace = stageInformation.evaluations.find(
         (t) => t.data.service === service.latestSequence?.service
       );


### PR DESCRIPTION
Fixes #7128 

The problem here is, that if we check if the `cachedSequence` exists, the property `latestEvaluationTrace` is set for the first stage but then will never be set for every following stage, as the sequence is already cached.
I removed the check for the `cachedSequence` and added one to check if the `latestEvaluationTrace` already exists for this particular stage. Then we don't have to set it again.