### PR TITLE
feat: [PoC] ARM64 Docker images

### DIFF
--- a/.github/workflows/test-and-build-docker-images.yml
+++ b/.github/workflows/test-and-build-docker-images.yml
@@ -166,6 +166,11 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@v3
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+      with:
+        platforms: arm64
       
     - name: Set up Docker Buildx
       id: buildx
@@ -215,6 +220,7 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         context: ${{ inputs.working-dir }}
+        platforms: linux/amd64,linux/arm64
         tags: ${{ inputs.tags }}
         build-args: |
           version=${{ inputs.version }}

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,21 +1,15 @@
-# Use the official Golang image to create a build artifact.
-# This is based on Debian and sets the GOPATH to /go.
-FROM golang:1.18.7-alpine3.16 as builder
+FROM --platform=$BUILDPLATFORM golang:1.18.7-alpine3.16 as builder
 
 ARG version=develop
 ARG debugBuild
 
 WORKDIR /go/src/github.com/keptn/keptn/api
 
-# Force the go compiler to use modules
-ENV GO111MODULE=on
 ENV BUILDFLAGS=""
 ENV GOPROXY=https://proxy.golang.org
 
-RUN apk add --no-cache gcc libc-dev git
+RUN apk add --no-cache gcc libc-dev
 
-# Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
-# in case of a change in the dependencies
 COPY go.mod go.sum ./
 
 # Download dependencies
@@ -24,14 +18,22 @@ RUN go mod download
 # Copy local code to the container image.
 COPY . .
 
+# Target OS and architecture to build against (set automatically)
+ARG TARGETOS
+ARG TARGETARCH
+ENV GOOS=$TARGETOS
+ENV GOARCH=$TARGETARCH
+
+RUN if [ "$GOARCH" == *'amd64'* ]; then export LINKERFLAGS="-ldflags '-linkmode=external'"; fi
+
 # set buildflags for debug build
+# set the gcflags for all packages, disable optimizations and inlining
 RUN if [ ! -z "$debugBuild" ]; then export BUILDFLAGS='-gcflags "all=-N -l"'; fi
 
-RUN sed -i "s/version: develop/version: ${version}/g" /go/src/github.com/keptn/keptn/api/swagger.yaml
+RUN sed -i "s/version: develop/version: ${version}/g" swagger.yaml
+RUN sed -i "s|basePath: /v1|basePath: /api/v1 |g" swagger.yaml
 
-# Build the command inside the container.
-# (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v cmd/api-server/main.go
+RUN go build $LINKERFLAGS $BUILDFLAGS -v cmd/api-server/main.go
 
 
 FROM alpine:3.16 as production
@@ -51,8 +53,6 @@ RUN apk add --no-cache ca-certificates libc6-compat
 COPY --from=builder /go/src/github.com/keptn/keptn/api/main /api
 COPY --from=builder /go/src/github.com/keptn/keptn/api/swagger-ui /swagger-ui
 COPY --from=builder /go/src/github.com/keptn/keptn/api/swagger.yaml /swagger-ui/swagger.yaml
-
-RUN sed -i "s|basePath: /v1|basePath: /api/v1 |g" /swagger-ui/swagger.yaml
 
 EXPOSE 8080
 

--- a/approval-service/Dockerfile
+++ b/approval-service/Dockerfile
@@ -20,10 +20,6 @@ RUN go mod download
 # Copy local code to the container image.
 COPY . .
 
-FROM builder-base as builder
-ARG version=develop
-ARG debugBuild
-
 # Target OS and architecture to build against (set automatically)
 ARG TARGETOS
 ARG TARGETARCH

--- a/approval-service/Dockerfile
+++ b/approval-service/Dockerfile
@@ -1,18 +1,14 @@
-# Use the official Golang image to create a build artifact.
-# This is based on Debian and sets the GOPATH to /go.
-FROM golang:1.18.7-alpine3.16 as builder
+FROM --platform=$BUILDPLATFORM golang:1.18.7-alpine3.16 as builder
 
 ARG version=develop
 ARG debugBuild
 
 WORKDIR /go/src/github.com/keptn/keptn/approval-service
 
-# Force the go compiler to use modules
-ENV GO111MODULE=on
 ENV BUILDFLAGS=""
 ENV GOPROXY=https://proxy.golang.org
 
