### PR TITLE
ci: Send metrics only on non-fork builds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -115,7 +115,6 @@ defaults:
 jobs:
   calculate-queue-time:
     name: "Calculate Queue Time"
-    if: ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository ) || ( github.event_name == 'push' )
     uses: ./.github/workflows/pipeline-queuetime.yml
     with:
       workflow_name: "CI"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -115,6 +115,7 @@ defaults:
 jobs:
   calculate-queue-time:
     name: "Calculate Queue Time"
+    if: ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository ) || ( github.event_name == 'push' )
     uses: ./.github/workflows/pipeline-queuetime.yml
     with:
       workflow_name: "CI"

--- a/.github/workflows/pipeline-queuetime.yml
+++ b/.github/workflows/pipeline-queuetime.yml
@@ -5,7 +5,7 @@ on:
       workflow_name:
         type: string
         required: true
-        description: "Name of the calling workflow for easy differentiation between metric datapoints"
+        description: "Name of the calling workflow for easy differentiation between metric data points"
     secrets:
       monitoring_api_token:
         required: true
@@ -48,6 +48,7 @@ jobs:
 
 
       - name: Ingest Pipeline Metrics
+        if: ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository ) || ( github.event_name == 'push' )
         uses: dynatrace-oss/dynatrace-github-action@v8
         with:
           url: ${{ secrets.monitoring_tenant_url }}


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- adds a condition to only send queue time metrics when the build is not triggered by a forked PR
This will prevent errors like the one shown here: https://github.com/keptn/keptn/actions/runs/2096576846