### PR TITLE
ci: Remove master branch restriction from re-used workflows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -336,7 +336,7 @@ jobs:
     name: Build Keptn CLI
     needs: [prepare_ci_run, unit-tests-cli]
     if: (needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (needs.prepare_ci_run.outputs.BUILD_CLI == 'true')
-    uses: keptn/keptn/.github/workflows/build-cli.yml@master
+    uses: ./.github/workflows/build-cli.yml
     with:
       branch: ${{ needs.prepare_ci_run.outputs.BRANCH }}
       version: ${{ needs.prepare_ci_run.outputs.VERSION }}
@@ -349,7 +349,7 @@ jobs:
     name: Build Helm Charts
     needs: prepare_ci_run
     if: (needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (needs.prepare_ci_run.outputs.BUILD_INSTALLER == 'true')
-    uses: keptn/keptn/.github/workflows/build-helm-charts.yml@master
+    uses: ./.github/workflows/build-helm-charts.yml
     with:
       branch: ${{ needs.prepare_ci_run.outputs.BRANCH }}
       version: ${{ needs.prepare_ci_run.outputs.VERSION }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -251,7 +251,7 @@ jobs:
   build-helm-charts:
     needs: prepare
     name: Build Helm Charts
-    uses: keptn/keptn/.github/workflows/build-helm-charts.yml@master
+    uses: ./.github/workflows/build-helm-charts.yml
     with:
       branch: ${{ needs.prepare.outputs.branch }}
       version: ${{ needs.prepare.outputs.next-version }}
@@ -263,7 +263,7 @@ jobs:
   ############################################################################
   build-cli:
     needs: prepare
-    uses: keptn/keptn/.github/workflows/build-cli.yml@master
+    uses: ./.github/workflows/build-cli.yml
     with:
       branch: ${{ needs.prepare.outputs.branch }}
       version: ${{ needs.prepare.outputs.next-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,7 +248,7 @@ jobs:
   build-helm-charts:
     needs: prepare
     name: Build Helm Charts
-    uses: keptn/keptn/.github/workflows/build-helm-charts.yml@master
+    uses: ./.github/workflows/build-helm-charts.yml
     with:
       branch: ${{ needs.prepare.outputs.branch }}
       version: ${{ needs.prepare.outputs.next-version }}
@@ -260,7 +260,7 @@ jobs:
   ############################################################################
   build-cli:
     needs: prepare
-    uses: keptn/keptn/.github/workflows/build-cli.yml@master
+    uses: ./.github/workflows/build-cli.yml
     with:
       branch: ${{ needs.prepare.outputs.branch }}
       version: ${{ needs.prepare.outputs.next-version }}


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- re-uses different workflows from the current branch instead of always using master
