### PR TITLE
ci: Pass datetime and git sha to docker build in release pipelines

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -449,9 +449,6 @@ jobs:
         name: "Docker Build keptn/${{ matrix.config.artifact }}"
         if: matrix.config.should-push-image == 'true' && ( matrix.config.should-run == 'true' || needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true' )
         uses: docker/build-push-action@v2
-        env:
-          DATETIME: ${{ needs.prepare_ci_run.outputs.DATE }}${{ needs.prepare_ci_run.outputs.TIME }}
-          GIT_SHA: ${{ needs.prepare_ci_run.outputs.GIT_SHA }}
         with:
           context: ${{ matrix.config.working-dir }}
           tags: |
@@ -459,7 +456,7 @@ jobs:
             keptndev/${{ matrix.config.artifact }}:${{ env.VERSION }}.${{ env.DATETIME }}
           build-args: |
             version=${{ env.VERSION }}
-            buildTime=${{ env.DATETIME }}
-            gitSha=${{ env.GIT_SHA }}
+            buildTime=${{ needs.prepare_ci_run.outputs.DATETIME }}
+            gitSha=${{ needs.prepare_ci_run.outputs.GIT_SHA }}
           push: ${{ matrix.config.should-push-image == 'true' && (( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository ) || ( github.event_name == 'push' )) && github.actor != 'renovate[bot]' && github.actor != 'dependabot[bot]' }}
           pull: true

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -128,6 +128,18 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.KEPTN_BOT_TOKEN }}
 
+      - name: Extract branch name
+        id: extract_branch
+        # see https://github.com/keptn/gh-action-extract-branch-name for details
+        uses: keptn/gh-action-extract-branch-name@main
+
+      - name: Get current date and time
+        id: get_datetime
+        run: |
+          echo "::set-output name=DATE::$(date +'%Y%m%d')"
+          echo "::set-output name=TIME::$(date +'%H%M')"
+          echo "::set-output name=DATETIME::$(date +'%Y%m%d')$(date +'%H%M')"
+
       - name: Find next version number
         id: version_number
         env:
@@ -217,6 +229,9 @@ jobs:
       - id: docker_build_image
         name: "Docker Build keptn/${{ matrix.config.artifact }}"
         uses: docker/build-push-action@v2
+        env:
+          DATETIME: ${{ steps.get_datetime.outputs.DATETIME }}
+          GIT_SHA: ${{ steps.extract_branch.outputs.GIT_SHA }}
         with:
           context: ${{ matrix.config.working-dir }}
           tags: |
@@ -225,6 +240,8 @@ jobs:
             ghcr.io/keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
           build-args: |
             version=${{ env.VERSION }}
+            buildTime=${{ env.DATETIME }}
+            gitSha=${{ env.GIT_SHA }}
           push: ${{ matrix.config.should-push-image }}
           pull: true
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -231,9 +231,6 @@ jobs:
       - id: docker_build_image
         name: "Docker Build keptn/${{ matrix.config.artifact }}"
         uses: docker/build-push-action@v2
-        env:
-          DATETIME: ${{ needs.prepare.outputs.datetime }}
-          GIT_SHA: ${{ needs.prepare.outputs.git_sha }}
         with:
           context: ${{ matrix.config.working-dir }}
           tags: |
@@ -242,8 +239,8 @@ jobs:
             ghcr.io/keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
           build-args: |
             version=${{ env.VERSION }}
-            buildTime=${{ env.DATETIME }}
-            gitSha=${{ env.GIT_SHA }}
+            buildTime=${{ needs.prepare.outputs.datetime }}
+            gitSha=${{ needs.prepare.outputs.git_sha }}
           push: ${{ matrix.config.should-push-image }}
           pull: true
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -98,6 +98,8 @@ jobs:
     outputs:
       next-version: ${{ steps.version_number.outputs.next-version }}
       branch: ${{ steps.current_branch.outputs.branch }}
+      datetime: ${{ steps.get_datetime.outputs.DATETIME }}
+      git_sha: ${{ steps.extract_branch.outputs.GIT_SHA }}
       keptn-spec-version: ${{ steps.keptn_spec_version.outputs.keptn-spec-version }}
       BUILD_EVERYTHING: ${{ steps.build_everything.outputs.BUILD_EVERYTHING }}
       BUILD_INSTALLER: ${{ steps.check_modified_files.outputs.BUILD_INSTALLER }}
