### PR TITLE
fix(bridge): Show remediation sequence in default color while running

### DIFF
--- a/bridge/client/app/_components/ktb-sequence-tasks-list/ktb-sequence-tasks-list.component.html
+++ b/bridge/client/app/_components/ktb-sequence-tasks-list/ktb-sequence-tasks-list.component.html
@@ -12,6 +12,7 @@
       [latestDeployment]="latestDeployment"
       (itemClicked)="focusEvent($event)"
       (click)="focusEvent(task)"
+      [attr.uitestid]="'keptn-task-item-' + task.getShortType()"
     ></ktb-task-item>
   </div>
 </div>

--- a/bridge/cypress/fixtures/get.events.29355a07-7b65-47fa-896e-06f656283c5d.mock.json
+++ b/bridge/cypress/fixtures/get.events.29355a07-7b65-47fa-896e-06f656283c5d.mock.json
@@ -1,0 +1,278 @@
+{
+  "events": [
+    {
+      "data": {
+        "labels": {
+          "Problem URL": "link"
+        },
+        "message": "could not retrieve Webhook config: no webhook config found",
+        "project": "sockshop",
+        "result": "fail",
+        "service": "carts",
+        "stage": "production",
+        "status": "errored"
+      },
+      "id": "9986776b-65a3-420b-b639-b6d5f2d51ffb",
+      "shkeptncontext": "29355a07-7b65-47fa-896e-06f656283c5d",
+      "shkeptnspecversion": "0.2.3",
+      "source": "shipyard-controller",
+      "specversion": "1.0",
+      "time": "2022-03-08T09:45:45.501Z",
+      "triggeredid": "250a869c-d9b0-486d-8f23-146ae1b9976b",
+      "type": "sh.keptn.event.production.remediation.finished"
+    },
+    {
+      "data": {
+        "labels": {
+          "Problem URL": "link"
+        },
+        "message": "could not retrieve Webhook config: no webhook config found",
+        "project": "sockshop",
+        "result": "fail",
+        "service": "carts",
+        "stage": "production",
+        "status": "errored"
+      },
+      "id": "d770a5a5-cda9-4ea3-9a67-58ef493691f8",
+      "shkeptncontext": "29355a07-7b65-47fa-896e-06f656283c5d",
+      "source": "webhook-service",
+      "specversion": "1.0",
+      "time": "2022-03-08T09:45:44.213Z",
+      "triggeredid": "cbb743f1-1f03-4655-bb27-4598e0965b29",
+      "type": "sh.keptn.event.action.finished"
+    },
+    {
+      "data": {
+        "labels": {
+          "Problem URL": "link"
+        },
+        "project": "sockshop",
+        "result": "pass",
+        "service": "carts",
+        "stage": "production",
+        "status": "succeeded"
+      },
+      "id": "4401ed78-446f-4b92-863a-b0bb76470d77",
+      "shkeptncontext": "29355a07-7b65-47fa-896e-06f656283c5d",
+      "source": "webhook-service",
+      "specversion": "1.0",
+      "time": "2022-03-08T09:45:44.206Z",
+      "triggeredid": "cbb743f1-1f03-4655-bb27-4598e0965b29",
+      "type": "sh.keptn.event.action.started"
+    },
+    {
+      "data": {
+        "action": {},
+        "labels": {
+          "Problem URL": "link"
+        },
+        "project": "sockshop",
+        "result": "pass",
+        "service": "carts",
+        "stage": "production",
+        "status": "succeeded"
+      },
+      "id": "8c0a80b2-4a3a-4b8b-808a-c713f3c996da",
+      "shkeptncontext": "29355a07-7b65-47fa-896e-06f656283c5d",
+      "source": "unleash-service",
+      "specversion": "1.0",
+      "time": "2022-03-08T09:45:43.027Z",
+      "triggeredid": "cbb743f1-1f03-4655-bb27-4598e0965b29",
+      "type": "sh.keptn.event.action.finished"
+    },
+    {
+      "data": {
+        "labels": {
+          "Problem URL": "link"
+        },
+        "project": "sockshop",
+        "service": "carts",
+        "stage": "production"
+      },
+      "id": "97925cac-10b3-4525-aee0-5bd270bbe175",
+      "shkeptncontext": "29355a07-7b65-47fa-896e-06f656283c5d",
+      "source": "unleash-service",
+      "specversion": "1.0",
+      "time": "2022-03-08T09:45:43.011Z",
+      "triggeredid": "cbb743f1-1f03-4655-bb27-4598e0965b29",
+      "type": "sh.keptn.event.action.started"
+    },
+    {
+      "data": {
+        "action": {
+          "action": "toggle-feature",
+          "description": "Toogle feature flag EnableItemCache to ON",
+          "name": "Toogle feature flag",
+          "value": {
+            "EnableItemCache": "on"
+          }
+        },
+        "get-action": {
+          "actionIndex": 1
+        },
+        "labels": {
+          "Problem URL": "link"
+        },
+        "message": "",
+        "problem": {
+          "ImpactedEntity": "Response time degradation on Web service sockshop.carts.production",
+          "PID": "asdf",
+          "ProblemDetails": {
+            "displayName": "P-21127",
+            "endTime": 1638888240000,
+            "hasRootCause": false,
+            "id": "asdf",
+            "impactLevel": "SERVICE",
+            "severityLevel": "PERFORMANCE",
+            "startTime": 1638887400000,
+            "status": "OPEN"
+          },
+          "ProblemID": "P-21127",
+          "ProblemTitle": "Response time degradation",
+          "ProblemURL": "link",
+          "State": "OPEN",
+          "Tags": "keptn_service:carts, keptn_project:sockshop, keptn_stage:production"
+        },
+        "project": "sockshop",
+        "result": "pass",
+        "service": "carts",
+        "stage": "production",
+        "status": "succeeded"
+      },
+      "gitcommitid": "64fd7e0079a5624d0e25a4dd40323342022236c7",
+      "id": "cbb743f1-1f03-4655-bb27-4598e0965b29",
+      "shkeptncontext": "29355a07-7b65-47fa-896e-06f656283c5d",
+      "shkeptnspecversion": "0.2.3",
+      "source": "shipyard-controller",
+      "specversion": "1.0",
+      "time": "2022-03-08T09:45:42.997Z",
+      "type": "sh.keptn.event.action.triggered"
+    },
+    {
+      "data": {
+        "action": {
+          "action": "toggle-feature",
+          "description": "Toogle feature flag EnableItemCache to ON",
+          "name": "Toogle feature flag",
+          "value": {
+            "EnableItemCache": "on"
+          }
+        },
+        "get-action": {
+          "actionIndex": 1
+        },
+        "labels": {
+          "Problem URL": "link"
+        },
+        "project": "sockshop",
+        "result": "pass",
+        "service": "carts",
+        "stage": "production",
+        "status": "succeeded"
+      },
+      "id": "6c5d5454-8f63-431e-bf8e-b99c0062fe1b",
+      "shkeptncontext": "29355a07-7b65-47fa-896e-06f656283c5d",
+      "source": "remediation-service",
+      "specversion": "1.0",
+      "time": "2022-03-08T09:45:42.794Z",
+      "triggeredid": "d7bd10ce-b14c-4ea5-a030-a983d20125e4",
+      "type": "sh.keptn.event.get-action.finished"
+    },
+    {
+      "data": {
+        "labels": {
+          "Problem URL": "link"
+        },
+        "project": "sockshop",
+        "service": "carts",
+        "stage": "production"
+      },
+      "id": "943aa1b0-8788-4f1e-b21e-3829b6c9a85b",
+      "shkeptncontext": "29355a07-7b65-47fa-896e-06f656283c5d",
+      "source": "remediation-service",
+      "specversion": "1.0",
+      "time": "2022-03-08T09:45:42.507Z",
+      "triggeredid": "d7bd10ce-b14c-4ea5-a030-a983d20125e4",
+      "type": "sh.keptn.event.get-action.started"
+    },
+    {
+      "data": {
+        "get-action": null,
+        "labels": {
+          "Problem URL": "link"
+        },
+        "message": "",
+        "problem": {
+          "ImpactedEntity": "Response time degradation on Web service sockshop.carts.production",
+          "PID": "asdf",
+          "ProblemDetails": {
+            "displayName": "P-21127",
+            "endTime": 1638888240000,
+            "hasRootCause": false,
+            "id": "asdf",
+            "impactLevel": "SERVICE",
+            "severityLevel": "PERFORMANCE",
+            "startTime": 1638887400000,
+            "status": "OPEN"
+          },
+          "ProblemID": "P-21127",
+          "ProblemTitle": "Response time degradation",
+          "ProblemURL": "link",
+          "State": "OPEN",
+          "Tags": "keptn_service:carts, keptn_project:sockshop, keptn_stage:production"
+        },
+        "project": "sockshop",
+        "result": "",
+        "service": "carts",
+        "stage": "production",
+        "status": ""
+      },
+      "gitcommitid": "64fd7e0079a5624d0e25a4dd40323342022236c7",
+      "id": "d7bd10ce-b14c-4ea5-a030-a983d20125e4",
+      "shkeptncontext": "29355a07-7b65-47fa-896e-06f656283c5d",
+      "shkeptnspecversion": "0.2.3",
+      "source": "shipyard-controller",
+      "specversion": "1.0",
+      "time": "2022-03-08T09:45:42.501Z",
+      "type": "sh.keptn.event.get-action.triggered"
+    },
+    {
+      "data": {
+        "labels": {
+          "Problem URL": "link"
+        },
+        "problem": {
+          "ImpactedEntity": "Response time degradation on Web service sockshop.carts.production",
+          "PID": "asdf",
+          "ProblemDetails": {
+            "displayName": "P-21127",
+            "endTime": 1638888240000,
+            "hasRootCause": false,
+            "id": "asdf",
+            "impactLevel": "SERVICE",
+            "severityLevel": "PERFORMANCE",
+            "startTime": 1638887400000,
+            "status": "OPEN"
+          },
+          "ProblemID": "P-21127",
+          "ProblemTitle": "Response time degradation",
+          "ProblemURL": "link",
+          "State": "OPEN",
+          "Tags": "keptn_service:carts, keptn_project:sockshop, keptn_stage:production"
+        },
+        "project": "sockshop",
+        "service": "carts",
+        "stage": "production"
+      },
+      "id": "250a869c-d9b0-486d-8f23-146ae1b9976b",
+      "shkeptncontext": "29355a07-7b65-47fa-896e-06f656283c5d",
+      "shkeptnspecversion": "0.2.4",
+      "source": "dynatrace-service",
+      "specversion": "1.0",
+      "time": "2022-03-08T09:45:41.799Z",
+      "type": "sh.keptn.event.production.remediation.triggered"
+    }
+  ],
+  "pageSize": 100,
+  "totalCount": 10
+}

