### PR TITLE
feat(shipyard-controller): stop pulling messages after receiving sigterm

### DIFF
--- a/shipyard-controller/main.go
+++ b/shipyard-controller/main.go
@@ -297,6 +297,7 @@ func main() {
 	GracefulShutdown(wg, srv, func() {
 		// invoke the cancel() function to shut down the periodically executed
 		// tasks such as nats subscription, sequence watcher, sequence dispatcher, event dispatcher
+		// this should ensure that no iteration of either of these tasks is attempted to be started right before the termination of the pod
 		cancel()
 	})
 

--- a/shipyard-controller/nats/pullsubscription.go
+++ b/shipyard-controller/nats/pullsubscription.go
@@ -58,6 +58,7 @@ func (ps *PullSubscription) pullMessages() {
 	for {
 		select {
 		case <-ps.ctx.Done():
+			logger.Info("Shutting down pull subscription")
 			ps.isActive = false
 			return
 		default:


### PR DESCRIPTION
Closes #7304

How to test:

1. Make sure the termination grace period of the shipyard controller is set
2. Shut down the shipyard controller pod
3. While shutting down, continue to send events to keptn (e.g. sequence.triggered events)
4. Make sure that during the grace period no events are processed by the old replica of the shipyard controller
5. Make sure that every event sent during the termination of the old pod is eventually picked up by the new replica of the shipyard controller