### PR TITLE
fix: Correct passing of projectNameMaxSize helm value with quotes

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/templates/shipyard-controller.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/shipyard-controller.yaml
@@ -94,7 +94,7 @@ spec:
               value: {{ .Values.shipyardController.config.disableLeaderElection | default false | quote }}
               {{- end}}
             - name: PROJECT_NAME_MAX_SIZE
-              value: {{ .Values.shipyardController.config.validation.projectNameMaxSize }}
+              value: {{ .Values.shipyardController.config.validation.projectNameMaxSize | quote }}
           ports:
             - containerPort: 8080
           resources:


### PR DESCRIPTION
Pass helm value for max project name size as string