### PR TITLE
fix(cli): Cleaned up Oauth command  

### DIFF
--- a/cli/cmd/add_resource.go
+++ b/cli/cmd/add_resource.go
@@ -80,7 +80,7 @@ keptn add-resource --project=keptn --service=keptn-control-plane --all-stages --
 
 		api, err := internal.APIProvider(endPoint.String(), apiToken)
 		if err != nil {
-			return err
+			return internal.OnAPIError(err)
 		}
 
 		// Handle different cases of adding resource to a projects default branch, stage branch, and/or service sub-directory

--- a/cli/cmd/auth.go
+++ b/cli/cmd/auth.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"github.com/keptn/keptn/cli/internal"
 	"net/http"
 	"net/url"
 	"os"
@@ -91,10 +92,12 @@ keptn auth --skip-namespace-listing # To skip the listing of namespaces and use 
 			if err != nil {
 				return err
 			}
+			fmt.Println("Successfully logged out")
 			return nil
 		}
 
 		if *authParams.oauth {
+
 			if *authParams.oauthDiscovery == "" {
 				return fmt.Errorf("Unable to login: No OAuth Discovery URL provided")
 			}
@@ -113,14 +116,15 @@ keptn auth --skip-namespace-listing # To skip the listing of namespaces and use 
 				return err
 			}
 		}
+
 		return authenticator.Auth(AuthenticatorOptions{Endpoint: *authParams.endPoint, APIToken: *authParams.apiToken})
 	},
 }
 
 func init() {
+
 	rootCmd.AddCommand(authCmd)
 	authParams = &authCmdParams{}
-
 	authParams.endPoint = authCmd.Flags().StringP("endpoint", "e", "", "The endpoint exposed by the Keptn installation (e.g., api.keptn.127.0.0.1.xip.io)")
 	authParams.apiToken = authCmd.Flags().StringP("api-token", "a", "", "The API token to communicate with the Keptn installation")
 	authParams.exportConfig = authCmd.Flags().BoolP("export", "c", false, "To export the current cluster config i.e API token and Endpoint")
@@ -155,7 +159,7 @@ func verifyAuthParams(authParams *authCmdParams, smartKeptnAuth smartKeptnAuthPa
 	if !*authParams.skipNamespaceListing && (authParams.endPoint == nil || *authParams.endPoint == "") && (authParams.apiToken == nil || *authParams.apiToken == "") {
 		namespace, err = smartKeptnCLIAuth()
 		if err != nil {
-			return err
+			return internal.OnAPIError(err)
 		}
 	}
 

--- a/cli/cmd/authenticator.go
+++ b/cli/cmd/authenticator.go
@@ -56,12 +56,12 @@ func (a *Authenticator) Auth(authenticatorOptions AuthenticatorOptions) error {
 	if authenticatorOptions.Endpoint == "" {
 		endpoint, apiToken, err = a.CredentialManager.GetCreds(a.Namespace)
 		if err != nil {
-			return err
+			return internal.OnAPIError(err)
 		}
 	} else {
 		endpoint, err = a.parseURL(authenticatorOptions.Endpoint)
 		if err != nil {
-			return err
+			return internal.OnAPIError(err)
 		}
 		apiToken = authenticatorOptions.APIToken
 	}
@@ -85,9 +85,6 @@ func (a *Authenticator) Auth(authenticatorOptions AuthenticatorOptions) error {
 	if a.OauthStore.Created() {
 		fmt.Printf("Successfully authenticated against the Keptn cluster %s\n", endpoint.String())
 		fmt.Printf("Bridge URL: %s\n", getBridgeURLFromAPIURL(endpoint))
-		if apiToken == "" {
-			fmt.Println("WARNING: You are using the OAuth integration feature without a Keptn API Token. Please verify that your configuration allows it")
-		}
 		return a.CredentialManager.SetCreds(endpoint, apiToken, namespace)
 	}
 

--- a/cli/cmd/configure_monitoring.go
+++ b/cli/cmd/configure_monitoring.go
@@ -86,7 +86,7 @@ keptn configure monitoring prometheus --project=PROJECTNAME --service=SERVICENAM
 
 		api, err := internal.APIProvider(endPoint.String(), apiToken)
 		if err != nil {
-			return err
+			return internal.OnAPIError(err)
 		}
 
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)

--- a/cli/cmd/create_project.go
+++ b/cli/cmd/create_project.go
@@ -168,7 +168,7 @@ keptn create project PROJECTNAME --shipyard=FILEPATH --git-user=GIT_USER --git-r
 
 		api, err := internal.APIProvider(endPoint.String(), apiToken)
 		if err != nil {
-			return err
+			return internal.OnAPIError(err)
 		}
 
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)

--- a/cli/cmd/create_service.go
+++ b/cli/cmd/create_service.go
@@ -62,7 +62,7 @@ var crServiceCmd = &cobra.Command{
 
 		api, err := internal.APIProvider(endPoint.String(), apiToken)
 		if err != nil {
-			return err
+			return internal.OnAPIError(err)
 		}
 
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)

--- a/cli/cmd/delete_project.go
+++ b/cli/cmd/delete_project.go
@@ -64,7 +64,7 @@ var delProjectCmd = &cobra.Command{
 
 		api, err := internal.APIProvider(endPoint.String(), apiToken)
 		if err != nil {
-			return err
+			return internal.OnAPIError(err)
 		}
 
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)

--- a/cli/cmd/delete_service.go
+++ b/cli/cmd/delete_service.go
@@ -47,7 +47,7 @@ Furthermore, if Keptn is used for continuous delivery (i.e. services have been o
 
 		api, err := internal.APIProvider(endPoint.String(), apiToken)
 		if err != nil {
-			return err
+			return internal.OnAPIError(err)
 		}
 
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)

--- a/cli/cmd/generate_support_archive.go
+++ b/cli/cmd/generate_support_archive.go
@@ -303,21 +303,21 @@ func recursiveZip(pathToZip, destPath string) error {
 			return nil
 		}
 		if err != nil {
-			return err
+			return internal.OnAPIError(err)
 		}
 		relPath := strings.TrimPrefix(filePath, filepath.Dir(pathToZip))
 		zipFile, err := myZip.Create(relPath)
 		if err != nil {
-			return err
+			return internal.OnAPIError(err)
 		}
 		filePath = filepath.Clean(filePath)
 		fsFile, err := os.Open(filePath)
 		if err != nil {
-			return err
+			return internal.OnAPIError(err)
 		}
 		_, err = io.Copy(zipFile, fsFile)
 		if err != nil {
-			return err
+			return internal.OnAPIError(err)
 		}
 		return nil
 	})