-RUN apk add --no-cache gcc libc-dev git
+RUN apk add --no-cache gcc libc-dev
 
 # Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
 # in case of a change in the dependencies
@@ -24,12 +20,24 @@ RUN go mod download
 # Copy local code to the container image.
 COPY . .
 
+FROM builder-base as builder
+ARG version=develop
+ARG debugBuild
+
+# Target OS and architecture to build against (set automatically)
+ARG TARGETOS
+ARG TARGETARCH
+ENV GOOS=$TARGETOS
+ENV GOARCH=$TARGETARCH
+
+RUN if [ "$GOARCH" == *'amd64'* ]; then export LINKERFLAGS="-ldflags '-linkmode=external'"; fi
+
 # set buildflags for debug build
 RUN if [ ! -z "$debugBuild" ]; then export BUILDFLAGS='-gcflags "all=-N -l"'; fi
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o approval-service
+RUN go build $LINKERFLAGS $BUILDFLAGS -v -o approval-service
 
 FROM alpine:3.16 as production
 ARG version=develop

--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine3.15 as bridge-builder
+FROM --platform=$BUILDPLATFORM node:14-alpine3.15 as bridge-builder
 
 ARG version=develop
 ENV VERSION="${version}"

--- a/distributor/Dockerfile
+++ b/distributor/Dockerfile
@@ -1,6 +1,4 @@
-# Use the official Golang image to create a build artifact.
-# This is based on Debian and sets the GOPATH to /go.
-FROM golang:1.18.7-alpine3.16 as builder
+FROM --platform=$BUILDPLATFORM golang:1.18.7-alpine3.16 as builder
 
 ARG debugBuild
 ARG buildTime=unknown
@@ -8,30 +6,34 @@ ARG gitSha=unknown
 
 WORKDIR /go/src/github.com/keptn/keptn/distributor
 
-# Force the go compiler to use modules
-ENV GO111MODULE=on
 ENV GOPROXY=https://proxy.golang.org
 
-RUN apk add --no-cache gcc libc-dev git
+RUN apk add --no-cache gcc libc-dev
 
 COPY go.mod go.sum ./
 
 # Download dependencies
 RUN go mod download
 
-# Copy local code to the container image.
 COPY . .
+
+# Target OS and architecture to build against (set automatically)
+ARG TARGETOS
+ARG TARGETARCH
+ENV GOOS=$TARGETOS
+ENV GOARCH=$TARGETARCH
+
+RUN if [ "$GOARCH" == *'amd64'* ]; then export LINKERFLAGS="-linkmode=external"; fi
 
 # set buildflags for debug build
 RUN if [ ! -z "$debugBuild" ]; then export BUILDFLAGS='-gcflags "all=-N -l"'; fi
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-linkmode=external -X main.gitCommit=$gitSha -X main.buildTime=$buildTime" $BUILDFLAGS -v -o distributor ./cmd/
+RUN go build -ldflags "$LINKERFLAGS -X main.gitCommit=$gitSha -X main.buildTime=$buildTime" $BUILDFLAGS -v -o distributor ./cmd/
 
 FROM alpine:3.16 as production
 ARG version=develop
-
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.url="https://keptn.sh" \
     org.opencontainers.image.title="Keptn Distributor" \
@@ -40,6 +42,7 @@ LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.licenses="Apache-2.0" \
     org.opencontainers.image.version="${version}"
 
+# we need to install ca-certificates and libc6-compat for go programs to work properly
 RUN apk add --no-cache ca-certificates libc6-compat
 
 # Copy the binary to the production image from the builder stage.

--- a/docs/developer/debugging.md
+++ b/docs/developer/debugging.md
@@ -41,7 +41,6 @@ Most of our services should already have a working setup. But just in case the s
 
     WORKDIR /go/src/github.com/keptn-contrib/some-go-service
 
-    ENV GO111MODULE=on
     COPY go.mod go.sum ./
     RUN go mod download
     COPY . .

--- a/lighthouse-service/Dockerfile
+++ b/lighthouse-service/Dockerfile
@@ -1,23 +1,15 @@
-# Use the official Golang image to create a build artifact.
-# This is based on Debian and sets the GOPATH to /go.
-# https://hub.docker.com/_/golang
-FROM golang:1.18.7-alpine3.16 as builder
+FROM --platform=$BUILDPLATFORM golang:1.18.7-alpine3.16 as builder
 
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
 
