### PR TITLE
chore(installer): Upgrade MongoDB to v11

### DIFF
--- a/installer/airgapped/pull_and_retag_images.sh
+++ b/installer/airgapped/pull_and_retag_images.sh
@@ -15,7 +15,7 @@ if [[ "$KEPTN_TAG" == *"dev"* ]]; then
 fi
 
 IMAGES_CONTROL_PLANE_THIRD_PARTY=(
-  "bitnami/mongodb:4.4.9-debian-10-r0"
+  "bitnami/mongodb:4.4.13-debian-10-r33"
   "nats:2.7.2-alpine"
   "natsio/nats-server-config-reloader:0.6.3"
   "natsio/prometheus-nats-exporter:0.9.1"

--- a/installer/manifests/keptn/charts/control-plane/Chart.yaml
+++ b/installer/manifests/keptn/charts/control-plane/Chart.yaml
@@ -24,7 +24,7 @@ appVersion: latest
 
 dependencies:
   - name: mongodb
-    version: 10.26.4
+    version: 11.1.5
     repository: https://charts.bitnami.com/bitnami
     condition: mongo.enabled
     alias: mongo

--- a/installer/manifests/keptn/charts/control-plane/templates/core.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/core.yaml
@@ -196,7 +196,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: mongodb-credentials
-                  key: mongodb-password
+                  key: mongodb-passwords
             - name: MONGODB_DATABASE
               value: {{ .Values.mongo.auth.bridgeAuthDatabase | default "openid" }}
             - name: CONFIG_DIR

--- a/installer/manifests/keptn/charts/control-plane/templates/mongodb-credentials.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/mongodb-credentials.yaml
@@ -26,21 +26,19 @@
   {{- if index $mongosecret.data "mongodb-user" -}}
     {{- $mongoUser = index $mongosecret.data "mongodb-user" -}}
   {{- end -}}
-{{- end -}}
 
-{{- if $mongosecret -}}
   {{- if index $mongosecret.data "mongodb-password" -}}
     {{- $mongoPassword = index $mongosecret.data "mongodb-password" -}}
   {{- end -}}
-{{- end -}}
 
-{{- if $mongosecret -}}
+  {{- if index $mongosecret.data "mongodb-passwords" -}}
+    {{- $mongoPassword = index $mongosecret.data "mongodb-passwords" -}}
+  {{- end -}}
+
   {{- if index $mongosecret.data "mongodb-root-password" -}}
     {{- $mongoRootPassword = index $mongosecret.data "mongodb-root-password" -}}
   {{- end -}}
-{{- end -}}
 
-{{- if $mongosecret -}}
   {{- if index $mongosecret.data "external_connection_string" -}}
     {{- $mongoExternalConnectionString = index $mongosecret.data "external_connection_string" -}}
   {{- end -}}
@@ -65,7 +63,7 @@ metadata:
 type: Opaque
 data:
   mongodb-user: {{ $mongoUser }}
-  mongodb-password: {{ $mongoPassword }}
+  mongodb-passwords: {{ $mongoPassword }}
   mongodb-root-user: {{ $mongoRootUser }}
   mongodb-root-password: {{ $mongoRootPassword }}
   external_connection_string: {{ $mongoExternalConnectionString }}

--- a/installer/manifests/keptn/charts/control-plane/templates/mongodb-datastore.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/mongodb-datastore.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: mongodb-credentials
-              key: mongodb-password
+              key: mongodb-passwords
         - name: MONGODB_EXTERNAL_CONNECTION_STRING
           valueFrom:
             secretKeyRef:

--- a/installer/manifests/keptn/charts/control-plane/templates/shipyard-controller.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/shipyard-controller.yaml
@@ -70,7 +70,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: mongodb-credentials
-                  key: mongodb-password
+                  key: mongodb-passwords
             - name: MONGODB_DATABASE
               value: {{ .Values.mongo.auth.database | default "keptn" }}
             - name: MONGODB_EXTERNAL_CONNECTION_STRING

--- a/installer/manifests/keptn/charts/control-plane/templates/statistics-service.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/statistics-service.yaml
@@ -62,7 +62,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: mongodb-credentials
-                  key: mongodb-password
+                  key: mongodb-passwords
             - name: MONGODB_DATABASE
               value: {{ .Values.mongo.auth.database | default "keptn" }}
             - name: MONGODB_EXTERNAL_CONNECTION_STRING

--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -6,9 +6,11 @@ mongo:
     nameOverride: 'mongo'
     port: 27017
   auth:
-    database: 'keptn'
+    databases:
+      - 'keptn'
     existingSecret: 'mongodb-credentials' # If the password and rootPassword values below are used, remove this field.
-    username: 'keptn'
+    usernames:
+      - 'keptn'
     password: null
     rootUser: 'admin'
     rootPassword: null


### PR DESCRIPTION
### This PR
- upgrades the MongoDB chart to v11.1.5
- updates the values for mongo to conform to the new changes that came in with the update
- introduces some minor refactoring

#### Notes
I manually tested the following:
- Install keptn 0.14.1
- trigger a few deliveries with carts example project
- upgrade to the helm chart from this PR with MongoDB upgraded to v11
- check if the mongo-credentials secret was updated correctly
- trigger more sequences and check if everything still works and that no data was lost