--- a/bridge/cypress/fixtures/get.events.cfaadbb1-3c47-46e5-a230-2e312cf1828a.mock.json
+++ b/bridge/cypress/fixtures/get.events.cfaadbb1-3c47-46e5-a230-2e312cf1828a.mock.json
@@ -1,0 +1,198 @@
+{
+  "events": [
+    {
+      "data": {
+        "labels": {
+          "Problem URL": "link"
+        },
+        "project": "sockshop",
+        "service": "carts",
+        "stage": "production"
+      },
+      "id": "0887e14f-c643-49c3-85ea-c4b13e10133b",
+      "shkeptncontext": "cfaadbb1-3c47-46e5-a230-2e312cf1828a",
+      "source": "unleash-service",
+      "specversion": "1.0",
+      "time": "2022-03-08T09:48:36.908Z",
+      "triggeredid": "1c522f96-f375-4205-b752-792b1f384d11",
+      "type": "sh.keptn.event.action.started"
+    },
+    {
+      "data": {
+        "action": {
+          "action": "toggle-feature",
+          "description": "Toogle feature flag EnableItemCache to ON",
+          "name": "Toogle feature flag",
+          "value": {
+            "EnableItemCache": "on"
+          }
+        },
+        "get-action": {
+          "actionIndex": 1
+        },
+        "labels": {
+          "Problem URL": "link"
+        },
+        "message": "",
+        "problem": {
+          "ImpactedEntity": "Response time degradation on Web service sockshop.carts.production",
+          "PID": "asdf",
+          "ProblemDetails": {
+            "displayName": "P-21127",
+            "endTime": 1638888240000,
+            "hasRootCause": false,
+            "id": "asdf",
+            "impactLevel": "SERVICE",
+            "severityLevel": "PERFORMANCE",
+            "startTime": 1638887400000,
+            "status": "OPEN"
+          },
+          "ProblemID": "P-21127",
+          "ProblemTitle": "Response time degradation",
+          "ProblemURL": "link",
+          "State": "OPEN",
+          "Tags": "keptn_service:carts, keptn_project:sockshop, keptn_stage:production"
+        },
+        "project": "sockshop",
+        "result": "pass",
+        "service": "carts",
+        "stage": "production",
+        "status": "succeeded"
+      },
+      "gitcommitid": "64fd7e0079a5624d0e25a4dd40323342022236c7",
+      "id": "1c522f96-f375-4205-b752-792b1f384d11",
+      "shkeptncontext": "cfaadbb1-3c47-46e5-a230-2e312cf1828a",
+      "shkeptnspecversion": "0.2.3",
+      "source": "shipyard-controller",
+      "specversion": "1.0",
+      "time": "2022-03-08T09:48:36.902Z",
+      "type": "sh.keptn.event.action.triggered"
+    },
+    {
+      "data": {
+        "action": {
+          "action": "toggle-feature",
+          "description": "Toogle feature flag EnableItemCache to ON",
+          "name": "Toogle feature flag",
+          "value": {
+            "EnableItemCache": "on"
+          }
+        },
+        "get-action": {
+          "actionIndex": 1
+        },
+        "labels": {
+          "Problem URL": "link"
+        },
+        "project": "sockshop",
+        "result": "pass",
+        "service": "carts",
+        "stage": "production",
+        "status": "succeeded"
+      },
+      "id": "67fb1ad4-98fe-43e5-bbfd-36dcb4117eec",
+      "shkeptncontext": "cfaadbb1-3c47-46e5-a230-2e312cf1828a",
+      "source": "remediation-service",
+      "specversion": "1.0",
+      "time": "2022-03-08T09:48:36.695Z",
+      "triggeredid": "8df20adf-38cf-4a89-8c8c-f69efc03e10d",
+      "type": "sh.keptn.event.get-action.finished"
+    },
+    {
+      "data": {
+        "labels": {
+          "Problem URL": "link"
+        },
+        "project": "sockshop",
+        "service": "carts",
+        "stage": "production"
+      },
+      "id": "a2b6ebda-3c69-4629-9b3a-f04babd925b6",
+      "shkeptncontext": "cfaadbb1-3c47-46e5-a230-2e312cf1828a",
+      "source": "remediation-service",
+      "specversion": "1.0",
+      "time": "2022-03-08T09:48:36.405Z",
+      "triggeredid": "8df20adf-38cf-4a89-8c8c-f69efc03e10d",
+      "type": "sh.keptn.event.get-action.started"
+    },
+    {
+      "data": {
+        "get-action": null,
+        "labels": {
+          "Problem URL": "link"
+        },
+        "message": "",
+        "problem": {
+          "ImpactedEntity": "Response time degradation on Web service sockshop.carts.production",
+          "PID": "asdf",
+          "ProblemDetails": {
+            "displayName": "P-21127",
+            "endTime": 1638888240000,
+            "hasRootCause": false,
+            "id": "asdf",
+            "impactLevel": "SERVICE",
+            "severityLevel": "PERFORMANCE",
+            "startTime": 1638887400000,
+            "status": "OPEN"
+          },
+          "ProblemID": "P-21127",
+          "ProblemTitle": "Response time degradation",
+          "ProblemURL": "link",
+          "State": "OPEN",
+          "Tags": "keptn_service:carts, keptn_project:sockshop, keptn_stage:production"
+        },
+        "project": "sockshop",
+        "result": "",
+        "service": "carts",
+        "stage": "production",
+        "status": ""
+      },
+      "gitcommitid": "64fd7e0079a5624d0e25a4dd40323342022236c7",
+      "id": "8df20adf-38cf-4a89-8c8c-f69efc03e10d",
+      "shkeptncontext": "cfaadbb1-3c47-46e5-a230-2e312cf1828a",
+      "shkeptnspecversion": "0.2.3",
+      "source": "shipyard-controller",
+      "specversion": "1.0",
+      "time": "2022-03-08T09:48:36.398Z",
+      "type": "sh.keptn.event.get-action.triggered"
+    },
+    {
+      "data": {
+        "labels": {
+          "Problem URL": "link"
+        },
+        "problem": {
+          "ImpactedEntity": "Response time degradation on Web service sockshop.carts.production",
+          "PID": "asdf",
+          "ProblemDetails": {
+            "displayName": "P-21127",
+            "endTime": 1638888240000,
+            "hasRootCause": false,
+            "id": "asdf",
+            "impactLevel": "SERVICE",
+            "severityLevel": "PERFORMANCE",
+            "startTime": 1638887400000,
+            "status": "OPEN"
+          },
+          "ProblemID": "P-21127",
+          "ProblemTitle": "Response time degradation",
+          "ProblemURL": "link",
+          "State": "OPEN",
+          "Tags": "keptn_service:carts, keptn_project:sockshop, keptn_stage:production"
+        },
+        "project": "sockshop",
+        "service": "carts",
+        "stage": "production"
+      },
+      "id": "d69f66fd-d4f0-4d4f-9856-0b08c557d8fc",
+      "shkeptncontext": "cfaadbb1-3c47-46e5-a230-2e312cf1828a",
+      "shkeptnspecversion": "0.2.4",
+      "source": "dynatrace-service",
+      "specversion": "1.0",
+      "time": "2022-03-08T09:48:35.563Z",
+      "type": "sh.keptn.event.production.remediation.triggered"
+    }
+  ],
+  "pageSize": 100,
+  "totalCount": 6
+}

