### PR TITLE
fix: URL-provisioning test should wait for pod restart

### DIFF
--- a/resource-service/common/gitsuite_test.go
+++ b/resource-service/common/gitsuite_test.go
@@ -1034,7 +1034,7 @@ func Test_getAuthMethod(t *testing.T) {
 					GitPrivateKey:     "",
 					GitPrivateKeyPass: "",
 					GitProxyURL:       "",
-					GitProxyInsecure:  false,
+					InsecureSkipTLS:   false,
 					GitProxyScheme:    "",
 					GitProxyUser:      "",
 					GitProxyPassword:  "",

--- a/test/go-tests/test_gitcommitid.go
+++ b/test/go-tests/test_gitcommitid.go
@@ -183,6 +183,9 @@ func performResourceServiceEvaluationTest(t *testing.T, projectName string, serv
 
 	require.Nil(t, err)
 
+	//some time should pass between started and finished event
+	time.Sleep(10 * time.Second)
+
 	t.Log("sending get-sli.finished event")
 	_, err = ApiPOSTRequest("/v1/event", models.KeptnContextExtendedCE{
 		Contenttype: "application/json",

--- a/test/go-tests/test_provisioningURL.go
+++ b/test/go-tests/test_provisioningURL.go
@@ -3,12 +3,10 @@ package go_tests
 import (
 	"encoding/json"
 	"fmt"
-	"os"
-	"testing"
-	"time"
-
 	"github.com/keptn/go-utils/pkg/api/models"
 	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
 )
 
 const provisioningShipyard = `YXBpVmVyc2lvbjogInNwZWMua2VwdG4uc2gvMC4yLjMiCmtpbmQ6ICJTaGlweWFyZCIKbWV0YWRhdGE6CiAgbmFtZTogInNoaXB5YXJkLXBvZHRhdG8tb2hlYWQiCnNwZWM6CiAgc3RhZ2VzOgogICAgLSBuYW1lOiAiZGV2IgogICAgICBzZXF1ZW5jZXM6CiAgICAgICAgLSBuYW1lOiAiZGVsaXZlcnkiCiAgICAgICAgICB0YXNrczoKICAgICAgICAgICAgLSBuYW1lOiAiZGVwbG95bWVudCIKICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgZGVwbG95bWVudHN0cmF0ZWd5OiAiZGlyZWN0IgogICAgICAgICAgICAtIG5hbWU6ICJ0ZXN0IgogICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICB0ZXN0c3RyYXRlZ3k6ICJmdW5jdGlvbmFsIgogICAgICAgICAgICAtIG5hbWU6ICJldmFsdWF0aW9uIgogICAgICAgICAgICAtIG5hbWU6ICJyZWxlYXNlIgogICAgICAgIC0gbmFtZTogImRlbGl2ZXJ5LWRpcmVjdCIKICAgICAgICAgIHRhc2tzOgogICAgICAgICAgICAtIG5hbWU6ICJkZXBsb3ltZW50IgogICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICBkZXBsb3ltZW50c3RyYXRlZ3k6ICJkaXJlY3QiCiAgICAgICAgICAgIC0gbmFtZTogInJlbGVhc2UiCgogICAgLSBuYW1lOiAicHJvZCIKICAgICAgc2VxdWVuY2VzOgogICAgICAgIC0gbmFtZTogImRlbGl2ZXJ5IgogICAgICAgICAgdHJpZ2dlcmVkT246CiAgICAgICAgICAgIC0gZXZlbnQ6ICJkZXYuZGVsaXZlcnkuZmluaXNoZWQiCiAgICAgICAgICB0YXNrczoKICAgICAgICAgICAgLSBuYW1lOiAiZGVwbG95bWVudCIKICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgZGVwbG95bWVudHN0cmF0ZWd5OiAiYmx1ZV9ncmVlbl9zZXJ2aWNlIgogICAgICAgICAgICAtIG5hbWU6ICJ0ZXN0IgogICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICB0ZXN0c3RyYXRlZ3k6ICJwZXJmb3JtYW5jZSIKICAgICAgICAgICAgLSBuYW1lOiAiZXZhbHVhdGlvbiIKICAgICAgICAgICAgLSBuYW1lOiAicmVsZWFzZSIKICAgICAgICAtIG5hbWU6ICJyb2xsYmFjayIKICAgICAgICAgIHRyaWdnZXJlZE9uOgogICAgICAgICAgICAtIGV2ZW50OiAicHJvZC5kZWxpdmVyeS5maW5pc2hlZCIKICAgICAgICAgICAgICBzZWxlY3RvcjoKICAgICAgICAgICAgICAgIG1hdGNoOgogICAgICAgICAgICAgICAgICByZXN1bHQ6ICJmYWlsIgogICAgICAgICAgdGFza3M6CiAgICAgICAgICAgIC0gbmFtZTogInJvbGxiYWNrIgoKICAgICAgICAtIG5hbWU6ICJkZWxpdmVyeS1kaXJlY3QiCiAgICAgICAgICB0cmlnZ2VyZWRPbjoKICAgICAgICAgICAgLSBldmVudDogImRldi5kZWxpdmVyeS1kaXJlY3QuZmluaXNoZWQiCiAgICAgICAgICB0YXNrczoKICAgICAgICAgICAgLSBuYW1lOiAiZGVwbG95bWVudCIKICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgZGVwbG95bWVudHN0cmF0ZWd5OiAiZGlyZWN0IgogICAgICAgICAgICAtIG5hbWU6ICJyZWxlYXNlIg==`
@@ -108,9 +106,9 @@ func Test_ProvisioningURL(t *testing.T) {
 	_, err = ExecuteCommandf("kubectl rollout restart deployment mockserver -n %s", keptnNamespace)
 	require.Nil(t, err)
 
-	t.Logf("Sleeping for 30s...")
-	time.Sleep(30 * time.Second)
-	t.Logf("Continue to work...")
+	t.Logf("Waiting for mockserver")
+	err = WaitForPodOfDeployment("mockserver")
+	require.Nil(t, err)
 
 	t.Logf("Setting up AUTOMATIC_PROVISIONING_URL env variable")
 	t.Logf("External mockserver IP address: %s", mockServerIP)
@@ -118,6 +116,7 @@ func Test_ProvisioningURL(t *testing.T) {
 	require.Nil(t, err)
 
 	//kubectl set kills shipyard pod, instead of sleeping we wait for the deployment to be ready
+	t.Logf("Waiting for Shipyard-controller")
 	err = WaitForPodOfDeployment(shipyardPod)
 	require.Nil(t, err)
 
@@ -158,6 +157,7 @@ func Test_ProvisioningURL(t *testing.T) {
 	_, err = ExecuteCommandf("kubectl set env deployment/shipyard-controller AUTOMATIC_PROVISIONING_URL=%s -n %s", "", keptnNamespace)
 	require.Nil(t, err)
 
+	t.Logf("Waiting for Shipyard-controller")
 	err = WaitForPodOfDeployment(shipyardPod)
 	require.Nil(t, err)
 

--- a/test/go-tests/test_provisioningURL.go
+++ b/test/go-tests/test_provisioningURL.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
+	"time"
 )
 
 const provisioningShipyard = `YXBpVmVyc2lvbjogInNwZWMua2VwdG4uc2gvMC4yLjMiCmtpbmQ6ICJTaGlweWFyZCIKbWV0YWRhdGE6CiAgbmFtZTogInNoaXB5YXJkLXBvZHRhdG8tb2hlYWQiCnNwZWM6CiAgc3RhZ2VzOgogICAgLSBuYW1lOiAiZGV2IgogICAgICBzZXF1ZW5jZXM6CiAgICAgICAgLSBuYW1lOiAiZGVsaXZlcnkiCiAgICAgICAgICB0YXNrczoKICAgICAgICAgICAgLSBuYW1lOiAiZGVwbG95bWVudCIKICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgZGVwbG95bWVudHN0cmF0ZWd5OiAiZGlyZWN0IgogICAgICAgICAgICAtIG5hbWU6ICJ0ZXN0IgogICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICB0ZXN0c3RyYXRlZ3k6ICJmdW5jdGlvbmFsIgogICAgICAgICAgICAtIG5hbWU6ICJldmFsdWF0aW9uIgogICAgICAgICAgICAtIG5hbWU6ICJyZWxlYXNlIgogICAgICAgIC0gbmFtZTogImRlbGl2ZXJ5LWRpcmVjdCIKICAgICAgICAgIHRhc2tzOgogICAgICAgICAgICAtIG5hbWU6ICJkZXBsb3ltZW50IgogICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICBkZXBsb3ltZW50c3RyYXRlZ3k6ICJkaXJlY3QiCiAgICAgICAgICAgIC0gbmFtZTogInJlbGVhc2UiCgogICAgLSBuYW1lOiAicHJvZCIKICAgICAgc2VxdWVuY2VzOgogICAgICAgIC0gbmFtZTogImRlbGl2ZXJ5IgogICAgICAgICAgdHJpZ2dlcmVkT246CiAgICAgICAgICAgIC0gZXZlbnQ6ICJkZXYuZGVsaXZlcnkuZmluaXNoZWQiCiAgICAgICAgICB0YXNrczoKICAgICAgICAgICAgLSBuYW1lOiAiZGVwbG95bWVudCIKICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgZGVwbG95bWVudHN0cmF0ZWd5OiAiYmx1ZV9ncmVlbl9zZXJ2aWNlIgogICAgICAgICAgICAtIG5hbWU6ICJ0ZXN0IgogICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICB0ZXN0c3RyYXRlZ3k6ICJwZXJmb3JtYW5jZSIKICAgICAgICAgICAgLSBuYW1lOiAiZXZhbHVhdGlvbiIKICAgICAgICAgICAgLSBuYW1lOiAicmVsZWFzZSIKICAgICAgICAtIG5hbWU6ICJyb2xsYmFjayIKICAgICAgICAgIHRyaWdnZXJlZE9uOgogICAgICAgICAgICAtIGV2ZW50OiAicHJvZC5kZWxpdmVyeS5maW5pc2hlZCIKICAgICAgICAgICAgICBzZWxlY3RvcjoKICAgICAgICAgICAgICAgIG1hdGNoOgogICAgICAgICAgICAgICAgICByZXN1bHQ6ICJmYWlsIgogICAgICAgICAgdGFza3M6CiAgICAgICAgICAgIC0gbmFtZTogInJvbGxiYWNrIgoKICAgICAgICAtIG5hbWU6ICJkZWxpdmVyeS1kaXJlY3QiCiAgICAgICAgICB0cmlnZ2VyZWRPbjoKICAgICAgICAgICAgLSBldmVudDogImRldi5kZWxpdmVyeS1kaXJlY3QuZmluaXNoZWQiCiAgICAgICAgICB0YXNrczoKICAgICAgICAgICAgLSBuYW1lOiAiZGVwbG95bWVudCIKICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgZGVwbG95bWVudHN0cmF0ZWd5OiAiZGlyZWN0IgogICAgICAgICAgICAtIG5hbWU6ICJyZWxlYXNlIg==`
@@ -106,7 +107,9 @@ func Test_ProvisioningURL(t *testing.T) {
 	_, err = ExecuteCommandf("kubectl rollout restart deployment mockserver -n %s", keptnNamespace)
 	require.Nil(t, err)
 
-	t.Logf("Waiting for mockserver")
+	t.Logf("Sleeping for 30s to make sure it is deleted...")
+	time.Sleep(30 * time.Second)
+	t.Logf("Checking if mockserver is running")
 	err = WaitForPodOfDeployment("mockserver")
 	require.Nil(t, err)
 
@@ -115,8 +118,10 @@ func Test_ProvisioningURL(t *testing.T) {
 	_, err = ExecuteCommandf("kubectl set env deployment/shipyard-controller AUTOMATIC_PROVISIONING_URL=%s -n %s", mockServerIP, keptnNamespace)
 	require.Nil(t, err)
 
+	t.Logf("Sleeping for 30s to make sure shipyard pod is deleted...")
+	time.Sleep(30 * time.Second)
 	//kubectl set kills shipyard pod, instead of sleeping we wait for the deployment to be ready
-	t.Logf("Waiting for Shipyard-controller")
+	t.Logf("Waiting for Shipyard-controller to be running")
 	err = WaitForPodOfDeployment(shipyardPod)
 	require.Nil(t, err)
 
@@ -157,7 +162,9 @@ func Test_ProvisioningURL(t *testing.T) {
 	_, err = ExecuteCommandf("kubectl set env deployment/shipyard-controller AUTOMATIC_PROVISIONING_URL=%s -n %s", "", keptnNamespace)
 	require.Nil(t, err)
 
-	t.Logf("Waiting for Shipyard-controller")
+	t.Logf("Sleeping for 30s to make sure shipyard pod is deleted...")
+	time.Sleep(30 * time.Second)
+	t.Logf("Waiting for Shipyard-controller to be running")
 	err = WaitForPodOfDeployment(shipyardPod)
 	require.Nil(t, err)
 

--- a/test/go-tests/test_utils.go
+++ b/test/go-tests/test_utils.go
@@ -198,7 +198,7 @@ func CreateProject(projectName string, shipyardFilePath string) (string, error) 
 
 	err := retry.Retry(func() error {
 		if err := RecreateProjectUpstream(newProjectName); err != nil {
-			return nil
+			return err
 		}
 
 		user := GetGiteaUser()
@@ -206,9 +206,9 @@ func CreateProject(projectName string, shipyardFilePath string) (string, error) 
 		if err != nil {
 			return err
 		}
-
+		var out string
 		// apply the k8s job for creating the git upstream
-		out, err := ExecuteCommand(fmt.Sprintf("keptn create project %s --shipyard=%s --git-remote-url=http://gitea-http:3000/%s/%s --git-user=%s --git-token=%s", newProjectName, shipyardFilePath, user, newProjectName, user, token))
+		out, err = ExecuteCommand(fmt.Sprintf("keptn create project %s --shipyard=%s --git-remote-url=http://gitea-http:3000/%s/%s --git-user=%s --git-token=%s", newProjectName, shipyardFilePath, user, newProjectName, user, token))
 
 		if !strings.Contains(out, "created successfully") {
 			return fmt.Errorf("unable to create project: %s", out)

--- a/test/go-tests/testsuite_gke_test.go
+++ b/test/go-tests/testsuite_gke_test.go
@@ -53,7 +53,7 @@ func Test_GKE(t *testing.T) {
 	t.Run("Test_SequenceControl_PauseAndResume_2", Test_SequenceControl_PauseAndResume_2)
 	if res, err := CompareServiceNameWithDeploymentName("configuration-service", "resource-service"); err == nil && res {
 		t.Run("Test_ResourceServiceGETCommitID", Test_ResourceServiceGETCommitID)
-		t.Run("Test_EvaluationGitCommitID", Test_EvaluationGitCommitID)
+		t.Run("Test_GitCommitID", Test_EvaluationGitCommitID)
 		t.Run("Test_SSHPublicKeyAuth", Test_SSHPublicKeyAuth)
 		t.Run("Test_ProxyAuth", Test_ProxyAuth)
 	}

--- a/test/go-tests/testsuite_gke_test.go
+++ b/test/go-tests/testsuite_gke_test.go
@@ -53,7 +53,7 @@ func Test_GKE(t *testing.T) {
 	t.Run("Test_SequenceControl_PauseAndResume_2", Test_SequenceControl_PauseAndResume_2)
 	if res, err := CompareServiceNameWithDeploymentName("configuration-service", "resource-service"); err == nil && res {
 		t.Run("Test_ResourceServiceGETCommitID", Test_ResourceServiceGETCommitID)
-		t.Run("Test_GitCommitID", Test_EvaluationGitCommitID)
+		t.Run("Test_EvaluationGitCommitID", Test_EvaluationGitCommitID)
 		t.Run("Test_SSHPublicKeyAuth", Test_SSHPublicKeyAuth)
 		t.Run("Test_ProxyAuth", Test_ProxyAuth)
 	}

--- a/test/go-tests/testsuite_gke_test.go
+++ b/test/go-tests/testsuite_gke_test.go
@@ -60,7 +60,6 @@ func Test_GKE(t *testing.T) {
 	t.Run("Test_ZeroDownTimeTriggerSequence", Test_ZeroDownTimeTriggerSequence)
 
 	// Platform-specific Tests
-	t.Run("Test_ResourceService", Test_ResourceServiceBasic)
 	t.Run("Test_QualityGates", Test_QualityGates)
 	t.Run("Test_QualityGates_SLIWrongFinishedPayloadSend", Test_QualityGates_SLIWrongFinishedPayloadSend)
 	t.Run("Test_QualityGates_AbortedFinishedPayloadSend", Test_QualityGates_AbortedFinishedPayloadSend)


### PR DESCRIPTION
Fixes #7408

### How to test
<!-- if applicable, add testing instructions under this section -->

https://github.com/keptn/keptn/runs/5987118021?check_suite_focus=true webhook test fails because of old master image 

CLI check also fails due to github issues