--- a/cli/cmd/get_event_evaluationFinished.go
+++ b/cli/cmd/get_event_evaluationFinished.go
@@ -56,7 +56,7 @@ var getEvaluationFinishedCmd = &cobra.Command{
 
 		api, err := internal.APIProvider(endPoint.String(), apiToken)
 		if err != nil {
-			return err
+			return internal.OnAPIError(err)
 		}
 
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)

--- a/cli/cmd/get_projects.go
+++ b/cli/cmd/get_projects.go
@@ -91,7 +91,7 @@ keptn get project sockshop -output=json  # Returns project details in JSON forma
 
 		api, err := internal.APIProvider(endPoint.String(), apiToken)
 		if err != nil {
-			return err
+			return internal.OnAPIError(err)
 		}
 
 		if !mocking {
@@ -104,7 +104,7 @@ keptn get project sockshop -output=json  # Returns project details in JSON forma
 
 			projects, err := api.ProjectsV1().GetAllProjects()
 			if err != nil {
-				return err
+				return internal.OnAPIError(err)
 			}
 
 			filteredProjects := filterProjects(projects, getProjectNameFromArgs(args))

--- a/cli/cmd/get_secrets.go
+++ b/cli/cmd/get_secrets.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"github.com/keptn/keptn/cli/internal"
 	"github.com/keptn/keptn/cli/pkg/credentialmanager"
 	"github.com/keptn/keptn/cli/pkg/logging"
 	"github.com/spf13/cobra"
@@ -42,7 +43,7 @@ keptn get secrets -output=json  # Returns secret list in JSON format
 		}
 		output, err := handler.GetSecrets(*getSecrets.outputFormat)
 		if err != nil {
-			return err
+			return internal.OnAPIError(err)
 		}
 		logging.PrintLog(output, logging.QuietLevel)
 		return nil