--- a/bridge/cypress/fixtures/get.events.cfaadbb1-3c47-46e5-a230-d0f055f4f518.mock.json
+++ b/bridge/cypress/fixtures/get.events.cfaadbb1-3c47-46e5-a230-d0f055f4f518.mock.json
@@ -1,0 +1,344 @@
+{
+  "events": [
+    {
+      "data": {
+        "labels": {
+          "Problem URL": "link"
+        },
+        "message": "no evaluation performed by lighthouse because no SLI-provider configured for project sockshop",
+        "project": "sockshop",
+        "result": "pass",
+        "service": "carts",
+        "stage": "production",
+        "status": "succeeded"
+      },
+      "id": "e2b8ae91-da35-4d65-a2d3-c64bad75558e",
+      "shkeptncontext": "cfaadbb1-3c47-46e5-a230-d0f055f4f518",
+      "shkeptnspecversion": "0.2.3",
+      "source": "shipyard-controller",
+      "specversion": "1.0",
+      "time": "2022-03-08T09:50:39.599Z",
+      "triggeredid": "d69f66fd-d4f0-4d4f-9856-0b08c557d8fc",
+      "type": "sh.keptn.event.production.remediation.finished"
+    },
+    {
+      "data": {
+        "evaluation": {
+          "gitCommit": "",
+          "indicatorResults": null,
+          "result": "pass",
+          "score": 0,
+          "sloFileContent": "",
+          "timeEnd": "2022-03-08T09:50:39.207Z",
+          "timeStart": "2022-03-08T09:48:39.207Z"
+        },
+        "labels": {
+          "Problem URL": "link"
+        },
+        "message": "no evaluation performed by lighthouse because no SLI-provider configured for project sockshop",
+        "project": "sockshop",
+        "result": "pass",
+        "service": "carts",
+        "stage": "production",
+        "status": "succeeded"
+      },
+      "gitcommitid": "64fd7e0079a5624d0e25a4dd40323342022236c7",
+      "id": "8d160d92-8fdc-4389-b81e-b0b33c8ea82b",
+      "shkeptncontext": "cfaadbb1-3c47-46e5-a230-d0f055f4f518",
+      "shkeptnspecversion": "0.2.4",
+      "source": "lighthouse-service",
+      "specversion": "1.0",
+      "time": "2022-03-08T09:50:39.416Z",
+      "triggeredid": "2c9732d6-9651-4dc2-9c42-3362dbccdd0d",
+      "type": "sh.keptn.event.evaluation.finished"
+    },
+    {
+      "data": {
+        "labels": {
+          "Problem URL": "link"
+        },
+        "project": "sockshop",
+        "result": "pass",
+        "service": "carts",
+        "stage": "production",
+        "status": "succeeded"
+      },
+      "gitcommitid": "64fd7e0079a5624d0e25a4dd40323342022236c7",
+      "id": "3d19cd99-6fe2-4ccd-8ef8-8c6f59efc2a8",
+      "shkeptncontext": "cfaadbb1-3c47-46e5-a230-d0f055f4f518",
+      "shkeptnspecversion": "0.2.4",
+      "source": "lighthouse-service",
+      "specversion": "1.0",
+      "time": "2022-03-08T09:50:39.211Z",
+      "triggeredid": "2c9732d6-9651-4dc2-9c42-3362dbccdd0d",
+      "type": "sh.keptn.event.evaluation.started"
+    },
+    {
+      "data": {
+        "action": {
+          "action": "toggle-feature",
+          "description": "Toogle feature flag EnableItemCache to ON",
+          "name": "Toogle feature flag",
+          "value": {
+            "EnableItemCache": "on"
+          }
+        },
+        "evaluation": {
+          "timeframe": "2m"
+        },
+        "get-action": {
+          "actionIndex": 1
+        },
+        "labels": {
+          "Problem URL": "link"
+        },
+        "message": "",
+        "problem": {
+          "ImpactedEntity": "Response time degradation on Web service sockshop.carts.production",
+          "PID": "asdf",
+          "ProblemDetails": {
+            "displayName": "P-21127",
+            "endTime": 1638888240000,
+            "hasRootCause": false,
+            "id": "asdf",
+            "impactLevel": "SERVICE",
+            "severityLevel": "PERFORMANCE",
+            "startTime": 1638887400000,
+            "status": "OPEN"
+          },
+          "ProblemID": "P-21127",
+          "ProblemTitle": "Response time degradation",
+          "ProblemURL": "link",
+          "State": "OPEN",
+          "Tags": "keptn_service:carts, keptn_project:sockshop, keptn_stage:production"
+        },
+        "project": "sockshop",
+        "result": "pass",
+        "service": "carts",
+        "stage": "production",
+        "status": "succeeded"
+      },
+      "gitcommitid": "64fd7e0079a5624d0e25a4dd40323342022236c7",
+      "id": "2c9732d6-9651-4dc2-9c42-3362dbccdd0d",
+      "shkeptncontext": "cfaadbb1-3c47-46e5-a230-d0f055f4f518",
+      "source": "shipyard-controller",
+      "specversion": "1.0",
+      "time": "2022-03-08T09:50:39.204Z",
+      "type": "sh.keptn.event.evaluation.triggered"
+    },
+    {
+      "data": {
+        "action": {},
+        "labels": {
+          "Problem URL": "link"
+        },
+        "project": "sockshop",
+        "result": "pass",
+        "service": "carts",
+        "stage": "production",
+        "status": "succeeded"
+      },
+      "id": "44cf1ec4-0ae2-4433-a1d2-ccf1aa40799c",
+      "shkeptncontext": "cfaadbb1-3c47-46e5-a230-d0f055f4f518",
+      "source": "unleash-service",
+      "specversion": "1.0",
+      "time": "2022-03-08T09:48:36.953Z",
+      "triggeredid": "1c522f96-f375-4205-b752-792b1f384d11",
+      "type": "sh.keptn.event.action.finished"
+    },
+    {
+      "data": {
+        "labels": {
+          "Problem URL": "link"
+        },
+        "project": "sockshop",
+        "service": "carts",
+        "stage": "production"
+      },
+      "id": "0887e14f-c643-49c3-85ea-c4b13e10133b",
+      "shkeptncontext": "cfaadbb1-3c47-46e5-a230-d0f055f4f518",
+      "source": "unleash-service",
+      "specversion": "1.0",
+      "time": "2022-03-08T09:48:36.908Z",
+      "triggeredid": "1c522f96-f375-4205-b752-792b1f384d11",
+      "type": "sh.keptn.event.action.started"
+    },
+    {
+      "data": {
+        "action": {
+          "action": "toggle-feature",
+          "description": "Toogle feature flag EnableItemCache to ON",
+          "name": "Toogle feature flag",
+          "value": {
+            "EnableItemCache": "on"
+          }
+        },
+        "get-action": {
+          "actionIndex": 1
+        },
+        "labels": {
+          "Problem URL": "link"
+        },
+        "message": "",
+        "problem": {
+          "ImpactedEntity": "Response time degradation on Web service sockshop.carts.production",
+          "PID": "asdf",
+          "ProblemDetails": {
+            "displayName": "P-21127",
+            "endTime": 1638888240000,
+            "hasRootCause": false,
+            "id": "asdf",
+            "impactLevel": "SERVICE",
+            "severityLevel": "PERFORMANCE",
+            "startTime": 1638887400000,
+            "status": "OPEN"
+          },
+          "ProblemID": "P-21127",
+          "ProblemTitle": "Response time degradation",
+          "ProblemURL": "link",
+          "State": "OPEN",
+          "Tags": "keptn_service:carts, keptn_project:sockshop, keptn_stage:production"
+        },
+        "project": "sockshop",
+        "result": "pass",
+        "service": "carts",
+        "stage": "production",
+        "status": "succeeded"
+      },
+      "gitcommitid": "64fd7e0079a5624d0e25a4dd40323342022236c7",
+      "id": "1c522f96-f375-4205-b752-792b1f384d11",
+      "shkeptncontext": "cfaadbb1-3c47-46e5-a230-d0f055f4f518",
+      "shkeptnspecversion": "0.2.3",
+      "source": "shipyard-controller",
+      "specversion": "1.0",
+      "time": "2022-03-08T09:48:36.902Z",
+      "type": "sh.keptn.event.action.triggered"
+    },
+    {
+      "data": {
+        "action": {
+          "action": "toggle-feature",
+          "description": "Toogle feature flag EnableItemCache to ON",
+          "name": "Toogle feature flag",
+          "value": {
+            "EnableItemCache": "on"
+          }
+        },
+        "get-action": {
+          "actionIndex": 1
+        },
+        "labels": {
+          "Problem URL": "link"
+        },
+        "project": "sockshop",
+        "result": "pass",
+        "service": "carts",
+        "stage": "production",
+        "status": "succeeded"
+      },
+      "id": "67fb1ad4-98fe-43e5-bbfd-36dcb4117eec",
+      "shkeptncontext": "cfaadbb1-3c47-46e5-a230-d0f055f4f518",
+      "source": "remediation-service",
+      "specversion": "1.0",
+      "time": "2022-03-08T09:48:36.695Z",
+      "triggeredid": "8df20adf-38cf-4a89-8c8c-f69efc03e10d",
+      "type": "sh.keptn.event.get-action.finished"
+    },
+    {
+      "data": {
+        "labels": {
+          "Problem URL": "link"
+        },
+        "project": "sockshop",
+        "service": "carts",
+        "stage": "production"
+      },
+      "id": "a2b6ebda-3c69-4629-9b3a-f04babd925b6",
+      "shkeptncontext": "cfaadbb1-3c47-46e5-a230-d0f055f4f518",
+      "source": "remediation-service",
+      "specversion": "1.0",
+      "time": "2022-03-08T09:48:36.405Z",
+      "triggeredid": "8df20adf-38cf-4a89-8c8c-f69efc03e10d",
+      "type": "sh.keptn.event.get-action.started"
+    },
+    {
+      "data": {
+        "get-action": null,
+        "labels": {
+          "Problem URL": "link"
+        },
+        "message": "",
+        "problem": {
+          "ImpactedEntity": "Response time degradation on Web service sockshop.carts.production",
+          "PID": "asdf",
+          "ProblemDetails": {
+            "displayName": "P-21127",
+            "endTime": 1638888240000,
+            "hasRootCause": false,
+            "id": "asdf",
+            "impactLevel": "SERVICE",
+            "severityLevel": "PERFORMANCE",
+            "startTime": 1638887400000,
+            "status": "OPEN"
+          },
+          "ProblemID": "P-21127",
+          "ProblemTitle": "Response time degradation",
+          "ProblemURL": "link",
+          "State": "OPEN",
+          "Tags": "keptn_service:carts, keptn_project:sockshop, keptn_stage:production"
+        },
+        "project": "sockshop",
+        "result": "",
+        "service": "carts",
+        "stage": "production",
+        "status": ""
+      },
+      "gitcommitid": "64fd7e0079a5624d0e25a4dd40323342022236c7",
+      "id": "8df20adf-38cf-4a89-8c8c-f69efc03e10d",
+      "shkeptncontext": "cfaadbb1-3c47-46e5-a230-d0f055f4f518",
+      "shkeptnspecversion": "0.2.3",
+      "source": "shipyard-controller",
+      "specversion": "1.0",
+      "time": "2022-03-08T09:48:36.398Z",
+      "type": "sh.keptn.event.get-action.triggered"
+    },
+    {
+      "data": {
+        "labels": {
+          "Problem URL": "link"
+        },
+        "problem": {
+          "ImpactedEntity": "Response time degradation on Web service sockshop.carts.production",
+          "PID": "asdf",
+          "ProblemDetails": {
+            "displayName": "P-21127",
+            "endTime": 1638888240000,
+            "hasRootCause": false,
+            "id": "asdf",
+            "impactLevel": "SERVICE",
+            "severityLevel": "PERFORMANCE",
+            "startTime": 1638887400000,
+            "status": "OPEN"
+          },
+          "ProblemID": "P-21127",
+          "ProblemTitle": "Response time degradation",
+          "ProblemURL": "link",
+          "State": "OPEN",
+          "Tags": "keptn_service:carts, keptn_project:sockshop, keptn_stage:production"
+        },
+        "project": "sockshop",
+        "service": "carts",
+        "stage": "production"
+      },
+      "id": "d69f66fd-d4f0-4d4f-9856-0b08c557d8fc",
+      "shkeptncontext": "cfaadbb1-3c47-46e5-a230-d0f055f4f518",
+      "shkeptnspecversion": "0.2.4",
+      "source": "dynatrace-service",
+      "specversion": "1.0",
+      "time": "2022-03-08T09:48:35.563Z",
+      "type": "sh.keptn.event.production.remediation.triggered"
+    }
+  ],
+  "pageSize": 100,
+  "totalCount": 11
+}

