### PR TITLE
fix(bridge): Do not send a start date for evaluation if none is given by the user

### DIFF
--- a/bridge/client/app/_components/ktb-trigger-sequence/ktb-trigger-sequence.component.spec.ts
+++ b/bridge/client/app/_components/ktb-trigger-sequence/ktb-trigger-sequence.component.spec.ts
@@ -268,48 +268,6 @@ describe('KtbTriggerSequenceComponent', () => {
     });
   });
 
-  it('should trigger the evaluation sequence with a timeframe set', () => {
-    // given
-    const dataService = TestBed.inject(DataService);
-    const spy = jest.spyOn(dataService, 'triggerEvaluation');
-    const date = moment();
-    component.sequenceType = TRIGGER_SEQUENCE.EVALUATION;
-    component.selectedStage = 'hardening';
-    component.selectedService = 'helloservice';
-    component.evaluationFormData = {
-      evaluationType: TRIGGER_EVALUATION_TIME.TIMEFRAME,
-      labels: 'key1=val1',
-      timeframe: {
-        hours: 1,
-        minutes: 15,
-        seconds: undefined,
-        millis: undefined,
-        micros: undefined,
-      },
-      timeframeStart: date.toISOString(),
-      startDatetime: undefined,
-      endDatetime: undefined,
-    };
-
-    // when
-    component.triggerSequence();
-
-    // then
-    const expectedDate = date.subtract(1, 'hours').subtract(15, 'minutes').toISOString();
-    expect(spy).toHaveBeenCalledWith({
-      project: 'podtato-head',
-      stage: 'hardening',
-      service: 'helloservice',
-      evaluation: {
-        labels: {
-          key1: 'val1',
-        },
-        timeframe: '1h15m',
-        start: expectedDate,
-      },
-    });
-  });
-
   it('should trigger the evaluation sequence with a start / end date set', () => {
     // given
     const dataService = TestBed.inject(DataService);
@@ -336,98 +294,126 @@ describe('KtbTriggerSequenceComponent', () => {
       project: 'podtato-head',
       stage: 'hardening',
       service: 'helloservice',
+      labels: {
+        key1: 'val1',
+      },
       evaluation: {
-        labels: {
-          key1: 'val1',
-        },
         start: start.toISOString(),
         end: end.toISOString(),
       },
     });
   });
 
