### PR TITLE
test: Fixed unit test in resource service

### DIFF
--- a/resource-service/common/gitsuite_test.go
+++ b/resource-service/common/gitsuite_test.go
@@ -1034,7 +1034,7 @@ func Test_getAuthMethod(t *testing.T) {
 					GitPrivateKey:     "",
 					GitPrivateKeyPass: "",
 					GitProxyURL:       "",
-					GitProxyInsecure:  false,
+					InsecureSkipTLS:   false,
 					GitProxyScheme:    "",
 					GitProxyUser:      "",
 					GitProxyPassword:  "",


### PR DESCRIPTION
During the last PR to the resource-service, somehow a failing test was slipping through. This PR fixes that