@@ -230,8 +232,8 @@ jobs:
         name: "Docker Build keptn/${{ matrix.config.artifact }}"
         uses: docker/build-push-action@v2
         env:
-          DATETIME: ${{ steps.get_datetime.outputs.DATETIME }}
-          GIT_SHA: ${{ steps.extract_branch.outputs.GIT_SHA }}
+          DATETIME: ${{ needs.prepare.outputs.datetime }}
+          GIT_SHA: ${{ needs.prepare.outputs.git_sha }}
         with:
           context: ${{ matrix.config.working-dir }}
           tags: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,18 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.KEPTN_BOT_TOKEN }}
 
+      - name: Extract branch name
+        id: extract_branch
+        # see https://github.com/keptn/gh-action-extract-branch-name for details
+        uses: keptn/gh-action-extract-branch-name@main
+
+      - name: Get current date and time
+        id: get_datetime
+        run: |
+          echo "::set-output name=DATE::$(date +'%Y%m%d')"
+          echo "::set-output name=TIME::$(date +'%H%M')"
+          echo "::set-output name=DATETIME::$(date +'%Y%m%d')$(date +'%H%M')"
+
       - name: Find next version number
         id: version_number
         env:
@@ -214,6 +226,9 @@ jobs:
       - id: docker_build_image
         name: "Docker Build keptn/${{ matrix.config.artifact }}"
         uses: docker/build-push-action@v2
+        env:
+          DATETIME: ${{ steps.get_datetime.outputs.DATETIME }}
+          GIT_SHA: ${{ steps.extract_branch.outputs.GIT_SHA }}
         with:
           context: ${{ matrix.config.working-dir }}
           tags: |
@@ -222,6 +237,8 @@ jobs:
             ghcr.io/keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
           build-args: |
             version=${{ env.VERSION }}
+            buildTime=${{ env.DATETIME }}
+            gitSha=${{ env.GIT_SHA }}
           push: ${{ matrix.config.should-push-image }}
           pull: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,9 +228,6 @@ jobs:
       - id: docker_build_image
         name: "Docker Build keptn/${{ matrix.config.artifact }}"
         uses: docker/build-push-action@v2
-        env:
-          DATETIME: ${{ needs.prepare.outputs.datetime }}
-          GIT_SHA: ${{ needs.prepare.outputs.git_sha }}
         with:
           context: ${{ matrix.config.working-dir }}
           tags: |
@@ -239,8 +236,8 @@ jobs:
             ghcr.io/keptn/${{ matrix.config.artifact }}:${{ env.VERSION }}
           build-args: |
             version=${{ env.VERSION }}
-            buildTime=${{ env.DATETIME }}
-            gitSha=${{ env.GIT_SHA }}
+            buildTime=${{ needs.prepare.outputs.datetime }}
+            gitSha=${{ needs.prepare.outputs.git_sha }}
           push: ${{ matrix.config.should-push-image }}
           pull: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,8 @@ jobs:
       next-version: ${{ steps.version_number.outputs.next-version }}
       branch: ${{ steps.current_branch.outputs.branch }}
       keptn-spec-version: ${{ steps.keptn_spec_version.outputs.keptn-spec-version }}
+      datetime: ${{ steps.get_datetime.outputs.DATETIME }}
+      git_sha: ${{ steps.extract_branch.outputs.GIT_SHA }}
       BUILD_EVERYTHING: ${{ steps.build_everything.outputs.BUILD_EVERYTHING }}
       BUILD_INSTALLER: ${{ steps.check_modified_files.outputs.BUILD_INSTALLER }}
       BUILD_CLI: ${{ steps.check_modified_files.outputs.BUILD_CLI }}
@@ -227,8 +229,8 @@ jobs:
         name: "Docker Build keptn/${{ matrix.config.artifact }}"
         uses: docker/build-push-action@v2
         env:
-          DATETIME: ${{ steps.get_datetime.outputs.DATETIME }}
-          GIT_SHA: ${{ steps.extract_branch.outputs.GIT_SHA }}
+          DATETIME: ${{ needs.prepare.outputs.datetime }}
+          GIT_SHA: ${{ needs.prepare.outputs.git_sha }}
         with:
           context: ${{ matrix.config.working-dir }}
           tags: |


### PR DESCRIPTION
This PR passes datetime and git sha to the docker build also in the release workflow like it is already done for the ci workflow.
part of  #7296