--- a/bridge/cypress/fixtures/get.project.sockshop.remediation.mock.json
+++ b/bridge/cypress/fixtures/get.project.sockshop.remediation.mock.json
@@ -1,0 +1,86 @@
+{
+  "stages": [
+    {
+      "services": [
+        {
+          "lastEventTypes": {
+            "sh.keptn.event.action.finished": {
+              "eventId": "44cf1ec4-0ae2-4433-a1d2-ccf1aa40799c",
+              "keptnContext": "cfaadbb1-3c47-46e5-a230-d0f055f4f518",
+              "time": "1646732919097753192"
+            },
+            "sh.keptn.event.action.started": {
+              "eventId": "0887e14f-c643-49c3-85ea-c4b13e10133b",
+              "keptnContext": "cfaadbb1-3c47-46e5-a230-2e312cf1828a",
+              "time": "1646732916998363944"
+            },
+            "sh.keptn.event.action.triggered": {
+              "eventId": "1c522f96-f375-4205-b752-792b1f384d11",
+              "keptnContext": "cfaadbb1-3c47-46e5-a230-2e312cf1828a",
+              "time": "1646732916896684028"
+            },
+            "sh.keptn.event.evaluation.finished": {
+              "eventId": "8d160d92-8fdc-4389-b81e-b0b33c8ea82b",
+              "keptnContext": "cfaadbb1-3c47-46e5-a230-d0f055f4f518",
+              "time": "1646733039496250690"
+            },
+            "sh.keptn.event.evaluation.started": {
+              "eventId": "3d19cd99-6fe2-4ccd-8ef8-8c6f59efc2a8",
+              "keptnContext": "cfaadbb1-3c47-46e5-a230-d0f055f4f518",
+              "time": "1646733039293028995"
+            },
+            "sh.keptn.event.evaluation.triggered": {
+              "eventId": "2c9732d6-9651-4dc2-9c42-3362dbccdd0d",
+              "keptnContext": "cfaadbb1-3c47-46e5-a230-d0f055f4f518",
+              "time": "1646732919297949716"
+            },
+            "sh.keptn.event.get-action.finished": {
+              "eventId": "67fb1ad4-98fe-43e5-bbfd-36dcb4117eec",
+              "keptnContext": "cfaadbb1-3c47-46e5-a230-2e312cf1828a",
+              "time": "1646732916793392167"
+            },
+            "sh.keptn.event.get-action.started": {
+              "eventId": "a2b6ebda-3c69-4629-9b3a-f04babd925b6",
+              "keptnContext": "cfaadbb1-3c47-46e5-a230-2e312cf1828a",
+              "time": "1646732916497820088"
+            },
+            "sh.keptn.event.get-action.triggered": {
+              "eventId": "8df20adf-38cf-4a89-8c8c-f69efc03e10d",
+              "keptnContext": "cfaadbb1-3c47-46e5-a230-2e312cf1828a",
+              "time": "1646732916193696156"
+            }
+          },
+          "openRemediations": [],
+          "openApprovals": [],
+          "creationDate": "1646731967299163474",
+          "serviceName": "carts",
+          "latestSequence": {
+            "name": "remediation",
+            "service": "carts",
+            "project": "sockshop",
+            "time": "2022-03-29T08:44:07.600Z",
+            "shkeptncontext": "cfaadbb1-3c47-46e5-a230-2e312cf1828a",
+            "state": "started",
+            "stages": [
+              {
+                "name": "production",
+                "state": "triggered",
+                "latestEvent": {
+                  "type": "sh.keptn.event.action.started",
+                  "id": "605b7950-ae61-4a25-9979-e66be562cfe9",
+                  "time": "2022-03-29T08:44:08.867Z"
+                }
+              }
+            ],
+            "problemTitle": "Response time degradation"
+          }
+        }
+      ],
+      "stageName": "production"
+    }
+  ],
+  "creationDate": "1646731884606469142",
+  "projectName": "sockshop",
+  "shipyard": "apiVersion: spec.keptn.sh/0.2.0\nkind: Shipyard\nmetadata:\n    name: shipyard-sockshop\nspec:\n    stages:\n        - name: production\n          sequences:\n            - name: remediation\n              triggeredOn:\n                - event: production.remediation.finished\n                  selector:\n                    match:\n                        evaluation.result: fail\n              tasks:\n                - name: get-action\n                  properties: null\n                - name: action\n                  properties: null\n                - name: evaluation\n                  triggeredAfter: 2m\n                  properties:\n                    timeframe: 2m\n",
+  "shipyardVersion": "spec.keptn.sh/0.2.0"
+}

