### PR TITLE
feat(bridge): Make filters in sequence view stable across page refresh

### DIFF
--- a/bridge/client/app/_components/ktb-root-events-list/ktb-root-events-list.component.html
+++ b/bridge/client/app/_components/ktb-root-events-list/ktb-root-events-list.component.html
@@ -49,10 +49,4 @@
       </ng-template>
     </ktb-selectable-tile>
   </div>
-  <div fxLayout="row" fxLayoutAlign="center center">
-    <ktb-loading-distractor *ngIf="loading" uitestid="keptn-loadingOldSequences">Loading …</ktb-loading-distractor>
-    <button dt-show-more *ngIf="!loading && !project?.allSequencesLoaded" (click)="loadOldSequences()">
-      Show older sequences
-    </button>
-  </div>
 </div>

--- a/bridge/client/app/_components/ktb-root-events-list/ktb-root-events-list.component.spec.ts
+++ b/bridge/client/app/_components/ktb-root-events-list/ktb-root-events-list.component.spec.ts
@@ -63,23 +63,6 @@ describe('KtbRootEventsListComponent', () => {
     expect(component.events).toEqual(project.sequences);
   });
 
-  it('should load old sequences and not show "show older sequences" when all loaded', () => {
-    // given
-    dataService.loadSequences(project);
-    component.events = project.sequences || [];
-
-    // when
-    component.loadOldSequences();
-    component.events = project.sequences || [];
-    fixture.detectChanges();
-
-    // then
-    const sequences = fixture.nativeElement.querySelectorAll('ktb-selectable-tile');
-    const showMoreButton = fixture.nativeElement.querySelector('button[dt-show-more]');
-    expect(sequences.length).toEqual(34);
-    expect(showMoreButton).toBeFalsy();
-  });
-
   it('should select provided sequence', () => {
     // given
     const selectedSequenceIndex = 1;

--- a/bridge/client/app/_components/ktb-root-events-list/ktb-root-events-list.component.spec.ts
+++ b/bridge/client/app/_components/ktb-root-events-list/ktb-root-events-list.component.spec.ts
@@ -57,9 +57,7 @@ describe('KtbRootEventsListComponent', () => {
 
     // then
     const sequences = fixture.nativeElement.querySelectorAll('ktb-selectable-tile');
-    const showMoreButton = fixture.nativeElement.querySelector('button[dt-show-more]');
     expect(sequences.length).toEqual(25);
-    expect(showMoreButton).toBeTruthy();
     expect(component.events).toEqual(project.sequences);
   });
 

--- a/bridge/client/app/_components/ktb-sequence-controls/ktb-sequence-controls.component.spec.ts
+++ b/bridge/client/app/_components/ktb-sequence-controls/ktb-sequence-controls.component.spec.ts
@@ -51,7 +51,7 @@ describe('KtbSequenceControlsComponent', () => {
   it('should show pause and abort for started sequence', () => {
     // given
     dataService.loadSequences(project);
-    component.sequence = project.sequences?.[6];
+    component.sequence = project.sequences?.[7];
     fixture.detectChanges();
 
     const sequencePauseButton = fixture.nativeElement.querySelector('button[uitestid=sequencePauseButton]');
@@ -73,7 +73,7 @@ describe('KtbSequenceControlsComponent', () => {
   it('should pause sequence on click', () => {
     // given
     dataService.loadSequences(project);
-    component.sequence = project.sequences?.[6];
+    component.sequence = project.sequences?.[7];
     fixture.detectChanges();
 
     const sequencePauseButton = fixture.nativeElement.querySelector('button[uitestid=sequencePauseButton]');
@@ -89,7 +89,7 @@ describe('KtbSequenceControlsComponent', () => {
   it('should abort sequence on click', () => {
     // given
     dataService.loadSequences(project);
-    component.sequence = project.sequences?.[6];
+    component.sequence = project.sequences?.[7];
     fixture.detectChanges();
 
     const sequenceAbortButton = fixture.nativeElement.querySelector('button[uitestid=sequenceAbortButton]');
@@ -105,7 +105,7 @@ describe('KtbSequenceControlsComponent', () => {
   it('should show resume and abort for paused sequence', () => {
     // given
     dataService.loadSequences(project);
-    component.sequence = project.sequences?.[3];
+    component.sequence = project.sequences?.[4];
     fixture.detectChanges();
 
     const sequencePauseButton = fixture.nativeElement.querySelector('button[uitestid=sequencePauseButton]');
@@ -127,7 +127,7 @@ describe('KtbSequenceControlsComponent', () => {
   it('should resume sequence on click', () => {
     // given
     dataService.loadSequences(project);
-    component.sequence = project.sequences?.[3];
+    component.sequence = project.sequences?.[4];
     fixture.detectChanges();
 
     const sequenceResumeButton = fixture.nativeElement.querySelector('button[uitestid=sequenceResumeButton]');
@@ -143,7 +143,7 @@ describe('KtbSequenceControlsComponent', () => {
   it('buttons should be disabled for finished sequence', () => {
     // given
     dataService.loadSequences(project);
-    component.sequence = project.sequences?.[0];
+    component.sequence = project.sequences?.[1];
     fixture.detectChanges();
 
     const sequencePauseButton = fixture.nativeElement.querySelector('button[uitestid=sequencePauseButton]');

--- a/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.spec.ts
+++ b/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.spec.ts
@@ -46,7 +46,7 @@ describe('KtbSequenceStateInfoComponent', () => {
   it('should show sequence info', () => {
     // given
     dataService.loadSequences(project);
-    component.sequence = project.sequences?.[11];
+    component.sequence = project.sequences?.[12];
     fixture.detectChanges();
 
     // then
@@ -62,7 +62,7 @@ describe('KtbSequenceStateInfoComponent', () => {
   it('should show sequence info with 3 stages', () => {
     // given
     dataService.loadSequences(project);
-    component.sequence = project.sequences?.[11];
+    component.sequence = project.sequences?.[12];
     fixture.detectChanges();
 
     // then
@@ -82,7 +82,7 @@ describe('KtbSequenceStateInfoComponent', () => {
   it('should show sequence info without stages if showStages is false', () => {
     // given
     dataService.loadSequences(project);
-    component.sequence = project.sequences?.[11];
+    component.sequence = project.sequences?.[12];
     component.showStages = false;
     fixture.detectChanges();
 
@@ -96,7 +96,7 @@ describe('KtbSequenceStateInfoComponent', () => {
   it('should trigger click callback on stage', () => {
     // given
     dataService.loadSequences(project);
-    const sequence = project.sequences?.[11];
+    const sequence = project.sequences?.[12];
     component.sequence = sequence;
     const spy = jest.spyOn(component, 'stageClick');
     fixture.detectChanges();

--- a/bridge/client/app/_components/ktb-sequence-tasks-list/ktb-sequence-tasks-list.component.ts
+++ b/bridge/client/app/_components/ktb-sequence-tasks-list/ktb-sequence-tasks-list.component.ts
@@ -1,6 +1,5 @@
 import { Component, HostBinding, Input, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Location } from '@angular/common';
 import { Trace } from '../../_models/trace';
 import { DateUtil } from '../../_utils/date.utils';
 import { takeUntil } from 'rxjs/operators';
@@ -25,6 +24,7 @@ export class KtbSequenceTasksListComponent implements OnInit, OnDestroy {
   get tasks(): Trace[] {
     return this._tasks;
   }
+
   set tasks(value: Trace[]) {
     if (this._tasks !== value) {
       this._tasks = value;
@@ -36,6 +36,7 @@ export class KtbSequenceTasksListComponent implements OnInit, OnDestroy {
   get stage(): string | undefined {
     return this._stage;
   }
+
   set stage(value: string | undefined) {
     if (this._stage !== value) {
       this._stage = value;
@@ -47,6 +48,7 @@ export class KtbSequenceTasksListComponent implements OnInit, OnDestroy {
   get focusedEventId(): string | undefined {
     return this._focusedEventId;
   }
+
   set focusedEventId(value: string | undefined) {
     if (this._focusedEventId !== value) {
       this._focusedEventId = value;
@@ -55,12 +57,7 @@ export class KtbSequenceTasksListComponent implements OnInit, OnDestroy {
 
   @Input() latestDeployment: string | undefined;
 
-  constructor(
-    private router: Router,
-    private location: Location,
-    public dateUtil: DateUtil,
-    private route: ActivatedRoute
-  ) {}
+  constructor(private router: Router, public dateUtil: DateUtil, private route: ActivatedRoute) {}
 
   ngOnInit(): void {
     this.route.params.pipe(takeUntil(this.unsubscribe$)).subscribe((params) => {
@@ -88,15 +85,9 @@ export class KtbSequenceTasksListComponent implements OnInit, OnDestroy {
 
   focusEvent(event: Trace): void {
     if (event.project) {
-      const routeUrl = this.router.createUrlTree([
-        '/project',
-        event.project,
-        'sequence',
-        event.shkeptncontext,
-        'event',
-        event.id,
-      ]);
-      this.location.go(routeUrl.toString());
+      this.router.navigate(['/project', event.project, 'sequence', event.shkeptncontext, 'event', event.id], {
+        queryParamsHandling: 'preserve',
+      });
     }
   }
 

--- a/bridge/client/app/_components/ktb-sequence-tasks-list/ktb-sequence-tasks-list.component.ts
+++ b/bridge/client/app/_components/ktb-sequence-tasks-list/ktb-sequence-tasks-list.component.ts
@@ -1,5 +1,6 @@
 import { Component, HostBinding, Input, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { Location } from '@angular/common';
 import { Trace } from '../../_models/trace';
 import { DateUtil } from '../../_utils/date.utils';
 import { takeUntil } from 'rxjs/operators';
@@ -57,7 +58,12 @@ export class KtbSequenceTasksListComponent implements OnInit, OnDestroy {
 
   @Input() latestDeployment: string | undefined;
 
-  constructor(private router: Router, public dateUtil: DateUtil, private route: ActivatedRoute) {}
+  constructor(
+    private router: Router,
+    private location: Location,
+    public dateUtil: DateUtil,
+    private route: ActivatedRoute
+  ) {}
 
   ngOnInit(): void {
     this.route.params.pipe(takeUntil(this.unsubscribe$)).subscribe((params) => {
@@ -85,9 +91,11 @@ export class KtbSequenceTasksListComponent implements OnInit, OnDestroy {
 
   focusEvent(event: Trace): void {
     if (event.project) {
-      this.router.navigate(['/project', event.project, 'sequence', event.shkeptncontext, 'event', event.id], {
-        queryParamsHandling: 'preserve',
-      });
+      const routeUrl = this.router.createUrlTree(
+        ['/project', event.project, 'sequence', event.shkeptncontext, 'event', event.id],
+        { queryParamsHandling: 'preserve' }
+      );
+      this.location.go(routeUrl.toString());
     }
   }
 

--- a/bridge/client/app/_models/sequence.spec.ts
+++ b/bridge/client/app/_models/sequence.spec.ts
@@ -519,7 +519,7 @@ describe('Sequence', () => {
   });
 
   function getDefaultSequence(): Sequence {
-    return Sequence.fromJSON(AppUtils.copyObject(SequenceResponseMock[0]));
+    return Sequence.fromJSON(AppUtils.copyObject(SequenceResponseMock[1]));
   }
 
   function getSequenceWithTwoStages(): Sequence {

--- a/bridge/client/app/_services/_mockData/sequences.mock.ts
+++ b/bridge/client/app/_services/_mockData/sequences.mock.ts
@@ -71,6 +71,53 @@ const sequencesData = [
     name: 'delivery',
     service: 'carts',
     project: 'sockshop',
+    time: '2022-04-11T11:17:43.292Z',
+    shkeptncontext: '99a20ef4-d822-4185-bbee-0d7a364c213a',
+    state: 'started',
+    stages: [
+      {
+        name: 'dev',
+        image: 'docker.io/keptnexamples/carts:0.13.1',
+        state: 'succeeded',
+        latestEvaluation: {
+          result: 'pass',
+          score: 0,
+        },
+        latestEvent: {
+          type: 'sh.keptn.event.dev.delivery.finished',
+          id: '0e1785ec-9282-4df7-a3f6-be70a2bdae65',
+          time: '2022-04-11T11:20:16.969Z',
+        },
+      },
+      {
+        name: 'staging',
+        image: 'docker.io/keptnexamples/carts:0.13.1',
+        state: 'succeeded',
+        latestEvaluation: {
+          result: 'pass',
+          score: 0,
+        },
+        latestEvent: {
+          type: 'sh.keptn.event.staging.delivery.finished',
+          id: '88a0c85d-b9b9-4b7f-8fba-45d7a1ab612f',
+          time: '2022-04-11T11:25:19.182Z',
+        },
+      },
+      {
+        name: 'production',
+        state: 'triggered',
+        latestEvent: {
+          type: 'sh.keptn.event.approval.started',
+          id: 'f4f767de-712c-4564-938e-eb6736e03cbf',
+          time: '2022-04-11T11:25:24.009Z',
+        },
+      },
+    ],
+  },
+  {
+    name: 'delivery',
+    service: 'carts',
+    project: 'sockshop',
     time: '2021-08-02T08:00:21.813Z',
     shkeptncontext: '80f87047-d5c2-4b3e-8aac-f376ff309ed5',
     state: 'finished',

--- a/bridge/client/app/_services/api.service.mock.ts
+++ b/bridge/client/app/_services/api.service.mock.ts
@@ -250,14 +250,14 @@ export class ApiServiceMock extends ApiService {
     keptnContext?: string
   ): Observable<HttpResponse<SequenceResult>> {
     let data = SequencesMock;
-    let totalCount = 34;
+    let totalCount = data.length;
 
     if (pageSize) {
       data = SequencesMock.slice(0, pageSize);
     }
 
     if (beforeTime) {
-      data = SequencesMock.slice(25, 34);
+      data = SequencesMock.slice(totalCount - 9);
       totalCount = 9;
     }
 

--- a/bridge/client/app/_services/api.service.ts
+++ b/bridge/client/app/_services/api.service.ts
@@ -55,18 +55,16 @@ export class ApiService {
     return this._baseUrl;
   }
 
-  public getSequenceFilters(projectName?: string): Record<string, string[]> {
-    if (!projectName) return {};
+  public getSequenceFilters(projectName: string): Record<string, string[]> {
     const filters = localStorage.getItem(this.getSequenceFiltersKey(projectName));
     return filters ? JSON.parse(filters) : {};
   }
 
-  public setSequenceFilters(filters: Record<string, string[]>, projectName?: string): void {
-    if (!projectName) return;
+  public setSequenceFilters(filters: Record<string, string[]>, projectName: string): void {
     localStorage.setItem(this.getSequenceFiltersKey(projectName), JSON.stringify(filters));
   }
 
-  private getSequenceFiltersKey(projectName?: string): string {
+  private getSequenceFiltersKey(projectName: string): string {
     return `${this.SEQUENCE_FILTERS_COOKIE}-${projectName}`;
   }
 

--- a/bridge/client/app/_services/api.service.ts
+++ b/bridge/client/app/_services/api.service.ts
@@ -55,12 +55,12 @@ export class ApiService {
     return this._baseUrl;
   }
 
-  public get sequenceFilters(): { [key: string]: string[] } {
+  public get sequenceFilters(): Record<string, string[]> {
     const filters = localStorage.getItem(this.SEQUENCE_FILTERS_COOKIE);
     return filters ? JSON.parse(filters) : {};
   }
 
-  public set sequenceFilters(filters: { [key: string]: string[] }) {
+  public set sequenceFilters(filters: Record<string, string[]>) {
     localStorage.setItem(this.SEQUENCE_FILTERS_COOKIE, JSON.stringify(filters));
   }
 

--- a/bridge/client/app/_services/api.service.ts
+++ b/bridge/client/app/_services/api.service.ts
@@ -60,7 +60,7 @@ export class ApiService {
     return filters ? JSON.parse(filters) : {};
   }
 
-  public set sequenceFilters(filters: { [key: string]: string[] }): void {
+  public set sequenceFilters(filters: { [key: string]: string[] }) {
     localStorage.setItem(this.SEQUENCE_FILTERS_COOKIE, JSON.stringify(filters));
   }
 

--- a/bridge/client/app/_services/api.service.ts
+++ b/bridge/client/app/_services/api.service.ts
@@ -41,6 +41,7 @@ export class ApiService {
   protected readonly VERSION_CHECK_COOKIE = 'keptn_versioncheck';
   protected readonly ENVIRONMENT_FILTER_COOKIE = 'keptn_environment_filter';
   protected readonly INTEGRATION_DATES = 'keptn_integration_dates';
+  protected readonly SEQUENCE_FILTERS_COOKIE = 'keptn_sequence_filters';
 
   constructor(protected http: HttpClient) {
     this._baseUrl = `./api`;
@@ -52,6 +53,15 @@ export class ApiService {
 
   public get baseUrl(): string {
     return this._baseUrl;
+  }
+
+  public get sequenceFilters(): { [key: string]: string[] } {
+    const filters = localStorage.getItem(this.SEQUENCE_FILTERS_COOKIE);
+    return filters ? JSON.parse(filters) : {};
+  }
+
+  public set sequenceFilters(filters: { [key: string]: string[] }): void {
+    localStorage.setItem(this.SEQUENCE_FILTERS_COOKIE, JSON.stringify(filters));
   }
 
   public get environmentFilter(): { [projectName: string]: { services: string[] } } {

--- a/bridge/client/app/_services/api.service.ts
+++ b/bridge/client/app/_services/api.service.ts
@@ -66,7 +66,7 @@ export class ApiService {
     localStorage.setItem(this.getSequenceFiltersKey(projectName), JSON.stringify(filters));
   }
 
-  public getSequenceFiltersKey(projectName?: string): string {
+  private getSequenceFiltersKey(projectName?: string): string {
     return `${this.SEQUENCE_FILTERS_COOKIE}-${projectName}`;
   }
 

--- a/bridge/client/app/_services/api.service.ts
+++ b/bridge/client/app/_services/api.service.ts
@@ -55,13 +55,19 @@ export class ApiService {
     return this._baseUrl;
   }
 
-  public get sequenceFilters(): Record<string, string[]> {
-    const filters = localStorage.getItem(this.SEQUENCE_FILTERS_COOKIE);
+  public getSequenceFilters(projectName?: string): Record<string, string[]> {
+    if (!projectName) return {};
+    const filters = localStorage.getItem(this.getSequenceFiltersKey(projectName));
     return filters ? JSON.parse(filters) : {};
   }
 
-  public set sequenceFilters(filters: Record<string, string[]>) {
-    localStorage.setItem(this.SEQUENCE_FILTERS_COOKIE, JSON.stringify(filters));
+  public setSequenceFilters(filters: Record<string, string[]>, projectName?: string): void {
+    if (!projectName) return;
+    localStorage.setItem(this.getSequenceFiltersKey(projectName), JSON.stringify(filters));
+  }
+
+  public getSequenceFiltersKey(projectName?: string): string {
+    return `${this.SEQUENCE_FILTERS_COOKIE}-${projectName}`;
   }
 
   public get environmentFilter(): { [projectName: string]: { services: string[] } } {

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.html
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.html
@@ -1,10 +1,11 @@
 <ng-template #triggerSequenceButton>
   <div>
-    <a (click)="navigateToTriggerSequence()"
-      ><button dt-button class="mb-3" uitestid="keptn-trigger-button-open">
-        <dt-icon name="flash"></dt-icon>Trigger a new sequence
-      </button></a
-    >
+    <a (click)="navigateToTriggerSequence()">
+      <button dt-button class="mb-3" uitestid="keptn-trigger-button-open">
+        <dt-icon name="flash"></dt-icon>
+        Trigger a new sequence
+      </button>
+    </a>
   </div>
 </ng-template>
 
@@ -14,7 +15,7 @@
       <dt-quick-filter
         [dataSource]="_filterDataSource"
         [filters]="_seqFilters"
-        (filterChanges)="filtersChanged($event)"
+        (filterChanges)="filtersClicked($event)"
         aria-label="Filter By Input value"
         label="Filter by"
         clearAllLabel="Clear all"
@@ -42,15 +43,15 @@
             fxLayout="row"
             fxLayoutAlign="start"
             uitestid="keptn-noSequencesFiltered"
-            *ngIf="getFilteredSequences(project.sequences).length === 0 && project.sequences.length !== 0"
+            *ngIf="filteredSequences.length === 0 && project.sequences.length !== 0"
           >
             <dt-icon fxFlex="20px" class="icon" name="information"></dt-icon>
             <p class="m-0 ml-2">No sequences found that match your filter criteria.</p>
           </div>
           <ktb-root-events-list
-            *ngIf="getFilteredSequences(project.sequences).length !== 0"
+            *ngIf="filteredSequences.length !== 0"
             uitestid="keptn-sequence-view-roots"
-            [events]="getFilteredSequences(project.sequences)"
+            [events]="filteredSequences"
             [selectedEvent]="currentSequence"
             (selectedEventChange)="selectSequence($event)"
             fxFlex

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.html
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.html
@@ -21,7 +21,7 @@
         clearAllLabel="Clear all"
         fxFlex
       >
-        <div fxFlex fxLayout="column">
+        <div fxFlexFill fxLayout="column">
           <div class="container trigger-sequence-button">
             <ng-container [ngTemplateOutlet]="triggerSequenceButton"></ng-container>
           </div>
@@ -60,11 +60,10 @@
                 Show older sequences
               </button>
             </div>
-            <div class="mb-3"></div>
           </div>
         </div>
         <ng-template #loadingSequences>
-          <div fxFlexFill fxLayout="row" fxLayoutAlign="center center" uitestid="keptn-loadingSequences">
+          <div fxFlex fxLayout="row" fxLayoutAlign="center center" uitestid="keptn-loadingSequences">
             <ktb-loading-distractor>Loading …</ktb-loading-distractor>
           </div>
         </ng-template>

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.html
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.html
@@ -1,7 +1,7 @@
 <ng-template #triggerSequenceButton>
   <div>
     <a (click)="navigateToTriggerSequence()">
-      <button dt-button class="mb-3" uitestid="keptn-trigger-button-open">
+      <button dt-button uitestid="keptn-trigger-button-open">
         <dt-icon name="flash"></dt-icon>
         Trigger a new sequence
       </button>
@@ -21,42 +21,47 @@
         clearAllLabel="Clear all"
         fxFlex
       >
-        <div class="p-3 trigger-sequence-button" *ngIf="project.sequences && project.sequences.length !== 0">
-          <ng-container [ngTemplateOutlet]="triggerSequenceButton"></ng-container>
-        </div>
-        <div
-          class="container"
-          [ngClass]="{ 'has-sequences': project.sequences.length !== 0 }"
-          fxFlex
-          fxLayout="column"
-          *ngIf="project.sequences; else loadingSequences"
-        >
-          <div uitestid="keptn-noSequences" *ngIf="project.sequences.length === 0">
-            <div fxLayout="row" fxLayoutAlign="start">
-              <dt-icon fxFlex="20px" class="icon" name="information"></dt-icon>
-              <p class="m-0 ml-2 mb-2">No sequences triggered yet.<br /></p>
-            </div>
+        <div fxFlex fxLayout="column">
+          <div class="container trigger-sequence-button">
             <ng-container [ngTemplateOutlet]="triggerSequenceButton"></ng-container>
           </div>
-
-          <div
-            fxLayout="row"
-            fxLayoutAlign="start"
-            uitestid="keptn-noSequencesFiltered"
-            *ngIf="filteredSequences.length === 0 && project.sequences.length !== 0"
-          >
-            <dt-icon fxFlex="20px" class="icon" name="information"></dt-icon>
-            <p class="m-0 ml-2">No sequences found that match your filter criteria.</p>
+          <div class="container" fxFlex fxLayout="column" *ngIf="project.sequences; else loadingSequences">
+            <div uitestid="keptn-noSequences" *ngIf="project.sequences.length === 0">
+              <div fxLayout="row" fxLayoutAlign="start">
+                <dt-icon fxFlex="20px" class="icon" name="information"></dt-icon>
+                <p class="m-0 ml-2 mb-2">No sequences triggered yet.<br /></p>
+              </div>
+              <ng-container [ngTemplateOutlet]="triggerSequenceButton"></ng-container>
+            </div>
+            <div
+              uitestid="keptn-noSequencesFiltered"
+              *ngIf="filteredSequences.length === 0 && project.sequences.length !== 0"
+            >
+              <dt-icon fxFlex="20px" class="icon" name="information"></dt-icon>
+              <p class="m-0 ml-2">No sequences found that match your filter criteria.</p>
+            </div>
+            <ktb-root-events-list
+              *ngIf="filteredSequences.length !== 0"
+              uitestid="keptn-sequence-view-roots"
+              [events]="filteredSequences"
+              [selectedEvent]="currentSequence"
+              (selectedEventChange)="selectSequence($event)"
+            ></ktb-root-events-list>
+            <div fxLayout="row" fxLayoutAlign="center">
+              <ktb-loading-distractor *ngIf="loading" uitestid="keptn-loadingOldSequences"
+                >Loading …</ktb-loading-distractor
+              >
+              <button
+                dt-show-more
+                *ngIf="!loading && !project?.allSequencesLoaded"
+                (click)="loadOldSequences()"
+                uitestid="keptn-show-older-sequences-button"
+              >
+                Show older sequences
+              </button>
+            </div>
+            <div class="mb-3"></div>
           </div>
-          <ktb-root-events-list
-            *ngIf="filteredSequences.length !== 0"
-            uitestid="keptn-sequence-view-roots"
-            [events]="filteredSequences"
-            [selectedEvent]="currentSequence"
-            (selectedEventChange)="selectSequence($event)"
-            fxFlex
-          ></ktb-root-events-list>
-          <div class="mb-3"></div>
         </div>
         <ng-template #loadingSequences>
           <div fxFlexFill fxLayout="row" fxLayoutAlign="center center" uitestid="keptn-loadingSequences">

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.html
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.html
@@ -22,7 +22,7 @@
         fxFlex
       >
         <div fxFlexFill fxLayout="column">
-          <div class="container trigger-sequence-button">
+          <div class="container" *ngIf="project.sequences && project.sequences.length !== 0">
             <ng-container [ngTemplateOutlet]="triggerSequenceButton"></ng-container>
           </div>
           <div class="container" fxFlex fxLayout="column" *ngIf="project.sequences; else loadingSequences">

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.scss
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.scss
@@ -19,15 +19,6 @@
 
     .dt-quick-filter-content {
       padding: 0 !important;
-
-      .trigger-sequence-button {
-        position: absolute;
-      }
-
-      > .container.has-sequences {
-        margin-top: calc(2.4em + 30px);
-
-      }
     }
   }
 }

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.spec.ts
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.spec.ts
@@ -15,7 +15,6 @@ import moment from 'moment';
 describe('KtbEventsListComponent', () => {
   let component: KtbSequenceViewComponent;
   let fixture: ComponentFixture<KtbSequenceViewComponent>;
-  let activatedRoute: ActivatedRoute;
   const queryParams: Subject<{ [p: string]: string | string[] }> = new BehaviorSubject({});
 
   const projectName = 'sockshop';
@@ -38,7 +37,6 @@ describe('KtbEventsListComponent', () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(KtbSequenceViewComponent);
-    activatedRoute = TestBed.inject(ActivatedRoute);
     component = fixture.componentInstance;
   });
 

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.spec.ts
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.spec.ts
@@ -193,4 +193,82 @@ describe('KtbEventsListComponent', () => {
     // then
     expect(showButton).toEqual(false);
   });
+
+  it('should save filters on click, load sequences and filter properly', () => {
+    // given
+    /* eslint-disable @typescript-eslint/ban-ts-comment */
+    /* @ts-ignore */ // Ignore private property
+    component.project = ProjectsMock[0];
+    const spySaveSequenceFilters = jest.spyOn(component, 'saveSequenceFilters');
+
+    // when
+    component.filtersClicked({
+      filters: [
+        [
+          {
+            name: 'Stage',
+            autocomplete: [],
+            showInSidebar: false,
+          },
+          {
+            name: 'dev',
+            value: 'dev',
+          },
+        ],
+        [
+          {
+            name: 'Stage',
+            autocomplete: [],
+            showInSidebar: false,
+          },
+          {
+            name: 'production',
+            value: 'production',
+          },
+        ],
+        [
+          {
+            name: 'Service',
+            autocomplete: [],
+            showInSidebar: false,
+          },
+          {
+            name: 'carts',
+            value: 'carts',
+          },
+        ],
+        [
+          {
+            name: 'Sequence',
+            autocomplete: [],
+            showInSidebar: false,
+          },
+          {
+            name: 'delivery',
+            value: 'delivery',
+          },
+        ],
+        [
+          {
+            name: 'Status',
+            autocomplete: [],
+            showInSidebar: false,
+          },
+          {
+            name: 'Active',
+            value: 'started',
+          },
+        ],
+      ],
+    });
+
+    // then
+    expect(spySaveSequenceFilters).toHaveBeenCalledWith({
+      Stage: ['dev', 'production'],
+      Service: ['carts'],
+      Sequence: ['delivery'],
+      Status: ['started'],
+    });
+    expect(component.filteredSequences).toEqual([SequencesMock[0]]);
+  });
 });

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.spec.ts
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.spec.ts
@@ -203,6 +203,7 @@ describe('KtbEventsListComponent', () => {
     /* @ts-ignore */ // Ignore private property
     component.project = ProjectsMock[0];
     const spySaveSequenceFilters = jest.spyOn(component, 'saveSequenceFilters');
+    fixture.detectChanges();
 
     // when
     component.filtersClicked({
@@ -282,6 +283,7 @@ describe('KtbEventsListComponent', () => {
     /* @ts-ignore */ // Ignore private property
     component.project = ProjectsMock[0];
     const spySetSequenceFilters = jest.spyOn(component, 'setSequenceFilters');
+    fixture.detectChanges();
 
     // when
     queryParams.next({

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.spec.ts
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.spec.ts
@@ -19,6 +19,64 @@ describe('KtbEventsListComponent', () => {
 
   const projectName = 'sockshop';
 
+  const sequenceFilters = [
+    [
+      {
+        name: 'Stage',
+        autocomplete: [],
+        showInSidebar: false,
+      },
+      {
+        name: 'dev',
+        value: 'dev',
+      },
+    ],
+    [
+      {
+        name: 'Stage',
+        autocomplete: [],
+        showInSidebar: false,
+      },
+      {
+        name: 'production',
+        value: 'production',
+      },
+    ],
+    [
+      {
+        name: 'Service',
+        autocomplete: [],
+        showInSidebar: false,
+      },
+      {
+        name: 'carts',
+        value: 'carts',
+      },
+    ],
+    [
+      {
+        name: 'Sequence',
+        autocomplete: [],
+        showInSidebar: false,
+      },
+      {
+        name: 'delivery',
+        value: 'delivery',
+      },
+    ],
+    [
+      {
+        name: 'Status',
+        autocomplete: [],
+        showInSidebar: false,
+      },
+      {
+        name: 'Active',
+        value: 'started',
+      },
+    ],
+  ];
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AppModule, HttpClientTestingModule],
@@ -205,63 +263,7 @@ describe('KtbEventsListComponent', () => {
 
     // when
     component.filtersClicked({
-      filters: [
-        [
-          {
-            name: 'Stage',
-            autocomplete: [],
-            showInSidebar: false,
-          },
-          {
-            name: 'dev',
-            value: 'dev',
-          },
-        ],
-        [
-          {
-            name: 'Stage',
-            autocomplete: [],
-            showInSidebar: false,
-          },
-          {
-            name: 'production',
-            value: 'production',
-          },
-        ],
-        [
-          {
-            name: 'Service',
-            autocomplete: [],
-            showInSidebar: false,
-          },
-          {
-            name: 'carts',
-            value: 'carts',
-          },
-        ],
-        [
-          {
-            name: 'Sequence',
-            autocomplete: [],
-            showInSidebar: false,
-          },
-          {
-            name: 'delivery',
-            value: 'delivery',
-          },
-        ],
-        [
-          {
-            name: 'Status',
-            autocomplete: [],
-            showInSidebar: false,
-          },
-          {
-            name: 'Active',
-            value: 'started',
-          },
-        ],
-      ],
+      filters: sequenceFilters,
     });
     fixture.detectChanges();
 

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.spec.ts
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.spec.ts
@@ -15,7 +15,7 @@ import moment from 'moment';
 describe('KtbEventsListComponent', () => {
   let component: KtbSequenceViewComponent;
   let fixture: ComponentFixture<KtbSequenceViewComponent>;
-  const queryParams: Subject<{ [p: string]: string | string[] }> = new BehaviorSubject({});
+  const queryParams: Subject<Record<string, string | string[]>> = new BehaviorSubject({});
 
   const projectName = 'sockshop';
 

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.spec.ts
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.spec.ts
@@ -197,7 +197,7 @@ describe('KtbEventsListComponent', () => {
 
   it('should save filters on click, load sequences and filter properly', () => {
     // given
-    /* eslint-disable @typescript-eslint/ban-ts-comment */
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     /* @ts-ignore */ // Ignore private property
     component.project = ProjectsMock[0];
     const spySaveSequenceFilters = jest.spyOn(component, 'saveSequenceFilters');
@@ -277,7 +277,7 @@ describe('KtbEventsListComponent', () => {
 
   it('should set sequence filters from query params', () => {
     // given
-    /* eslint-disable @typescript-eslint/ban-ts-comment */
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     /* @ts-ignore */ // Ignore private property
     component.project = ProjectsMock[0];
     const spySetSequenceFilters = jest.spyOn(component, 'setSequenceFilters');
@@ -304,7 +304,7 @@ describe('KtbEventsListComponent', () => {
 
   it('should load sequence filters from local storage', () => {
     // given
-    /* eslint-disable @typescript-eslint/ban-ts-comment */
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     /* @ts-ignore */ // Ignore private property
     component.project = ProjectsMock[0];
     const spyLoadSequenceFilters = jest.spyOn(component, 'loadSequenceFilters');

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
@@ -325,13 +325,7 @@ export class KtbSequenceViewComponent implements OnInit, OnDestroy {
   filtersClicked(event: DtQuickFilterChangeEvent<any> | { filters: any[] }): void {
     this._seqFilters = event.filters as FilterType[];
     const sequenceFilters: Record<string, string[]> = this._seqFilters.reduce(
-      (
-        filters: Record<string, string[]>,
-        currentFilter: [
-          { name: string; autocomplete: { name: string; value: string }[] },
-          ...{ name: string; value: string }[]
-        ]
-      ) => {
+      (filters: Record<string, string[]>, currentFilter: FilterType) => {
         if (!filters[currentFilter[0].name]) {
           // Stage | Service | Sequence | Status
           filters[currentFilter[0].name] = [];

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
@@ -404,7 +404,7 @@ export class KtbSequenceViewComponent implements OnInit, OnDestroy {
   }
 
   getFilteredSequences(sequences: Sequence[], filters: Record<string, string[]>): Sequence[] {
-    const filterSequence = (s: Sequence) => {
+    const filterSequence = (s: Sequence): boolean => {
       const mapFilter = (key: string): boolean => {
         switch (key) {
           case 'Service':
@@ -414,7 +414,7 @@ export class KtbSequenceViewComponent implements OnInit, OnDestroy {
           case 'Sequence':
             return filters[key].includes(s.name);
           case 'Status':
-            filters[key].includes(s.getStatus());
+            return filters[key].includes(s.getStatus());
           default:
             return true;
         }

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectorRef, Component, HostBinding, Inject, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
+import { Location } from '@angular/common';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import {
   DtQuickFilterChangeEvent,
@@ -113,6 +114,7 @@ export class KtbSequenceViewComponent implements OnInit, OnDestroy {
     private route: ActivatedRoute,
     public dateUtil: DateUtil,
     private router: Router,
+    private location: Location,
     private changeDetectorRef_: ChangeDetectorRef,
     @Inject(POLLING_INTERVAL_MILLIS) private initialDelayMillis: number
   ) {
@@ -248,13 +250,14 @@ export class KtbSequenceViewComponent implements OnInit, OnDestroy {
 
   public selectSequence(event: { sequence: Sequence; stage?: string; eventId?: string }, loadTraces = true): void {
     if (event.eventId) {
-      this.router.navigate(
+      const routeUrl = this.router.createUrlTree(
         ['/project', event.sequence.project, 'sequence', event.sequence.shkeptncontext, 'event', event.eventId],
         { queryParamsHandling: 'preserve' }
       );
+      this.location.go(routeUrl.toString());
     } else {
       const stage = event.stage || event.sequence.getStages().pop();
-      this.router.navigate(
+      const routeUrl = this.router.createUrlTree(
         [
           '/project',
           event.sequence.project,
@@ -264,6 +267,7 @@ export class KtbSequenceViewComponent implements OnInit, OnDestroy {
         ],
         { queryParamsHandling: 'preserve' }
       );
+      this.location.go(routeUrl.toString());
     }
 
     this.currentSequence = event.sequence;
@@ -431,10 +435,12 @@ export class KtbSequenceViewComponent implements OnInit, OnDestroy {
 
   selectStage(stageName: string): void {
     if (this.currentSequence) {
-      this.router.navigate(
+      const routeUrl = this.router.createUrlTree(
         ['/project', this.currentSequence.project, 'sequence', this.currentSequence.shkeptncontext, 'stage', stageName],
         { queryParamsHandling: 'preserve' }
       );
+      this.location.go(routeUrl.toString());
+
       this.selectedStage = stageName;
       this.updateLatestDeployedImage();
     }
@@ -447,10 +453,11 @@ export class KtbSequenceViewComponent implements OnInit, OnDestroy {
 
   public saveSequenceFilters(sequenceFilters: { [p: string]: string[] }): void {
     this.apiService.sequenceFilters = sequenceFilters;
-    this.router.navigate([], {
+    const routeUrl = this.router.createUrlTree([], {
       relativeTo: this.route,
       queryParams: sequenceFilters,
     });
+    this.location.go(routeUrl.toString());
   }
 
   public loadSequenceFilters(): void {

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
@@ -215,7 +215,7 @@ export class KtbSequenceViewComponent implements OnInit, OnDestroy {
 
     this.sequencesUpdated$.pipe(takeUntil(this.unsubscribe$)).subscribe(() => {
       const sequences = this.project?.sequences;
-      if (sequences != undefined) {
+      if (sequences !== undefined) {
         this.updateFilterSequence(sequences);
         this.refreshFilterDataSource();
         // Update filteredSequences based on current filters

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
@@ -277,15 +277,17 @@ export class KtbSequenceViewComponent implements OnInit, OnDestroy {
   }
 
   public updateSequencesData(): void {
-    const sequences = this.project?.sequences;
-    if (sequences !== undefined) {
-      // Update filteredSequences based on current filters
-      this.filteredSequences = this.getFilteredSequences(
-        sequences,
-        this.apiService.getSequenceFilters(this.project?.projectName)
-      );
-      // Set unfinished sequences so that the state updates can be loaded
-      this.unfinishedSequences = sequences.filter((sequence: Sequence) => !sequence.isFinished());
+    if (this.project) {
+      const sequences = this.project.sequences;
+      if (sequences !== undefined) {
+        // Update filteredSequences based on current filters
+        this.filteredSequences = this.getFilteredSequences(
+          sequences,
+          this.apiService.getSequenceFilters(this.project.projectName)
+        );
+        // Set unfinished sequences so that the state updates can be loaded
+        this.unfinishedSequences = sequences.filter((sequence: Sequence) => !sequence.isFinished());
+      }
     }
   }
 
@@ -459,7 +461,9 @@ export class KtbSequenceViewComponent implements OnInit, OnDestroy {
   }
 
   public saveSequenceFilters(sequenceFilters: { [p: string]: string[] }): void {
-    this.apiService.setSequenceFilters(sequenceFilters, this.project?.projectName);
+    if (this.project) {
+      this.apiService.setSequenceFilters(sequenceFilters, this.project.projectName);
+    }
     const routeUrl = this.router.createUrlTree([], {
       relativeTo: this.route,
       queryParams: sequenceFilters,
@@ -468,15 +472,19 @@ export class KtbSequenceViewComponent implements OnInit, OnDestroy {
   }
 
   public loadSequenceFilters(): void {
-    this.router.navigate([], {
-      relativeTo: this.route,
-      queryParams: this.apiService.getSequenceFilters(this.project?.projectName),
-      replaceUrl: true,
-    });
+    if (this.project) {
+      this.router.navigate([], {
+        relativeTo: this.route,
+        queryParams: this.apiService.getSequenceFilters(this.project.projectName),
+        replaceUrl: true,
+      });
+    }
   }
 
   public setSequenceFilters(sequenceFilters: { [p: string]: string[] }): void {
-    this.apiService.setSequenceFilters(sequenceFilters, this.project?.projectName);
+    if (this.project) {
+      this.apiService.setSequenceFilters(sequenceFilters, this.project.projectName);
+    }
     this._seqFilters = Object.keys(sequenceFilters).reduce((_seqFilters: FilterType[], filterName: string) => {
       sequenceFilters[filterName].forEach((value: string) => {
         const name = filterName === 'Status' ? SEQUENCE_STATUS[value] : value;

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
@@ -271,6 +271,8 @@ export class KtbSequenceViewComponent implements OnInit, OnDestroy {
     if (sequences !== undefined) {
       this.updateFilterSequence(sequences);
       this.refreshFilterDataSource();
+      // Needed for the updates to work properly
+      this.changeDetectorRef_.detectChanges();
     }
   }
 

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
@@ -190,7 +190,7 @@ export class KtbSequenceViewComponent implements OnInit, OnDestroy {
       )
       .subscribe(([params]: [Params, void]) => {
         if (params.shkeptncontext && this.project?.sequences) {
-          const sequence = this.project?.sequences.find((s) => s.shkeptncontext === params.shkeptncontext);
+          const sequence = this.project.sequences.find((s) => s.shkeptncontext === params.shkeptncontext);
           const stage = params.eventId ? undefined : params.stage;
           const eventId = params.eventId;
 

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
@@ -299,6 +299,10 @@ export class KtbSequenceViewComponent implements OnInit, OnDestroy {
       },
       {}
     );
+    const filterParams = Object.keys(this.sequenceFilters).reduce((params, key) => {
+      return params.concat(this.sequenceFilters[key].map((value) => [key, value]));
+    }, [] as string[][]);
+    console.log('URLSearchParams', new URLSearchParams(filterParams).toString());
   }
 
   updateFilterSequence(sequences?: Sequence[]): void {

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
@@ -40,7 +40,7 @@ const SEQUENCE_STATUS = {
   failed: 'Failed',
   aborted: 'Aborted',
   succeeded: 'Succeeded',
-} as { [key: string]: string };
+} as Record<string, string>;
 
 @Component({
   selector: 'ktb-sequence-view',
@@ -311,9 +311,9 @@ export class KtbSequenceViewComponent implements OnInit, OnDestroy {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   filtersClicked(event: DtQuickFilterChangeEvent<any> | { filters: any[] }): void {
     this._seqFilters = event.filters as FilterType[];
-    const sequenceFilters: { [key: string]: string[] } = this._seqFilters.reduce(
+    const sequenceFilters: Record<string, string[]> = this._seqFilters.reduce(
       (
-        filters: { [key: string]: string[] },
+        filters: Record<string, string[]>,
         currentFilter: [
           { name: string; autocomplete: { name: string; value: string }[] },
           ...{ name: string; value: string }[]
@@ -400,7 +400,7 @@ export class KtbSequenceViewComponent implements OnInit, OnDestroy {
     this._filterDataSource = new DtQuickFilterDefaultDataSource(this.filterFieldData, this._config);
   }
 
-  getFilteredSequences(sequences: Sequence[], filters: { [key: string]: string[] }): Sequence[] {
+  getFilteredSequences(sequences: Sequence[], filters: Record<string, string[]>): Sequence[] {
     return sequences.filter((s) => {
       let res = true;
       Object.keys(filters).forEach((key) => {

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
@@ -307,7 +307,6 @@ export class KtbSequenceViewComponent implements OnInit, OnDestroy {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   filtersClicked(event: DtQuickFilterChangeEvent<any> | { filters: any[] }): void {
     this._seqFilters = event.filters as FilterType[];
-    console.log('_seqFilters', this._seqFilters);
     const sequenceFilters: { [key: string]: string[] } = this._seqFilters.reduce(
       (
         filters: { [key: string]: string[] },

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
@@ -212,6 +212,7 @@ export class KtbSequenceViewComponent implements OnInit, OnDestroy {
     this.sequencesUpdated$.pipe(takeUntil(this.unsubscribe$)).subscribe(() => {
       this.loading = false;
       this.updateSequenceView();
+      this.updateSequencesData();
     });
 
     this.route.queryParams.pipe(takeUntil(this.unsubscribe$)).subscribe((queryParams) => {
@@ -270,6 +271,12 @@ export class KtbSequenceViewComponent implements OnInit, OnDestroy {
     if (sequences !== undefined) {
       this.updateFilterSequence(sequences);
       this.refreshFilterDataSource();
+    }
+  }
+
+  public updateSequencesData(): void {
+    const sequences = this.project?.sequences;
+    if (sequences !== undefined) {
       // Update filteredSequences based on current filters
       this.filteredSequences = this.getFilteredSequences(
         sequences,
@@ -277,8 +284,6 @@ export class KtbSequenceViewComponent implements OnInit, OnDestroy {
       );
       // Set unfinished sequences so that the state updates can be loaded
       this.unfinishedSequences = sequences.filter((sequence: Sequence) => !sequence.isFinished());
-      // Needed for the updates to work properly
-      this.changeDetectorRef_.detectChanges();
     }
   }
 
@@ -333,7 +338,7 @@ export class KtbSequenceViewComponent implements OnInit, OnDestroy {
       {}
     );
     this.saveSequenceFilters(sequenceFilters);
-    this.updateSequenceView();
+    this.updateSequencesData();
   }
 
   updateFilterSequence(sequences?: Sequence[]): void {
@@ -486,7 +491,7 @@ export class KtbSequenceViewComponent implements OnInit, OnDestroy {
       return _seqFilters;
     }, []);
 
-    this.updateSequenceView();
+    this.updateSequencesData();
   }
 
   loadOldSequences(): void {

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
@@ -404,28 +404,26 @@ export class KtbSequenceViewComponent implements OnInit, OnDestroy {
   }
 
   getFilteredSequences(sequences: Sequence[], filters: Record<string, string[]>): Sequence[] {
-    return sequences.filter((s) => {
-      let res = true;
-      Object.keys(filters).forEach((key) => {
+    const filterSequence = (s: Sequence) => {
+      const mapFilter = (key: string): boolean => {
         switch (key) {
           case 'Service':
-            res = res && filters[key].includes(s.service);
-            break;
+            return filters[key].includes(s.service);
           case 'Stage':
-            res = res && filters[key].every((f) => s.getStages().includes(f));
-            break;
+            return filters[key].every((f) => s.getStages().includes(f));
           case 'Sequence':
-            res = res && filters[key].includes(s.name);
-            break;
+            return filters[key].includes(s.name);
           case 'Status':
-            res = res && filters[key].includes(s.getStatus());
-            break;
+            filters[key].includes(s.getStatus());
           default:
-            break;
+            return true;
         }
-      });
-      return res;
-    });
+      };
+      const reduceFilter = (prior: boolean, current: boolean): boolean => prior && current;
+      return Object.keys(filters).map(mapFilter).reduce(reduceFilter, true);
+    };
+
+    return sequences.filter(filterSequence);
   }
 
   public getTracesLastUpdated(sequence: Sequence): Date | undefined {

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
@@ -489,6 +489,10 @@ export class KtbSequenceViewComponent implements OnInit, OnDestroy {
       });
       return _seqFilters;
     }, []);
+
+    if (this.project) {
+      this.dataService.loadSequences(this.project);
+    }
   }
 
   ngOnDestroy(): void {

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
@@ -464,6 +464,7 @@ export class KtbSequenceViewComponent implements OnInit, OnDestroy {
     this.router.navigate([], {
       relativeTo: this.route,
       queryParams: this.apiService.sequenceFilters,
+      replaceUrl: true,
     });
   }
 

--- a/bridge/client/app/app-header/app-header.component.ts
+++ b/bridge/client/app/app-header/app-header.component.ts
@@ -206,7 +206,7 @@ export class AppHeaderComponent implements OnInit, OnDestroy {
   }
 
   setProject(): void {
-    const urlPieces = this.router.url.split('/');
+    const urlPieces = this.router.url.split('?')[0].split('/');
     if (urlPieces[1] === 'project') {
       this.selectedProject = urlPieces[2];
 

--- a/bridge/cypress/fixtures/sequences-page-2.sockshop.json
+++ b/bridge/cypress/fixtures/sequences-page-2.sockshop.json
@@ -1,0 +1,274 @@
+{
+  "states": [
+    {
+      "name": "evaluation",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2021-07-06T09:21:43.659Z",
+      "shkeptncontext": "88d5f9c0-1e2c-474b-af27-13fe12e038a7",
+      "state": "finished",
+      "stages": [
+        {
+          "name": "staging",
+          "latestEvaluation": {
+            "result": "fail",
+            "score": 66.66666666666666
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.staging.evaluation.finished",
+            "id": "16614663-aea7-4420-bafe-41f480b572d8",
+            "time": "2021-07-06T09:21:53.145Z"
+          },
+          "latestFailedEvent": {
+            "type": "sh.keptn.event.staging.evaluation.finished",
+            "id": "16614663-aea7-4420-bafe-41f480b572d8",
+            "time": "2021-07-06T09:21:53.145Z"
+          }
+        }
+      ]
+    },
+    {
+      "name": "evaluation",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2021-07-06T09:13:00.939Z",
+      "shkeptncontext": "f83f1f12-4601-4fbd-a6f7-304458e5442c",
+      "state": "finished",
+      "stages": [
+        {
+          "name": "staging",
+          "latestEvaluation": {
+            "result": "fail",
+            "score": 66.66666666666666
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.staging.evaluation.finished",
+            "id": "10643917-00cc-46da-873b-5254626663cd",
+            "time": "2021-07-06T09:13:13.942Z"
+          },
+          "latestFailedEvent": {
+            "type": "sh.keptn.event.staging.evaluation.finished",
+            "id": "10643917-00cc-46da-873b-5254626663cd",
+            "time": "2021-07-06T09:13:13.942Z"
+          }
+        }
+      ]
+    },
+    {
+      "name": "evaluation",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2021-07-06T09:10:45.712Z",
+      "shkeptncontext": "714397cc-e648-474f-bd6e-fa79463691d3",
+      "state": "finished",
+      "stages": [
+        {
+          "name": "staging",
+          "latestEvaluation": {
+            "result": "fail",
+            "score": 66.66666666666666
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.staging.evaluation.finished",
+            "id": "e5cf45e4-b8f0-48a9-8cdb-ec0ee3ea0219",
+            "time": "2021-07-06T09:10:55.248Z"
+          },
+          "latestFailedEvent": {
+            "type": "sh.keptn.event.staging.evaluation.finished",
+            "id": "e5cf45e4-b8f0-48a9-8cdb-ec0ee3ea0219",
+            "time": "2021-07-06T09:10:55.248Z"
+          }
+        }
+      ]
+    },
+    {
+      "name": "evaluation",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2021-07-06T09:02:09.612Z",
+      "shkeptncontext": "5b8d8f9c-faba-43f2-9c87-fc0b69d6fc3e",
+      "state": "finished",
+      "stages": [
+        {
+          "name": "staging",
+          "latestEvaluation": {
+            "result": "pass",
+            "score": 100
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.staging.evaluation.finished",
+            "id": "ec195981-f095-4f7b-9568-be9ca0fe18c5",
+            "time": "2021-07-06T09:02:26.842Z"
+          }
+        }
+      ]
+    },
+    {
+      "name": "evaluation",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2021-07-06T09:02:06.635Z",
+      "shkeptncontext": "d229e6f9-573b-4d07-8d08-b2502cb8c320",
+      "state": "finished",
+      "stages": [
+        {
+          "name": "staging",
+          "latestEvaluation": {
+            "result": "pass",
+            "score": 100
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.staging.evaluation.finished",
+            "id": "4a3bd7d7-a786-4e36-a781-a1b22e06b556",
+            "time": "2021-07-06T09:02:23.043Z"
+          }
+        }
+      ]
+    },
+    {
+      "name": "evaluation",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2021-07-06T09:01:40.989Z",
+      "shkeptncontext": "450e8156-ac3e-4e76-89f9-364a92faef3a",
+      "state": "finished",
+      "stages": [
+        {
+          "name": "staging",
+          "latestEvaluation": {
+            "result": "fail",
+            "score": 66.66666666666666
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.staging.evaluation.finished",
+            "id": "46fc0a0d-739e-4101-b043-bad09399bf70",
+            "time": "2021-07-06T09:01:50.662Z"
+          },
+          "latestFailedEvent": {
+            "type": "sh.keptn.event.staging.evaluation.finished",
+            "id": "46fc0a0d-739e-4101-b043-bad09399bf70",
+            "time": "2021-07-06T09:01:50.662Z"
+          }
+        }
+      ]
+    },
+    {
+      "name": "evaluation",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2021-07-06T08:59:04.719Z",
+      "shkeptncontext": "bd41e3fe-edbd-4245-8d18-93433143ac7f",
+      "state": "finished",
+      "stages": [
+        {
+          "name": "staging",
+          "latestEvaluation": {
+            "result": "pass",
+            "score": 100
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.staging.evaluation.finished",
+            "id": "31d7a31f-acb7-4f2b-820f-ee387d4f187d",
+            "time": "2021-07-06T08:59:14.340Z"
+          }
+        }
+      ]
+    },
+    {
+      "name": "evaluation",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2021-07-06T08:58:36.662Z",
+      "shkeptncontext": "9a7eaa00-1019-41e5-be3a-441738338cf4",
+      "state": "finished",
+      "stages": [
+        {
+          "name": "staging",
+          "latestEvaluation": {
+            "result": "fail",
+            "score": 66.66666666666666
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.staging.evaluation.finished",
+            "id": "993ec5e5-c3e2-4515-8bf0-f9be93f77125",
+            "time": "2021-07-06T08:58:45.965Z"
+          },
+          "latestFailedEvent": {
+            "type": "sh.keptn.event.staging.evaluation.finished",
+            "id": "993ec5e5-c3e2-4515-8bf0-f9be93f77125",
+            "time": "2021-07-06T08:58:45.965Z"
+          }
+        }
+      ]
+    },
+    {
+      "name": "evaluation",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2021-07-06T08:57:38.264Z",
+      "shkeptncontext": "238e1c43-501a-4a7f-a725-802cf36e16f5",
+      "state": "finished",
+      "stages": [
+        {
+          "name": "staging",
+          "latestEvaluation": {
+            "result": "fail",
+            "score": 66.66666666666666
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.staging.evaluation.finished",
+            "id": "a6222bca-2619-48ea-933e-d4f2fbf97937",
+            "time": "2021-07-06T08:57:48.047Z"
+          },
+          "latestFailedEvent": {
+            "type": "sh.keptn.event.staging.evaluation.finished",
+            "id": "a6222bca-2619-48ea-933e-d4f2fbf97937",
+            "time": "2021-07-06T08:57:48.047Z"
+          }
+        }
+      ]
+    },
+    {
+      "name": "delivery",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2021-07-06T08:13:53.766Z",
+      "shkeptncontext": "1663de8a-a414-47ba-9566-10a9730f406f",
+      "state": "finished",
+      "stages": [
+        {
+          "name": "dev",
+          "image": "docker.io/keptnexamples/carts:0.12.3",
+          "latestEvaluation": {
+            "result": "pass",
+            "score": 0
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.dev.delivery.finished",
+            "id": "92207803-7d49-4081-ad0a-897e3f4229d2",
+            "time": "2021-07-06T08:17:42.285Z"
+          }
+        },
+        {
+          "name": "staging",
+          "image": "docker.io/keptnexamples/carts:0.12.3",
+          "latestEvaluation": {
+            "result": "fail",
+            "score": 33.33333333333333
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.staging.rollback.finished",
+            "id": "d23e5ed6-0025-4273-bc7f-09ff94eab160",
+            "time": "2021-07-06T08:22:47.310Z"
+          },
+          "latestFailedEvent": {
+            "type": "sh.keptn.event.staging.delivery.finished",
+            "id": "26d927cd-274e-406d-bb40-d7a47a553632",
+            "time": "2021-07-06T08:22:36.842Z"
+          }
+        }
+      ]
+    }
+  ],
+  "totalCount": 15
+}

--- a/bridge/cypress/fixtures/sequences-page-3.sockshop.json
+++ b/bridge/cypress/fixtures/sequences-page-3.sockshop.json
@@ -1,0 +1,158 @@
+{
+  "states": [
+    {
+      "name": "delivery",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2021-07-06T08:04:16.338Z",
+      "shkeptncontext": "26d6fbd3-42e5-4ec7-9f22-4fd102a2e414",
+      "state": "finished",
+      "stages": [
+        {
+          "name": "dev",
+          "image": "docker.io/keptnexamples/carts:0.12.1",
+          "latestEvaluation": {
+            "result": "pass",
+            "score": 0
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.dev.delivery.finished",
+            "id": "a3ba36e1-2edb-419f-8a24-d624e2100d43",
+            "time": "2021-07-06T08:07:55.662Z"
+          }
+        },
+        {
+          "name": "staging",
+          "image": "docker.io/keptnexamples/carts:0.12.1",
+          "latestEvaluation": {
+            "result": "fail",
+            "score": 33.33333333333333
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.staging.rollback.finished",
+            "id": "9892abf9-0528-4108-834c-47f98dc6caa2",
+            "time": "2021-07-06T08:12:57.479Z"
+          },
+          "latestFailedEvent": {
+            "type": "sh.keptn.event.staging.delivery.finished",
+            "id": "9693825e-b6d7-43a3-97ee-d136ed3f03c3",
+            "time": "2021-07-06T08:12:47.145Z"
+          }
+        }
+      ]
+    },
+    {
+      "name": "delivery",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2021-07-06T07:50:28.004Z",
+      "shkeptncontext": "29761b1a-374f-4bb1-b5ab-3e9d809b6108",
+      "state": "finished",
+      "stages": [
+        {
+          "name": "dev",
+          "image": "docker.io/keptnexamples/carts:0.12.3",
+          "latestEvaluation": {
+            "result": "pass",
+            "score": 0
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.dev.delivery.finished",
+            "id": "fbb56094-9ef7-45df-bc4e-525202e4c302",
+            "time": "2021-07-06T07:54:21.353Z"
+          }
+        },
+        {
+          "name": "staging",
+          "image": "docker.io/keptnexamples/carts:0.12.3",
+          "latestEvaluation": {
+            "result": "fail",
+            "score": 33.33333333333333
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.staging.rollback.finished",
+            "id": "c5f88cd1-7efb-4f24-b0b3-eb5998a9d00d",
+            "time": "2021-07-06T07:59:12.673Z"
+          },
+          "latestFailedEvent": {
+            "type": "sh.keptn.event.staging.delivery.finished",
+            "id": "40dc9d08-f87a-4785-a037-7d76a9745a0c",
+            "time": "2021-07-06T07:58:58.241Z"
+          }
+        }
+      ]
+    },
+    {
+      "name": "evaluation",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2021-07-05T14:12:15.566Z",
+      "shkeptncontext": "dda949d7-81e8-43db-a002-b736c2d27843",
+      "state": "finished",
+      "stages": [
+        {
+          "name": "testing",
+          "latestEvaluation": {
+            "result": "pass",
+            "score": 100
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.staging.evaluation.finished",
+            "id": "4b7e9733-46d2-44a5-aadc-709e881d6403",
+            "time": "2021-07-05T14:12:25.169Z"
+          }
+        }
+      ]
+    },
+    {
+      "name": "evaluation",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2021-07-05T13:47:23.145Z",
+      "shkeptncontext": "23e404ee-e9ab-4e06-a97f-6408854e6553",
+      "state": "finished",
+      "stages": [
+        {
+          "name": "staging",
+          "latestEvaluation": {
+            "result": "pass",
+            "score": 100
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.staging.evaluation.finished",
+            "id": "bbed850c-8c43-431e-86b0-0cffbc0f938f",
+            "time": "2021-07-05T13:47:32.749Z"
+          }
+        }
+      ]
+    },
+    {
+      "name": "evaluation",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2021-07-05T13:35:36.482Z",
+      "shkeptncontext": "7a5127e2-8dc0-4d85-9046-450ef054484b",
+      "state": "finished",
+      "stages": [
+        {
+          "name": "staging",
+          "latestEvaluation": {
+            "result": "fail",
+            "score": 66.66666666666666
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.staging.evaluation.finished",
+            "id": "074fe4e5-af9d-41fb-ac7e-92e7e8c4e0a3",
+            "time": "2021-07-05T13:35:45.947Z"
+          },
+          "latestFailedEvent": {
+            "type": "sh.keptn.event.staging.evaluation.finished",
+            "id": "074fe4e5-af9d-41fb-ac7e-92e7e8c4e0a3",
+            "time": "2021-07-05T13:35:45.947Z"
+          }
+        }
+      ]
+    }
+  ],
+  "totalCount": 5
+}

--- a/bridge/cypress/fixtures/sequences.sockshop.json
+++ b/bridge/cypress/fixtures/sequences.sockshop.json
@@ -4,6 +4,53 @@
       "name": "delivery",
       "service": "carts",
       "project": "sockshop",
+      "time": "2022-04-11T11:17:43.292Z",
+      "shkeptncontext": "99a20ef4-d822-4185-bbee-0d7a364c213a",
+      "state": "started",
+      "stages": [
+        {
+          "name": "dev",
+          "image": "docker.io/keptnexamples/carts:0.13.1",
+          "state": "succeeded",
+          "latestEvaluation": {
+            "result": "pass",
+            "score": 0
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.dev.delivery.finished",
+            "id": "0e1785ec-9282-4df7-a3f6-be70a2bdae65",
+            "time": "2022-04-11T11:20:16.969Z"
+          }
+        },
+        {
+          "name": "staging",
+          "image": "docker.io/keptnexamples/carts:0.13.1",
+          "state": "succeeded",
+          "latestEvaluation": {
+            "result": "pass",
+            "score": 0
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.staging.delivery.finished",
+            "id": "88a0c85d-b9b9-4b7f-8fba-45d7a1ab612f",
+            "time": "2022-04-11T11:25:19.182Z"
+          }
+        },
+        {
+          "name": "production",
+          "state": "triggered",
+          "latestEvent": {
+            "type": "sh.keptn.event.approval.started",
+            "id": "f4f767de-712c-4564-938e-eb6736e03cbf",
+            "time": "2022-04-11T11:25:24.009Z"
+          }
+        }
+      ]
+    },
+    {
+      "name": "delivery",
+      "service": "carts",
+      "project": "sockshop",
       "time": "2022-01-10T15:33:59.105Z",
       "shkeptncontext": "62cca6f3-dc54-4df6-a04c-6ffc894a4b5e",
       "state": "finished",

--- a/bridge/cypress/fixtures/sequences.sockshop.json
+++ b/bridge/cypress/fixtures/sequences.sockshop.json
@@ -212,7 +212,623 @@
           "state": "waiting"
         }
       ]
+    },
+    {
+      "name": "delivery",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2022-04-11T11:17:43.292Z",
+      "shkeptncontext": "99a20ef4-d822-4185-bbee-0d7a364c213b",
+      "state": "started",
+      "stages": [
+        {
+          "name": "dev",
+          "image": "docker.io/keptnexamples/carts:0.13.1",
+          "state": "succeeded",
+          "latestEvaluation": {
+            "result": "pass",
+            "score": 0
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.dev.delivery.finished",
+            "id": "0e1785ec-9282-4df7-a3f6-be70a2bdae65",
+            "time": "2022-04-11T11:20:16.969Z"
+          }
+        },
+        {
+          "name": "staging",
+          "image": "docker.io/keptnexamples/carts:0.13.1",
+          "state": "succeeded",
+          "latestEvaluation": {
+            "result": "pass",
+            "score": 0
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.staging.delivery.finished",
+            "id": "88a0c85d-b9b9-4b7f-8fba-45d7a1ab612f",
+            "time": "2022-04-11T11:25:19.182Z"
+          }
+        },
+        {
+          "name": "production",
+          "state": "triggered",
+          "latestEvent": {
+            "type": "sh.keptn.event.approval.started",
+            "id": "f4f767de-712c-4564-938e-eb6736e03cbf",
+            "time": "2022-04-11T11:25:24.009Z"
+          }
+        }
+      ]
+    },
+    {
+      "name": "delivery",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2021-08-02T08:00:21.813Z",
+      "shkeptncontext": "80f87047-d5c2-4b3e-8aac-f376ff309ed5",
+      "state": "finished",
+      "stages": [
+        {
+          "name": "dev",
+          "state": "finished",
+          "image": "docker.io/keptnexamples/carts:0.12.1",
+          "latestEvent": {
+            "type": "sh.keptn.event.dev.delivery.finished",
+            "id": "852ab5f7-c9c1-4ef9-93b1-3394219b8009",
+            "time": "2021-08-02T08:03:29.173Z"
+          },
+          "latestFailedEvent": {
+            "type": "sh.keptn.event.dev.delivery.finished",
+            "id": "852ab5f7-c9c1-4ef9-93b1-3394219b8009",
+            "time": "2021-08-02T08:03:29.173Z"
+          }
+        }
+      ]
+    },
+    {
+      "name": "remediation",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2021-07-31T00:09:15.891Z",
+      "shkeptncontext": "2d343931-3339-4134-b234-333831333236",
+      "state": "finished",
+      "stages": [
+        {
+          "name": "production",
+          "latestEvent": {
+            "type": "sh.keptn.event.production.remediation.finished",
+            "id": "64e1e73c-974d-43e9-91d1-82d916a9be1a",
+            "time": "2021-07-31T00:09:17.950Z"
+          },
+          "latestFailedEvent": {
+            "type": "sh.keptn.event.production.remediation.finished",
+            "id": "64e1e73c-974d-43e9-91d1-82d916a9be1a",
+            "time": "2021-07-31T00:09:17.950Z"
+          }
+        }
+      ]
+    },
+    {
+      "name": "delivery",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2021-07-28T11:43:04.585Z",
+      "shkeptncontext": "722782ba-5ad9-4d8b-a79a-a38c27ea40f1",
+      "state": "finished",
+      "stages": [
+        {
+          "name": "dev",
+          "image": "docker.io/keptnexamples/carts:0.12.1",
+          "latestEvent": {
+            "type": "sh.keptn.event.dev.delivery.finished",
+            "id": "c742ee26-0a90-40ae-9f72-7707366e2922",
+            "time": "2021-07-28T11:46:09.450Z"
+          },
+          "latestFailedEvent": {
+            "type": "sh.keptn.event.dev.delivery.finished",
+            "id": "c742ee26-0a90-40ae-9f72-7707366e2922",
+            "time": "2021-07-28T11:46:09.450Z"
+          }
+        }
+      ]
+    },
+    {
+      "name": "delivery",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2021-07-28T11:38:00.783Z",
+      "shkeptncontext": "75dfd139-2dd3-41df-8dc1-0cb3426f4506",
+      "state": "paused",
+      "stages": [
+        {
+          "name": "dev",
+          "image": "docker.io/keptnexamples/carts:0.12.1",
+          "latestEvent": {
+            "type": "sh.keptn.event.dev.delivery.finished",
+            "id": "b0679db1-9830-481e-bd99-90f09dfcba89",
+            "time": "2021-07-28T11:41:09.547Z"
+          },
+          "latestFailedEvent": {
+            "type": "sh.keptn.event.dev.delivery.finished",
+            "id": "b0679db1-9830-481e-bd99-90f09dfcba89",
+            "time": "2021-07-28T11:41:09.547Z"
+          }
+        }
+      ]
+    },
+    {
+      "name": "remediation",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2021-07-15T19:23:15.121Z",
+      "shkeptncontext": "2d313534-3438-4536-b731-393431363639",
+      "state": "triggered",
+      "stages": [
+        {
+          "name": "dev",
+          "latestEvent": {
+            "type": "sh.keptn.event.dev.remediation.triggered",
+            "id": "744763a9-697d-4ebe-afd4-2fb0c518b9d2",
+            "time": "2021-07-15T19:23:15.121Z"
+          }
+        }
+      ]
+    },
+    {
+      "name": "remediation",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2021-07-15T15:23:16.573Z",
+      "shkeptncontext": "2d383636-3132-4632-b133-323636343331",
+      "state": "triggered",
+      "stages": [
+        {
+          "name": "dev",
+          "latestEvent": {
+            "type": "sh.keptn.events.problem",
+            "id": "8f446a88-0012-4fad-a483-c4d4c736a8c6",
+            "time": "2021-07-15T19:26:15.640Z"
+          }
+        }
+      ]
+    },
+    {
+      "name": "delivery",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2021-07-15T15:11:20.113Z",
+      "shkeptncontext": "007649c6-a704-4c21-9ad1-add9bbf20941",
+      "state": "finished",
+      "stages": [
+        {
+          "name": "dev",
+          "image": "docker.io/keptnexamples/carts:0.12.1",
+          "latestEvaluation": {
+            "result": "pass",
+            "score": 0
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.dev.delivery.finished",
+            "id": "b066e786-53a2-4eea-95af-dfba709f8a27",
+            "time": "2021-07-15T15:15:17.187Z"
+          }
+        },
+        {
+          "name": "staging",
+          "image": "docker.io/keptnexamples/carts:0.12.1",
+          "latestEvent": {
+            "type": "sh.keptn.event.staging.rollback.finished",
+            "id": "0e990b0a-97f1-4d31-9249-97d721603d33",
+            "time": "2021-07-15T15:21:36.128Z"
+          },
+          "latestFailedEvent": {
+            "type": "sh.keptn.event.staging.rollback.finished",
+            "id": "0e990b0a-97f1-4d31-9249-97d721603d33",
+            "time": "2021-07-15T15:21:36.128Z"
+          }
+        }
+      ]
+    },
+    {
+      "name": "delivery",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2021-07-15T12:20:24.826Z",
+      "shkeptncontext": "d4165d39-e686-46ef-bf5b-d9edcb375e10",
+      "state": "finished",
+      "stages": [
+        {
+          "name": "dev",
+          "image": "docker.io/keptnexamples/carts:0.12.3",
+          "latestEvaluation": {
+            "result": "pass",
+            "score": 0
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.dev.delivery.finished",
+            "id": "ce06258d-070e-46b8-99f2-d5206c7c4fff",
+            "time": "2021-07-15T12:24:10.497Z"
+          }
+        },
+        {
+          "name": "staging",
+          "image": "docker.io/keptnexamples/carts:0.12.3",
+          "latestEvent": {
+            "type": "sh.keptn.event.staging.rollback.finished",
+            "id": "eb1e88c7-50f6-4e05-971e-4436e2faf82c",
+            "time": "2021-07-15T12:30:22.034Z"
+          },
+          "latestFailedEvent": {
+            "type": "sh.keptn.event.staging.rollback.finished",
+            "id": "eb1e88c7-50f6-4e05-971e-4436e2faf82c",
+            "time": "2021-07-15T12:30:22.034Z"
+          }
+        }
+      ]
+    },
+    {
+      "name": "delivery",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2021-07-15T11:58:51.729Z",
+      "shkeptncontext": "e28592c6-d857-44fe-aea6-e65de02929bf",
+      "state": "finished",
+      "stages": [
+        {
+          "name": "dev",
+          "image": "docker.io/keptnexamples/carts:0.12.3",
+          "latestEvaluation": {
+            "result": "pass",
+            "score": 0
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.dev.delivery.finished",
+            "id": "0838ff2c-f736-41f1-9d7e-5e420f07830d",
+            "time": "2021-07-15T12:02:45.561Z"
+          }
+        },
+        {
+          "name": "staging",
+          "image": "docker.io/keptnexamples/carts:0.12.3",
+          "latestEvaluation": {
+            "result": "pass",
+            "score": 0
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.staging.rollback.finished",
+            "id": "5d16ec19-e0ef-453d-b312-03e5988a0905",
+            "time": "2021-07-15T12:13:40.942Z"
+          },
+          "latestFailedEvent": {
+            "type": "sh.keptn.event.staging.rollback.finished",
+            "id": "5d16ec19-e0ef-453d-b312-03e5988a0905",
+            "time": "2021-07-15T12:13:40.942Z"
+          }
+        }
+      ]
+    },
+    {
+      "name": "delivery",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2021-07-13T11:28:56.573Z",
+      "shkeptncontext": "8657fcab-7fd6-4e7a-98a6-e22fea3be97e",
+      "state": "finished",
+      "stages": [
+        {
+          "name": "dev",
+          "image": "docker.io/keptnexamples/carts:0.12.1",
+          "latestEvaluation": {
+            "result": "pass",
+            "score": 0
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.dev.delivery.finished",
+            "id": "1089b1cb-ca34-4203-8a72-ae2a52961689",
+            "time": "2021-07-13T11:32:47.062Z"
+          }
+        },
+        {
+          "name": "staging",
+          "image": "docker.io/keptnexamples/carts:0.12.1",
+          "latestEvaluation": {
+            "result": "pass",
+            "score": 0
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.staging.delivery.finished",
+            "id": "b2de8b58-c717-4c6f-be6c-6375a602713d",
+            "time": "2021-07-13T11:39:00.165Z"
+          }
+        },
+        {
+          "name": "production",
+          "image": "docker.io/keptnexamples/carts:0.12.1",
+          "latestEvent": {
+            "type": "sh.keptn.event.production.delivery.finished",
+            "id": "d91c4870-b95c-4ef0-944e-19ccafd4b23d",
+            "time": "2021-07-13T11:41:58.250Z"
+          }
+        }
+      ]
+    },
+    {
+      "name": "delivery-direct",
+      "service": "carts-db",
+      "project": "sockshop",
+      "time": "2021-07-13T06:56:12.168Z",
+      "shkeptncontext": "57c4b0ac-1756-4da8-9f8b-7cf3515a8b13",
+      "state": "finished",
+      "stages": [
+        {
+          "name": "dev",
+          "image": "docker.io/mongo:4.2.2",
+          "latestEvent": {
+            "type": "sh.keptn.event.dev.delivery-direct.finished",
+            "id": "c28f8ed8-4b13-47bd-98d5-c0e43eb5df1a",
+            "time": "2021-07-13T06:56:20.174Z"
+          }
+        },
+        {
+          "name": "staging",
+          "image": "docker.io/mongo:4.2.2",
+          "latestEvent": {
+            "type": "sh.keptn.event.staging.delivery-direct.finished",
+            "id": "867ded48-14a8-4848-8a52-d9655973a94a",
+            "time": "2021-07-13T06:56:30.369Z"
+          }
+        },
+        {
+          "name": "production",
+          "image": "docker.io/mongo:4.2.2",
+          "latestEvent": {
+            "type": "sh.keptn.event.production.delivery-direct.finished",
+            "id": "3d06b4f7-a5e7-43b2-83b3-b3ec68ad6aea",
+            "time": "2021-07-13T06:56:40.267Z"
+          }
+        }
+      ]
+    },
+    {
+      "name": "delivery",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2021-07-12T11:40:09.871Z",
+      "shkeptncontext": "0073b17b-c614-4d0a-9757-b4b93019e1a2",
+      "state": "finished",
+      "stages": [
+        {
+          "name": "dev",
+          "image": "docker.io/keptnexamples/carts:0.12.1",
+          "latestEvaluation": {
+            "result": "pass",
+            "score": 0
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.dev.delivery.finished",
+            "id": "a42319cc-c1ff-48c1-8582-d2978a3048f3",
+            "time": "2021-07-12T11:43:53.484Z"
+          }
+        },
+        {
+          "name": "staging",
+          "image": "docker.io/keptnexamples/carts:0.12.1",
+          "latestEvaluation": {
+            "result": "fail",
+            "score": 33.33333333333333
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.staging.rollback.finished",
+            "id": "e8b00713-8e2e-439e-9150-bdcbf1dc6131",
+            "time": "2021-07-12T11:48:46.208Z"
+          },
+          "latestFailedEvent": {
+            "type": "sh.keptn.event.staging.delivery.finished",
+            "id": "a8ee31d1-629e-4f3c-8211-0d42e32aa6e2",
+            "time": "2021-07-12T11:48:35.575Z"
+          }
+        }
+      ]
+    },
+    {
+      "name": "delivery",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2021-07-12T11:17:04.414Z",
+      "shkeptncontext": "0fca7c48-106f-47ff-a23c-caa9724645e4",
+      "state": "finished",
+      "stages": [
+        {
+          "name": "dev",
+          "image": "docker.io/keptnexamples/carts:0.12.2",
+          "latestEvaluation": {
+            "result": "pass",
+            "score": 0
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.dev.delivery.finished",
+            "id": "fb1fec26-0b0b-4ddd-83e7-0c6a74838f13",
+            "time": "2021-07-12T11:20:50.481Z"
+          }
+        },
+        {
+          "name": "staging",
+          "image": "docker.io/keptnexamples/carts:0.12.2",
+          "latestEvaluation": {
+            "result": "fail",
+            "score": 0
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.staging.rollback.finished",
+            "id": "e6d53765-4e00-42e0-b428-dc39b8bff019",
+            "time": "2021-07-12T11:31:35.387Z"
+          },
+          "latestFailedEvent": {
+            "type": "sh.keptn.event.staging.delivery.finished",
+            "id": "85581bab-2f86-4d8f-b1bf-3bcefa9be5c6",
+            "time": "2021-07-12T11:31:24.658Z"
+          }
+        }
+      ]
+    },
+    {
+      "name": "delivery",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2021-07-12T11:04:59.465Z",
+      "shkeptncontext": "67af8b62-6cea-48ca-9a42-81dceab3fa69",
+      "state": "finished",
+      "stages": [
+        {
+          "name": "dev",
+          "image": "docker.io/keptnexamples/carts:0.12.1",
+          "latestEvaluation": {
+            "result": "pass",
+            "score": 0
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.dev.delivery.finished",
+            "id": "76b3c992-3c67-493e-883b-95041a7e7dd8",
+            "time": "2021-07-12T11:08:51.261Z"
+          }
+        },
+        {
+          "name": "staging",
+          "image": "docker.io/keptnexamples/carts:0.12.1",
+          "latestEvaluation": {
+            "result": "fail",
+            "score": 33.33333333333333
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.staging.rollback.finished",
+            "id": "838c152d-8d3c-4726-a1f8-3227e7e8a724",
+            "time": "2021-07-12T11:13:44.653Z"
+          },
+          "latestFailedEvent": {
+            "type": "sh.keptn.event.staging.delivery.finished",
+            "id": "1872fa32-0295-45cd-b79e-f3f7e17427bb",
+            "time": "2021-07-12T11:13:34.253Z"
+          }
+        }
+      ]
+    },
+    {
+      "name": "delivery",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2021-07-12T10:52:41.635Z",
+      "shkeptncontext": "27f03034-ab6c-4679-ba4f-6592a86fb823",
+      "state": "finished",
+      "stages": [
+        {
+          "name": "dev",
+          "image": "docker.io/keptnexamples/carts:0.12.3",
+          "latestEvaluation": {
+            "result": "pass",
+            "score": 0
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.dev.delivery.finished",
+            "id": "07f71278-1d98-4abe-aafa-026819d65d69",
+            "time": "2021-07-12T10:56:31.864Z"
+          }
+        },
+        {
+          "name": "staging",
+          "image": "docker.io/keptnexamples/carts:0.12.3",
+          "latestEvaluation": {
+            "result": "fail",
+            "score": 33.33333333333333
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.staging.rollback.finished",
+            "id": "1e445c95-f6c6-4713-9ac8-0389e4abd0c6",
+            "time": "2021-07-12T11:02:13.051Z"
+          },
+          "latestFailedEvent": {
+            "type": "sh.keptn.event.staging.delivery.finished",
+            "id": "3d2d3f1b-752e-4513-a185-f01afe3355d3",
+            "time": "2021-07-12T11:02:00.354Z"
+          }
+        }
+      ]
+    },
+    {
+      "name": "evaluation",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2021-07-06T09:25:10.147Z",
+      "shkeptncontext": "5e8d9270-0701-42a2-b7c3-6d5b9aaef9e8",
+      "state": "finished",
+      "stages": [
+        {
+          "name": "staging",
+          "latestEvaluation": {
+            "result": "pass",
+            "score": 100
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.staging.evaluation.finished",
+            "id": "4953c64b-314d-45a0-ab5e-a74d9b47b24e",
+            "time": "2021-07-06T09:25:20.242Z"
+          }
+        }
+      ]
+    },
+    {
+      "name": "evaluation",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2021-07-06T09:24:42.020Z",
+      "shkeptncontext": "2f8fce31-3513-4931-bb3d-fa8fc470334c",
+      "state": "finished",
+      "stages": [
+        {
+          "name": "staging",
+          "latestEvaluation": {
+            "result": "fail",
+            "score": 66.66666666666666
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.staging.evaluation.finished",
+            "id": "99b80add-8f24-4259-b52e-e3a0eac74fd3",
+            "time": "2021-07-06T09:24:51.353Z"
+          },
+          "latestFailedEvent": {
+            "type": "sh.keptn.event.staging.evaluation.finished",
+            "id": "99b80add-8f24-4259-b52e-e3a0eac74fd3",
+            "time": "2021-07-06T09:24:51.353Z"
+          }
+        }
+      ]
+    },
+    {
+      "name": "evaluation",
+      "service": "carts",
+      "project": "sockshop",
+      "time": "2021-07-06T09:22:56.433Z",
+      "shkeptncontext": "43580c5f-258f-4aae-9883-5a5c33fe4516",
+      "state": "finished",
+      "stages": [
+        {
+          "name": "staging",
+          "latestEvaluation": {
+            "result": "fail",
+            "score": 66.66666666666666
+          },
+          "latestEvent": {
+            "type": "sh.keptn.event.staging.evaluation.finished",
+            "id": "118d424d-33ac-4d15-88c4-2ae77fcc8ad1",
+            "time": "2021-07-06T09:23:09.238Z"
+          },
+          "latestFailedEvent": {
+            "type": "sh.keptn.event.staging.evaluation.finished",
+            "id": "118d424d-33ac-4d15-88c4-2ae77fcc8ad1",
+            "time": "2021-07-06T09:23:09.238Z"
+          }
+        }
+      ]
     }
   ],
-  "totalCount": 5
+  "totalCount": 40
 }

--- a/bridge/cypress/integration/sequences.spec.ts
+++ b/bridge/cypress/integration/sequences.spec.ts
@@ -102,6 +102,7 @@ describe('Sequences', () => {
   it('should load older sequences', () => {
     sequencePage.visit('sockshop');
     cy.wait('@Sequences');
+    cy.wait(500);
 
     sequencePage
       .assertSequenceCount(25)
@@ -120,6 +121,7 @@ describe('Sequences', () => {
     it('should show a filtered list if filters are applied for Service', () => {
       sequencePage.visit('sockshop');
       cy.wait('@Sequences');
+      cy.wait(500);
 
       sequencePage
         .checkServiceFilter('carts')
@@ -135,6 +137,7 @@ describe('Sequences', () => {
     it('should show a filtered list if filters are applied for Stage', () => {
       sequencePage.visit('sockshop');
       cy.wait('@Sequences');
+      cy.wait(500);
 
       sequencePage
         .checkStageFilter('production')
@@ -153,6 +156,7 @@ describe('Sequences', () => {
     it('should show a filtered list if filters are applied for Sequence', () => {
       sequencePage.visit('sockshop');
       cy.wait('@Sequences');
+      cy.wait(500);
 
       sequencePage
         .checkSequenceFilter('delivery')
@@ -168,6 +172,7 @@ describe('Sequences', () => {
     it('should show a filtered list if filters are applied for Status', () => {
       sequencePage.visit('sockshop');
       cy.wait('@Sequences');
+      cy.wait(500);
 
       sequencePage
         .checkStatusFilter('Active')
@@ -193,6 +198,7 @@ describe('Sequences', () => {
     it('should show a filtered list if combined filters are applied', () => {
       sequencePage.visit('sockshop');
       cy.wait('@Sequences');
+      cy.wait(500);
 
       sequencePage
         .checkServiceFilter('carts')
@@ -210,6 +216,7 @@ describe('Sequences', () => {
     it('should filter waiting sequences', () => {
       sequencePage.visit('sockshop');
       cy.wait('@Sequences');
+      cy.wait(500);
 
       sequencePage
         .checkStatusFilter('Waiting')
@@ -221,6 +228,7 @@ describe('Sequences', () => {
     it('should save filters to query params', () => {
       sequencePage.visit('sockshop');
       cy.wait('@Sequences');
+      cy.wait(500);
 
       sequencePage
         .checkServiceFilter('carts')
@@ -240,6 +248,7 @@ describe('Sequences', () => {
         Status: 'started',
       });
       cy.wait('@Sequences');
+      cy.wait(500);
 
       sequencePage
         .assertFilterIsChecked('Stage', 'dev', true)
@@ -269,6 +278,7 @@ describe('Sequences', () => {
 
       sequencePage.visit('sockshop', {});
       cy.wait('@Sequences');
+      cy.wait(500);
 
       sequencePage
         .assertFilterIsChecked('Stage', 'dev', false)
@@ -294,6 +304,7 @@ describe('Sequences', () => {
         Service: 'carts',
       });
       cy.wait('@Sequences');
+      cy.wait(500);
 
       sequencePage
         .assertSequenceCount(3)

--- a/bridge/cypress/integration/sequences.spec.ts
+++ b/bridge/cypress/integration/sequences.spec.ts
@@ -32,7 +32,7 @@ describe('Sequences', () => {
   });
 
   it('should show a list of sequences if everything is loaded', () => {
-    sequencePage.visit('sockshop').assertSequenceCount(5);
+    sequencePage.visit('sockshop').assertSequenceCount(6);
   });
 
   it('should select sequence and show the right timestamps in the timeline', () => {

--- a/bridge/cypress/integration/sequences.spec.ts
+++ b/bridge/cypress/integration/sequences.spec.ts
@@ -220,6 +220,7 @@ describe('Sequences', () => {
         Sequence: 'delivery',
         Status: 'started',
       });
+      environmentPage.intercept();
       environmentPage.visit('sockshop');
       sequencePage.visit('sockshop', {});
       cy.wait('@Sequences');

--- a/bridge/cypress/integration/sequences.spec.ts
+++ b/bridge/cypress/integration/sequences.spec.ts
@@ -99,7 +99,7 @@ describe('Sequences', () => {
       .assertIsSelectedSequenceWaiting(true);
   });
 
-  describe.only('filtering', () => {
+  describe('filtering', () => {
     it('should show a filtered list if filters are applied', () => {
       sequencePage.visit('sockshop');
       cy.wait('@Sequences');

--- a/bridge/cypress/integration/sequences.spec.ts
+++ b/bridge/cypress/integration/sequences.spec.ts
@@ -100,9 +100,10 @@ describe('Sequences', () => {
   });
 
   it('should load older sequences', () => {
-    sequencePage
-      .visit('sockshop')
+    sequencePage.visit('sockshop');
+    cy.wait('@Sequences');
 
+    sequencePage
       .assertSequenceCount(25)
       .assertLoadOlderSequencesButtonExists(true)
 
@@ -117,9 +118,10 @@ describe('Sequences', () => {
 
   describe('filtering', () => {
     it('should show a filtered list if filters are applied for Service', () => {
-      sequencePage
-        .visit('sockshop')
+      sequencePage.visit('sockshop');
+      cy.wait('@Sequences');
 
+      sequencePage
         .checkServiceFilter('carts')
         .assertSequenceCount(22)
         .assertServiceNameOfSequences('carts')
@@ -131,9 +133,10 @@ describe('Sequences', () => {
     });
 
     it('should show a filtered list if filters are applied for Stage', () => {
-      sequencePage
-        .visit('sockshop')
+      sequencePage.visit('sockshop');
+      cy.wait('@Sequences');
 
+      sequencePage
         .checkStageFilter('production')
         .assertSequenceCount(7)
         .assertStageNamesOfSequences(['production'], false)
@@ -148,9 +151,10 @@ describe('Sequences', () => {
     });
 
     it('should show a filtered list if filters are applied for Sequence', () => {
-      sequencePage
-        .visit('sockshop')
+      sequencePage.visit('sockshop');
+      cy.wait('@Sequences');
 
+      sequencePage
         .checkSequenceFilter('delivery')
         .assertSequenceCount(16)
         .assertSequenceNameOfSequences('delivery')
@@ -162,9 +166,10 @@ describe('Sequences', () => {
     });
 
     it('should show a filtered list if filters are applied for Status', () => {
-      sequencePage
-        .visit('sockshop')
+      sequencePage.visit('sockshop');
+      cy.wait('@Sequences');
 
+      sequencePage
         .checkStatusFilter('Active')
         .assertSequenceCount(2)
         .assertStatusOfSequences('started')
@@ -186,9 +191,10 @@ describe('Sequences', () => {
     });
 
     it('should show a filtered list if combined filters are applied', () => {
-      sequencePage
-        .visit('sockshop')
+      sequencePage.visit('sockshop');
+      cy.wait('@Sequences');
 
+      sequencePage
         .checkServiceFilter('carts')
         .checkStageFilter('production')
         .checkSequenceFilter('delivery')
@@ -202,9 +208,10 @@ describe('Sequences', () => {
     });
 
     it('should filter waiting sequences', () => {
-      sequencePage
-        .visit('sockshop')
+      sequencePage.visit('sockshop');
+      cy.wait('@Sequences');
 
+      sequencePage
         .checkStatusFilter('Waiting')
 
         .assertSequenceCount(1)
@@ -212,9 +219,10 @@ describe('Sequences', () => {
     });
 
     it('should save filters to query params', () => {
-      sequencePage
-        .visit('sockshop')
+      sequencePage.visit('sockshop');
+      cy.wait('@Sequences');
 
+      sequencePage
         .checkServiceFilter('carts')
         .checkStageFilter('dev')
         .checkStageFilter('production')
@@ -225,14 +233,15 @@ describe('Sequences', () => {
     });
 
     it('should load filters from query params', () => {
-      sequencePage
-        .visit('sockshop', {
-          Stage: 'dev',
-          Service: 'carts',
-          Sequence: 'delivery',
-          Status: 'started',
-        })
+      sequencePage.visit('sockshop', {
+        Stage: 'dev',
+        Service: 'carts',
+        Sequence: 'delivery',
+        Status: 'started',
+      });
+      cy.wait('@Sequences');
 
+      sequencePage
         .assertFilterIsChecked('Stage', 'dev', true)
         .assertFilterIsChecked('Stage', 'staging', false)
         .assertFilterIsChecked('Stage', 'production', false)
@@ -258,9 +267,10 @@ describe('Sequences', () => {
       });
       environmentPage.intercept().visit('sockshop');
 
-      sequencePage
-        .visit('sockshop', {})
+      sequencePage.visit('sockshop', {});
+      cy.wait('@Sequences');
 
+      sequencePage
         .assertFilterIsChecked('Stage', 'dev', false)
         .assertFilterIsChecked('Stage', 'staging', true)
         .assertFilterIsChecked('Stage', 'production', false)
@@ -278,13 +288,14 @@ describe('Sequences', () => {
     });
 
     it('should apply filters also when loading more sequences', () => {
-      sequencePage
-        .visit('sockshop', {
-          Stage: 'staging',
-          Sequence: 'evaluation',
-          Service: 'carts',
-        })
+      sequencePage.visit('sockshop', {
+        Stage: 'staging',
+        Sequence: 'evaluation',
+        Service: 'carts',
+      });
+      cy.wait('@Sequences');
 
+      sequencePage
         .assertSequenceCount(3)
         .assertLoadOlderSequencesButtonExists(true)
 

--- a/bridge/cypress/support/commands.ts
+++ b/bridge/cypress/support/commands.ts
@@ -14,8 +14,14 @@ declare global {
        * @param status
        */
       dtCheck<E extends Node = HTMLElement>(status: boolean): Cypress.Chainable<JQuery<E>>;
+      dtIsChecked<E extends Node = HTMLElement>(status: boolean): Cypress.Chainable<JQuery<E>>;
       dtSelect<E extends Node = HTMLElement>(element: string): Cypress.Chainable<JQuery<E>>;
       dtQuickFilterCheck<E extends Node = HTMLElement>(
+        filterName: string,
+        itemName: string,
+        status: boolean
+      ): Cypress.Chainable<JQuery<E>>;
+      dtQuickFilterIsChecked<E extends Node = HTMLElement>(
         filterName: string,
         itemName: string,
         status: boolean
@@ -48,6 +54,10 @@ Cypress.Commands.add('dtCheck', { prevSubject: 'element' }, (subject: JQuery<HTM
     cy.wrap(subject).click();
   }
 });
+Cypress.Commands.add('dtIsChecked', { prevSubject: 'element' }, (subject: JQuery<HTMLElement>, status: boolean) => {
+  const isChecked = subject.find('input').attr('aria-checked') as 'true' | 'false' | undefined;
+  expect(isChecked).to.equal(status.toString());
+});
 
 Cypress.Commands.add('dtSelect', { prevSubject: 'element' }, (subject: JQuery<HTMLElement>, element: string) => {
   cy.wrap(subject).click();
@@ -68,7 +78,21 @@ Cypress.Commands.add(
   }
 );
 
+Cypress.Commands.add(
+  'dtQuickFilterIsChecked',
+  { prevSubject: 'element' },
+  (subject: JQuery<HTMLElement>, filterName: string, itemName: string, status: boolean) => {
+    cy.wrap(subject)
+      .find('.dt-quick-filter-group .dt-quick-filter-group-headline')
+      .contains(filterName)
+      .parent()
+      .find('dt-checkbox')
+      .contains(itemName)
+      .dtIsChecked(status);
+  }
+);
+
 Cypress.Commands.add('clearDtFilter', { prevSubject: 'element' }, (subject: JQuery<HTMLElement>) => {
   subject.find('.dt-filter-field-clear-all-button').trigger('click');
-  cy.wrap(subject).find('.dt-filter-field-input ').type('{esc}');
+  cy.wrap(subject).find('.dt-filter-field-input').trigger('click').type('{esc}');
 });

--- a/bridge/cypress/support/intercept.ts
+++ b/bridge/cypress/support/intercept.ts
@@ -131,6 +131,12 @@ export function interceptServicesPage(): void {
 
 export function interceptSequencesPage(): void {
   cy.intercept('/api/controlPlane/v1/sequence/sockshop?pageSize=25', { fixture: 'sequences.sockshop' }).as('Sequences');
+  cy.intercept('/api/controlPlane/v1/sequence/sockshop?pageSize=10&beforeTime=2021-07-06T09:22:56.433Z', {
+    fixture: 'sequences-page-2.sockshop',
+  }).as('SequencesPage2');
+  cy.intercept('/api/controlPlane/v1/sequence/sockshop?pageSize=10&beforeTime=2021-07-06T08:13:53.766Z', {
+    fixture: 'sequences-page-3.sockshop',
+  }).as('SequencesPage3');
   cy.intercept('/api/controlPlane/v1/sequence/sockshop?pageSize=25&fromTime=*', {
     body: {
       states: [],

--- a/bridge/cypress/support/intercept.ts
+++ b/bridge/cypress/support/intercept.ts
@@ -135,7 +135,7 @@ export function interceptSequencesPage(): void {
     body: {
       states: [],
     },
-  });
+  }).as('SequencesUpdate');
 
   cy.intercept('/api/project/sockshop/sequences/metadata', { fixture: 'sequence.metadata.mock' }).as(
     'SequencesMetadata'

--- a/bridge/cypress/support/intercept.ts
+++ b/bridge/cypress/support/intercept.ts
@@ -27,7 +27,7 @@ export function interceptEnvironmentScreen(): void {
     fixture: 'eventByContext.mock',
   }).as('triggeredSequence');
   cy.intercept(
-    '/api/controlPlane/v1/sequence/sockshop?pageSize=10&fromTime=2022-02-23T14:28:50.504Z&beforeTime=2022-01-09T15:04:09.199Z',
+    '/api/controlPlane/v1/sequence/sockshop?pageSize=10&fromTime=2022-02-23T14:28:50.504Z&beforeTime=2021-07-06T09:22:56.433Z',
     {
       body: {
         states: [],

--- a/bridge/cypress/support/pageobjects/SequencesPage.ts
+++ b/bridge/cypress/support/pageobjects/SequencesPage.ts
@@ -87,6 +87,7 @@ export class SequencesPage {
 
   private setFilterForGroup(filterGroup: string, itemName: string, status: boolean): this {
     cy.byTestId('keptn-sequence-view-filter').find('dt-quick-filter').dtQuickFilterCheck(filterGroup, itemName, status);
+    cy.wait('@SequencesUpdate');
     return this;
   }
 

--- a/bridge/cypress/support/pageobjects/SequencesPage.ts
+++ b/bridge/cypress/support/pageobjects/SequencesPage.ts
@@ -87,7 +87,6 @@ export class SequencesPage {
 
   private setFilterForGroup(filterGroup: string, itemName: string, status: boolean): this {
     cy.byTestId('keptn-sequence-view-filter').find('dt-quick-filter').dtQuickFilterCheck(filterGroup, itemName, status);
-    cy.wait('@SequencesUpdate');
     return this;
   }
 
@@ -119,8 +118,22 @@ export class SequencesPage {
     return this;
   }
 
+  public clickLoadOlderSequences(): this {
+    cy.byTestId('keptn-show-older-sequences-button').click();
+    return this;
+  }
+
+  public assertLoadOlderSequencesButtonExists(exists: boolean): this {
+    cy.byTestId('keptn-show-older-sequences-button').should(exists ? 'exist' : 'not.exist');
+    return this;
+  }
+
   public assertSequenceCount(count: number): this {
-    cy.byTestId('keptn-sequence-view-roots').get('ktb-selectable-tile').should('have.length', count);
+    if (count === 0) {
+      cy.byTestId('keptn-sequence-view-roots').should('not.exist');
+    } else {
+      cy.byTestId('keptn-sequence-view-roots').get('ktb-selectable-tile').should('have.length', count);
+    }
     return this;
   }
 

--- a/bridge/cypress/support/pageobjects/SequencesPage.ts
+++ b/bridge/cypress/support/pageobjects/SequencesPage.ts
@@ -9,8 +9,13 @@ export class SequencesPage {
     return this;
   }
 
-  public visit(projectName: string): this {
-    cy.visit(`/project/${projectName}/sequence`).wait('@metadata').wait('@SequencesMetadata');
+  public visit(projectName: string, queryParams?: { [p: string]: string | string[] }): this {
+    cy.visit({
+      url: `/project/${projectName}/sequence`,
+      qs: queryParams,
+    })
+      .wait('@metadata')
+      .wait('@SequencesMetadata');
     return this;
   }
 
@@ -82,6 +87,13 @@ export class SequencesPage {
 
   private setFilterForGroup(filterGroup: string, itemName: string, status: boolean): this {
     cy.byTestId('keptn-sequence-view-filter').find('dt-quick-filter').dtQuickFilterCheck(filterGroup, itemName, status);
+    return this;
+  }
+
+  public assertFilterIsChecked(filterGroup: string, itemName: string, status: boolean): this {
+    cy.byTestId('keptn-sequence-view-filter')
+      .find('dt-quick-filter')
+      .dtQuickFilterIsChecked(filterGroup, itemName, status);
     return this;
   }
 
@@ -230,6 +242,11 @@ export class SequencesPage {
   public assertServiceName(name: string, tag?: string): this {
     const serviceName = tag ? `${name}:${tag}` : name;
     cy.byTestId('keptn-sequence-view-serviceName').should('have.text', serviceName);
+    return this;
+  }
+
+  public assertQueryParams(query: string): this {
+    cy.location('search').should('eq', query);
     return this;
   }
 }


### PR DESCRIPTION
Signed-off-by: ermin.muratovic <ermin.muratovic@gmail.com>

## This PR
- makes sure that the filters in the sequence view are kept across page refresh
- sequence view can be shared with filters

### Related Issues
Fixes #6182

### Notes
The applied filters are stored as query parameters to the URL and also persisted to the local storage, so that it can be restored after changing views. For example:

![image](https://user-images.githubusercontent.com/6098219/168611814-0aa8acc7-ae57-4d8f-ba8a-18363336109c.png)
