### PR TITLE
feat: add `datadog` flag to `keptn configure monitoring`

### DIFF
--- a/cli/cmd/configure_monitoring.go
+++ b/cli/cmd/configure_monitoring.go
@@ -52,7 +52,7 @@ keptn configure monitoring prometheus --project=PROJECTNAME --service=SERVICENAM
 		return nil
 	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		if args[0] == "prometheus" {
+		if args[0] == "prometheus" || args[0] == "datadog" {
 			if *params.Project == "" {
 				return errors.New("Please specify a project")
 			}

--- a/cli/cmd/configure_monitoring.go
+++ b/cli/cmd/configure_monitoring.go
@@ -41,7 +41,9 @@ var monitoringCmd = &cobra.Command{
 See https://keptn.sh/docs/` + getReleaseDocsURL() + `/monitoring/dynatrace/install/ for more information.
 `,
 	Example: `keptn configure monitoring dynatrace --project=PROJECTNAME
-keptn configure monitoring prometheus --project=PROJECTNAME --service=SERVICENAME`,
+keptn configure monitoring prometheus --project=PROJECTNAME --service=SERVICENAME
+keptn configure monitoring datadog --project=PROJECTNAME --service=SERVICENAME
+**Note:** datadog support is experimental.`,
 	SilenceUsage: true,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 1 {

--- a/cli/cmd/configure_monitoring_test.go
+++ b/cli/cmd/configure_monitoring_test.go
@@ -14,7 +14,7 @@ func init() {
 	logging.InitLoggers(os.Stdout, os.Stdout, os.Stderr)
 }
 
-func TestConfigureMonitoringCmd(t *testing.T) {
+func TestConfigureMonitoringCmdForPrometheus(t *testing.T) {
 
 	credentialmanager.MockAuthCreds = true
 	*params.Project = ""
@@ -26,7 +26,21 @@ func TestConfigureMonitoringCmd(t *testing.T) {
 	}
 }
 
-func TestConfigureMonitoringCmdForPrometheus(t *testing.T) {
+func TestConfigureMonitoringCmdForDatadog(t *testing.T) {
+
+	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
+
+	*params.Project = ""
+	*params.Service = ""
+	cmd := fmt.Sprintf("configure monitoring datadog --project=%s --service=%s --mock", "sockshop", "carts")
+	_, err := executeActionCommandC(cmd)
+	if err != nil {
+		t.Errorf(unexpectedErrMsg, err)
+	}
+}
+
+func TestConfigureMonitoringCmdForPrometheusWithWrongArgs(t *testing.T) {
 
 	credentialmanager.MockAuthCreds = true
 
@@ -35,6 +49,32 @@ func TestConfigureMonitoringCmdForPrometheus(t *testing.T) {
 	cmd := fmt.Sprintf("configure monitoring prometheus --project=%s --mock", "sockshop")
 	_, err := executeActionCommandC(cmd)
 	if err.Error() != "Please specify a service" {
+		t.Errorf(unexpectedErrMsg, err)
+	}
+
+	cmd = fmt.Sprintf("configure monitoring prometheus --service=%s --mock", "carts")
+	_, err = executeActionCommandC(cmd)
+	if err.Error() != "Please specify a project" {
+		t.Errorf(unexpectedErrMsg, err)
+	}
+}
+
+func TestConfigureMonitoringCmdForDatadogWithWrongArgs(t *testing.T) {
+
+	credentialmanager.MockAuthCreds = true
+	checkEndPointStatusMock = true
+
+	*params.Project = ""
+	*params.Service = ""
+	cmd := fmt.Sprintf("configure monitoring datadog --project=%s --mock", "sockshop")
+	_, err := executeActionCommandC(cmd)
+	if err.Error() != "Please specify a service" {
+		t.Errorf(unexpectedErrMsg, err)
+	}
+
+	cmd = fmt.Sprintf("configure monitoring datadog --service=%s --mock", "carts")
+	_, err = executeActionCommandC(cmd)
+	if err.Error() != "Please specify a project" {
 		t.Errorf(unexpectedErrMsg, err)
 	}
 }

--- a/cli/cmd/configure_monitoring_test.go
+++ b/cli/cmd/configure_monitoring_test.go
@@ -51,6 +51,12 @@ func TestConfigureMonitoringCmdForPrometheusWithWrongArgs(t *testing.T) {
 		t.Errorf(unexpectedErrMsg, err)
 	}
 
+	// Note: params are defined in configure_monitoring.go
+	// params.Project and params.Service are set for all tests every time we run a test
+	// which executes `configure monitoring` command.
+	// We have to reset them every time before a test which runs `configure monitoring`
+	*params.Project = ""
+	*params.Service = ""
 	cmd = fmt.Sprintf("configure monitoring prometheus --service=%s --mock", "carts")
 	_, err = executeActionCommandC(cmd)
 	if err.Error() != "Please specify a project" {
@@ -70,6 +76,8 @@ func TestConfigureMonitoringCmdForDatadogWithWrongArgs(t *testing.T) {
 		t.Errorf(unexpectedErrMsg, err)
 	}
 
+	*params.Project = ""
+	*params.Service = ""
 	cmd = fmt.Sprintf("configure monitoring datadog --service=%s --mock", "carts")
 	_, err = executeActionCommandC(cmd)
 	if err.Error() != "Please specify a project" {

--- a/cli/cmd/configure_monitoring_test.go
+++ b/cli/cmd/configure_monitoring_test.go
@@ -29,7 +29,6 @@ func TestConfigureMonitoringCmdForPrometheus(t *testing.T) {
 func TestConfigureMonitoringCmdForDatadog(t *testing.T) {
 
 	credentialmanager.MockAuthCreds = true
-	checkEndPointStatusMock = true
 
 	*params.Project = ""
 	*params.Service = ""
@@ -62,7 +61,6 @@ func TestConfigureMonitoringCmdForPrometheusWithWrongArgs(t *testing.T) {
 func TestConfigureMonitoringCmdForDatadogWithWrongArgs(t *testing.T) {
 
 	credentialmanager.MockAuthCreds = true
-	checkEndPointStatusMock = true
 
 	*params.Project = ""
 	*params.Service = ""


### PR DESCRIPTION
- add tests
- add test for prometheus and datadog code (check if project is not specified)

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
- Adds `datadog` as a valid argument/flag to the `keptn configure monitoring` command
- This is for https://github.com/keptn/keptn/issues/2652 . Datadog integration sits at https://github.com/keptn-sandbox/datadog-service

### Related Issues
https://github.com/keptn/keptn/issues/2652
https://github.com/keptn-sandbox/datadog-service/issues/15

### How to test
<!-- if applicable, add testing instructions under this section -->
1. Run `datadog-service` in keptn using
Clone https://github.com/keptn-sandbox/datadog-service
```
datadog-service $ export DD_API_KEY="<your-datadog-api-key>" DD_APP_KEY="<your-datadog-app-key>" DD_SITE="datadoghq.com" 
```
Run 
```
datadog-service $ helm install datadog-service ./helm --set datadogservice.ddApikey=${DD_API_KEY} --set datadogservice.ddAppKey=${DD_APP_KEY} --set datadogservice.ddSite=${DD_SITE}
```
2. Fetch the branch for this PR
```
keptn/cli $ go run main.go configure monitoring datadog --project podtatohead --service helloservice
```
Replace `podtatohead` with your project and `helloservice` with your service name. 

![image](https://user-images.githubusercontent.com/34534103/165233439-e16b1e70-9e95-41e0-89ec-93c2be80ef48.png)
![image](https://user-images.githubusercontent.com/34534103/165233362-f5acdcc5-9aa2-4514-910f-b12c73a96a18.png)
Clockwise: 
Tab1: `watch "kubectl get po"` (namespace is set to `keptn`)
Tab2: `kubectl logs -f datadog-service-7c87746bb9-gcd77 datadog-service`
Tab3: `kubectl port-forward svc/api-gateway-nginx 5000:80 -nkeptn`
Tab4: `kubectl logs -f datadog-service-7c87746bb9-gcd77 distributor`
