### PR TITLE
fix(bridge): Fix failing ui test in sequences.spec.ts

### DIFF
--- a/bridge/cypress/support/pageobjects/SequencesPage.ts
+++ b/bridge/cypress/support/pageobjects/SequencesPage.ts
@@ -63,7 +63,7 @@ export class SequencesPage {
     cy.get('.stage-info')
       .contains(stage)
       .parentsUntilTestId(`keptn-sequence-timeline-stage-${stage}`)
-      .should('contain.text', time);
+      .should('contain.text', `${stage}|${time}`);
     return this;
   }
 


### PR DESCRIPTION
This PR fixes a failing ui test in `/bridge`

Fixes #7337

### How to test
1. Start bridge (`yarn start:dev`)
2. Run UI tests (`yarn cypress:run` or `yarn cypress:run:win32`)