### PR TITLE
test(bridge): Fix flaky sequence UI test

### DIFF
--- a/bridge/client/app/_services/data.service.ts
+++ b/bridge/client/app/_services/data.service.ts
@@ -224,7 +224,7 @@ export class DataService {
     return this._rootsLastUpdated[project.projectName];
   }
 
-  public getTracesLastUpdated(sequence: Sequence): Date {
+  public getTracesLastUpdated(sequence: Sequence): Date | undefined {
     return this._tracesLastUpdated[sequence.shkeptncontext];
   }
 

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.html
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.html
@@ -127,9 +127,13 @@
         <dt-tag
           >Last time fetched:
           <span
-            [textContent]="getTracesLastUpdated(currentSequence) | amCalendar: dateUtil.getCalendarFormats(true)"
-          ></span
-        ></dt-tag>
+            *ngIf="getTracesLastUpdated(currentSequence) as time; else noTime"
+            [textContent]="time | amCalendar: dateUtil.getCalendarFormats(true)"
+          ></span>
+          <ng-template #noTime>
+            <span>never</span>
+          </ng-template>
+        </dt-tag>
         <button class="ml-2" dt-button (click)="loadTraces(currentSequence)" *ngIf="showReloadButton(currentSequence)">
           <dt-icon name="refresh"></dt-icon>
           Reload

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
@@ -359,7 +359,7 @@ export class KtbSequenceViewComponent implements OnInit, OnDestroy {
     });
   }
 
-  getTracesLastUpdated(sequence: Sequence): Date {
+  public getTracesLastUpdated(sequence: Sequence): Date | undefined {
     return this.dataService.getTracesLastUpdated(sequence);
   }
 


### PR DESCRIPTION
Some UI tests for the sequence screen may fail if a sequence is selected because Angular throws an error `expression changed after it has been checked`. This is because the time for `Last time fetched` is `undefined` at the start until the traces are loaded and then the current date is returned, which changes on every call.
Therefore if the date is undefined `Last time fetched: never` is displayed instead of the current date.

Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>