### PR TITLE
fix: add default helm value for project name max size

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/templates/shipyard-controller.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/shipyard-controller.yaml
@@ -94,7 +94,7 @@ spec:
               value: {{ .Values.shipyardController.config.disableLeaderElection | default false | quote }}
               {{- end}}
             - name: PROJECT_NAME_MAX_SIZE
-              value: {{ .Values.shipyardController.config.validation.projectNameMaxSize | quote }}
+              value: {{ .Values.shipyardController.config.validation.projectNameMaxSize | default 200 | quote }}
           ports:
             - containerPort: 8080
           resources:


### PR DESCRIPTION
This PR adds a default value to projectNameMaxSize helm value