-  it('should calculate the proper start utc timestamp for a timeframe with start date', () => {
+  it('should trigger the evaluation sequence with a timeframe and a date set', () => {
     // given
-    const start = moment();
-    const timeframe: Timeframe = {
-      hours: 1,
-      minutes: 2,
-      seconds: 3,
-      millis: 4,
-      micros: 5,
+    const dataService = TestBed.inject(DataService);
+    const spy = jest.spyOn(dataService, 'triggerEvaluation');
+    const date = moment();
+    component.sequenceType = TRIGGER_SEQUENCE.EVALUATION;
+    component.selectedStage = 'hardening';
+    component.selectedService = 'helloservice';
+    component.evaluationFormData = {
+      evaluationType: TRIGGER_EVALUATION_TIME.TIMEFRAME,
+      labels: 'key1=val1',
+      timeframe: {
+        hours: 1,
+        minutes: 15,
+        seconds: undefined,
+        millis: undefined,
+        micros: undefined,
+      },
+      timeframeStart: date.toISOString(),
+      startDatetime: undefined,
+      endDatetime: undefined,
     };
 
     // when
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    const calculatedTime = component.calculateTimeframeStartTime(start.toISOString(), timeframe);
+    component.triggerSequence();
 
     // then
-    const expectedTime = start
-      .subtract(timeframe.hours, 'hours')
-      .subtract(timeframe.minutes, 'minutes')
-      .subtract(timeframe.seconds, 'seconds')
-      .subtract(timeframe.millis, 'milliseconds');
-    expect(calculatedTime).toEqual(expectedTime.toISOString());
+    expect(spy).toHaveBeenCalledWith({
+      project: 'podtato-head',
+      stage: 'hardening',
+      service: 'helloservice',
+      labels: {
+        key1: 'val1',
+      },
+      evaluation: {
+        timeframe: '1h15m',
+        start: date.toISOString(),
+      },
+    });
   });
 
-  it('should ignore milliseconds in the start time calculation', () => {
+  it('should trigger the evaluation sequence with only a timeframe and no date set', () => {
     // given
-    const start = moment();
-    const timeframe: Timeframe = {
-      hours: undefined,
-      minutes: undefined,
-      seconds: undefined,
-      millis: undefined,
-      micros: 5000, // corresponds to 5 millis
+    const dataService = TestBed.inject(DataService);
+    const spy = jest.spyOn(dataService, 'triggerEvaluation');
+    component.sequenceType = TRIGGER_SEQUENCE.EVALUATION;
+    component.selectedStage = 'hardening';
+    component.selectedService = 'helloservice';
+    component.evaluationFormData = {
+      evaluationType: TRIGGER_EVALUATION_TIME.TIMEFRAME,
+      labels: 'key1=val1',
+      timeframe: {
+        hours: 1,
+        minutes: 15,
+        seconds: undefined,
+        millis: undefined,
+        micros: undefined,
+      },
+      timeframeStart: undefined,
+      startDatetime: undefined,
+      endDatetime: undefined,
     };
 
     // when
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    const calculatedTime = component.calculateTimeframeStartTime(start.toISOString(), timeframe);
+    component.triggerSequence();
 
     // then
-    expect(calculatedTime).toEqual(start.toISOString());
-  });
+    expect(spy).toHaveBeenCalledWith({
+      project: 'podtato-head',
+      stage: 'hardening',
+      service: 'helloservice',
+      labels: {
+        key1: 'val1',
+      },
+      evaluation: {
+        timeframe: '1h15m',
+      },
+    });
 
-  it('should have a now date set if no start date is given to the start date calculation', () => {
-    // given
-    const timeframe: Timeframe = {
-      hours: undefined,
-      minutes: undefined,
-      seconds: undefined,
-      millis: undefined,
-      micros: undefined,
+    //given
+    component.evaluationFormData = {
+      evaluationType: TRIGGER_EVALUATION_TIME.TIMEFRAME,
+      labels: 'key1=val1',
+      timeframe: {
+        hours: 1,
+        minutes: 15,
+        seconds: undefined,
+        millis: undefined,
+        micros: undefined,
+      },
+      timeframeStart: '',
+      startDatetime: undefined,
+      endDatetime: undefined,
     };
 
     // when
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    const calculatedTime = component.calculateTimeframeStartTime(undefined, timeframe);
+    component.triggerSequence();
 
     // then
-    expect(calculatedTime).toBeDefined();
-  });
-
-  it('should have the same date if no timeframe is set for start date calcuation', () => {
-    // given
-    const start = moment();
-    const timeframe: Timeframe = {
-      hours: undefined,
-      minutes: undefined,
-      seconds: undefined,
-      millis: undefined,
-      micros: undefined,
-    };
-
-    // when
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    const calculatedTime = component.calculateTimeframeStartTime(start.toISOString(), timeframe);
-
-    // then
-    expect(calculatedTime).toEqual(start.toISOString());
+    expect(spy).toHaveBeenCalledWith({
+      project: 'podtato-head',
+      stage: 'hardening',
+      service: 'helloservice',
+      labels: {
+        key1: 'val1',
+      },
+      evaluation: {
+        timeframe: '1h15m',
+      },
+    });
   });
 
   it('should trigger the evaluation sequence with no timeframe set', () => {
@@ -457,17 +443,16 @@ describe('KtbTriggerSequenceComponent', () => {
     component.triggerSequence();
 
     // then
-    const expectedDate = date.subtract(5, 'minutes');
     expect(spy).toHaveBeenCalledWith({
       project: 'podtato-head',
       stage: 'hardening',
       service: 'helloservice',
+      labels: {
+        key1: 'val1',
+      },
       evaluation: {
-        labels: {
-          key1: 'val1',
-        },
         timeframe: '5m',
-        start: expectedDate.toISOString(),
+        start: date.toISOString(),
       },
     });
   });

--- a/bridge/client/app/_components/ktb-trigger-sequence/ktb-trigger-sequence.component.spec.ts
+++ b/bridge/client/app/_components/ktb-trigger-sequence/ktb-trigger-sequence.component.spec.ts
@@ -457,6 +457,7 @@ describe('KtbTriggerSequenceComponent', () => {
     component.triggerSequence();
 
     // then
+    const expectedDate = date.subtract(5, 'minutes');
     expect(spy).toHaveBeenCalledWith({
       project: 'podtato-head',
       stage: 'hardening',
@@ -466,7 +467,7 @@ describe('KtbTriggerSequenceComponent', () => {
           key1: 'val1',
         },
         timeframe: '5m',
-        start: date.toISOString(),
+        start: expectedDate.toISOString(),
       },
     });
   });

--- a/bridge/client/app/_components/ktb-trigger-sequence/ktb-trigger-sequence.component.spec.ts
+++ b/bridge/client/app/_components/ktb-trigger-sequence/ktb-trigger-sequence.component.spec.ts
@@ -295,6 +295,7 @@ describe('KtbTriggerSequenceComponent', () => {
     component.triggerSequence();
 
     // then
+    const expectedDate = date.subtract(1, 'hours').subtract(15, 'minutes').toISOString();
     expect(spy).toHaveBeenCalledWith({
       project: 'podtato-head',
       stage: 'hardening',
@@ -304,7 +305,7 @@ describe('KtbTriggerSequenceComponent', () => {
           key1: 'val1',
         },
         timeframe: '1h15m',
-        start: date.toISOString(),
+        start: expectedDate,
       },
     });
   });
@@ -343,6 +344,90 @@ describe('KtbTriggerSequenceComponent', () => {
         end: end.toISOString(),
       },
     });
+  });
+
+  it('should calculate the proper start utc timestamp for a timeframe with start date', () => {
+    // given
+    const start = moment();
+    const timeframe: Timeframe = {
+      hours: 1,
+      minutes: 2,
+      seconds: 3,
+      millis: 4,
+      micros: 5,
+    };
+
+    // when
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const calculatedTime = component.calculateTimeframeStartTime(start.toISOString(), timeframe);
+
+    // then
+    const expectedTime = start
+      .subtract(timeframe.hours, 'hours')
+      .subtract(timeframe.minutes, 'minutes')
+      .subtract(timeframe.seconds, 'seconds')
+      .subtract(timeframe.millis, 'milliseconds');
+    expect(calculatedTime).toEqual(expectedTime.toISOString());
+  });
+
+  it('should ignore milliseconds in the start time calculation', () => {
+    // given
+    const start = moment();
+    const timeframe: Timeframe = {
+      hours: undefined,
+      minutes: undefined,
+      seconds: undefined,
+      millis: undefined,
+      micros: 5000, // corresponds to 5 millis
+    };
+
+    // when
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const calculatedTime = component.calculateTimeframeStartTime(start.toISOString(), timeframe);
+
+    // then
+    expect(calculatedTime).toEqual(start.toISOString());
+  });
+
+  it('should have a now date set if no start date is given to the start date calculation', () => {
+    // given
+    const timeframe: Timeframe = {
+      hours: undefined,
+      minutes: undefined,
+      seconds: undefined,
+      millis: undefined,
+      micros: undefined,
+    };
+
+    // when
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const calculatedTime = component.calculateTimeframeStartTime(undefined, timeframe);
+
+    // then
+    expect(calculatedTime).toBeDefined();
+  });
+
+  it('should have the same date if no timeframe is set for start date calcuation', () => {
+    // given
+    const start = moment();
+    const timeframe: Timeframe = {
+      hours: undefined,
+      minutes: undefined,
+      seconds: undefined,
+      millis: undefined,
+      micros: undefined,
+    };
+
+    // when
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const calculatedTime = component.calculateTimeframeStartTime(start.toISOString(), timeframe);
+
+    // then
+    expect(calculatedTime).toEqual(start.toISOString());
   });
 
   it('should trigger the evaluation sequence with no timeframe set', () => {

--- a/bridge/client/app/_components/ktb-trigger-sequence/ktb-trigger-sequence.component.ts
+++ b/bridge/client/app/_components/ktb-trigger-sequence/ktb-trigger-sequence.component.ts
@@ -271,12 +271,22 @@ export class KtbTriggerSequenceComponent implements OnInit, OnDestroy {
     }
 
     if (this.evaluationFormData.evaluationType === TRIGGER_EVALUATION_TIME.TIMEFRAME) {
+      let timeframe: Timeframe;
       if (this.evaluationFormData.timeframe && !this.isTimeframeEmpty(this.evaluationFormData.timeframe)) {
         data.evaluation.timeframe = this.parseTimeframe(this.evaluationFormData.timeframe);
+        timeframe = this.evaluationFormData.timeframe;
       } else {
+        timeframe = {
+          hours: undefined,
+          minutes: 5,
+          seconds: undefined,
+          millis: undefined,
+          micros: undefined,
+        };
         data.evaluation.timeframe = '5m';
       }
-      data.evaluation.start = moment(this.evaluationFormData.timeframeStart || undefined).toISOString();
+
+      data.evaluation.start = this.calculateTimeframeStartTime(this.evaluationFormData.timeframeStart, timeframe);
     } else if (this.evaluationFormData.evaluationType === TRIGGER_EVALUATION_TIME.START_END) {
       data.evaluation.start = moment(this.evaluationFormData.startDatetime || undefined).toISOString();
       data.evaluation.end = moment(this.evaluationFormData.endDatetime || undefined).toISOString();
@@ -336,6 +346,27 @@ export class KtbTriggerSequenceComponent implements OnInit, OnDestroy {
           }
         );
       });
+  }
+
+  private calculateTimeframeStartTime(start: string | undefined, timeframe: Timeframe): string {
+    const date = moment(start || undefined);
+
+    if (timeframe.hours) {
+      date.subtract(timeframe.hours, 'hours');
+    }
+    if (timeframe.minutes) {
+      date.subtract(timeframe.minutes, 'minutes');
+    }
+    if (timeframe.seconds) {
+      date.subtract(timeframe.seconds, 'seconds');
+    }
+    if (timeframe.millis) {
+      date.subtract(timeframe.millis, 'milliseconds');
+    }
+    // To be consistent with the CLI, we do not process microseconds,
+    // as UTC timestamp only supports a granularity of milliseconds
+
+    return date.toISOString();
   }
 
   private isTimeframeEmpty(timeframe: Timeframe): boolean {

--- a/bridge/client/app/_models/trigger-sequence.ts
+++ b/bridge/client/app/_models/trigger-sequence.ts
@@ -49,15 +49,8 @@ export type TriggerSequenceData = {
   service: string;
   labels?: { [key: string]: string };
   configurationChange?: { values: unknown };
-};
-
-export type TriggerEvaluationData = {
-  project: string;
-  stage: string;
-  service: string;
-  evaluation: {
+  evaluation?: {
     end?: string; // ISO 8601
-    labels?: { [key: string]: string };
     start?: string; // ISO 8601
     timeframe?: string; // e.g. 1h5m
   };

--- a/bridge/client/app/_services/api.service.mock.ts
+++ b/bridge/client/app/_services/api.service.mock.ts
@@ -41,7 +41,7 @@ import { ServiceStatesResultResponseMock } from './_mockData/api-responses/servi
 import { DeploymentResponseMock } from './_mockData/api-responses/deployment-response.mock';
 import { ISequencesMetadata } from '../../../shared/interfaces/sequencesMetadata';
 import { SequenceMetadataMock } from './_mockData/sequence-metadata.mock';
-import { TriggerEvaluationData, TriggerResponse, TriggerSequenceData } from '../_models/trigger-sequence';
+import { TriggerResponse, TriggerSequenceData } from '../_models/trigger-sequence';
 
 @Injectable({
   providedIn: null,
@@ -404,10 +404,6 @@ export class ApiServiceMock extends ApiService {
 
   public triggerSequence(type: string, data: TriggerSequenceData): Observable<TriggerResponse> {
     return of({ keptnContext: '6c98fbb0-4c40-4bff-ba9f-b20556a57c8a' });
-  }
-
-  public triggerEvaluation(data: TriggerEvaluationData): Observable<TriggerResponse> {
-    return of({ keptnContext: 'c59d9760-4955-4181-b26a-82a366a60e5c' });
   }
 }
 /* eslint-enable @typescript-eslint/no-unused-vars */

--- a/bridge/client/app/_services/api.service.ts
+++ b/bridge/client/app/_services/api.service.ts
@@ -25,7 +25,7 @@ import { Deployment } from '../../../shared/interfaces/deployment';
 import { IServiceRemediationInformation } from '../_interfaces/service-remediation-information';
 import { EndSessionData } from '../../../shared/interfaces/end-session-data';
 import { ISequencesMetadata } from '../../../shared/interfaces/sequencesMetadata';
-import { TriggerEvaluationData, TriggerResponse, TriggerSequenceData } from '../_models/trigger-sequence';
+import { TriggerResponse, TriggerSequenceData } from '../_models/trigger-sequence';
 import { IScopesResult } from '../_interfaces/scopes-result';
 import { SecretScope } from '../../../shared/interfaces/secret-scope';
 
@@ -503,13 +503,6 @@ export class ApiService {
       source: 'bridge',
     };
     return this.http.post<TriggerResponse>(`${this._baseUrl}/v1/event`, JSON.stringify(body));
-  }
-
-  public triggerEvaluation(data: TriggerEvaluationData): Observable<TriggerResponse> {
-    return this.http.post<TriggerResponse>(
-      `${this._baseUrl}/controlPlane/v1/project/${data.project}/stage/${data.stage}/service/${data.service}/evaluation`,
-      data.evaluation
-    );
   }
 
   public getSecretScopes(): Observable<IScopesResult> {

--- a/bridge/client/app/_services/data.service.spec.ts
+++ b/bridge/client/app/_services/data.service.spec.ts
@@ -3,7 +3,7 @@ import { DataService } from './data.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { AppModule } from '../app.module';
 import { ApiService } from './api.service';
-import { TriggerEvaluationData, TriggerSequenceData } from '../_models/trigger-sequence';
+import { TriggerSequenceData } from '../_models/trigger-sequence';
 import moment from 'moment';
 
 describe('DataService', () => {
@@ -46,9 +46,9 @@ describe('DataService', () => {
 
   it('should trigger an evaluation', () => {
     // given
-    const spy = jest.spyOn(apiService, 'triggerEvaluation');
+    const spy = jest.spyOn(apiService, 'triggerSequence');
     const date = moment().toISOString();
-    const data: TriggerEvaluationData = {
+    const data: TriggerSequenceData = {
       project: 'podtato-head',
       stage: 'hardening',
       service: 'helloservice',
@@ -62,7 +62,7 @@ describe('DataService', () => {
     dataService.triggerEvaluation(data);
 
     // then
-    expect(spy).toHaveBeenCalledWith(data);
+    expect(spy).toHaveBeenCalledWith('sh.keptn.event.hardening.evaluation.triggered', data);
   });
 
   it('should trigger a custom sequence', () => {

--- a/bridge/client/app/_services/data.service.ts
+++ b/bridge/client/app/_services/data.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, forkJoin, from, Observable, of, Subject } from 'rxjs';
-import { map, mergeMap, switchMap, take, tap, toArray, catchError } from 'rxjs/operators';
+import { catchError, map, mergeMap, switchMap, take, tap, toArray } from 'rxjs/operators';
 import { Trace } from '../_models/trace';
 import { Stage } from '../_models/stage';
 import { Project } from '../_models/project';
@@ -29,7 +29,7 @@ import { ServiceState } from '../_models/service-state';
 import { ServiceRemediationInformation } from '../_models/service-remediation-information';
 import { EndSessionData } from '../../../shared/interfaces/end-session-data';
 import { ISequencesMetadata } from '../../../shared/interfaces/sequencesMetadata';
-import { TriggerEvaluationData, TriggerResponse, TriggerSequenceData } from '../_models/trigger-sequence';
+import { TriggerResponse, TriggerSequenceData } from '../_models/trigger-sequence';
 import { EventData } from '../_components/ktb-evaluation-info/ktb-evaluation-info.component';
 import { SecretScope } from '../../../shared/interfaces/secret-scope';
 
@@ -247,7 +247,7 @@ export class DataService {
     this.apiService.getKeptnInfo().subscribe((bridgeInfo: KeptnInfoResult) => {
       forkJoin({
         availableVersions: bridgeInfo.enableVersionCheckFeature
-          ? this.apiService.getAvailableVersions().pipe(catchError((err) => of(undefined)))
+          ? this.apiService.getAvailableVersions().pipe(catchError(() => of(undefined)))
           : of(undefined),
         versionCheckEnabled: of(this.apiService.isVersionCheckEnabled()),
         metadata: this.apiService.getMetadata(),
@@ -786,8 +786,9 @@ export class DataService {
     return this.apiService.triggerSequence(type, data);
   }
 
-  public triggerEvaluation(data: TriggerEvaluationData): Observable<TriggerResponse> {
-    return this.apiService.triggerEvaluation(data);
+  public triggerEvaluation(data: TriggerSequenceData): Observable<TriggerResponse> {
+    const type = EventTypes.PREFIX + data.stage + EventTypes.EVALUATION_TRIGGERED_SUFFIX;
+    return this.apiService.triggerSequence(type, data);
   }
 
   public triggerCustomSequence(data: TriggerSequenceData, sequence: string): Observable<TriggerResponse> {


### PR DESCRIPTION
Fixes #7268 

I changed the endpoint to POST `/event` instead of POST `project/${project}/stage/${stage}/service/${service}/evaluation` to align the evaluation payload with what is used by the CLI.

The behavior is be the following:
* If a timeframe and no start date is given, we also do not send a start date. Lighthouse-service is then taking the current date and performs an evaluation to the past.
* If a timeframe and a start date is given, the backend calculates the end date from it. If the end date lies in the future, the error from dynatrace-service `no evaluation performed by lighthouse because SLI failed with message error validating time range` is expected. It was aligned, that no validation in the frontend is needed in this case.