--- a/bridge/cypress/fixtures/get.sequences.remediation.mock.json
+++ b/bridge/cypress/fixtures/get.sequences.remediation.mock.json
@@ -1,0 +1,74 @@
+{
+  "states": [
+    {
+      "name": "remediation",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2022-03-29T08:44:07.600Z",
+      "shkeptncontext": "cfaadbb1-3c47-46e5-a230-2e312cf1828a",
+      "state": "started",
+      "stages": [
+        {
+          "name": "production",
+          "state": "triggered",
+          "latestEvent": {
+            "type": "sh.keptn.event.action.started",
+            "id": "605b7950-ae61-4a25-9979-e66be562cfe9",
+            "time": "2022-03-29T08:44:08.867Z"
+          }
+        }
+      ],
+      "problemTitle": "Response time degradation"
+    },
+    {
+      "name": "remediation",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2022-03-08T09:48:35.562Z",
+      "shkeptncontext": "cfaadbb1-3c47-46e5-a230-d0f055f4f518",
+      "state": "finished",
+      "stages": [
+        {
+          "name": "production",
+          "state": "succeeded",
+          "latestEvaluation": {
+            "result": "pass",
+            "score": 0
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.production.remediation.finished",
+            "id": "e2b8ae91-da35-4d65-a2d3-c64bad75558e",
+            "time": "2022-03-08T09:50:39.596Z"
+          }
+        }
+      ],
+      "problemTitle": "Response time degradation"
+    },
+    {
+      "name": "remediation",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2022-03-08T09:45:41.795Z",
+      "shkeptncontext": "29355a07-7b65-47fa-896e-06f656283c5d",
+      "state": "finished",
+      "stages": [
+        {
+          "name": "production",
+          "state": "errored",
+          "latestEvent": {
+            "type": "sh.keptn.event.production.remediation.finished",
+            "id": "9986776b-65a3-420b-b639-b6d5f2d51ffb",
+            "time": "2022-03-08T09:45:45.498Z"
+          },
+          "latestFailedEvent": {
+            "type": "sh.keptn.event.production.remediation.finished",
+            "id": "9986776b-65a3-420b-b639-b6d5f2d51ffb",
+            "time": "2022-03-08T09:45:45.498Z"
+          }
+        }
+      ],
+      "problemTitle": "Response time degradation"
+    }
+  ],
+  "totalCount": 3
+}