-# Copy local code to the container image.
 WORKDIR /go/src/github.com/keptn/keptn/lighthouse-service
 
-# Force the go compiler to use modules
-ENV GO111MODULE=on
 ENV BUILDFLAGS=""
 ENV GOPROXY=https://proxy.golang.org
 
-RUN apk add --no-cache gcc libc-dev git
+RUN apk add --no-cache gcc libc-dev
 
-# Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
-# in case of a change in the dependencies
 COPY go.mod go.sum ./
 
 # Download dependencies
@@ -25,12 +17,18 @@ RUN go mod download
 
 COPY . .
 
+# Target OS and architecture to build against (set automatically)
+ARG TARGETOS
+ARG TARGETARCH
+ENV GOOS=$TARGETOS
+ENV GOARCH=$TARGETARCH
+
+RUN if [ "$GOARCH" == *'amd64'* ]; then export LINKERFLAGS="-ldflags '-linkmode=external'"; fi
+
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v -o lighthouse-service
+RUN go build $LINKERFLAGS -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v -o lighthouse-service
 
-# Use a Docker multi-stage build to create a lean production image.
-# https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.16 as production
 ARG version=develop
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \

--- a/mongodb-datastore/Dockerfile
+++ b/mongodb-datastore/Dockerfile
@@ -1,37 +1,40 @@
-# Use the official Golang image to create a build artifact.
-# This is based on Debian and sets the GOPATH to /go.
-FROM golang:1.18.7 as builder
+FROM --platform=$BUILDPLATFORM golang:1.18.7 as builder
 
 ARG version=develop
 ARG debugBuild
 
 WORKDIR /go/src/github.com/keptn/keptn/mongodb-datastore
 
-# Force the go compiler to use modules
-ENV GO111MODULE=on
 ENV BUILDFLAGS=""
 ENV GOPROXY=https://proxy.golang.org
 
-RUN apt-get install -y gcc libc-dev git
+RUN apt-get install -y gcc libc-dev
 
-# Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
-# in case of a change in the dependencies
 COPY go.mod go.sum ./
 
 # Download dependencies
 RUN go mod download
 
-# Copy local code to the container image.
 COPY . .
+
+# Target OS and architecture to build against (set automatically)
+ARG TARGETOS
+ARG TARGETARCH
+ENV GOOS=$TARGETOS
+ENV GOARCH=$TARGETARCH
+
+RUN if [ "$GOARCH" == *'amd64'* ]; then export LINKERFLAGS="-ldflags '-linkmode=external'"; fi
 
 # set buildflags for debug build
 RUN if [ ! -z "$debugBuild" ]; then export BUILDFLAGS='-gcflags "all=-N -l"'; fi
 
-RUN sed -i "s/version: develop/version: ${version}/g" /go/src/github.com/keptn/keptn/mongodb-datastore/swagger.yaml
+RUN sed -i "s/version: develop/version: ${version}/g" ./swagger.yaml
+RUN sed -i "s|basePath: /|basePath: /api/mongodb-datastore |g" ./swagger.yaml
+RUN sed -i '/paths:/i securityDefinitions:\n  key:\n    type: apiKey\n    in: header\n    name: x-token\nsecurity:\n  - key: []\n' ./swagger.yaml
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN cd cmd/mongodb-datastore-server && GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o mongodb-datastore
+RUN cd cmd/mongodb-datastore-server && go build $LINKERFLAGS $BUILDFLAGS -v -o mongodb-datastore
 
 FROM alpine:3.16 as production
 ARG version=develop
@@ -50,11 +53,7 @@ RUN apk add --no-cache ca-certificates libc6-compat
 COPY --from=builder /go/src/github.com/keptn/keptn/mongodb-datastore/cmd/mongodb-datastore-server/mongodb-datastore /mongodb-datastore
 COPY --from=builder /go/src/github.com/keptn/keptn/mongodb-datastore/swagger-ui /swagger-ui
 COPY --from=builder /go/src/github.com/keptn/keptn/mongodb-datastore/swagger.yaml /swagger-ui/swagger-original.yaml
-
 COPY --from=builder /go/src/github.com/keptn/keptn/mongodb-datastore/swagger.yaml /swagger-ui/swagger.yaml
