### PR TITLE
fix(shipyard-controller): Proceed with service deletion if the service is not present on the configuration service anymore

### DIFF
--- a/shipyard-controller/common/configurationstore_test.go
+++ b/shipyard-controller/common/configurationstore_test.go
@@ -221,3 +221,52 @@ func TestConfigurationStore(t *testing.T) {
 	})
 
 }
+
+func Test_isServiceNotFoundErr(t *testing.T) {
+	configSvcErrMsg := configServiceSvcDoesNotExistErrorMsg
+	resourceSvcErrMsg := resourceServiceSvcDoesNotExistErrorMsg
+	type args struct {
+		err apimodels.Error
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "service not found error from configuration-service",
+			args: args{
+				err: apimodels.Error{
+					Code:    http.StatusBadRequest,
+					Message: &configSvcErrMsg,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "service not found error from resource-service",
+			args: args{
+				err: apimodels.Error{
+					Code:    http.StatusNotFound,
+					Message: &resourceSvcErrMsg,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "other error",
+			args: args{
+				err: apimodels.Error{
+					Code:    http.StatusNotFound,
+					Message: nil,
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, isServiceNotFoundErr(tt.args.err), "isServiceNotFoundErr(%v)", tt.args.err)
+		})
+	}
+}

--- a/shipyard-controller/handler/servicemanager.go
+++ b/shipyard-controller/handler/servicemanager.go
@@ -136,7 +136,16 @@ func (sm *serviceManager) DeleteService(projectName, serviceName string) error {
 	for _, stage := range stages {
 		log.Infof("Deleting service %s from stage %s", serviceName, stage.StageName)
 		if err := sm.configurationStore.DeleteService(projectName, stage.StageName, serviceName); err != nil {
-			return sm.logAndReturnError(fmt.Sprintf("could not delete service %s from stage %s: %s", serviceName, stage.StageName, err.Error()))
+			// If we get a ErrServiceNotFound, we can proceed with deleting the service from the db.
+			// For other types of errors (e.g. due to a temporary upstream repo connection issue), we return without deleting it from the db.
+			// Otherwise, it could be that the service directory is still present in the configuration service, but gone from the db, which means we cannot
+			// retry the deletion via the bridge (since the service won't show up anymore), and recreating the service will fail because we'll get a 409 from
+			// the configuration service
+			if errors.Is(err, common.ErrServiceNotFound) {
+				log.Infof("Service %s has already been deleted from stage %s", serviceName, stage.StageName)
+			} else {
+				return sm.logAndReturnError(fmt.Sprintf("could not delete service %s from stage %s: %s", serviceName, stage.StageName, err.Error()))
+			}
 		}
 		if err := sm.projectMVRepo.DeleteService(projectName, stage.StageName, serviceName); err != nil {
 			return sm.logAndReturnError(fmt.Sprintf("could not delete service %s from stage %s: %s", serviceName, stage.StageName, err.Error()))

--- a/shipyard-controller/handler/servicemanager_test.go
+++ b/shipyard-controller/handler/servicemanager_test.go
@@ -249,6 +249,50 @@ func TestDeleteService_DeleteServiceInConfigurationServiceFails(t *testing.T) {
 	assert.Equal(t, 0, len(projectMVRepo.DeleteServiceCalls()))
 }
 
+func TestDeleteService_DeleteServiceInConfigurationServiceReturnsServiceNotFound(t *testing.T) {
+	projectMVRepo := &db_mock.ProjectMVRepoMock{}
+	configurationStore := &common_mock.ConfigurationStoreMock{}
+	uniformRepo := &db_mock.UniformRepoMock{}
+	instance := NewServiceManager(projectMVRepo, configurationStore, uniformRepo)
+	projectMVRepo.GetProjectFunc = func(projectName string) (*apimodels.ExpandedProject, error) {
+		service := &apimodels.ExpandedService{
+			ServiceName: "service-name",
+		}
+		stage1 := &apimodels.ExpandedStage{
+			Services:  []*apimodels.ExpandedService{service},
+			StageName: "dev",
+		}
+		stage2 := &apimodels.ExpandedStage{
+			Services:  []*apimodels.ExpandedService{service},
+			StageName: "prod",
+		}
+
+		project := &apimodels.ExpandedProject{
+			ProjectName: "my-project",
+			Stages:      []*apimodels.ExpandedStage{stage1, stage2},
+		}
+		return project, nil
+	}
+	projectMVRepo.DeleteServiceFunc = func(project string, stage string, service string) error {
+		return nil
+	}
+
+	uniformRepo.DeleteServiceFromSubscriptionsFunc = func(subscriptionName string) error {
+		return nil
+	}
+
+	configurationStore.DeleteServiceFunc = func(projectName string, stageName string, serviceName string) error {
+		return common.ErrServiceNotFound
+	}
+
+	err := instance.DeleteService("my-project", "my-service")
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(configurationStore.DeleteServiceCalls()))
+	// in this case we expect the service to be deleted from the database, because it is already gone from the upstream
+	assert.Equal(t, 2, len(projectMVRepo.DeleteServiceCalls()))
+	assert.Equal(t, 2, len(uniformRepo.DeleteServiceFromSubscriptionsCalls()))
+}
+
 func TestDeleteService_DeleteServiceInDBFails(t *testing.T) {
 	projectMVRepo := &db_mock.ProjectMVRepoMock{}
 	configurationStore := &common_mock.ConfigurationStoreMock{}


### PR DESCRIPTION
Closes #7446 

This PR adds a check for a `ErrServiceNotFound` error when trying to delete a service from the configuration service. If the shipyard controller detects such an error when attempting to delete a service from a project, it will proceed with deleting the service from the database as well, to keep the state of the project consistent with what is available in the project's git repo

How to test:

1. Create. project
2. Create a service within that project
3. Delete the service directory from the upstream (or the configuration-service, if no upstream is configured)
4. Try to delete the service via the Bridge
5. The service should now be deleted successfully
(6. Try to recreate the service with the same name - this should also work)