### PR TITLE
fix: Clean up Resource-service

### DIFF
--- a/resource-service/handler/common.go
+++ b/resource-service/handler/common.go
@@ -30,6 +30,8 @@ func OnAPIError(c *gin.Context, err error) {
 		SetNotFoundErrorResponse(c, "Could not find credentials for upstream repository")
 	} else if errors.Is(err, errors2.ErrMalformedCredentials) {
 		SetFailedDependencyErrorResponse(c, "Could not decode credentials for upstream repository")
+	} else if errors.Is(err, errors2.ErrCredentialsInvalidRemoteURI) {
+		SetBadRequestErrorResponse(c, "Upstream repository not found")
 	} else if errors.Is(err, errors2.ErrRepositoryNotFound) {
 		SetNotFoundErrorResponse(c, "Upstream repository not found")
 	} else if errors.Is(err, errors2.ErrProjectNotFound) {

--- a/resource-service/handler/common.go
+++ b/resource-service/handler/common.go
@@ -13,9 +13,11 @@ const pathParamProjectName = "projectName"
 const pathParamStageName = "stageName"
 const pathParamServiceName = "serviceName"
 const pathParamResourceURI = "resourceURI"
+const upstreamNotFound = "Upstream repository not found"
 
 func OnAPIError(c *gin.Context, err error) {
 	logger.Infof("Could not complete request %s %s: %v", c.Request.Method, c.Request.RequestURI, err)
+
 	if errors.Is(err, errors2.ErrProjectAlreadyExists) {
 		SetConflictErrorResponse(c, "Project already exists")
 	} else if errors.Is(err, errors2.ErrStageAlreadyExists) || errors.Is(err, errors2.ErrBranchExists) {
@@ -25,15 +27,13 @@ func OnAPIError(c *gin.Context, err error) {
 	} else if errors.Is(err, errors2.ErrInvalidGitToken) {
 		SetFailedDependencyErrorResponse(c, "Invalid git token")
 	} else if errors.Is(err, errors2.ErrCredentialsTokenMustNotBeEmpty) {
-		SetBadRequestErrorResponse(c, "Upstream repository not found")
+		SetBadRequestErrorResponse(c, upstreamNotFound)
 	} else if errors.Is(err, errors2.ErrCredentialsNotFound) {
 		SetNotFoundErrorResponse(c, "Could not find credentials for upstream repository")
 	} else if errors.Is(err, errors2.ErrMalformedCredentials) {
 		SetFailedDependencyErrorResponse(c, "Could not decode credentials for upstream repository")
-	} else if errors.Is(err, errors2.ErrCredentialsInvalidRemoteURI) {
-		SetBadRequestErrorResponse(c, "Upstream repository not found")
-	} else if errors.Is(err, errors2.ErrRepositoryNotFound) {
-		SetNotFoundErrorResponse(c, "Upstream repository not found")
+	} else if errors.Is(err, errors2.ErrCredentialsInvalidRemoteURI) || errors.Is(err, errors2.ErrRepositoryNotFound) {
+		SetBadRequestErrorResponse(c, upstreamNotFound)
 	} else if errors.Is(err, errors2.ErrProjectNotFound) {
 		SetNotFoundErrorResponse(c, "Project not found")
 	} else if errors.Is(err, errors2.ErrStageNotFound) || errors.Is(err, errors2.ErrReferenceNotFound) {

--- a/resource-service/handler/pagination.go
+++ b/resource-service/handler/pagination.go
@@ -50,7 +50,7 @@ func Paginate(totalCount int, pageSize int64, nextPageKeyString string) *Paginat
 }
 
 // GetPaginatedResources returns a paginated resources set
-func GetPaginatedResources(dir string, pageSize int64, nextPageKey string, writer common.IFileSystem) (*models.GetResourcesResponse, error) {
+func GetPaginatedResources(dir string, pageSize int64, nextPageKey string, writer common.IFileSystem, metadata models.Version) (*models.GetResourcesResponse, error) {
 	var result = &models.GetResourcesResponse{
 		PageSize:    0,
 		NextPageKey: "0",
@@ -86,9 +86,12 @@ func GetPaginatedResources(dir string, pageSize int64, nextPageKey string, write
 	totalCount := len(files)
 	if paginationInfo.NextPageKey < int64(totalCount) {
 		for _, resourceURI := range files[paginationInfo.NextPageKey:paginationInfo.EndIndex] {
-			var resource = models.GetResourceResponse{Resource: models.Resource{
-				ResourceURI: resourceURI,
-			}}
+			var resource = models.GetResourceResponse{
+				Resource: models.Resource{
+					ResourceURI: resourceURI,
+				},
+				Metadata: metadata,
+			}
 			result.Resources = append(result.Resources, resource)
 		}
 	}

--- a/resource-service/handler/project_handler.go
+++ b/resource-service/handler/project_handler.go
@@ -26,7 +26,8 @@ func NewProjectHandler(projectManager IProjectManager) *ProjectHandler {
 
 // CreateProject godoc
 // @Summary Create a new project
-// @Description Create a new project
+// @Deprecated true
+// @Description INTERNAL Endpoint: Create a new project
 // @Tags Project
 // @Security ApiKeyAuth
 // @Accept  json
@@ -59,7 +60,8 @@ func (ph *ProjectHandler) CreateProject(c *gin.Context) {
 
 // UpdateProject godoc
 // @Summary Updates an existing project
-// @Description Updates an existing project
+// @Deprecated true
+// @Description INTERNAL Endpoint: Updates an existing project
 // @Tags Project
 // @Security ApiKeyAuth
 // @Accept  json
@@ -92,7 +94,8 @@ func (ph *ProjectHandler) UpdateProject(c *gin.Context) {
 
 // DeleteProject godoc
 // @Summary Updates an existing project
-// @Description Updates an existing project
+// @Deprecated true
+// @Description INTERNAL Endpoint: Updates an existing project
 // @Tags Project
 // @Security ApiKeyAuth
 // @Accept  json

--- a/resource-service/handler/project_handler_test.go
+++ b/resource-service/handler/project_handler_test.go
@@ -91,6 +91,19 @@ func TestProjectHandler_CreateProject(t *testing.T) {
 			wantStatus: http.StatusNotFound,
 		},
 		{
+			name: "invalid url or empty credentials",
+			fields: fields{
+				ProjectManager: &handler_mock.IProjectManagerMock{CreateProjectFunc: func(project models.CreateProjectParams) error {
+					return errors2.ErrCredentialsInvalidRemoteURI
+				}},
+			},
+			request: httptest.NewRequest(http.MethodPost, "/project", bytes.NewBuffer([]byte(createProjectTestPayload))),
+			wantParams: &models.CreateProjectParams{
+				Project: models.Project{ProjectName: "my-project"},
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
 			name: "invalid git token",
 			fields: fields{
 				ProjectManager: &handler_mock.IProjectManagerMock{CreateProjectFunc: func(project models.CreateProjectParams) error {

--- a/resource-service/handler/resource_manager.go
+++ b/resource-service/handler/resource_manager.go
@@ -124,7 +124,12 @@ func (p ResourceManager) DeleteResource(params models.DeleteResourceParams) (*mo
 		return nil, err
 	}
 
-	resourcePath := configPath + "/" + params.ResourceURI
+	unescapedResource, err := url.QueryUnescape(params.ResourceURI)
+	if err != nil {
+		return nil, err
+	}
+
+	resourcePath := configPath + "/" + unescapedResource
 
 	var resultErr error
 	var resultCommit *models.WriteResourceResponse

--- a/resource-service/handler/resource_manager.go
+++ b/resource-service/handler/resource_manager.go
@@ -301,8 +301,15 @@ func (p ResourceManager) stageAndCommit(gitContext *common_models.GitContext, me
 	if err != nil {
 		return nil, err
 	}
+	result := &models.WriteResourceResponse{
+		CommitID: commitID,
+		Metadata: models.Version{
+			UpstreamURL: gitContext.Credentials.RemoteURI,
+			Version:     commitID,
+		},
+	}
 
-	return &models.WriteResourceResponse{CommitID: commitID}, nil
+	return result, nil
 }
 
 func (p ResourceManager) deleteResource(gitContext *common_models.GitContext, resourcePath string) (*models.WriteResourceResponse, error) {

--- a/resource-service/handler/resource_manager_test.go
+++ b/resource-service/handler/resource_manager_test.go
@@ -52,7 +52,7 @@ func TestResourceManager_CreateResources_ProjectResource(t *testing.T) {
 
 	require.Nil(t, err)
 
-	require.Equal(t, &models.WriteResourceResponse{CommitID: "my-revision"}, revision)
+	require.Equal(t, &models.WriteResourceResponse{CommitID: "my-revision", Metadata: models.Version{Branch: "", UpstreamURL: "remote-url", Version: "my-revision"}}, revision)
 
 	require.Len(t, fields.git.StageAndCommitAllCalls(), 1)
 
@@ -92,7 +92,7 @@ func TestResourceManager_CreateResources_StageResource(t *testing.T) {
 
 	require.Nil(t, err)
 
-	require.Equal(t, &models.WriteResourceResponse{CommitID: "my-revision"}, revision)
+	require.Equal(t, &models.WriteResourceResponse{CommitID: "my-revision", Metadata: models.Version{Branch: "", UpstreamURL: "remote-url", Version: "my-revision"}}, revision)
 
 	require.Len(t, fields.stageContext.EstablishCalls(), 1)
 	require.Equal(t, models.Project{ProjectName: "my-project"}, fields.stageContext.EstablishCalls()[0].Params.Project, 1)
@@ -133,7 +133,7 @@ func TestResourceManager_CreateResources_ServiceResource(t *testing.T) {
 
 	require.Nil(t, err)
 
-	require.Equal(t, &models.WriteResourceResponse{CommitID: "my-revision"}, revision)
+	require.Equal(t, &models.WriteResourceResponse{CommitID: "my-revision", Metadata: models.Version{Branch: "", UpstreamURL: "remote-url", Version: "my-revision"}}, revision)
 
 	require.Len(t, fields.stageContext.EstablishCalls(), 1)
 	require.Equal(t, models.Project{ProjectName: "my-project"}, fields.stageContext.EstablishCalls()[0].Params.Project, 1)
@@ -170,7 +170,7 @@ func TestResourceManager_CreateResources_ServiceResource_HelmChart(t *testing.T)
 
 	require.Nil(t, err)
 
-	require.Equal(t, &models.WriteResourceResponse{CommitID: "my-revision"}, revision)
+	require.Equal(t, &models.WriteResourceResponse{CommitID: "my-revision", Metadata: models.Version{Branch: "", UpstreamURL: "remote-url", Version: "my-revision"}}, revision)
 
 	require.Len(t, fields.git.StageAndCommitAllCalls(), 1)
 
@@ -353,7 +353,7 @@ func TestResourceManager_UpdateResources_ProjectResource(t *testing.T) {
 
 	require.Nil(t, err)
 
-	require.Equal(t, &models.WriteResourceResponse{CommitID: "my-revision"}, revision)
+	require.Equal(t, &models.WriteResourceResponse{CommitID: "my-revision", Metadata: models.Version{Branch: "", UpstreamURL: "remote-url", Version: "my-revision"}}, revision)
 
 	require.Len(t, fields.git.StageAndCommitAllCalls(), 1)
 
@@ -546,7 +546,7 @@ func TestResourceManager_UpdateResources_ProjectResource_CommitFailsOnFirstTry(t
 
 	require.Nil(t, err)
 
-	require.Equal(t, &models.WriteResourceResponse{CommitID: "my-revision"}, revision)
+	require.Equal(t, &models.WriteResourceResponse{CommitID: "my-revision", Metadata: models.Version{Branch: "", UpstreamURL: "remote-url", Version: "my-revision"}}, revision)
 
 	require.Len(t, fields.git.StageAndCommitAllCalls(), 2)
 
@@ -572,7 +572,7 @@ func TestResourceManager_UpdateResource_ProjectResource(t *testing.T) {
 
 	require.Nil(t, err)
 
-	require.Equal(t, &models.WriteResourceResponse{CommitID: "my-revision"}, revision)
+	require.Equal(t, &models.WriteResourceResponse{CommitID: "my-revision", Metadata: models.Version{Branch: "", UpstreamURL: "remote-url", Version: "my-revision"}}, revision)
 
 	require.Len(t, fields.git.StageAndCommitAllCalls(), 1)
 
@@ -721,7 +721,7 @@ func TestResourceManager_UpdateResource_ProjectResource_CommitFailsOnFirstTry(t 
 
 	require.Nil(t, err)
 
-	require.Equal(t, &models.WriteResourceResponse{CommitID: "my-revision"}, revision)
+	require.Equal(t, &models.WriteResourceResponse{CommitID: "my-revision", Metadata: models.Version{Branch: "", UpstreamURL: "remote-url", Version: "my-revision"}}, revision)
 
 	require.Len(t, fields.git.StageAndCommitAllCalls(), 2)
 
@@ -743,7 +743,7 @@ func TestResourceManager_DeleteResource_ProjectResource(t *testing.T) {
 
 	require.Nil(t, err)
 
-	require.Equal(t, &models.WriteResourceResponse{CommitID: "my-revision"}, revision)
+	require.Equal(t, &models.WriteResourceResponse{CommitID: "my-revision", Metadata: models.Version{Branch: "", UpstreamURL: "remote-url", Version: "my-revision"}}, revision)
 
 	require.Len(t, fields.git.StageAndCommitAllCalls(), 1)
 
@@ -854,7 +854,7 @@ func TestResourceManager_DeleteResource_Git_ThrowsNonFastForward_Or_ThrowsForceN
 
 	require.Nil(t, err)
 
-	require.Equal(t, &models.WriteResourceResponse{CommitID: "my-revision"}, revision)
+	require.Equal(t, &models.WriteResourceResponse{CommitID: "my-revision", Metadata: models.Version{Branch: "", UpstreamURL: "remote-url", Version: "my-revision"}}, revision)
 
 	require.Len(t, fields.git.StageAndCommitAllCalls(), 3)
 	require.Len(t, fields.fileSystem.DeleteFileCalls(), 3)
@@ -1186,8 +1186,8 @@ func TestResourceManager_GetResources(t *testing.T) {
 				},
 				Metadata: models.Version{
 					Branch:      "",
-					UpstreamURL: "",
-					Version:     "",
+					UpstreamURL: "remote-url",
+					Version:     "my-revision",
 				},
 			},
 			{
@@ -1197,8 +1197,8 @@ func TestResourceManager_GetResources(t *testing.T) {
 				},
 				Metadata: models.Version{
 					Branch:      "",
-					UpstreamURL: "",
-					Version:     "",
+					UpstreamURL: "remote-url",
+					Version:     "my-revision",
 				},
 			},
 			{
@@ -1208,8 +1208,8 @@ func TestResourceManager_GetResources(t *testing.T) {
 				},
 				Metadata: models.Version{
 					Branch:      "",
-					UpstreamURL: "",
-					Version:     "",
+					UpstreamURL: "remote-url",
+					Version:     "my-revision",
 				},
 			},
 		},

--- a/resource-service/handler/service_resource_handler.go
+++ b/resource-service/handler/service_resource_handler.go
@@ -121,9 +121,9 @@ func (ph *ServiceResourceHandler) GetServiceResources(c *gin.Context) {
 }
 
 // UpdateServiceResources godoc
-// @Summary Updates project resources
+// @Summary Updates service resources
 // @Description Update list of new resources for the service in the given stage of a project
-// @Tags Project Resource
+// @Tags Service Resource
 // @Security ApiKeyAuth
 // @Accept  json
 // @Produce  json

--- a/resource-service/models/resource.go
+++ b/resource-service/models/resource.go
@@ -209,7 +209,7 @@ type GetResourcesResponse struct {
 // swagger:model GetResourceResponse
 type GetResourceResponse struct {
 	Resource
-	Metadata Version
+	Metadata Version `json:"metadata"`
 }
 
 type WriteResourceResponse struct {

--- a/resource-service/models/resource.go
+++ b/resource-service/models/resource.go
@@ -213,7 +213,8 @@ type GetResourceResponse struct {
 }
 
 type WriteResourceResponse struct {
-	CommitID string `json:"commitID"`
+	CommitID string  `json:"commitID"`
+	Metadata Version `json:"metadata"`
 }
 
 func validateResourceURI(uri string) error {

--- a/resource-service/skaffold.yaml
+++ b/resource-service/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v2beta22
+apiVersion: skaffold/v2beta25
 kind: Config
 build:
   local:
@@ -13,3 +13,7 @@ deploy:
     defaultNamespace: keptn
     manifests:
       - deploy/service.yaml
+profiles:
+  - name: gcp
+    build:
+      googleCloudBuild: {}

--- a/shipyard-controller/common/configurationstore.go
+++ b/shipyard-controller/common/configurationstore.go
@@ -114,7 +114,7 @@ func (g GitConfigurationStore) DeleteService(projectName string, stageName strin
 func (g GitConfigurationStore) buildErrResponse(err *apimodels.Error) error {
 	if err.Code == http.StatusFailedDependency {
 		return ErrConfigStoreInvalidToken
-	} else if err.Code == http.StatusNotFound {
+	} else if err.Code == http.StatusNotFound || err.Code == http.StatusBadRequest {
 		return ErrConfigStoreUpstreamNotFound
 	}
 	return errors.New(*err.Message)

--- a/shipyard-controller/handler/projecthandler.go
+++ b/shipyard-controller/handler/projecthandler.go
@@ -318,9 +318,14 @@ func (ph *ProjectHandler) CreateProject(c *gin.Context) {
 		if err := ph.sendProjectCreateFailFinishedEvent(keptnContext, params); err != nil {
 			log.Errorf("could not send project.create.finished event: %s", err.Error())
 		}
+
 		rollback()
 		if errors.Is(err, ErrProjectAlreadyExists) {
 			SetConflictErrorResponse(c, err.Error())
+			return
+		}
+		if errors.Is(err, common.ErrConfigStoreUpstreamNotFound) {
+			SetBadRequestErrorResponse(c, err.Error())
 			return
 		}
 		SetInternalServerErrorResponse(c, err.Error())

--- a/shipyard-controller/handler/projecthandler_test.go
+++ b/shipyard-controller/handler/projecthandler_test.go
@@ -319,6 +319,26 @@ func TestCreateProject(t *testing.T) {
 			projectNameParam: "my-project",
 		},
 		{
+			name: "Create project project resource-service cannot find repo",
+			fields: fields{
+				ProjectManager: &fake.IProjectManagerMock{
+					CreateFunc: func(params *models.CreateProjectParams) (error, common.RollbackFunc) {
+						return common.ErrConfigStoreUpstreamNotFound, func() error { return nil }
+					},
+				},
+				EventSender: &fake.IEventSenderMock{
+					SendEventFunc: func(eventMoqParam event.Event) error {
+						return nil
+					},
+				},
+				EnvConfig:             config.EnvConfig{ProjectNameMaxSize: 20},
+				RepositoryProvisioner: &fake.IRepositoryProvisionerMock{},
+			},
+			jsonPayload:      examplePayload,
+			expectHttpStatus: http.StatusBadRequest,
+			projectNameParam: "my-project",
+		},
+		{
 			name: "Create project creating project fails",
 			fields: fields{
 				ProjectManager: &fake.IProjectManagerMock{


### PR DESCRIPTION
Currently, the resource-service has some incompatibilities (I guess, this wasn't in place with the configuration-service)
- [x] Deleting a webhook is not possible anymore (404 not found)
`DELETE /project/{projectName}/resource/{resourceURI}`
`DELETE /project/{projectName}/stage/{stageName}/resource/{resourceURI}`
`DELETE /project/{projectName}/stage/{stageName}/service/{serviceName}/resource/{resourceURI}`
Previously the resourceURI was double escaped with `webhook%252Fwebhook.yaml` (`webhook%2Fwebhook.yaml` in the Swagger UI), but seems like this isn't working anymore. The GET endpoints seem to work.

**added query parsing to delete endpoint**
![162258899-756dacbd-fd74-4d56-8ea3-24dc1a51d5b6](https://user-images.githubusercontent.com/89971034/162439180-1c590acb-baf3-41b9-bef5-9944bfd9914b.png)


- [x] The project, stage, and service resource response returns `Metadata` instead of `metadata`.
**added json format to the model**
![image](https://user-images.githubusercontent.com/89971034/162258710-97778004-033f-478e-95c0-ab31c22e11a1.png)

- [X] The PUT and POST requests to a project, stage, and service don't contain the metadata anymore (or at least it isn't shown in the Swagger UI anymore).
  **Now they return metadata**
![image](https://user-images.githubusercontent.com/89971034/162438836-d63a55be-b02f-47c0-adaf-cb0b2a201673.png)


- [X] Seems like the `branch` property of `metadata` is always empty. Is this intended? Double-check with the branch structure enabled.
  **since the branches will be deprecated, it does not make sense to have this info.  This is also available in the URL of the endpoint 
  so it does not make sense to me...**

- [x] GET `​/project​/{projectName}​/stage​/{stageName}​/resource` always returns an empty object for the metadata. When the resource is fetched with GET `​/project​/{projectName}​/stage​/{stageName}​/resource/{resourceURI}` , the correct metadata is returned.
  **metadata is generated dynamically by looking at the resource commitid, in case of the whole project we fill in the result with the latest commit of that branch/repo**  
![image](https://user-images.githubusercontent.com/89971034/162442738-604c0e2d-33a5-40ae-97e1-b6fac47d5276.png)
   
- [x] The following project endpoints are not marked as internal anymore. Not sure about the changed parameters here. Is this intended? -> remove these from the swagger doc
   added deprecated tag
  - POST `/project`
  - DELETE `/project/{projectName}`
  - PUT `/project(projectName}`

![image](https://user-images.githubusercontent.com/89971034/162258293-befec99f-e667-4227-bc92-ef3430f2d57d.png)

- [X] Swagger UI: The placeholder for the gitCommitID is longer than the width of the input 
![image](https://user-images.githubusercontent.com/11599148/161540392-f44ba538-b048-494b-8f70-32fb515593be.png) 
	**we decided to wait to switch to a Swagger version that allows this changes**
- [x] Swagger UI: The endpoint PUT `/project/{projectName}/stage/{stageName}/service/{serviceName}/resource` is inside `Project Resource` instead of `Service Resource` and the description should be changed to `Updates service resources` instead of `Updates project resources`
 **Changed** 

![image](https://user-images.githubusercontent.com/89971034/162259125-ac787565-96c2-4423-b6c9-bdf252ad50b7.png)

- [X] When the user wants to create a project without a Git upstream a 500 status code is returned instead of 400.
 
![image](https://user-images.githubusercontent.com/89971034/162715451-699088b3-b8e8-4bfd-b480-6e150caa741e.png)


### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #7353 