-# Replace contents for api proxy
-RUN sed -i "s|basePath: /|basePath: /api/mongodb-datastore |g" /swagger-ui/swagger.yaml
-RUN sed -i '/paths:/i securityDefinitions:\n  key:\n    type: apiKey\n    in: header\n    name: x-token\nsecurity:\n  - key: []\n' /swagger-ui/swagger.yaml
 
 EXPOSE 8080
 

--- a/remediation-service/Dockerfile
+++ b/remediation-service/Dockerfile
@@ -1,36 +1,38 @@
-# Use the official Golang image to create a build artifact.
-# This is based on Debian and sets the GOPATH to /go.
-# https://hub.docker.com/_/golang
-FROM golang:1.18.7-alpine3.16 as builder
+FROM --platform=$BUILDPLATFORM golang:1.18.7-alpine3.16 as builder
 
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
 
 WORKDIR /go/src/github.com/keptn/keptn/remediation-service
 
-# Force the go compiler to use modules
-ENV GO111MODULE=on
 ENV BUILDFLAGS=""
 ENV GOPROXY=https://proxy.golang.org
 
-RUN apk add --no-cache gcc libc-dev git
-
-# Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
-# in case of a change in the dependencies
+RUN apk add --no-cache gcc libc-dev
 COPY go.mod go.sum ./
 
 # Download dependencies
 RUN go mod download
 
-# Copy local code to the container image.
 COPY . .
+
+FROM builder-base as builder
+
+# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
+ARG SKAFFOLD_GO_GCFLAGS
+
+# Target OS and architecture to build against (set automatically)
+ARG TARGETOS
+ARG TARGETARCH
+ENV GOOS=$TARGETOS
+ENV GOARCH=$TARGETARCH
+
+RUN if [ "$GOARCH" == *'amd64'* ]; then export LINKERFLAGS="-ldflags '-linkmode=external'"; fi
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v -o remediation-service
+RUN go build $LINKERFLAGS -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v -o remediation-service
 
-# Use a Docker multi-stage build to create a lean production image.
-# https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.16 as production
 ARG version=develop
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \

--- a/remediation-service/Dockerfile
+++ b/remediation-service/Dockerfile
@@ -16,11 +16,6 @@ RUN go mod download
 
 COPY . .
 
-FROM builder-base as builder
-
-# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
-ARG SKAFFOLD_GO_GCFLAGS
-
 # Target OS and architecture to build against (set automatically)
 ARG TARGETOS
 ARG TARGETARCH

--- a/resource-service/Dockerfile
+++ b/resource-service/Dockerfile
@@ -20,12 +20,6 @@ RUN go mod download
 
 COPY . .
 
-FROM builder-base as builder
-ARG version=develop
-
-# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
-ARG SKAFFOLD_GO_GCFLAGS
-
 # Target OS and architecture to build against (set automatically)
 ARG TARGETOS
 ARG TARGETARCH

--- a/resource-service/Dockerfile
+++ b/resource-service/Dockerfile
@@ -1,16 +1,11 @@
-# Use the official Golang image to create a build artifact.
-# This is based on Debian and sets the GOPATH to /go.
-FROM golang:1.18.7-alpine3.16 as builder
+FROM --platform=$BUILDPLATFORM golang:1.18.7-alpine3.16 as builder
 
 ARG version=develop
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
 
-# install additional dependencies
-RUN apk add --no-cache gcc libc-dev git
+RUN apk add --no-cache gcc libc-dev
 
-# Force the go compiler to use modules
-ENV GO111MODULE=on
 ENV BUILDFLAGS=""
 ENV GOPROXY=https://proxy.golang.org
 
@@ -19,30 +14,37 @@ RUN go install github.com/swaggo/swag/cmd/swag@v1.7.0
 
 WORKDIR /go/src/github.com/keptn/keptn/resource-service
 
-# Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
-# in case of a change in the dependencies
 COPY go.mod go.sum ./
 
-# Download dependencies
 RUN go mod download
 
-# Copy local code to the container image.
 COPY . .
 
+FROM builder-base as builder
+ARG version=develop
+
+# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
+ARG SKAFFOLD_GO_GCFLAGS
+
+# Target OS and architecture to build against (set automatically)
+ARG TARGETOS
+ARG TARGETARCH
+ENV GOOS=$TARGETOS
+ENV GOARCH=$TARGETARCH
+
+RUN if [ "$GOARCH" == *'amd64'* ]; then export LINKERFLAGS="-ldflags '-linkmode=external'"; fi
+
 # generate swagger docs
