### PR TITLE
fix(cli): Hide warning message during upgrade

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -82,3 +82,4 @@ For a realtime overview of current contributors to the Keptn project, we refer t
 * [Eric Y. Kim](https://github.com/eyskim)
 * [Markus Lackner](https://github.com/markuslackner)
 * [René Panzar](https://github.com/renepanzar)
+* [Avik Kundu](https://github.com/Lucifergene)

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -2,12 +2,13 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/keptn/keptn/cli/pkg/config"
 	"github.com/keptn/keptn/cli/pkg/logging"
 	"github.com/keptn/keptn/cli/pkg/version"
 	"github.com/spf13/cobra"
-	"os"
-	"strings"
 )
 
 var cfgFile string
@@ -130,7 +131,9 @@ func runVersionCheck(vChecker *version.VersionChecker, flags []string, cliConfig
 		}
 
 		if clusterVersion != Version {
-			fmt.Fprintf(os.Stderr, "* Warning: Your Keptn CLI version (%s) and Keptn cluster version (%s) don't match. This can lead to problems. Please make sure to use the same versions.\n", Version, clusterVersion)
+			if len(flags) == 0 || flags[0] != "upgrade" {
+				fmt.Fprintf(os.Stderr, "* Warning: Your Keptn CLI version (%s) and Keptn cluster version (%s) don't match. This can lead to problems. Please make sure to use the same versions.\n", Version, clusterVersion)
+			}
 		}
 	}
 

--- a/cli/cmd/root_test.go
+++ b/cli/cmd/root_test.go
@@ -232,6 +232,16 @@ func Test_runVersionCheck(t *testing.T) {
 			doNotWantOutput: "* Warning: could not check Keptn server version: Error connecting to server:",
 		},
 		{
+			name:           "dont show warning for 'keptn upgrade'",
+			cliVersion:     "0.8.0",
+			metadataStatus: http.StatusOK,
+			args:           []string{"upgrade"},
+			metadataResponse: apimodels.Metadata{
+				Keptnversion: "0.8.1-dev",
+			},
+			doNotWantOutput: "* Warning: Your Keptn CLI version (0.8.0) and Keptn cluster version (0.8.1-dev) don't match. This can lead to problems. Please make sure to use the same versions.",
+		},
+		{
 			name:            "skip version check for 'keptn --any-flag install'",
 			cliVersion:      "0.8.0",
 			metadataStatus:  http.StatusServiceUnavailable,


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- Hides the warning message during `keptn upgrade`

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #7419 