--- a/bridge/cypress/integration/remediation-sequences.spec.ts
+++ b/bridge/cypress/integration/remediation-sequences.spec.ts
@@ -1,0 +1,58 @@
+import { SequencesPage } from '../support/pageobjects/SequencesPage';
+
+describe('Sequences', () => {
+  const sequencePage = new SequencesPage();
+
+  beforeEach(() => {
+    cy.intercept('/api/v1/metadata', { fixture: 'metadata.mock' });
+    cy.intercept('/api/bridgeInfo', { fixture: 'bridgeInfo.mock' });
+    cy.intercept('/api/project/sockshop?approval=true&remediation=true', {
+      fixture: 'get.project.sockshop.remediation.mock',
+    });
+    cy.intercept('/api/hasUnreadUniformRegistrationLogs', { body: false });
+
+    cy.intercept('/api/controlPlane/v1/project?disableUpstreamSync=true&pageSize=50', { fixture: 'projects.mock' });
+    cy.intercept('/api/controlPlane/v1/sequence/sockshop?pageSize=25', {
+      fixture: 'get.sequences.remediation.mock',
+    }).as('Sequences');
+    cy.intercept('/api/controlPlane/v1/sequence/sockshop?pageSize=25&fromTime=*', {
+      body: {
+        states: [],
+      },
+    });
+    cy.intercept('/api/project/sockshop/sequences/metadata', { fixture: 'sequence.metadata.mock' }).as(
+      'SequencesMetadata'
+    );
+
+    cy.intercept('/api/mongodb-datastore/event?keptnContext=cfaadbb1-3c47-46e5-a230-2e312cf1828a&project=sockshop', {
+      fixture: 'get.events.cfaadbb1-3c47-46e5-a230-2e312cf1828a.mock.json',
+    });
+    cy.intercept('/api/mongodb-datastore/event?keptnContext=cfaadbb1-3c47-46e5-a230-d0f055f4f518&project=sockshop', {
+      fixture: 'get.events.cfaadbb1-3c47-46e5-a230-d0f055f4f518.mock.json',
+    });
+    cy.intercept('/api/mongodb-datastore/event?keptnContext=29355a07-7b65-47fa-896e-06f656283c5d&project=sockshop', {
+      fixture: 'get.events.29355a07-7b65-47fa-896e-06f656283c5d.mock.json',
+    });
+  });
+
+  it('should show remediation in regular state while running', () => {
+    sequencePage
+      .visit('sockshop')
+      .selectSequence('cfaadbb1-3c47-46e5-a230-2e312cf1828a')
+      .assertTaskState('remediation', false, false);
+  });
+
+  it('should show remediation green when successful', () => {
+    sequencePage
+      .visit('sockshop')
+      .selectSequence('cfaadbb1-3c47-46e5-a230-d0f055f4f518')
+      .assertTaskState('remediation', false, true);
+  });
+
+  it('should show remediation red when failed', () => {
+    sequencePage
+      .visit('sockshop')
+      .selectSequence('29355a07-7b65-47fa-896e-06f656283c5d')
+      .assertTaskState('remediation', true, false);
+  });
+});

