### PR TITLE
ci: Introduce pipeline queue time metrics

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -218,14 +218,24 @@ jobs:
           script: |
             const repo = "keptn";
             
-            const workflowRun = await github.rest.actions.getWorkflowRun({
+            const workflowRunReponse = await github.rest.actions.getWorkflowRun({
               owner: repo,
               repo: repo,
               run_id: context.runId
             });
+            
+            const jobResponse = await github.rest.actions.getJobForWorkflowRun({
+              owner: repo,
+              repo: repo,
+              job_id: context.jobId
+            });
+            const workflowRun = workflowRunReponse.data;
+            const job = jobResponse.data;
+            
+            console.log(job);
               
-            console.log(workflowRun);
-            return workflowRun;
+            const runStartedTime = workflowRun.created_at;
+            const jobStartedTime = job.started_at;
 
 #      - name: Ingest Pipeline Metrics
 #        uses: dynatrace-oss/dynatrace-github-action@v8

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -212,9 +212,8 @@ jobs:
       - name: Calculate queue time
         id: calculate_queue_time
         uses: actions/github-script@v6
-        env:
-          RUN_ID: ${{ env.GITHUB_RUN_ID }}
         with:
+          result-encoding: string
           script: |
             const repo = "keptn";
             
@@ -242,16 +241,16 @@ jobs:
             return queueTime;
             
 
-#      - name: Ingest Pipeline Metrics
-#        uses: dynatrace-oss/dynatrace-github-action@v8
-#        with:
-#          url: ${{ secrets.MONITORING_TENANT_URL }}
-#          token: ${{ secrets.MONITORING_API_TOKEN }}
-#          metrics: |
-#            - metric: "github.workflow_queue_time"
-#            value: "${{ steps.calculate_queue_time.queue_time }}"
-#            dimensions:
-#              workflow_name: "CI"
+      - name: Ingest Pipeline Metrics
+        uses: dynatrace-oss/dynatrace-github-action@v8
+        with:
+          url: ${{ secrets.MONITORING_TENANT_URL }}
+          token: ${{ secrets.MONITORING_API_TOKEN }}
+          metrics: |
+            - metric: "github.workflow_queue_time"
+            value: "${{ steps.calculate_queue_time.outputs.result }}"
+            dimensions:
+              workflow_name: "CI"
 
   store-output-in-build-config:
     name: "Store output of last step in build-config.env"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -216,13 +216,12 @@ jobs:
           RUN_ID: ${{ env.GITHUB_RUN_ID }}
         with:
           script: |
-            console.log(context);
             const repo = "keptn";
             
             const workflowRun = github.rest.actions.getWorkflowRun({
               owner: repo,
               repo: repo,
-              run_id: "0"
+              run_id: context.runId
             });
               
             console.log(workflowRun);

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -118,8 +118,9 @@ jobs:
     uses: keptn/keptn/.github/workflows/pipeline-queuetime.yml@pipeline-metrics
     with:
       workflow_name: "CI"
-      monitoring_api_token: "${{ secrets.MONITORING_API_TOKEN }}"
-      monitoring_tenant_url: "${{ secrets.MONITORING_TENANT_URL }}"
+    secrets:
+      monitoring_api_token: ${{ secrets.MONITORING_API_TOKEN }}
+      monitoring_tenant_url: ${{ secrets.MONITORING_TENANT_URL }}
 
   prepare_ci_run:
     name: Prepare CI Run

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -118,8 +118,8 @@ jobs:
     uses: keptn/keptn/.github/workflows/pipeline-queuetime.yml@pipeline-metrics
     with:
       workflow_name: "CI"
-      monitoring_api_token: ${{ secrets.MONITORING_API_TOKEN }}
-      monitoring_tenant_url: ${{ secrets.MONITORING_TENANT_URL }}
+      monitoring_api_token: "${{ secrets.MONITORING_API_TOKEN }}"
+      monitoring_tenant_url: "${{ secrets.MONITORING_TENANT_URL }}"
 
   prepare_ci_run:
     name: Prepare CI Run

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -115,7 +115,7 @@ defaults:
 jobs:
   calculate-queue-time:
     name: "Calculate Queue Time"
-    uses: keptn/keptn/.github/workflows/pipeline-queuetime.yml@master
+    uses: keptn/keptn/.github/workflows/pipeline-queuetime.yml@pipeline-metrics
     with:
       workflow_name: "CI"
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -223,6 +223,10 @@ jobs:
               run_id: context.runId
             });
             
