### PR TITLE
fix(jmeter-service): Avoid nil pointer access when logging results

### DIFF
--- a/jmeter-service/jmeterUtils.go
+++ b/jmeter-service/jmeterUtils.go
@@ -210,12 +210,14 @@ func execute(testInfo TestInfo, workload *Workload, err error, jMeterCommandLine
 		}
 	}
 	// Step 3: Parse result and lets analyze the result
+	logger.Debugf("Executing jmeter tests with the following configuration: %v", testInfo)
 	result, err := parseJMeterResult(jmeterCommandResult, testInfo, workload, funcValidation)
 	if err != nil {
 		logger.Errorf("Could not parse JMeter test (%v). Error: %v  ", testInfo, err)
+		return false, err
 	}
-	logger.Debugf("Jmeter tests passed: %t. TestInfo: %v", result, testInfo)
-	return result, err
+	logger.Debugf("Jmeter tests passed: %t", result)
+	return result, nil
 }
 
 func createDir(dir string) error {

--- a/jmeter-service/jmeterUtils.go
+++ b/jmeter-service/jmeterUtils.go
@@ -211,11 +211,10 @@ func execute(testInfo TestInfo, workload *Workload, err error, jMeterCommandLine
 	}
 	// Step 3: Parse result and lets analyze the result
 	result, err := parseJMeterResult(jmeterCommandResult, testInfo, workload, funcValidation)
-	if result && err != nil {
-		logger.Debugf("Successfully executed JMeter test: %v", testInfo)
-	} else {
-		logger.Errorf("Could not parse JMeter test (%v). Error: %s  ", testInfo, err.Error())
+	if err != nil {
+		logger.Errorf("Could not parse JMeter test (%v). Error: %v  ", testInfo, err)
 	}
+	logger.Debugf("Jmeter tests passed: %t. TestInfo: %v", result, testInfo)
 	return result, err
 }
 


### PR DESCRIPTION
Closes #7388

Integration test run: https://github.com/keptn/keptn/actions/runs/2107598753

Unfortunately the codecov diff check is failing, but in the service's current form we would need to add a test that actually performs a jmeter test using the jmeter CLI - which might be out of scope for the issue addressed with this PR