-RUN GOOS=linux swag init
+RUN swag init
 
 # replace github.com/alecthomas/template; with text/template in docs/docs.go
 RUN sed -i "s|github.com/alecthomas/template|text/template|g" docs/docs.go
 # replace version "develop" with actual version
 RUN sed -i "s/version: develop/version: ${version}/g" docs/swagger.yaml
+RUN sed -i "s|basePath: /v1|basePath: /api/resource-service/v1 |g" docs/swagger.yaml
 
-# Build the command inside the container. 
-# (You may fetch or manage dependencies here, 
-# either manually or with a tool like "godep".)
-RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v main.go
+RUN go build $LINKERFLAGS -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v main.go
 
-# Use a Docker multi-stage build to create a lean production image.
 FROM alpine:3.16 as production
 ARG version=develop
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
@@ -66,8 +68,6 @@ COPY --from=builder /go/src/github.com/keptn/keptn/resource-service/main /resour
 COPY --from=builder /go/src/github.com/keptn/keptn/resource-service/swagger-ui /swagger-ui
 COPY --from=builder /go/src/github.com/keptn/keptn/resource-service/docs/swagger.yaml /swagger-ui/swagger-original.yaml
 COPY --from=builder /go/src/github.com/keptn/keptn/resource-service/docs/swagger.yaml /swagger-ui/swagger.yaml
-# Replace contents for api proxy
-RUN sed -i "s|basePath: /v1|basePath: /api/resource-service/v1 |g" /swagger-ui/swagger.yaml
 
 EXPOSE 8080
 

--- a/secret-service/Dockerfile
+++ b/secret-service/Dockerfile
@@ -1,16 +1,12 @@
-# Use the official Golang image to create a build artifact.
-# This is based on Debian and sets the GOPATH to /go.
-FROM golang:1.18.7-alpine3.16 as builder
+FROM --platform=$BUILDPLATFORM golang:1.18.7-alpine3.16 as builder
 
 ARG version=develop
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
 
 # install additional dependencies
-RUN apk add --no-cache gcc libc-dev git
+RUN apk add --no-cache gcc libc-dev
 
-# Force the go compiler to use modules
-ENV GO111MODULE=on
 ENV BUILDFLAGS=""
 ENV GOPROXY=https://proxy.golang.org
 
@@ -19,28 +15,33 @@ RUN go install github.com/swaggo/swag/cmd/swag@v1.7.0
 
 WORKDIR /go/src/github.com/keptn/keptn/secret-service
 
-# Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
-# in case of a change in the dependencies
 COPY go.mod go.sum ./
 
-# Download dependencies
 RUN go mod download
 
-# Copy local code to the container image.
 COPY . .
 
+# Target OS and architecture to build against (set automatically)
+ARG TARGETOS
+ARG TARGETARCH
+ENV GOOS=$TARGETOS
+ENV GOARCH=$TARGETARCH
+
+RUN if [ "$GOARCH" == *'amd64'* ]; then export LINKERFLAGS="-ldflags '-linkmode=external'"; fi
+
 # generate swagger docs
-RUN GOOS=linux swag init --parseDependency
+RUN swag init --parseDependency
 
 # replace github.com/alecthomas/template; with text/template in docs/docs.go
 RUN sed -i "s|github.com/alecthomas/template|text/template|g" docs/docs.go
 # replace version "develop" with actual version
 RUN sed -i "s/version: develop/version: ${version}/g" docs/swagger.yaml
+RUN sed -i "s|basePath: /v1|basePath: /api/secrets/v1 |g" docs/swagger.yaml
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here,
 # either manually or with a tool like "godep".)
-RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v main.go
+RUN go build $LINKERFLAGS -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v main.go
 
 # Use a Docker multi-stage build to create a lean production image.
 FROM alpine:3.16 as production
@@ -53,7 +54,6 @@ LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.licenses="Apache-2.0" \
     org.opencontainers.image.version="${version}"
 
-
 ENV env=production
 
 # we need to install ca-certificates and libc6-compat for go programs to work properly
@@ -65,7 +65,6 @@ COPY --from=builder /go/src/github.com/keptn/keptn/secret-service/swagger-ui /sw
 
 COPY --from=builder /go/src/github.com/keptn/keptn/secret-service/docs/swagger.yaml /swagger-ui/swagger-original.yaml
 COPY --from=builder /go/src/github.com/keptn/keptn/secret-service/docs/swagger.yaml /swagger-ui/swagger.yaml
