### PR TITLE
fix(cli): Provide values needed for upgrading the nats dependency

### DIFF
--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -325,24 +325,12 @@ func doUpgrade() error {
 	// if yes, they need to be installed separately as they have moved to their own charts
 	helmHelper := helm.NewHelper()
 
-	// this object holds values that were not set in previous versions of Keptn and which need to be explicitly set if using the --reuse-values flag
-	newVals := map[string]interface{}{
-		"control-plane": map[string]interface{}{
-			"nats": map[string]interface{}{
-				"nats": map[string]interface{}{
-					"image": "nats:2.7.2-alpine",
-					"jetstream": map[string]interface{}{
-						"enabled": true,
-					},
-				},
-				"exporter": map[string]interface{}{
-					"image": "natsio/prometheus-nats-exporter:0.9.1",
-				},
-			},
-		},
+	previousValues, err := helmHelper.GetValues(keptnReleaseName, keptnNamespace)
+	if err != nil {
+		return fmt.Errorf("Could not complete Keptn upgrade: %s", err.Error())
 	}
 
-	if err := helmHelper.UpgradeChart(keptnUpgradeChart, keptnReleaseName, keptnNamespace, newVals); err != nil {
+	if err := helmHelper.UpgradeChart(keptnUpgradeChart, keptnReleaseName, keptnNamespace, previousValues); err != nil {
 		msg := fmt.Sprintf("Could not complete Keptn upgrade: %s \nFor troubleshooting, please check the status of the keptn deployment by executing the following command: \n\nkubectl get pods -n %s\n", err.Error(), keptnNamespace)
 		return errors.New(msg)
 	}

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -325,6 +325,8 @@ func doUpgrade() error {
 	// if yes, they need to be installed separately as they have moved to their own charts
 	helmHelper := helm.NewHelper()
 
+	// fetch user-defined values of the previous Keptn installation and provide those to the upgrade command
+	// this will ensure that options such as 'apiGatewayNginx.type' will stay the same, but newly introduced values will correctly be set to their default
 	previousValues, err := helmHelper.GetValues(keptnReleaseName, keptnNamespace)
 	if err != nil {
 		return fmt.Errorf("Could not complete Keptn upgrade: %s", err.Error())

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -325,7 +325,24 @@ func doUpgrade() error {
 	// if yes, they need to be installed separately as they have moved to their own charts
 	helmHelper := helm.NewHelper()
 
-	if err := helmHelper.UpgradeChart(keptnUpgradeChart, keptnReleaseName, keptnNamespace, nil); err != nil {
+	// this object holds values that were not set in previous versions of Keptn and which need to be explicitly set if using the --reuse-values flag
+	newVals := map[string]interface{}{
+		"control-plane": map[string]interface{}{
+			"nats": map[string]interface{}{
+				"nats": map[string]interface{}{
+					"image": "nats:2.7.2-alpine",
+					"jetstream": map[string]interface{}{
+						"enabled": true,
+					},
+				},
+				"exporter": map[string]interface{}{
+					"image": "natsio/prometheus-nats-exporter:0.9.1",
+				},
+			},
+		},
+	}
+
+	if err := helmHelper.UpgradeChart(keptnUpgradeChart, keptnReleaseName, keptnNamespace, newVals); err != nil {
 		msg := fmt.Sprintf("Could not complete Keptn upgrade: %s \nFor troubleshooting, please check the status of the keptn deployment by executing the following command: \n\nkubectl get pods -n %s\n", err.Error(), keptnNamespace)
 		return errors.New(msg)
 	}

--- a/cli/pkg/helm/helm_helper.go
+++ b/cli/pkg/helm/helm_helper.go
@@ -1,3 +1,4 @@
+//go:build !nokubectl
 // +build !nokubectl
 
 // Copyright © 2019 NAME HERE <EMAIL ADDRESS>
@@ -208,7 +209,6 @@ func (c Helper) UpgradeChart(ch *chart.Chart, releaseName, namespace string, val
 		iCli.Namespace = namespace
 		iCli.Wait = true
 		iCli.Timeout = time.Duration(timeoutInMinutes) * time.Minute
-		iCli.ReuseValues = true // reuse values when overwriting existing installation (similar to keptn upgrade)
 		newRelease, err = iCli.Run(releaseName, ch, vals)
 	}
 	// check if install/upgrade worked


### PR DESCRIPTION
Closes #7315
This PR makes sure the values provided to the nats dependency are compatible with the currently used nats helm chart. Unfortunately this meas that in this case we also need to set the image of nats and the nats metrics exporter, since those are defined via the values file of the nats helm chart, and the values that have been used by the previous version are incompatible with the current chart.

For adding unit tests, a bigger refactoring will be needed, as outlined in https://github.com/keptn/keptn/issues/6439 