+            console.log(context);
+            console.log(context.runId);
+            console.log(context.jobId);
+            
             const jobResponse = await github.rest.actions.getJobForWorkflowRun({
               owner: repo,
               repo: repo,

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -115,7 +115,7 @@ defaults:
 jobs:
   calculate-queue-time:
     name: "Calculate Queue Time"
-    uses: ./keptn/keptn/.github/workflows/pipeline-queuetime.yml
+    uses: ./.github/workflows/pipeline-queuetime.yml
     with:
       workflow_name: "CI"
     secrets:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -218,7 +218,7 @@ jobs:
           script: |
             const repo = "keptn";
             
-            const workflowRun = github.rest.actions.getWorkflowRun({
+            const workflowRun = await github.rest.actions.getWorkflowRun({
               owner: repo,
               repo: repo,
               run_id: context.runId

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -209,6 +209,36 @@ jobs:
           echo "::set-output name=TIME::$(date +'%H%M')"
           echo "::set-output name=DATETIME::$(date +'%Y%m%d')$(date +'%H%M')"
 
+      - name: Calculate queue time
+        id: calculate_queue_time
+        uses: actions/github-script@v6
+        env:
+          RUN_ID: ${{ env.GITHUB_RUN_ID }}
+        with:
+          script: |
+            const { RUN_ID } = process.env;
+            const repo = "keptn";
+            
+            const workflowRun = octokit.rest.actions.getWorkflowRun({
+              repo,
+              repo,
+              RUN_ID
+            });
+              
+            console.log(workflowRun);
+            return workflowRun;
+
+#      - name: Ingest Pipeline Metrics
+#        uses: dynatrace-oss/dynatrace-github-action@v8
+#        with:
+#          url: ${{ secrets.MONITORING_TENANT_URL }}
+#          token: ${{ secrets.MONITORING_API_TOKEN }}
+#          metrics: |
+#            - metric: "github.workflow_queue_time"
+#            value: "${{ steps.calculate_queue_time.queue_time }}"
+#            dimensions:
+#              workflow_name: "CI"
+
   store-output-in-build-config:
     name: "Store output of last step in build-config.env"
     needs: prepare_ci_run

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -118,6 +118,8 @@ jobs:
     uses: keptn/keptn/.github/workflows/pipeline-queuetime.yml@pipeline-metrics
     with:
       workflow_name: "CI"
+      monitoring_api_token: ${{ secrets.MONITORING_API_TOKEN }}
+      monitoring_tenant_url: ${{ secrets.MONITORING_TENANT_URL }}
 
   prepare_ci_run:
     name: Prepare CI Run

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -223,17 +223,13 @@ jobs:
               run_id: context.runId
             });
             
-            console.log(workflowRunReponse.data);
-            
             const jobResponse = await github.rest.actions.listJobsForWorkflowRun({
               owner: repo,
               repo: repo,
               run_id: context.runId
             });
             const workflowRun = workflowRunReponse.data;
-            const jobs = jobResponse.data;
-            
-            console.log(jobs);
+            const jobs = jobResponse.data.jobs;
               
             const runStartedTime = new Date(workflowRun.created_at).getTime();
             const jobStartedTime = new Date(jobs[0].started_at).getTime();

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -225,18 +225,18 @@ jobs:
             
             console.log(workflowRunReponse.data);
             
-            const jobResponse = await github.rest.actions.getJobForWorkflowRun({
+            const jobResponse = await github.rest.actions.listJobsForWorkflowRun({
               owner: repo,
               repo: repo,
-              job_id: context.jobId
+              run_id: context.runId
             });
             const workflowRun = workflowRunReponse.data;
-            const job = jobResponse.data;
+            const jobs = jobResponse.data;
             
-            console.log(job);
+            console.log(jobs);
               
             const runStartedTime = new Date(workflowRun.created_at).getTime();
-            const jobStartedTime = new Date(job.started_at).getTime();
+            const jobStartedTime = new Date(jobs[0].started_at).getTime();
             
             const queueTime = jobStartedTime - runStartedTime;
             console.log(queueTime);

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -234,8 +234,13 @@ jobs:
             
             console.log(job);
               
-            const runStartedTime = workflowRun.created_at;
-            const jobStartedTime = job.started_at;
+            const runStartedTime = new Date(workflowRun.created_at).getTime();
+            const jobStartedTime = new Date(job.started_at).getTime();
+            
+            const queueTime = jobStartedTime - runStartedTime;
+            console.log(queueTime);
+            return queueTime;
+            
 
 #      - name: Ingest Pipeline Metrics
 #        uses: dynatrace-oss/dynatrace-github-action@v8

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -216,46 +216,6 @@ jobs:
           echo "::set-output name=TIME::$(date +'%H%M')"
           echo "::set-output name=DATETIME::$(date +'%Y%m%d')$(date +'%H%M')"
 
-      - name: Calculate queue time
-        id: calculate_queue_time
-        uses: actions/github-script@v6
-        with:
-          result-encoding: string
-          script: |
-            const repo = "keptn";
-            
-            const workflowRunReponse = await github.rest.actions.getWorkflowRun({
-              owner: repo,
-              repo: repo,
-              run_id: context.runId
-            });
-            
-            const jobResponse = await github.rest.actions.listJobsForWorkflowRun({
-              owner: repo,
-              repo: repo,
-              run_id: context.runId
-            });
-            const workflowRun = workflowRunReponse.data;
-            const jobs = jobResponse.data.jobs;
-              
-            const runStartedTime = new Date(workflowRun.created_at).getTime();
-            const jobStartedTime = new Date(jobs[0].started_at).getTime();
-            
-            const queueTime = (jobStartedTime - runStartedTime) / 1000;
-            return queueTime;
-            
-
-      - name: Ingest Pipeline Metrics
-        uses: dynatrace-oss/dynatrace-github-action@v8
-        with:
-          url: ${{ secrets.MONITORING_TENANT_URL }}
-          token: ${{ secrets.MONITORING_API_TOKEN }}
-          metrics: |
-            - metric: "github.workflow_queue_time"
-              value: "${{ steps.calculate_queue_time.outputs.result }}"
-              dimensions:
-                workflow_name: "CI"
-
   store-output-in-build-config:
     name: "Store output of last step in build-config.env"
     needs: prepare_ci_run

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -216,13 +216,13 @@ jobs:
           RUN_ID: ${{ env.GITHUB_RUN_ID }}
         with:
           script: |
-            const { RUN_ID } = process.env;
+            console.log(context);
             const repo = "keptn";
             
             const workflowRun = github.rest.actions.getWorkflowRun({
               owner: repo,
               repo: repo,
-              run_id: RUN_ID
+              run_id: "0"
             });
               
             console.log(workflowRun);

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -115,7 +115,7 @@ defaults:
 jobs:
   calculate-queue-time:
     name: "Calculate Queue Time"
-    uses: keptn/keptn/.github/workflows/pipeline-queuetime.yml@pipeline-metrics
+    uses: keptn/keptn/.github/workflows/pipeline-queuetime.yml@master
     with:
       workflow_name: "CI"
     secrets:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -234,7 +234,7 @@ jobs:
             const runStartedTime = new Date(workflowRun.created_at).getTime();
             const jobStartedTime = new Date(jobs[0].started_at).getTime();
             
-            const queueTime = jobStartedTime - runStartedTime;
+            const queueTime = (jobStartedTime - runStartedTime) / 1000;
             console.log(queueTime);
             return queueTime;
             

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -223,9 +223,7 @@ jobs:
               run_id: context.runId
             });
             
-            console.log(context);
-            console.log(context.runId);
-            console.log(context.jobId);
+            console.log(workflowRunReponse.data);
             
             const jobResponse = await github.rest.actions.getJobForWorkflowRun({
               owner: repo,

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -113,10 +113,17 @@ defaults:
   run:
     shell: bash
 jobs:
+  calculate-queue-time:
+    name: "Calculate Queue Time"
+    uses: keptn/keptn/.github/workflows/pipeline-queuetime.yml@master
+    with:
+      workflow_name: "CI"
+
   prepare_ci_run:
     name: Prepare CI Run
     # Prepare CI Run looks at what has been changed in this commit/PR/... and determines which artifacts should be
     # built afterwards (in other jobs that depend on this one).
+    needs: calculate-queue-time
     runs-on: ubuntu-20.04
     outputs: # declare what this job outputs (so it can be re-used for other jobs)
       # build config

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -235,7 +235,6 @@ jobs:
             const jobStartedTime = new Date(jobs[0].started_at).getTime();
             
             const queueTime = (jobStartedTime - runStartedTime) / 1000;
-            console.log(queueTime);
             return queueTime;
             
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -115,7 +115,7 @@ defaults:
 jobs:
   calculate-queue-time:
     name: "Calculate Queue Time"
-    uses: keptn/keptn/.github/workflows/pipeline-queuetime.yml@master
+    uses: ./keptn/keptn/.github/workflows/pipeline-queuetime.yml
     with:
       workflow_name: "CI"
     secrets:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -246,9 +246,9 @@ jobs:
           token: ${{ secrets.MONITORING_API_TOKEN }}
           metrics: |
             - metric: "github.workflow_queue_time"
-            value: "${{ steps.calculate_queue_time.outputs.result }}"
-            dimensions:
-              workflow_name: "CI"
+              value: "${{ steps.calculate_queue_time.outputs.result }}"
+              dimensions:
+                workflow_name: "CI"
 
   store-output-in-build-config:
     name: "Store output of last step in build-config.env"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -219,10 +219,10 @@ jobs:
             const { RUN_ID } = process.env;
             const repo = "keptn";
             
-            const workflowRun = octokit.rest.actions.getWorkflowRun({
-              repo,
-              repo,
-              RUN_ID
+            const workflowRun = github.rest.actions.getWorkflowRun({
+              owner: repo,
+              repo: repo,
+              run_id: RUN_ID
             });
               
             console.log(workflowRun);

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -24,7 +24,7 @@ defaults:
 jobs:
   calculate-queue-time:
     name: "Calculate Queue Time"
-    uses: ./keptn/keptn/.github/workflows/pipeline-queuetime.yml
+    uses: ./.github/workflows/pipeline-queuetime.yml
     with:
       workflow_name: "Integration Tests"
     secrets:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -24,7 +24,7 @@ defaults:
 jobs:
   calculate-queue-time:
     name: "Calculate Queue Time"
-    uses: keptn/keptn/.github/workflows/pipeline-queuetime.yml@pipeline-metrics
+    uses: keptn/keptn/.github/workflows/pipeline-queuetime.yml@master
     with:
       workflow_name: "Integration Tests"
     secrets:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -22,54 +22,16 @@ defaults:
   run:
     shell: bash
 jobs:
-  prepare:
-    name: "Prepare"
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Calculate queue time
-        id: calculate_queue_time
-        uses: actions/github-script@v6
-        with:
-          result-encoding: string
-          script: |
-            const repo = "keptn";
-
-            const workflowRunReponse = await github.rest.actions.getWorkflowRun({
-              owner: repo,
-              repo: repo,
-              run_id: context.runId
-            });
-
-            const jobResponse = await github.rest.actions.listJobsForWorkflowRun({
-              owner: repo,
-              repo: repo,
-              run_id: context.runId
-            });
-            const workflowRun = workflowRunReponse.data;
-            const jobs = jobResponse.data.jobs;
-
-            const runStartedTime = new Date(workflowRun.created_at).getTime();
-            const jobStartedTime = new Date(jobs[0].started_at).getTime();
-
-            const queueTime = (jobStartedTime - runStartedTime) / 1000;
-            return queueTime;
-
-
-      - name: Ingest Pipeline Metrics
-        uses: dynatrace-oss/dynatrace-github-action@v8
-        with:
-          url: ${{ secrets.MONITORING_TENANT_URL }}
-          token: ${{ secrets.MONITORING_API_TOKEN }}
-          metrics: |
-            - metric: "github.workflow_queue_time"
-              value: "${{ steps.calculate_queue_time.outputs.result }}"
-              dimensions:
-                workflow_name: "Integration Tests"
+  calculate-queue-time:
+    name: "Calculate Queue Time"
+    uses: keptn/keptn/.github/workflows/pipeline-queuetime.yml@master
+    with:
+      workflow_name: "CI"
 
   integration-test:
     name: "Tests"
     runs-on: ubuntu-20.04
-    needs: prepare
+    needs: calculate-queue-time
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -24,7 +24,7 @@ defaults:
 jobs:
   calculate-queue-time:
     name: "Calculate Queue Time"
-    uses: keptn/keptn/.github/workflows/pipeline-queuetime.yml@master
+    uses: keptn/keptn/.github/workflows/pipeline-queuetime.yml@pipeline-metrics
     with:
       workflow_name: "Integration Tests"
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -24,7 +24,7 @@ defaults:
 jobs:
   calculate-queue-time:
     name: "Calculate Queue Time"
-    uses: keptn/keptn/.github/workflows/pipeline-queuetime.yml@master
+    uses: ./keptn/keptn/.github/workflows/pipeline-queuetime.yml
     with:
       workflow_name: "Integration Tests"
     secrets:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -27,6 +27,7 @@ jobs:
     uses: keptn/keptn/.github/workflows/pipeline-queuetime.yml@pipeline-metrics
     with:
       workflow_name: "Integration Tests"
+    secrets:
       monitoring_api_token: ${{ secrets.MONITORING_API_TOKEN }}
       monitoring_tenant_url: ${{ secrets.MONITORING_TENANT_URL }}
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -26,7 +26,7 @@ jobs:
     name: "Calculate Queue Time"
     uses: keptn/keptn/.github/workflows/pipeline-queuetime.yml@master
     with:
-      workflow_name: "CI"
+      workflow_name: "Integration Tests"
 
   integration-test:
     name: "Tests"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -22,6 +22,50 @@ defaults:
   run:
     shell: bash
 jobs:
+  prepare:
+    name: "Prepare"
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Calculate queue time
+        id: calculate_queue_time
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            const repo = "keptn";
+
+            const workflowRunReponse = await github.rest.actions.getWorkflowRun({
+              owner: repo,
+              repo: repo,
+              run_id: context.runId
+            });
+
+            const jobResponse = await github.rest.actions.listJobsForWorkflowRun({
+              owner: repo,
+              repo: repo,
+              run_id: context.runId
+            });
+            const workflowRun = workflowRunReponse.data;
+            const jobs = jobResponse.data.jobs;
+
+            const runStartedTime = new Date(workflowRun.created_at).getTime();
+            const jobStartedTime = new Date(jobs[0].started_at).getTime();
+
+            const queueTime = (jobStartedTime - runStartedTime) / 1000;
+            return queueTime;
+
+
+      - name: Ingest Pipeline Metrics
+        uses: dynatrace-oss/dynatrace-github-action@v8
+        with:
+          url: ${{ secrets.MONITORING_TENANT_URL }}
+          token: ${{ secrets.MONITORING_API_TOKEN }}
+          metrics: |
+            - metric: "github.workflow_queue_time"
+              value: "${{ steps.calculate_queue_time.outputs.result }}"
+              dimensions:
+                workflow_name: "Integration Tests"
+
   integration-test:
     name: "Tests"
     runs-on: ubuntu-20.04

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -69,6 +69,7 @@ jobs:
   integration-test:
     name: "Tests"
     runs-on: ubuntu-20.04
+    needs: prepare
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -27,6 +27,8 @@ jobs:
     uses: keptn/keptn/.github/workflows/pipeline-queuetime.yml@pipeline-metrics
     with:
       workflow_name: "Integration Tests"
+      monitoring_api_token: ${{ secrets.MONITORING_API_TOKEN }}
+      monitoring_tenant_url: ${{ secrets.MONITORING_TENANT_URL }}
 
   integration-test:
     name: "Tests"

--- a/.github/workflows/pipeline-queuetime.yml
+++ b/.github/workflows/pipeline-queuetime.yml
@@ -51,4 +51,4 @@ jobs:
             - metric: "github.workflow_queue_time"
               value: "${{ steps.calculate_queue_time.outputs.result }}"
               dimensions:
-                workflow_name: ${{ inputs.workflow_name }}
+                workflow_name: "${{ inputs.workflow_name }}"

--- a/.github/workflows/pipeline-queuetime.yml
+++ b/.github/workflows/pipeline-queuetime.yml
@@ -57,3 +57,5 @@ jobs:
               value: "${{ steps.calculate_queue_time.outputs.result }}"
               dimensions:
                 workflow_name: "${{ inputs.workflow_name }}"
+                owner_name: "keptn"
+                repo_name: "keptn"

--- a/.github/workflows/pipeline-queuetime.yml
+++ b/.github/workflows/pipeline-queuetime.yml
@@ -6,6 +6,11 @@ on:
         type: string
         required: true
         description: "Name of the calling workflow for easy differentiation between metric datapoints"
+    secrets:
+      monitoring_api_token:
+        required: true
+      monitoring_tenant_url:
+        required: true
 defaults:
   run:
     shell: bash
@@ -45,8 +50,8 @@ jobs:
       - name: Ingest Pipeline Metrics
         uses: dynatrace-oss/dynatrace-github-action@v8
         with:
-          url: ${{ secrets.MONITORING_TENANT_URL }}
-          token: ${{ secrets.MONITORING_API_TOKEN }}
+          url: ${{ secrets.monitoring_tenant_url }}
+          token: ${{ secrets.monitoring_api_token }}
           metrics: |
             - metric: "github.workflow_queue_time"
               value: "${{ steps.calculate_queue_time.outputs.result }}"

--- a/.github/workflows/pipeline-queuetime.yml
+++ b/.github/workflows/pipeline-queuetime.yml
@@ -1,0 +1,54 @@
+name: Build Helm Charts
+on:
+  workflow_call:
+    inputs:
+      workflow_name:
+        type: string
+        required: true
+        description: "Name of the calling workflow for easy differentiation between metric datapoints"
+defaults:
+  run:
+    shell: bash
+jobs:
+  calculate-queuetime:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Calculate queue time
+        id: calculate_queue_time
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            const repo = "keptn";
+
+            const workflowRunReponse = await github.rest.actions.getWorkflowRun({
+              owner: repo,
+              repo: repo,
+              run_id: context.runId
+            });
+
+            const jobResponse = await github.rest.actions.listJobsForWorkflowRun({
+              owner: repo,
+              repo: repo,
+              run_id: context.runId
+            });
+            const workflowRun = workflowRunReponse.data;
+            const jobs = jobResponse.data.jobs;
+
+            const runStartedTime = new Date(workflowRun.created_at).getTime();
+            const jobStartedTime = new Date(jobs[0].started_at).getTime();
+
+            const queueTime = (jobStartedTime - runStartedTime) / 1000;
+            return queueTime;
+
+
+      - name: Ingest Pipeline Metrics
+        uses: dynatrace-oss/dynatrace-github-action@v8
+        with:
+          url: ${{ secrets.MONITORING_TENANT_URL }}
+          token: ${{ secrets.MONITORING_API_TOKEN }}
+          metrics: |
+            - metric: "github.workflow_queue_time"
+              value: "${{ steps.calculate_queue_time.outputs.result }}"
+              dimensions:
+                workflow_name: ${{ inputs.workflow_name }}


### PR DESCRIPTION
### This PR
- introduces ingestion of pipeline queue time metrics into Keptn's monitoring tenant
- adds ingestion for the CI and integration test pipelines