-RUN sed -i "s|basePath: /v1|basePath: /api/secrets/v1 |g" /swagger-ui/swagger.yaml
 
 EXPOSE 8080
 

--- a/shipyard-controller/Dockerfile
+++ b/shipyard-controller/Dockerfile
@@ -1,16 +1,12 @@
-# Use the official Golang image to create a build artifact.
-# This is based on Debian and sets the GOPATH to /go.
-FROM golang:1.18.7 as builder
+FROM --platform=$BUILDPLATFORM golang:1.18.7 as builder
 
 ARG version=develop
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
 
 # install additional dependencies
-RUN apt-get install -y gcc libc-dev git
+RUN apt-get install -y gcc libc-dev
 
-# Force the go compiler to use modules
-ENV GO111MODULE=on
 ENV BUILDFLAGS=""
 ENV GOPROXY=https://proxy.golang.org
 
@@ -29,18 +25,27 @@ RUN go mod download
 # Copy local code to the container image.
 COPY . .
 
+# Target OS and architecture to build against (set automatically)
+ARG TARGETOS
+ARG TARGETARCH
+ENV GOOS=$TARGETOS
+ENV GOARCH=$TARGETARCH
+
+RUN if [ "$GOARCH" == *'amd64'* ]; then export LINKERFLAGS="-ldflags '-linkmode=external'"; fi
+
 # generate swagger docs
-RUN GOOS=linux swag init --parseDependency
+RUN swag init --parseDependency
 
 # replace github.com/alecthomas/template; with text/template in docs/docs.go
 RUN sed -i "s|github.com/alecthomas/template|text/template|g" docs/docs.go
 # replace version "develop" with actual version
 RUN sed -i "s/version: develop/version: ${version}/g" docs/swagger.yaml
+RUN sed -i "s|basePath: /v1|basePath: /api/controlPlane/v1 |g" docs/swagger.yaml
 
-# Build the command inside the container. 
-# (You may fetch or manage dependencies here, 
+# Build the command inside the container.
+# (You may fetch or manage dependencies here,
 # either manually or with a tool like "godep".)
-RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v main.go
+RUN go build $LINKERFLAGS -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v main.go
 
 # Use a Docker multi-stage build to create a lean production image.
 FROM alpine:3.16 as production
@@ -52,7 +57,6 @@ LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \
     org.opencontainers.image.licenses="Apache-2.0" \
     org.opencontainers.image.version="${version}"
-
 
 ENV env=production
 
@@ -72,8 +76,6 @@ COPY --from=builder /go/src/github.com/keptn/keptn/shipyard-controller/debugdocs
 
 COPY --from=builder /go/src/github.com/keptn/keptn/shipyard-controller/docs/swagger.yaml /swagger-ui/swagger-original.yaml
 COPY --from=builder /go/src/github.com/keptn/keptn/shipyard-controller/docs/swagger.yaml /swagger-ui/swagger.yaml
-
-RUN sed -i "s|basePath: /v1|basePath: /api/controlPlane/v1 |g" /swagger-ui/swagger.yaml
 
 EXPOSE 8080
 EXPOSE 9090

--- a/statistics-service/Dockerfile
+++ b/statistics-service/Dockerfile
@@ -1,16 +1,12 @@
-# Use the official Golang image to create a build artifact.
-# This is based on Debian and sets the GOPATH to /go.
-FROM golang:1.18.7 as builder
+FROM --platform=$BUILDPLATFORM golang:1.18.7 as builder
 
 ARG version=develop
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
 
 # install additional dependencies
-RUN apt-get install -y gcc libc-dev git
+RUN apt-get install -y gcc libc-dev
 
-# Force the go compiler to use modules
-ENV GO111MODULE=on
 ENV BUILDFLAGS=""
 ENV GOPROXY=https://proxy.golang.org
 
@@ -19,30 +15,33 @@ RUN go install github.com/swaggo/swag/cmd/swag@v1.7.0
 
 WORKDIR /go/src/github.com/keptn/keptn/statistics-service
 
-# Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
-# in case of a change in the dependencies
 COPY go.mod go.sum ./
 
-# Download dependencies
 RUN go mod download
 