--- a/cli/cmd/get_services.go
+++ b/cli/cmd/get_services.go
@@ -72,7 +72,7 @@ keptn get services carts --project=sockshop -o=json  # Get details of the carts 
 
 		api, err := internal.APIProvider(endPoint.String(), apiToken)
 		if err != nil {
-			return err
+			return internal.OnAPIError(err)
 		}
 
 		if !mocking {

--- a/cli/cmd/get_stages.go
+++ b/cli/cmd/get_stages.go
@@ -65,7 +65,7 @@ staging        2020-04-06T14:37:45.210Z
 
 		api, err := internal.APIProvider(endPoint.String(), apiToken)
 		if err != nil {
-			return err
+			return internal.OnAPIError(err)
 		}
 
 		if !mocking {

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -146,7 +146,6 @@ func runVersionCheck(vChecker *version.VersionChecker, flags []string, cliConfig
 // skipVersionCheck checks if the subcommand is `install` or `--oauth`
 // args here does not contain the main command
 // e.g., For `keptn -q install`, args would be just ['-q', 'install']
-//
 func skipVersionCheck(args []string) bool {
 	for _, arg := range args {
 		switch {

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -2,13 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-	"strings"
-
 	"github.com/keptn/keptn/cli/pkg/config"
 	"github.com/keptn/keptn/cli/pkg/logging"
 	"github.com/keptn/keptn/cli/pkg/version"
 	"github.com/spf13/cobra"
+	"os"
+	"strings"
 )
 
 var cfgFile string
@@ -88,11 +87,10 @@ func initConfig() {
 	logging.PrintLog(fmt.Sprintf("Using config file: %s", cfgMgr.CLIConfigPath), logging.VerboseLevel)
 
 	var err error
-	configCLI, err := cfgMgr.LoadCLIConfig()
+	rootCLIConfig, err = cfgMgr.LoadCLIConfig()
 	if err != nil {
 		logging.PrintLog(err.Error(), logging.InfoLevel)
 	}
-	rootCLIConfig = configCLI
 
 }
 
@@ -149,7 +147,6 @@ func runVersionCheck(vChecker *version.VersionChecker, flags []string, cliConfig
 // args here does not contain the main command
 // e.g., For `keptn -q install`, args would be just ['-q', 'install']
 //
-
 func skipVersionCheck(args []string) bool {
 	for _, arg := range args {
 		switch {

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -143,7 +143,8 @@ func runVersionCheck(vChecker *version.VersionChecker, flags []string, cliConfig
 	}
 }
 
-// skipVersionCheck checks if the subcommand is `install` or `--oauth`
+// skipVersionCheck checks if the subcommand requires to skip the version check step
+// (for now this is true in case of  `install` or `--oauth`)
 // args here does not contain the main command
 // e.g., For `keptn -q install`, args would be just ['-q', 'install']
 func skipVersionCheck(args []string) bool {

--- a/cli/cmd/send_event.go
+++ b/cli/cmd/send_event.go
@@ -50,7 +50,7 @@ In addition, the payload of the CloudEvent needs to follow the Keptn spec (https
 		}
 		eventString, err := fileutils.ReadFile(*eventFilePath)
 		if err != nil {
-			return err
+			return internal.OnAPIError(err)
 		}
 
 		apiEvent := apimodels.KeptnContextExtendedCE{}
@@ -61,7 +61,7 @@ In addition, the payload of the CloudEvent needs to follow the Keptn spec (https
 
 		api, err := internal.APIProvider(endPoint.String(), apiToken)
 		if err != nil {
-			return err
+			return internal.OnAPIError(err)
 		}
 
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)

--- a/cli/cmd/set_config.go
+++ b/cli/cmd/set_config.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"github.com/keptn/keptn/cli/internal"
 	"strconv"
 	"strings"
 	"time"
@@ -38,7 +39,7 @@ Supported keys:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cliConfig, err := configMng.LoadCLIConfig()
 		if err != nil {
-			return err
+			return internal.OnAPIError(err)
 		}
 
 		key := strings.ToLower(args[0])

--- a/cli/cmd/update_project.go
+++ b/cli/cmd/update_project.go
@@ -146,7 +146,7 @@ keptn update project PROJECTNAME --git-user=GIT_USER --git-remote-url=GIT_REMOTE
 
 		api, err := internal.APIProvider(endPoint.String(), apiToken)
 		if err != nil {
-			return err
+			return internal.OnAPIError(err)
 		}
 
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -106,7 +106,7 @@ func doUpgradePreRunCheck(vChecker *version.KeptnVersionChecker) error {
 	if !*upgradeParams.SkipUpgradeCheck {
 		res, err := isUpgradeCompatible(vChecker)
 		if err != nil {
-			return err
+			return internal.OnAPIError(err)
 		}
 		if !res {
 			installedKeptnVersion, err := getInstalledKeptnVersion()
@@ -162,7 +162,7 @@ func doUpgradePreRunCheck(vChecker *version.KeptnVersionChecker) error {
 	} else {
 		err = platformManager.ReadCreds(assumeYes)
 		if err != nil {
-			return err
+			return internal.OnAPIError(err)
 		}
 	}
 
@@ -190,7 +190,7 @@ func doUpgradePreRunCheck(vChecker *version.KeptnVersionChecker) error {
 	if statisticsDeploymentAvailable {
 		statisticsServiceManagedByHelm, err := kube.CheckDeploymentManagedByHelm("statistics-service", namespace)
 		if err != nil {
-			return err
+			return internal.OnAPIError(err)
 		}
 		if !statisticsServiceManagedByHelm {
 			return errors.New("deployment for statistics-service is already running and not managed by Helm. Please uninstall it")

--- a/cli/internal/api.go
+++ b/cli/internal/api.go
@@ -10,6 +10,9 @@ import (
 )
 
 const ErrWithStatusCode = "error with status code %d"
+const ErrNotAuthenticated = "You are not authenticated. Use the keptn auth command to authenticate based on the API token or an OAuth client"
+const ErrForbidden = "You do not have enough permissions"
+const ErrInternalServerError = "Keptn API seems to be down"
 
 var PublicDiscovery = auth.NewOauthDiscovery(&http.Client{})
 
@@ -75,11 +78,11 @@ func getAPISetWithOauthGetter(baseURL string, keptnXToken string, oauthAuthentic
 func OnAPIError(err error) error {
 	switch 0 {
 	case compareError(err, ErrWithStatusCode, 401):
-		return fmt.Errorf("You are not authenticated. Use the keptn auth command to authenticate based on the API token or an OAuth client.")
+		return fmt.Errorf(ErrNotAuthenticated)
 	case compareError(err, ErrWithStatusCode, 403):
-		return fmt.Errorf("You do not have enough permissions. This for all commands")
+		return fmt.Errorf(ErrForbidden)
 	case compareError(err, ErrWithStatusCode, 500):
-		return fmt.Errorf("Keptn API seems to be down")
+		return fmt.Errorf(ErrInternalServerError)
 	default:
 		return err
 	}

--- a/cli/internal/api.go
+++ b/cli/internal/api.go
@@ -2,10 +2,14 @@ package internal
 
 import (
 	"context"
+	"fmt"
 	apiutils "github.com/keptn/go-utils/pkg/api/utils"
 	"github.com/keptn/keptn/cli/internal/auth"
 	"net/http"
+	"strings"
 )
+
+const ErrWithStatusCode = "error with status code %d"
 
 var PublicDiscovery = auth.NewOauthDiscovery(&http.Client{})
 
@@ -66,4 +70,21 @@ func getAPISetWithOauthGetter(baseURL string, keptnXToken string, oauthAuthentic
 		}
 	}
 	return apiutils.New(baseURL, apiutils.WithAuthToken(keptnXToken), apiutils.WithHTTPClient(client))
+}
+
+func OnAPIError(err error) error {
+	switch 0 {
+	case compareError(err, ErrWithStatusCode, 401):
+		return fmt.Errorf("You are not authenticated. Use the keptn auth command to authenticate based on the API token or an OAuth client.")
+	case compareError(err, ErrWithStatusCode, 403):
+		return fmt.Errorf("You do not have enough permissions. This for all commands")
+	case compareError(err, ErrWithStatusCode, 500):
+		return fmt.Errorf("Keptn API seems to be down")
+	default:
+		return err
+	}
+}
+
+func compareError(err error, msg string, code int) int {
+	return strings.Compare(err.Error(), fmt.Sprintf(msg, code))
 }

--- a/cli/internal/auth/oauth.go
+++ b/cli/internal/auth/oauth.go
@@ -11,9 +11,14 @@ import (
 )
 
 const (
-	loginSuccessHTML = `<p><strong>Login successful!</strong></p>`
-	redirectURL      = "http://localhost:3000/oauth/redirect"
-	openIDScope      = "openid"
+	loginSuccessHTML = `<p><strong>Login successful!</strong></p>
+						<script type="text/javascript">	
+								setTimeout(function(){
+											close();
+								},1500)
+						</script>`
+	redirectURL = "http://localhost:3000/oauth/redirect"
+	openIDScope = "openid"
 )
 
 // OAuthenticator represents just the interface for a component performing OAuth authentication
@@ -100,6 +105,7 @@ func (a *OauthAuthenticator) Auth(clientValues OauthClientValues) error {
 // GetOauthClient will eventually return an already ready to use http client which is configured to use
 // a OAUth Access Token
 func (a *OauthAuthenticator) OauthClient(ctx context.Context) (*http.Client, error) {
+
 	oauthInfo, err := a.tokenStore.GetOauthInfo()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get OAuth HTTP client: %w", err)

--- a/distributor/go.mod
+++ b/distributor/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/benbjohnson/clock v1.3.0
 	github.com/cloudevents/sdk-go/protocol/nats/v2 v2.8.0
 	github.com/cloudevents/sdk-go/v2 v2.8.0
+	github.com/imroc/req v0.3.2
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/keptn/go-utils v0.13.1-0.20220318125157-fe974e59cc65
 	github.com/nats-io/nats-server/v2 v2.7.2

--- a/distributor/go.sum
+++ b/distributor/go.sum
@@ -135,6 +135,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFb
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/imroc/req v0.3.2 h1:M/JkeU6RPmX+WYvT2vaaOL0K+q8ufL5LxwvJc4xeB4o=
+github.com/imroc/req v0.3.2/go.mod h1:F+NZ+2EFSo6EFXdeIbpfE9hcC233id70kf0byW97Caw=
 github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr68=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=

--- a/test/go-tests/test_continuous_delivery.go
+++ b/test/go-tests/test_continuous_delivery.go
@@ -126,7 +126,7 @@ spec:
 func Test_ContinuousDelivery(t *testing.T) {
 	repoLocalDir, err := filepath.Abs("../assets/podtato-head")
 	require.Nil(t, err)
-	projectName := "po"
+	projectName := "podtato-head"
 	serviceName := "helloservice"
 	chartFileName := "helloservice.tgz"
 	serviceChartSrcPath := path.Join(repoLocalDir, "helm-charts", "helloservice")

--- a/test/go-tests/test_continuous_delivery.go
+++ b/test/go-tests/test_continuous_delivery.go
@@ -126,7 +126,7 @@ spec:
 func Test_ContinuousDelivery(t *testing.T) {
 	repoLocalDir, err := filepath.Abs("../assets/podtato-head")
 	require.Nil(t, err)
-	projectName := "podtato-head"
+	projectName := "po"
 	serviceName := "helloservice"
 	chartFileName := "helloservice.tgz"
 	serviceChartSrcPath := path.Join(repoLocalDir, "helm-charts", "helloservice")


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- [x] Given the user is not authenticated,  `keptn get services --project=podtato` returns `You are not authenticated. Use the keptn auth command to authenticate based on the API token or an OAuth client.`
- [x] Given the user is not authenticated, when it runs the `keptn auth --oauth ...` command, then the CLI does not perform the version checks.
- [x] Given the user is not authenticated, when it runs the `keptn auth --oauth ...` command the CLI prints the following:
```
Successfully authenticated against: https://mykeptn.url/api
Bridge URL: https://mykeptn.url/bridge
```

- [x] When the CLI correctly authenticates a user with OAuth, the browser page/tab automatically closes.
- [x] When the CLI receives a 403 error, CLI  prints `You do not have enough permissions. This for all commands.
- [x] When the user runs `keptn auth --oauth-logout`, then the CLI prints `Successfully logged out`. 

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #7222

### How to test
<!-- if applicable, add testing instructions under this section -->

before  running auth run  keptn get services --project=podtato , run oauth command as described in https://keptn.sh/docs/0.13.x/operate/user_management/microsoft/ 

https://github.com/keptn/keptn/runs/5755512785?check_suite_focus=true