--- a/bridge/cypress/integration/remediation-sequences.spec.ts
+++ b/bridge/cypress/integration/remediation-sequences.spec.ts
@@ -4,55 +4,30 @@ describe('Sequences', () => {
   const sequencePage = new SequencesPage();
 
   beforeEach(() => {
-    cy.intercept('/api/v1/metadata', { fixture: 'metadata.mock' });
-    cy.intercept('/api/bridgeInfo', { fixture: 'bridgeInfo.mock' });
-    cy.intercept('/api/project/sockshop?approval=true&remediation=true', {
-      fixture: 'get.project.sockshop.remediation.mock',
-    });
-    cy.intercept('/api/hasUnreadUniformRegistrationLogs', { body: false });
-
-    cy.intercept('/api/controlPlane/v1/project?disableUpstreamSync=true&pageSize=50', { fixture: 'projects.mock' });
-    cy.intercept('/api/controlPlane/v1/sequence/sockshop?pageSize=25', {
-      fixture: 'get.sequences.remediation.mock',
-    }).as('Sequences');
-    cy.intercept('/api/controlPlane/v1/sequence/sockshop?pageSize=25&fromTime=*', {
-      body: {
-        states: [],
-      },
-    });
-    cy.intercept('/api/project/sockshop/sequences/metadata', { fixture: 'sequence.metadata.mock' }).as(
-      'SequencesMetadata'
-    );
-
-    cy.intercept('/api/mongodb-datastore/event?keptnContext=cfaadbb1-3c47-46e5-a230-2e312cf1828a&project=sockshop', {
-      fixture: 'get.events.cfaadbb1-3c47-46e5-a230-2e312cf1828a.mock.json',
-    });
-    cy.intercept('/api/mongodb-datastore/event?keptnContext=cfaadbb1-3c47-46e5-a230-d0f055f4f518&project=sockshop', {
-      fixture: 'get.events.cfaadbb1-3c47-46e5-a230-d0f055f4f518.mock.json',
-    });
-    cy.intercept('/api/mongodb-datastore/event?keptnContext=29355a07-7b65-47fa-896e-06f656283c5d&project=sockshop', {
-      fixture: 'get.events.29355a07-7b65-47fa-896e-06f656283c5d.mock.json',
-    });
+    sequencePage.interceptRemediationSequences();
   });
 
   it('should show remediation in regular state while running', () => {
     sequencePage
       .visit('sockshop')
       .selectSequence('cfaadbb1-3c47-46e5-a230-2e312cf1828a')
-      .assertTaskState('remediation', false, false);
+      .assertTaskFailed('remediation', false)
+      .assertTaskSuccessful('remediation', false);
   });
 
   it('should show remediation green when successful', () => {
     sequencePage
       .visit('sockshop')
       .selectSequence('cfaadbb1-3c47-46e5-a230-d0f055f4f518')
-      .assertTaskState('remediation', false, true);
+      .assertTaskFailed('remediation', false)
+      .assertTaskSuccessful('remediation', true);
   });
 
   it('should show remediation red when failed', () => {
     sequencePage
       .visit('sockshop')
       .selectSequence('29355a07-7b65-47fa-896e-06f656283c5d')
-      .assertTaskState('remediation', true, false);
+      .assertTaskFailed('remediation', true)
+      .assertTaskSuccessful('remediation', false);
   });
 });