-# Copy local code to the container image.
 COPY . .
 
+# Target OS and architecture to build against (set automatically)
+ARG TARGETOS
+ARG TARGETARCH
+ENV GOOS=$TARGETOS
+ENV GOARCH=$TARGETARCH
+
+RUN if [ "$GOARCH" == *'amd64'* ]; then export LINKERFLAGS="-ldflags '-linkmode=external'"; fi
+
 # generate swagger docs
-RUN GOOS=linux swag init --parseDependency
+RUN swag init --parseDependency
 
 # replace github.com/alecthomas/template; with text/template in docs/docs.go
 RUN sed -i "s|github.com/alecthomas/template|text/template|g" docs/docs.go
 # replace version "develop" with actual version
 RUN sed -i "s/version: develop/version: ${version}/g" docs/swagger.yaml
+RUN sed -i "s|basePath: /v1|basePath: /api/statistics/v1 |g" docs/swagger.yaml
 
 # Build the command inside the container.
-# (You may fetch or manage dependencies here,
-# either manually or with a tool like "godep".)
-RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v main.go
+# (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
+RUN go build $LINKERFLAGS -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v main.go
 
-# Use a Docker multi-stage build to create a lean production image.
 FROM alpine:3.16 as production
 ARG version=develop
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
@@ -64,7 +63,6 @@ COPY --from=builder /go/src/github.com/keptn/keptn/statistics-service/swagger-ui
 
 COPY --from=builder /go/src/github.com/keptn/keptn/statistics-service/docs/swagger.yaml /swagger-ui/swagger-original.yaml
 COPY --from=builder /go/src/github.com/keptn/keptn/statistics-service/docs/swagger.yaml /swagger-ui/swagger.yaml
-RUN sed -i "s|basePath: /v1|basePath: /api/statistics/v1 |g" /swagger-ui/swagger.yaml
 
 EXPOSE 8080
 

--- a/webhook-service/Dockerfile
+++ b/webhook-service/Dockerfile
@@ -1,36 +1,33 @@
-# Use the official Golang image to create a build artifact.
-# This is based on Debian and sets the GOPATH to /go.
-# https://hub.docker.com/_/golang
-FROM golang:1.18.7-alpine3.16 as builder
+FROM --platform=$BUILDPLATFORM golang:1.18.7-alpine3.16 as builder
 
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
 
 WORKDIR /go/src/github.com/keptn/keptn/webhook-service
 
-# Force the go compiler to use modules
-ENV GO111MODULE=on
 ENV BUILDFLAGS=""
 ENV GOPROXY=https://proxy.golang.org
 
-RUN apk add --no-cache gcc libc-dev git
+RUN apk add --no-cache gcc libc-dev
 
-# Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
-# in case of a change in the dependencies
 COPY go.mod go.sum ./
 
-# Download dependencies
 RUN go mod download
 
-# Copy local code to the container image.
 COPY . .
+
+# Target OS and architecture to build against (set automatically)
+ARG TARGETOS
+ARG TARGETARCH
+ENV GOOS=$TARGETOS
+ENV GOARCH=$TARGETARCH
+
+RUN if [ "$GOARCH" == *'amd64'* ]; then export LINKERFLAGS="-ldflags '-linkmode=external'"; fi
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v -o webhook-service
+RUN go build $LINKERFLAGS -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v -o webhook-service
 
-# Use a Docker multi-stage build to create a lean production image.
-# https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.16 as production
 ARG version=develop
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \


### PR DESCRIPTION
Research results:
- This PR produces working ARM64 based container images for Keptn 🎉
- Keptn on ARM only works with an external MongoDB, since the Bitnami MongoDB does not have ARM support
- Cross platform docker builds are enabled through the docker-build-push GH action and QEMU
  - The docker build CI step now builds both the x86 and the ARM image in parallel and pushes both
- Dockerfiles are adjusted slightly to cross-compile from x86 to ARM. The final images then have the copied over version for the correct architecture inside
- Dockerfiles were also refactored slightly
- The installation of the `git` package was removed from most container images since it's not needed

References:
https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/
https://www.digitalocean.com/community/tutorials/how-to-build-go-executables-for-multiple-platforms-on-ubuntu-16-04
https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/

PoC for #3409
Integration test run (on x86 images): https://github.com/keptn/keptn/actions/runs/2746706711