--- a/bridge/cypress/integration/sequences.spec.ts
+++ b/bridge/cypress/integration/sequences.spec.ts
@@ -152,12 +152,6 @@ describe('Sequences', () => {
     cy.get('.dt-filter-field-input ').type('{esc}');
   }
 
-  it('should show remediation in regular state while running', () => {});
-
-  it('should show remediation green when successful', () => {});
-
-  it('should show remediation red when failed', () => {});
-
   function testSelectableTiles(expectedLength: number, textElementSelector: string, expectedText: string): void {
     const selectableTiles = cy.byTestId('keptn-sequence-view-roots').get('ktb-selectable-tile');
     selectableTiles.should('have.length', expectedLength);

--- a/bridge/cypress/integration/sequences.spec.ts
+++ b/bridge/cypress/integration/sequences.spec.ts
@@ -152,6 +152,12 @@ describe('Sequences', () => {
     cy.get('.dt-filter-field-input ').type('{esc}');
   }
 
+  it('should show remediation in regular state while running', () => {});
+
+  it('should show remediation green when successful', () => {});
+
+  it('should show remediation red when failed', () => {});
+
   function testSelectableTiles(expectedLength: number, textElementSelector: string, expectedText: string): void {
     const selectableTiles = cy.byTestId('keptn-sequence-view-roots').get('ktb-selectable-tile');
     selectableTiles.should('have.length', expectedLength);

--- a/bridge/cypress/support/pageobjects/SequencesPage.ts
+++ b/bridge/cypress/support/pageobjects/SequencesPage.ts
@@ -4,16 +4,54 @@ export class SequencesPage {
     return this;
   }
 
+  public interceptRemediationSequences(): this {
+    cy.intercept('/api/v1/metadata', { fixture: 'metadata.mock' });
+    cy.intercept('/api/bridgeInfo', { fixture: 'bridgeInfo.mock' });
+    cy.intercept('/api/project/sockshop?approval=true&remediation=true', {
+      fixture: 'get.project.sockshop.remediation.mock',
+    });
+    cy.intercept('/api/hasUnreadUniformRegistrationLogs', { body: false });
+
+    cy.intercept('/api/controlPlane/v1/project?disableUpstreamSync=true&pageSize=50', { fixture: 'projects.mock' });
+    cy.intercept('/api/controlPlane/v1/sequence/sockshop?pageSize=25', {
+      fixture: 'get.sequences.remediation.mock',
+    }).as('Sequences');
+    cy.intercept('/api/controlPlane/v1/sequence/sockshop?pageSize=25&fromTime=*', {
+      body: {
+        states: [],
+      },
+    });
+    cy.intercept('/api/project/sockshop/sequences/metadata', { fixture: 'sequence.metadata.mock' }).as(
+      'SequencesMetadata'
+    );
+
+    cy.intercept('/api/mongodb-datastore/event?keptnContext=cfaadbb1-3c47-46e5-a230-2e312cf1828a&project=sockshop', {
+      fixture: 'get.events.cfaadbb1-3c47-46e5-a230-2e312cf1828a.mock.json',
+    });
+    cy.intercept('/api/mongodb-datastore/event?keptnContext=cfaadbb1-3c47-46e5-a230-d0f055f4f518&project=sockshop', {
+      fixture: 'get.events.cfaadbb1-3c47-46e5-a230-d0f055f4f518.mock.json',
+    });
+    cy.intercept('/api/mongodb-datastore/event?keptnContext=29355a07-7b65-47fa-896e-06f656283c5d&project=sockshop', {
+      fixture: 'get.events.29355a07-7b65-47fa-896e-06f656283c5d.mock.json',
+    });
+
+    return this;
+  }
+
   public selectSequence(keptnContext: string): this {
     cy.byTestId(`keptn-root-events-list-${keptnContext}`).click();
     return this;
   }
 
-  public assertTaskState(taskName: string, isFailed: boolean, isSuccess: boolean): this {
+  public assertTaskFailed(taskName: string, isFailed: boolean): this {
     cy.byTestId(`keptn-task-item-${taskName}`)
       .find('ktb-expandable-tile')
       .eq(0)
       .should(isFailed ? 'have.class' : 'not.have.class', 'ktb-tile-error');
+    return this;
+  }
+
+  public assertTaskSuccessful(taskName: string, isSuccess: boolean): this {
     cy.byTestId(`keptn-task-item-${taskName}`)
       .find('ktb-expandable-tile')
       .eq(0)

--- a/bridge/cypress/support/pageobjects/SequencesPage.ts
+++ b/bridge/cypress/support/pageobjects/SequencesPage.ts
@@ -9,6 +9,16 @@ export class SequencesPage {
     return this;
   }
 
+  public assertTaskState(taskName: string, isFailed: boolean, isSuccess: boolean): this {
+    cy.byTestId(`keptn-task-item-${taskName}`)
+      .find('ktb-expandable-tile')
+      .should(isFailed ? 'have.class' : 'not.have.class', 'ktb-tile-error');
+    cy.byTestId(`keptn-task-item-${taskName}`)
+      .find('ktb-expandable-tile')
+      .should(isSuccess ? 'have.class' : 'not.have.class', 'ktb-tile-success');
+    return this;
+  }
+
   public assertTimelineTime(stage: string, time: string): this {
     cy.get('.stage-info')
       .contains(stage)

--- a/bridge/cypress/support/pageobjects/SequencesPage.ts
+++ b/bridge/cypress/support/pageobjects/SequencesPage.ts
@@ -12,9 +12,11 @@ export class SequencesPage {
   public assertTaskState(taskName: string, isFailed: boolean, isSuccess: boolean): this {
     cy.byTestId(`keptn-task-item-${taskName}`)
       .find('ktb-expandable-tile')
+      .eq(0)
       .should(isFailed ? 'have.class' : 'not.have.class', 'ktb-tile-error');
     cy.byTestId(`keptn-task-item-${taskName}`)
       .find('ktb-expandable-tile')
+      .eq(0)
       .should(isSuccess ? 'have.class' : 'not.have.class', 'ktb-tile-success');
     return this;
   }

--- a/bridge/shared/models/trace.ts
+++ b/bridge/shared/models/trace.ts
@@ -230,12 +230,7 @@ export class Trace {
   public isFaulty(stageName?: string): boolean {
     let result = false;
     if (this.data) {
-      if (
-        this.isFailed() ||
-        (this.isProblem() && !this.isProblemResolvedOrClosed()) ||
-        (this.isRemediation() && !this.isSuccessfulRemediation()) ||
-        this.traces.some((t) => t.isFaulty())
-      ) {
+      if (this.isFailed() || this.traces.some((t) => t.isFaulty())) {
         result = stageName ? this.data.stage === stageName : true;
       }
     }


### PR DESCRIPTION
## This PR
- makes sure that remediation sequences are displayed in default color (not red) while running

### Related Issues
Fixes #7129 

![image](https://user-images.githubusercontent.com/6098219/160672016-c276be35-5752-471e-99d8-7de4b9f77701.png)
