### PR TITLE
feat(bridge): Unify loading indicators (#5568)

### DIFF
--- a/bridge/client/app/_components/_dialogs/ktb-deletion-dialog/ktb-deletion-dialog.component.html
+++ b/bridge/client/app/_components/_dialogs/ktb-deletion-dialog/ktb-deletion-dialog.component.html
@@ -30,8 +30,8 @@
     (click)="deleteConfirm()"
     [disabled]="deletionConfirmationForm.invalid || (isDeleteProjectInProgress$ | async)"
   >
+    <ktb-loading-spinner *ngIf="isDeleteProjectInProgress$ | async"></ktb-loading-spinner>
     I understand the consequences, delete this {{ data.type }}
-    <dt-loading-spinner *ngIf="isDeleteProjectInProgress$ | async"></dt-loading-spinner>
   </button>
   <div class="mt-3" *ngIf="deletionError$ | async as error">
     <span class="error">{{ error }}</span>

--- a/bridge/client/app/_components/ktb-certificate-input/ktb-certificate-input.component.html
+++ b/bridge/client/app/_components/ktb-certificate-input/ktb-certificate-input.component.html
@@ -22,7 +22,7 @@
       placeholder="Begins with -----BEGIN CERTIFICATE-----"
       uitestid="ktb-certificate-input"
     ></textarea>
-    <dt-loading-spinner *ngIf="isLoading" dtPrefix aria-label="Loading data"></dt-loading-spinner>
+    <ktb-loading-spinner *ngIf="isLoading" dtPrefix aria-label="Loading data"></ktb-loading-spinner>
     <dt-error>
       The certificate must start with "-----BEGIN CERTIFICATE-----" and end with "-----END CERTIFICATE-----"
     </dt-error>

--- a/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.html
+++ b/bridge/client/app/_components/ktb-create-secret-form/ktb-create-secret-form.component.html
@@ -3,7 +3,8 @@
     <div class="mb-3 settings-section" fxFlex fxLayout="column">
       <h2>Create Secret</h2>
       <div fxLayout="row" class="icon-inline-left">
-        <dt-icon name="information" class="inline-text-icon"></dt-icon> Secrets are shared among all projects.
+        <dt-icon name="information" class="inline-text-icon"></dt-icon>
+        Secrets are shared among all projects.
       </div>
       <p class="mt-1 mb-3">Create a secret to store sensitive data like credentials or URIs for integrations.</p>
 
@@ -36,7 +37,7 @@
           >
             <dt-option *ngFor="let scope of scopes" [value]="scope" [textContent]="scope"></dt-option>
           </dt-select>
-          <dt-loading-spinner *ngIf="isLoading" dtPrefix aria-label="Loading scopes"></dt-loading-spinner>
+          <ktb-loading-spinner *ngIf="isLoading" dtPrefix aria-label="Loading scopes"></ktb-loading-spinner>
         </dt-form-field>
 
         <div formArrayName="data">
@@ -57,11 +58,11 @@
                   />
                   <dt-error *ngIf="dataGroup.get('key')?.errors?.required">Must not be empty</dt-error>
                   <dt-error *ngIf="dataGroup.get('key')?.errors?.pattern"
-                    >Key must consist of alphanumeric characters, '-', '_' or '.'</dt-error
-                  >
+                    >Key must consist of alphanumeric characters, '-', '_' or '.'
+                  </dt-error>
                   <dt-error *ngIf="dataGroup.get('key')?.errors?.maxlength"
-                    >Key must not have more than 253 characters</dt-error
-                  >
+                    >Key must not have more than 253 characters
+                  </dt-error>
                 </dt-form-field>
                 <dt-form-field fxFlex>
                   <dt-label class="required">Value</dt-label>
@@ -102,12 +103,13 @@
           (click)="addPair()"
           uitestid="keptn-secret-add-pair-button"
         >
-          <dt-icon name="addrowonbottom"></dt-icon> Add key-value pair
+          <dt-icon name="addrowonbottom"></dt-icon>
+          Add key-value pair
         </button>
 
         <div fxLayout="row" fxLayoutAlign="none end" fxLayoutGap="15px" class="mt-3">
           <button (click)="createSecret()" [disabled]="!isFormValid()" dt-button uitestid="keptn-secret-create-button">
-            <dt-loading-spinner *ngIf="isUpdating" aria-label="Create secret"></dt-loading-spinner>
+            <ktb-loading-spinner *ngIf="isUpdating" aria-label="Create secret"></ktb-loading-spinner>
             Add secret
           </button>
           <button type="reset" dt-button variant="secondary" routerLink="../">Cancel</button>

--- a/bridge/client/app/_components/ktb-create-service/ktb-create-service.component.html
+++ b/bridge/client/app/_components/ktb-create-service/ktb-create-service.component.html
@@ -1,7 +1,7 @@
 <div fxLayout="column">
   <div class="container settings-section">
     <h2>Create service</h2>
-    <dt-loading-spinner *ngIf="isLoading"></dt-loading-spinner>
+    <ktb-loading-distractor *ngIf="isLoading">Loading ...</ktb-loading-distractor>
     <form [formGroup]="formGroup" class="mb-3" *ngIf="projectName && !isLoading">
       <div fxLayout="column" fxLayoutGap="10px">
         <dt-form-field>
@@ -29,7 +29,7 @@
             [disabled]="!formGroup.valid || isCreating"
             (click)="createService(projectName)"
           >
-            <dt-loading-spinner *ngIf="isCreating" aria-label="Creating service"></dt-loading-spinner>
+            <ktb-loading-spinner *ngIf="isCreating" aria-label="Creating service"></ktb-loading-spinner>
             Create service
           </button>
           <button dt-button variant="secondary" type="reset" (click)="cancel()">Cancel</button>

--- a/bridge/client/app/_components/ktb-edit-service/ktb-edit-service.component.html
+++ b/bridge/client/app/_components/ktb-edit-service/ktb-edit-service.component.html
@@ -7,7 +7,7 @@
         <h3>Configuration files</h3>
         <ng-template #loading>
           <div class="mt-3">
-            <dt-loading-spinner></dt-loading-spinner>
+            <ktb-loading-distractor>Loading ...</ktb-loading-distractor>
           </div>
         </ng-template>
         <ng-container *ngIf="project; else loading">

--- a/bridge/client/app/_components/ktb-evaluation-info/ktb-evaluation-info.component.html
+++ b/bridge/client/app/_components/ktb-evaluation-info/ktb-evaluation-info.component.html
@@ -5,7 +5,7 @@
       [class.border]="true"
       class="m-0 justify-content-center"
     >
-      <dt-loading-spinner aria-label="Loading evaluation"></dt-loading-spinner>
+      <ktb-loading-spinner aria-label="Loading evaluation"></ktb-loading-spinner>
     </dt-tag>
     <dt-tag
       *ngFor="let pastEvaluation of evaluationHistory"

--- a/bridge/client/app/_components/ktb-evaluation-info/ktb-evaluation-info.component.scss
+++ b/bridge/client/app/_components/ktb-evaluation-info/ktb-evaluation-info.component.scss
@@ -8,9 +8,11 @@
   &.success {
     border: 1px solid $cta-color !important;
   }
+
   &.warning {
     border: 1px solid $warning-color !important;
   }
+
   &.error {
     border: 1px solid $error-color !important;
   }
@@ -21,7 +23,7 @@
   color: white;
 }
 
-dt-loading-spinner {
+ktb-loading-spinner {
   height: 20px;
   width: 20px;
   vertical-align: bottom;

--- a/bridge/client/app/_components/ktb-keptn-services-list/ktb-keptn-services-list.component.html
+++ b/bridge/client/app/_components/ktb-keptn-services-list/ktb-keptn-services-list.component.html
@@ -1,6 +1,6 @@
 <div fxFlexFill fxLayout="column" class="container" *ngIf="projectName as projectName">
   <div fxLayout="column" fxFlex="0 0 60%" class="overflow-y-scroll">
-    <dt-loading-spinner *ngIf="isLoadingUniformRegistrations"></dt-loading-spinner>
+    <ktb-loading-distractor *ngIf="isLoadingUniformRegistrations">Loading ...</ktb-loading-distractor>
 
     <div *ngIf="!isLoadingUniformRegistrations && uniformRegistrations.data && uniformRegistrations.data.length === 0">
       No integrations available.
@@ -114,7 +114,7 @@
             <h3 class="mt-0 mb-0">Error events</h3>
           </ktb-expandable-tile-header>
 
-          <dt-loading-spinner *ngIf="isLoadingLogs"></dt-loading-spinner>
+          <ktb-loading-distractor *ngIf="isLoadingLogs">Loading ...</ktb-loading-distractor>
 
           <div fxLayout="column" *ngIf="!isLoadingLogs">
             <ktb-uniform-registration-logs

--- a/bridge/client/app/_components/ktb-loading-spinner/ktb-loading-spinner.component.scss
+++ b/bridge/client/app/_components/ktb-loading-spinner/ktb-loading-spinner.component.scss
@@ -35,8 +35,8 @@ $ktb-loading-spinner-ease: cubic-bezier(0.645, 0.045, 0.355, 1);
   animation: ktb-loading-spinner-spin $ktb-loading-spinner-duration * 2 linear infinite;
 }
 
-:host-context(.dt-form-field) .ktb-loading-spinner-svg[dtPrefix],
-:host-context(.dt-form-field) .ktb-loading-spinner-svg[dtSuffix],
+:host-context(.dt-form-field) :host[dtPrefix] .ktb-loading-spinner-svg,
+:host-context(.dt-form-field) :host[dtSuffix] .ktb-loading-spinner-svg,
 :host-context(.dt-filter-field) .ktb-loading-spinner-svg {
   stroke: $gray-500;
 }

--- a/bridge/client/app/_components/ktb-loading-spinner/ktb-loading-spinner.component.ts
+++ b/bridge/client/app/_components/ktb-loading-spinner/ktb-loading-spinner.component.ts
@@ -1,9 +1,18 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 
 @Component({
   selector: 'ktb-loading-spinner',
   templateUrl: './ktb-loading-spinner.component.html',
   styleUrls: ['./ktb-loading-spinner.component.scss'],
+  host: {
+    role: 'progressbar',
+    'aria-busy': 'true',
+    'aria-live': 'assertive',
+    '[attr.aria-label]': 'ariaLabel',
+  },
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class KtbLoadingSpinnerComponent {}
+export class KtbLoadingSpinnerComponent {
+  /** The aria-label attribute. */
+  @Input('aria-label') ariaLabel?: string;
+}

--- a/bridge/client/app/_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component.html
+++ b/bridge/client/app/_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component.html
@@ -24,8 +24,8 @@
             </ng-template>
             <ng-template #isGlobalCheckbox>
               <dt-checkbox formControlName="isGlobal" uitestid="ktb-modify-subscription-project-checkbox"
-                >Use for all projects</dt-checkbox
-              >
+                >Use for all projects
+              </dt-checkbox>
             </ng-template>
           </dt-form-field>
         </div>
@@ -75,8 +75,8 @@
             uitestid="edit-subscription-field-filterStageService"
           ></dt-filter-field>
           <dt-error *ngIf="data.subscription.filter.services?.length && !data.subscription.filter.stages?.length"
-            >If you add a service you must add a stage</dt-error
-          >
+            >If you add a service you must add a stage
+          </dt-error>
         </div>
         <ktb-payload-viewer
           [buttonTitle]="'Show example payload'"
@@ -101,10 +101,10 @@
             (click)="updateSubscription(data.project.projectName, data.integrationId, data.subscription, data.webhook)"
             dt-button
           >
-            <dt-loading-spinner
+            <ktb-loading-spinner
               *ngIf="updating"
               aria-label="{{ editMode ? 'Updating' : 'Creating' }} subscription"
-            ></dt-loading-spinner>
+            ></ktb-loading-spinner>
             {{ editMode ? 'Update' : 'Create' }} subscription
           </button>
           <button type="reset" dt-button variant="secondary" [routerLink]="editMode ? '../../../' : '../../'">
@@ -116,6 +116,6 @@
     </ng-container>
   </ng-container>
   <ng-template #loading>
-    <dt-loading-spinner></dt-loading-spinner>
+    <ktb-loading-distractor>Loading ...</ktb-loading-distractor>
   </ng-template>
 </div>

--- a/bridge/client/app/_components/ktb-payload-viewer/ktb-payload-viewer.component.html
+++ b/bridge/client/app/_components/ktb-payload-viewer/ktb-payload-viewer.component.html
@@ -36,7 +36,7 @@
     </ng-template>
   </div>
   <ng-template #loadingEvent>
-    <dt-loading-spinner></dt-loading-spinner>
+    <ktb-loading-distractor>Loading ...</ktb-loading-distractor>
   </ng-template>
   <div mat-dialog-actions>
     <button dt-button (click)="closeDialog()" uitestid="keptn-close-payload-dialog-button">Close</button>

--- a/bridge/client/app/_components/ktb-project-settings-git-extended/ktb-project-settings-git-extended.component.html
+++ b/bridge/client/app/_components/ktb-project-settings-git-extended/ktb-project-settings-git-extended.component.html
@@ -41,7 +41,7 @@
     dt-button
     uitestid="ktb-project-update-button"
   >
-    <dt-loading-spinner *ngIf="isGitUpstreamInProgress" aria-label="Setting Git upstream URL"></dt-loading-spinner>
+    <ktb-loading-spinner *ngIf="isGitUpstreamInProgress" aria-label="Setting Git upstream URL"></ktb-loading-spinner>
     Set Git upstream
   </button>
 </div>

--- a/bridge/client/app/_components/ktb-project-settings-git-https/ktb-project-settings-git-https.component.html
+++ b/bridge/client/app/_components/ktb-project-settings-git-https/ktb-project-settings-git-https.component.html
@@ -22,9 +22,9 @@
   (change)="proxyEnabled = $event.checked; inputChanged()"
   [checked]="proxyEnabled"
   uitestid="ktb-enable-git-proxy"
-  >Use proxy</dt-switch
->
-<dt-loading-spinner *ngIf="isLoading" class="gray-loading" aria-label="Loading data"></dt-loading-spinner>
+  >Use proxy
+</dt-switch>
+<ktb-loading-spinner *ngIf="isLoading" class="gray-loading" aria-label="Loading data"></ktb-loading-spinner>
 <ktb-proxy-input
   [hidden]="!proxyEnabled"
   [proxy]="proxyInput"

--- a/bridge/client/app/_components/ktb-project-settings-git-https/ktb-project-settings-git-https.component.html
+++ b/bridge/client/app/_components/ktb-project-settings-git-https/ktb-project-settings-git-https.component.html
@@ -23,8 +23,8 @@
   [checked]="proxyEnabled"
   uitestid="ktb-enable-git-proxy"
   >Use proxy
+  <ktb-loading-spinner *ngIf="isLoading" class="smaller" aria-label="Loading data"></ktb-loading-spinner>
 </dt-switch>
-<ktb-loading-spinner *ngIf="isLoading" class="gray-loading" aria-label="Loading data"></ktb-loading-spinner>
 <ktb-proxy-input
   [hidden]="!proxyEnabled"
   [proxy]="proxyInput"

--- a/bridge/client/app/_components/ktb-project-settings-git-ssh-input/ktb-project-settings-git-ssh-input.component.html
+++ b/bridge/client/app/_components/ktb-project-settings-git-ssh-input/ktb-project-settings-git-ssh-input.component.html
@@ -9,7 +9,7 @@
         placeholder="ssh://git-repo.com/repo.git"
         uitestid="ktb-ssh-git-url-input"
       />
-      <dt-loading-spinner *ngIf="isLoading" dtprefix aria-label="Loading data"></dt-loading-spinner>
+      <ktb-loading-spinner *ngIf="isLoading" dtprefix aria-label="Loading data"></ktb-loading-spinner>
       <dt-error *ngIf="gitUrlControl.errors?.required">Must not be empty</dt-error>
       <dt-error *ngIf="gitUrlControl.errors?.ssh">Must start with ssh://</dt-error>
     </dt-form-field>
@@ -22,7 +22,7 @@
         placeholder="Username"
         uitestid="ktb-ssh-git-username-input"
       />
-      <dt-loading-spinner *ngIf="isLoading" dtprefix aria-label="Loading data"></dt-loading-spinner>
+      <ktb-loading-spinner *ngIf="isLoading" dtprefix aria-label="Loading data"></ktb-loading-spinner>
     </dt-form-field>
   </div>
 </form>

--- a/bridge/client/app/_components/ktb-project-settings-git/ktb-project-settings-git.component.html
+++ b/bridge/client/app/_components/ktb-project-settings-git/ktb-project-settings-git.component.html
@@ -24,7 +24,7 @@
         placeholder="https://git-repo.com/repo.git"
         uitestid="ktb-git-url-input"
       />
-      <dt-loading-spinner *ngIf="isLoading" dtPrefix aria-label="Loading data"></dt-loading-spinner>
+      <ktb-loading-spinner *ngIf="isLoading" dtPrefix aria-label="Loading data"></ktb-loading-spinner>
       <dt-error *ngIf="gitUrlControl.hasError('required')">Must not be empty</dt-error>
       <dt-error *ngIf="gitUrlControl.hasError('url')">Must start with http(s)://</dt-error>
       <dt-error *ngIf="gitUrlControl.hasError('space')">Must not contain spaces</dt-error>
@@ -33,7 +33,7 @@
       <dt-form-field class="mr-3">
         <dt-label>Git user</dt-label>
         <input formControlName="gitUser" type="text" dtInput placeholder="Username" uitestid="ktb-git-username-input" />
-        <dt-loading-spinner *ngIf="isLoading" dtPrefix aria-label="Loading data"></dt-loading-spinner>
+        <ktb-loading-spinner *ngIf="isLoading" dtPrefix aria-label="Loading data"></ktb-loading-spinner>
       </dt-form-field>
       <dt-form-field>
         <dt-label [class.required]="required">Token</dt-label>
@@ -51,7 +51,7 @@
   </div>
   <div class="ml-3" *ngIf="!isCreateMode && !isInGitExtended">
     <button [disabled]="isButtonDisabled()" (click)="setGitUpstream()" dt-button uitestid="ktb-project-update-button">
-      <dt-loading-spinner *ngIf="isGitUpstreamInProgress" aria-label="Setting Git upstream URL"></dt-loading-spinner>
+      <ktb-loading-spinner *ngIf="isGitUpstreamInProgress" aria-label="Setting Git upstream URL"></ktb-loading-spinner>
       Set Git upstream
     </button>
   </div>

--- a/bridge/client/app/_components/ktb-project-settings/ktb-project-settings.component.html
+++ b/bridge/client/app/_components/ktb-project-settings/ktb-project-settings.component.html
@@ -62,7 +62,7 @@
           dt-button
           uitestid="ktb-create-project"
         >
-          <dt-loading-spinner *ngIf="isCreatingProjectInProgress" aria-label="Creating project"></dt-loading-spinner>
+          <ktb-loading-spinner *ngIf="isCreatingProjectInProgress" aria-label="Creating project"></ktb-loading-spinner>
           Create project
         </button>
       </div>

--- a/bridge/client/app/_components/ktb-root-events-list/ktb-root-events-list.component.html
+++ b/bridge/client/app/_components/ktb-root-events-list/ktb-root-events-list.component.html
@@ -50,7 +50,7 @@
     </ktb-selectable-tile>
   </div>
   <div fxLayout="row" fxLayoutAlign="center center">
-    <dt-loading-distractor *ngIf="loading" uitestid="keptn-loadingOldSequences">Loading …</dt-loading-distractor>
+    <ktb-loading-distractor *ngIf="loading" uitestid="keptn-loadingOldSequences">Loading …</ktb-loading-distractor>
     <button dt-show-more *ngIf="!loading && !project?.allSequencesLoaded" (click)="loadOldSequences()">
       Show older sequences
     </button>

--- a/bridge/client/app/_components/ktb-sequence-list/ktb-sequence-list.component.html
+++ b/bridge/client/app/_components/ktb-sequence-list/ktb-sequence-list.component.html
@@ -6,7 +6,7 @@
       <ng-container *ngIf="isRemediation(row) as sequence; else trace">
         <div fxLayout="row" fxLayoutAlign="start center">
           <button *ngIf="sequence.isLoading(); else finished" class="m-0 p-0" dt-button disabled variant="nested">
-            <dt-loading-spinner aria-label="Remediation is running..."></dt-loading-spinner>
+            <ktb-loading-spinner aria-label="Remediation is running..."></ktb-loading-spinner>
           </button>
           <ng-template #finished>
             <dt-icon
@@ -33,7 +33,7 @@
           ></dt-icon>
           <ng-template #loading>
             <button class="m-0 p-0" dt-button disabled variant="nested">
-              <dt-loading-spinner aria-label="Task is running..."></dt-loading-spinner>
+              <ktb-loading-spinner aria-label="Task is running..."></ktb-loading-spinner>
             </button>
           </ng-template>
           <span

--- a/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.html
+++ b/bridge/client/app/_components/ktb-sequence-state-info/ktb-sequence-state-info.component.html
@@ -12,7 +12,7 @@
     ></dt-icon>
     <ng-template #showLoading>
       <button class="m-0 p-0" dt-button disabled variant="nested" *ngIf="sequence.isLoading() && !sequence.isWaiting()">
-        <dt-loading-spinner aria-label="Task is running..."></dt-loading-spinner>
+        <ktb-loading-spinner aria-label="Task is running..."></ktb-loading-spinner>
       </button>
       <dt-icon *ngIf="sequence.isWaiting()" class="event-icon" name="idle"></dt-icon>
     </ng-template>

--- a/bridge/client/app/_components/ktb-sequence-timeline/ktb-sequence-timeline.component.html
+++ b/bridge/client/app/_components/ktb-sequence-timeline/ktb-sequence-timeline.component.html
@@ -53,7 +53,7 @@
           [textContent]="currentSequence.getStageTime(stage) | date: 'HH:mm'"
         ></p>
         <ng-template #showLoadingSpinner>
-          <ktb-loading-distractor class="smaller">Fetching events ...</ktb-loading-distractor>
+          <ktb-loading-spinner class="smaller" aria-label="Fetching events ..."></ktb-loading-spinner>
         </ng-template>
       </div>
     </div>

--- a/bridge/client/app/_components/ktb-sequence-timeline/ktb-sequence-timeline.component.html
+++ b/bridge/client/app/_components/ktb-sequence-timeline/ktb-sequence-timeline.component.html
@@ -31,7 +31,7 @@
               variant="nested"
               *ngIf="currentSequence.isLoading() && !currentSequence.isWaiting()"
             >
-              <dt-loading-spinner aria-label="Task is running..."></dt-loading-spinner>
+              <ktb-loading-spinner aria-label="Task is running..."></ktb-loading-spinner>
             </button>
             <dt-icon *ngIf="currentSequence.isWaiting()" class="event-icon" name="idle"></dt-icon>
           </ng-template>
@@ -53,7 +53,7 @@
           [textContent]="currentSequence.getStageTime(stage) | date: 'HH:mm'"
         ></p>
         <ng-template #showLoadingSpinner>
-          <dt-loading-spinner class="gray-loading" aria-label="Fetching events..."></dt-loading-spinner>
+          <ktb-loading-distractor class="smaller">Fetching events ...</ktb-loading-distractor>
         </ng-template>
       </div>
     </div>

--- a/bridge/client/app/_components/ktb-sequence-timeline/ktb-sequence-timeline.component.scss
+++ b/bridge/client/app/_components/ktb-sequence-timeline/ktb-sequence-timeline.component.scss
@@ -22,6 +22,7 @@
 
   .stage-info {
     height: 25px;
+
     & > * {
       vertical-align: middle;
     }
@@ -43,22 +44,21 @@
     &.error {
       background-color: $error-color;
     }
+
     &.success {
       background-color: $cta-color-active;
     }
+
     &.highlight {
       background-color: $approval-color;
     }
+
     &.warning {
       background-color: $warning-color;
     }
+
     &.aborted {
       background-color: $aborted-color;
     }
-  }
-
-  dt-loading-spinner.gray-loading {
-    height: 20px;
-    width: 20px;
   }
 }

--- a/bridge/client/app/_components/ktb-service-settings-list/ktb-service-settings-list.component.html
+++ b/bridge/client/app/_components/ktb-service-settings-list/ktb-service-settings-list.component.html
@@ -1,7 +1,7 @@
 <dt-table *ngIf="dataSource.data.length > 0; else noServices" [dataSource]="dataSource" class="settings-section">
   <ng-container dtColumnDef="serviceName" dtColumnAlign="text">
     <dt-header-cell *dtHeaderCellDef>Service name</dt-header-cell>
-    <dt-cell *dtCellDef="let row" [textContent]="row"> </dt-cell>
+    <dt-cell *dtCellDef="let row" [textContent]="row"></dt-cell>
   </ng-container>
 
   <ng-container dtColumnDef="edit" dtColumnAlign="right" dtColumnProportion="0.01" dtColumnMinWidth="50px">
@@ -19,11 +19,11 @@
   </ng-container>
 
   <dt-header-row *dtHeaderRowDef="['serviceName', 'edit']"></dt-header-row>
-  <dt-row *dtRowDef="let row; columns: ['serviceName', 'edit']"> </dt-row>
+  <dt-row *dtRowDef="let row; columns: ['serviceName', 'edit']"></dt-row>
 </dt-table>
 
 <ng-template #noServices>
-  <dt-loading-spinner *ngIf="isLoading"></dt-loading-spinner>
+  <ktb-loading-distractor *ngIf="isLoading">Loading ...</ktb-loading-distractor>
   <p *ngIf="!isLoading">
     There are no services for this project yet. Use the button "Create service" or the
     <a [href]="'/reference/cli/commands/keptn_create_service/' | keptnUrl" target="_blank" rel="noopener noreferrer"

--- a/bridge/client/app/_components/ktb-services-list/ktb-services-list.component.html
+++ b/bridge/client/app/_components/ktb-services-list/ktb-services-list.component.html
@@ -25,7 +25,7 @@
               ></dt-icon>
               <ng-template #showLoading>
                 <button class="m-0 p-0" dt-button disabled variant="nested">
-                  <dt-loading-spinner aria-label="Task is running..."></dt-loading-spinner>
+                  <ktb-loading-spinner aria-label="Task is running..."></ktb-loading-spinner>
                 </button>
               </ng-template>
               <a

--- a/bridge/client/app/_components/ktb-stage-details/ktb-stage-details.component.html
+++ b/bridge/client/app/_components/ktb-stage-details/ktb-stage-details.component.html
@@ -103,8 +103,11 @@
                           [href]="deployment.deploymentUrl"
                           [title]="'View ' + service.serviceName + ' in ' + selectedStage.stageName"
                           target="_blank"
-                          ><button dt-icon-button variant="nested"><dt-icon name="externallink"></dt-icon></button
-                        ></a>
+                        >
+                          <button dt-icon-button variant="nested">
+                            <dt-icon name="externallink"></dt-icon>
+                          </button>
+                        </a>
                       </ng-container>
                     </div>
                   </dt-info-group-title>
@@ -175,7 +178,7 @@
                     variant="nested"
                     *ngIf="!remediationAction.isFinished()"
                   >
-                    <dt-loading-spinner aria-label="Action is running..."></dt-loading-spinner>
+                    <ktb-loading-spinner aria-label="Action is running..."></ktb-loading-spinner>
                   </button>
                   <ng-container
                     *ngIf="remediationSequence.getEvaluationTrace(service.stage)?.getFinishedEvent() as evaluation"
@@ -200,11 +203,9 @@
                           ?.getEvaluationFinishedEvent() as evaluation
                       "
                     >
-                      <ktb-evaluation-info
-                        class="display-inline-block"
-                        [evaluation]="evaluation"
-                      ></ktb-evaluation-info> </ng-container
-                    >.
+                      <ktb-evaluation-info class="display-inline-block" [evaluation]="evaluation"></ktb-evaluation-info>
+                    </ng-container>
+                    .
                   </p>
                 </div>
                 <button

--- a/bridge/client/app/_components/ktb-task-item/ktb-task-item.component.html
+++ b/bridge/client/app/_components/ktb-task-item/ktb-task-item.component.html
@@ -24,7 +24,7 @@
             disabled
             variant="nested"
           >
-            <dt-loading-spinner aria-label="Task is running..."></dt-loading-spinner>
+            <ktb-loading-spinner aria-label="Task is running..."></ktb-loading-spinner>
           </button>
           <dt-icon
             *ngIf="!task.isLoading() || task.isApproval() || task.getLastTrace().isApproval()"

--- a/bridge/client/app/_components/ktb-trigger-sequence/ktb-trigger-sequence.component.html
+++ b/bridge/client/app/_components/ktb-trigger-sequence/ktb-trigger-sequence.component.html
@@ -23,7 +23,6 @@
           <dt-select
             [disabled]="stages.length === 0"
             [(ngModel)]="selectedStage"
-            (selectionChange)="selectedStageChanged()"
             placeholder="Select ..."
             uitestid="keptn-trigger-stage-selection"
           >
@@ -33,72 +32,6 @@
           </dt-select>
         </dt-form-field>
       </div>
-
-      <!--   Sequence Selection   -->
-      <dt-form-field>
-        <dt-label class="mb-1 mt-2">Sequence</dt-label>
-        <dt-radio-group
-          class="mb-3"
-          name="sequenceType"
-          fxLayout="row"
-          fxLayoutGap="15px"
-          fxLayoutAlign="start center"
-          [(ngModel)]="sequenceType"
-          uitestid="keptn-trigger-sequence-selection"
-        >
-          <dt-radio-button
-            *ngIf="!isQualityGatesOnly"
-            [value]="TRIGGER_SEQUENCE.DELIVERY"
-            uitestid="ktb-trigger-sequence-delivery-radio"
-          >
-            Delivery
-          </dt-radio-button>
-          <dt-radio-button [value]="TRIGGER_SEQUENCE.EVALUATION" uitestid="ktb-trigger-sequence-evaluation-radio"
-            >Evaluation</dt-radio-button
-          >
-          <div
-            *ngIf="customSequencesOfStage?.length === 0; else customSequencesSelect"
-            [dtOverlay]="noCustomSequencesOverlay"
-            fxFlex="0 1 300px"
-          >
-            <ng-container *ngTemplateOutlet="customSequencesSelect"></ng-container>
-          </div>
-          <ng-template #customSequencesSelect>
-            <dt-radio-button
-              [value]="TRIGGER_SEQUENCE.CUSTOM"
-              [disabled]="!customSequencesOfStage?.length"
-              uitestid="ktb-trigger-sequence-custom-radio"
-              class="custom-sequence-radio"
-              fxFlex="0 1 300px"
-            >
-              <dt-select
-                [disabled]="!customSequencesOfStage?.length"
-                [(ngModel)]="customFormData.sequence"
-                class="sequence-select"
-                name="customSequence"
-                placeholder="Select ..."
-                uitestid="keptn-trigger-custom-sequence-select"
-              >
-                <dt-option
-                  *ngFor="let sequence of customSequencesOfStage"
-                  [value]="sequence"
-                  [textContent]="sequence"
-                ></dt-option>
-              </dt-select>
-            </dt-radio-button>
-          </ng-template>
-          <div *ngIf="!customSequences">
-            <dt-loading-spinner></dt-loading-spinner>
-            <span>Loading custom sequences ...</span>
-          </div>
-
-          <ng-template #noCustomSequencesOverlay>
-            There are no custom sequences available for this stage in the shipyard.yaml file
-          </ng-template>
-        </dt-radio-group>
-      </dt-form-field>
-      <!--   Sequence Selection   -->
-
       <div class="mt-3" fxLayout="row" fxLayoutAlign="space-between">
         <button dt-button variant="secondary" (click)="formClosed.emit()" uitestid="keptn-trigger-button-close">
           Cancel
@@ -382,7 +315,7 @@
       (click)="triggerSequence()"
     >
       <dt-icon name="flash" *ngIf="!isLoading"></dt-icon>
-      <dt-loading-spinner *ngIf="isLoading"></dt-loading-spinner>
+      <ktb-loading-spinner *ngIf="isLoading"></ktb-loading-spinner>
       Trigger sequence
     </button>
   </div>

--- a/bridge/client/app/_components/ktb-trigger-sequence/ktb-trigger-sequence.component.html
+++ b/bridge/client/app/_components/ktb-trigger-sequence/ktb-trigger-sequence.component.html
@@ -23,6 +23,7 @@
           <dt-select
             [disabled]="stages.length === 0"
             [(ngModel)]="selectedStage"
+            (selectionChange)="selectedStageChanged()"
             placeholder="Select ..."
             uitestid="keptn-trigger-stage-selection"
           >
@@ -32,6 +33,71 @@
           </dt-select>
         </dt-form-field>
       </div>
+
+      <!--   Sequence Selection   -->
+      <dt-form-field>
+        <dt-label class="mb-1 mt-2">Sequence</dt-label>
+        <dt-radio-group
+          class="mb-3"
+          name="sequenceType"
+          fxLayout="row"
+          fxLayoutGap="15px"
+          fxLayoutAlign="start center"
+          [(ngModel)]="sequenceType"
+          uitestid="keptn-trigger-sequence-selection"
+        >
+          <dt-radio-button
+            *ngIf="!isQualityGatesOnly"
+            [value]="TRIGGER_SEQUENCE.DELIVERY"
+            uitestid="ktb-trigger-sequence-delivery-radio"
+          >
+            Delivery
+          </dt-radio-button>
+          <dt-radio-button [value]="TRIGGER_SEQUENCE.EVALUATION" uitestid="ktb-trigger-sequence-evaluation-radio"
+            >Evaluation</dt-radio-button
+          >
+          <div
+            *ngIf="customSequencesOfStage?.length === 0; else customSequencesSelect"
+            [dtOverlay]="noCustomSequencesOverlay"
+            fxFlex="0 1 300px"
+          >
+            <ng-container *ngTemplateOutlet="customSequencesSelect"></ng-container>
+          </div>
+          <ng-template #customSequencesSelect>
+            <dt-radio-button
+              [value]="TRIGGER_SEQUENCE.CUSTOM"
+              [disabled]="!customSequencesOfStage?.length"
+              uitestid="ktb-trigger-sequence-custom-radio"
+              class="custom-sequence-radio"
+              fxFlex="0 1 300px"
+            >
+              <dt-select
+                [disabled]="!customSequencesOfStage?.length"
+                [(ngModel)]="customFormData.sequence"
+                class="sequence-select"
+                name="customSequence"
+                placeholder="Select ..."
+                uitestid="keptn-trigger-custom-sequence-select"
+              >
+                <dt-option
+                  *ngFor="let sequence of customSequencesOfStage"
+                  [value]="sequence"
+                  [textContent]="sequence"
+                ></dt-option>
+              </dt-select>
+            </dt-radio-button>
+          </ng-template>
+          <ktb-loading-distractor *ngIf="!customSequences" class="smaller"
+            >Loading custom sequences ...
+          </ktb-loading-distractor>
+
+          <ng-template #noCustomSequencesOverlay>
+            There are no custom sequences available for this stage in the shipyard.yaml file
+          </ng-template>
+        </dt-radio-group>
+      </dt-form-field>
+      <!--   Sequence Selection   -->
+
       <div class="mt-3" fxLayout="row" fxLayoutAlign="space-between">
         <button dt-button variant="secondary" (click)="formClosed.emit()" uitestid="keptn-trigger-button-close">
           Cancel

--- a/bridge/client/app/_views/ktb-environment-view/ktb-environment-view.component.html
+++ b/bridge/client/app/_views/ktb-environment-view/ktb-environment-view.component.html
@@ -10,6 +10,6 @@
 </div>
 <ng-template #loading>
   <div fxFlexFill fxLayout="row" fxLayoutAlign="center center">
-    <dt-loading-distractor>Loading …</dt-loading-distractor>
+    <ktb-loading-distractor>Loading …</ktb-loading-distractor>
   </div>
 </ng-template>

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.html
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.html
@@ -60,7 +60,7 @@
         </div>
         <ng-template #loadingSequences>
           <div fxFlexFill fxLayout="row" fxLayoutAlign="center center" uitestid="keptn-loadingSequences">
-            <dt-loading-distractor>Loading …</dt-loading-distractor>
+            <ktb-loading-distractor>Loading …</ktb-loading-distractor>
           </div>
         </ng-template>
       </dt-quick-filter>

--- a/bridge/client/app/_views/ktb-service-view/ktb-service-view.component.html
+++ b/bridge/client/app/_views/ktb-service-view/ktb-service-view.component.html
@@ -93,6 +93,6 @@
 </div>
 <ng-template #loading>
   <div fxFlexFill fxLayout="row" fxLayoutAlign="center center">
-    <dt-loading-distractor>Loading …</dt-loading-distractor>
+    <ktb-loading-distractor>Loading …</ktb-loading-distractor>
   </div>
 </ng-template>

--- a/bridge/client/app/app.module.ts
+++ b/bridge/client/app/app.module.ts
@@ -1,12 +1,14 @@
+import { OverlayModule } from '@angular/cdk/overlay';
 import { APP_BASE_HREF, registerLocaleData } from '@angular/common';
 import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
 import localeEn from '@angular/common/locales/en';
 import { APP_INITIALIZER, NgModule } from '@angular/core';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { FlexLayoutModule } from '@angular/flex-layout';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatDialogModule } from '@angular/material/dialog';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { DtAlertModule } from '@dynatrace/barista-components/alert';
 import { DtButtonModule } from '@dynatrace/barista-components/button';
 import { DtButtonGroupModule } from '@dynatrace/barista-components/button-group';
 import { DtCardModule } from '@dynatrace/barista-components/card';
@@ -15,32 +17,60 @@ import { DtCheckboxModule } from '@dynatrace/barista-components/checkbox';
 import { DtConfirmationDialogModule } from '@dynatrace/barista-components/confirmation-dialog';
 import { DtConsumptionModule } from '@dynatrace/barista-components/consumption';
 import { DtContextDialogModule } from '@dynatrace/barista-components/context-dialog';
+import { DtCopyToClipboardModule } from '@dynatrace/barista-components/copy-to-clipboard';
 import { DtDrawerModule } from '@dynatrace/barista-components/drawer';
 import { DtEmptyStateModule } from '@dynatrace/barista-components/empty-state';
 import { DtExpandablePanelModule } from '@dynatrace/barista-components/expandable-panel';
-import { DtExpandableTextModule } from '@dynatrace/barista-components/expandable-text';
 import { DtExpandableSectionModule } from '@dynatrace/barista-components/expandable-section';
+import { DtExpandableTextModule } from '@dynatrace/barista-components/expandable-text';
+import { DtDatepickerModule } from '@dynatrace/barista-components/experimental/datepicker';
+import { DtFilterFieldModule } from '@dynatrace/barista-components/filter-field';
 import { DtIconModule } from '@dynatrace/barista-components/icon';
 import { DtIndicatorModule } from '@dynatrace/barista-components/indicator';
 import { DtInfoGroupModule } from '@dynatrace/barista-components/info-group';
 import { DtInputModule } from '@dynatrace/barista-components/input';
 import { DtKeyValueListModule } from '@dynatrace/barista-components/key-value-list';
-import { DtLoadingDistractorModule } from '@dynatrace/barista-components/loading-distractor';
 import { DtMenuModule } from '@dynatrace/barista-components/menu';
 import { DtOverlayModule } from '@dynatrace/barista-components/overlay';
 import { DtProgressBarModule } from '@dynatrace/barista-components/progress-bar';
 import { DtProgressCircleModule } from '@dynatrace/barista-components/progress-circle';
+import { DtQuickFilterModule } from '@dynatrace/barista-components/quick-filter';
+import { DtRadioModule } from '@dynatrace/barista-components/radio';
 import { DtSelectModule } from '@dynatrace/barista-components/select';
 import { DtShowMoreModule } from '@dynatrace/barista-components/show-more';
 import { DtSwitchModule } from '@dynatrace/barista-components/switch';
 import { DtTableModule } from '@dynatrace/barista-components/table';
 import { DtTagModule } from '@dynatrace/barista-components/tag';
-import { DtTopBarNavigationModule } from '@dynatrace/barista-components/top-bar-navigation';
-import { DtCopyToClipboardModule } from '@dynatrace/barista-components/copy-to-clipboard';
-import { DtToggleButtonGroupModule } from '@dynatrace/barista-components/toggle-button-group';
-import { DtQuickFilterModule } from '@dynatrace/barista-components/quick-filter';
+import { DtThemingModule } from '@dynatrace/barista-components/theming';
 import { DtTileModule } from '@dynatrace/barista-components/tile';
+import { DtToggleButtonGroupModule } from '@dynatrace/barista-components/toggle-button-group';
+import { DtTopBarNavigationModule } from '@dynatrace/barista-components/top-bar-navigation';
+import { DtTreeTableModule } from '@dynatrace/barista-components/tree-table';
 import { MomentModule } from 'ngx-moment';
+import { environment } from '../environments/environment';
+import { KtbConfirmationDialogComponent } from './_components/_dialogs/ktb-confirmation-dialog/ktb-confirmation-dialog.component';
+import { KtbDeleteConfirmationComponent } from './_components/_dialogs/ktb-delete-confirmation/ktb-delete-confirmation.component';
+import { KtbDeletionDialogComponent } from './_components/_dialogs/ktb-deletion-dialog/ktb-deletion-dialog.component';
+import { KtbProjectCreateMessageComponent } from './_components/_status-messages/ktb-project-create-message/ktb-project-create-message.component';
+import { KtbApprovalItemComponent } from './_components/ktb-approval-item/ktb-approval-item.component';
+import { KtbCopyToClipboardComponent } from './_components/ktb-copy-to-clipboard/ktb-copy-to-clipboard.component';
+import { KtbCreateSecretFormComponent } from './_components/ktb-create-secret-form/ktb-create-secret-form.component';
+import { KtbCreateServiceComponent } from './_components/ktb-create-service/ktb-create-service.component';
+import { KtbDangerZoneComponent } from './_components/ktb-danger-zone/ktb-danger-zone.component';
+import {
+  KtbDatetimePickerComponent,
+  KtbDatetimePickerDirective,
+} from './_components/ktb-datetime-picker/ktb-datetime-picker.component';
+import { KtbDeploymentListComponent } from './_components/ktb-deployment-list/ktb-deployment-list.component';
+import { KtbDeploymentStageTimelineComponent } from './_components/ktb-deployment-stage-timeline/ktb-deployment-stage-timeline.component';
+import { KtbEditServiceFileListComponent } from './_components/ktb-edit-service-file-list/ktb-edit-service-file-list.component';
+import { KtbEditServiceComponent } from './_components/ktb-edit-service/ktb-edit-service.component';
+import { KtbEvaluationDetailsComponent } from './_components/ktb-evaluation-details/ktb-evaluation-details.component';
+import { KtbEvaluationInfoComponent } from './_components/ktb-evaluation-info/ktb-evaluation-info.component';
+import {
+  KtbEventItemComponent,
+  KtbEventItemDetailDirective,
+} from './_components/ktb-event-item/ktb-event-item.component';
 import {
   KtbExpandableTileComponent,
   KtbExpandableTileHeaderDirective,
@@ -49,111 +79,82 @@ import {
   KtbHorizontalSeparatorComponent,
   KtbHorizontalSeparatorTitleDirective,
 } from './_components/ktb-horizontal-separator/ktb-horizontal-separator.component';
+import { KtbKeptnServicesListComponent } from './_components/ktb-keptn-services-list/ktb-keptn-services-list.component';
+import { KtbLoadingDistractorComponent } from './_components/ktb-loading-distractor/ktb-loading-distractor.component';
+import { KtbLoadingSpinnerComponent } from './_components/ktb-loading-spinner/ktb-loading-spinner.component';
+import { KtbMarkdownComponent } from './_components/ktb-markdown/ktb-markdown.component';
+import { KtbModifyUniformSubscriptionComponent } from './_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component';
+import { KtbNoServiceInfoComponent } from './_components/ktb-no-service-info/ktb-no-service-info.component';
 import { KtbNotificationBarComponent } from './_components/ktb-notification-bar/ktb-notification-bar.component';
+import { KtbNotificationComponent } from './_components/ktb-notification/ktb-notification.component';
+import { KtbPayloadViewerComponent } from './_components/ktb-payload-viewer/ktb-payload-viewer.component';
 import { KtbProjectListComponent } from './_components/ktb-project-list/ktb-project-list.component';
+import { KtbProjectSettingsGitComponent } from './_components/ktb-project-settings-git/ktb-project-settings-git.component';
+import { KtbProjectSettingsShipyardComponent } from './_components/ktb-project-settings-shipyard/ktb-project-settings-shipyard.component';
+import { KtbProjectSettingsComponent } from './_components/ktb-project-settings/ktb-project-settings.component';
 import { KtbProjectTileComponent } from './_components/ktb-project-tile/ktb-project-tile.component';
 import { KtbRootEventsListComponent } from './_components/ktb-root-events-list/ktb-root-events-list.component';
+import { KtbSecretsListComponent } from './_components/ktb-secrets-list/ktb-secrets-list.component';
 import {
   KtbSelectableTileComponent,
   KtbSelectableTileHeaderDirective,
 } from './_components/ktb-selectable-tile/ktb-selectable-tile.component';
-import { KtbSliBreakdownComponent } from './_components/ktb-sli-breakdown/ktb-sli-breakdown.component';
-import { KtbHideHttpLoadingDirective } from './_directives/ktb-hide-http-loading/ktb-hide-http-loading.directive';
-import { KtbShowHttpLoadingDirective } from './_directives/ktb-show-http-loading/ktb-show-http-loading.directive';
-import { KtbApprovalItemComponent } from './_components/ktb-approval-item/ktb-approval-item.component';
-import { KtbCopyToClipboardComponent } from './_components/ktb-copy-to-clipboard/ktb-copy-to-clipboard.component';
-import { KtbMarkdownComponent } from './_components/ktb-markdown/ktb-markdown.component';
-import { KtbEvaluationDetailsComponent } from './_components/ktb-evaluation-details/ktb-evaluation-details.component';
-import { KtbEvaluationInfoComponent } from './_components/ktb-evaluation-info/ktb-evaluation-info.component';
-import {
-  KtbEventItemComponent,
-  KtbEventItemDetailDirective,
-} from './_components/ktb-event-item/ktb-event-item.component';
-import { KtbTaskItemComponent, KtbTaskItemDetailDirective } from './_components/ktb-task-item/ktb-task-item.component';
-import { KtbSequenceTasksListComponent } from './_components/ktb-sequence-tasks-list/ktb-sequence-tasks-list.component';
-import { HttpErrorInterceptor } from './_interceptors/http-error-interceptor';
-import { HttpLoadingInterceptor } from './_interceptors/http-loading-interceptor';
-import { HttpDefaultInterceptor } from './_interceptors/http-default-interceptor';
-import { AppComponent } from './app.component';
-import { AppRouting } from './app.routing';
-import { AppHeaderComponent } from './app-header/app-header.component';
-import { DashboardComponent } from './dashboard/dashboard.component';
-import { ProjectBoardComponent } from './project-board/project-board.component';
-import { EvaluationBoardComponent } from './evaluation-board/evaluation-board.component';
-import { KtbSequenceTimelineComponent } from './_components/ktb-sequence-timeline/ktb-sequence-timeline.component';
-import { KtbEnvironmentViewComponent } from './_views/ktb-environment-view/ktb-environment-view.component';
-import { KtbIntegrationViewComponent } from './_views/ktb-integration-view/ktb-integration-view.component';
-import { KtbStageOverviewComponent } from './_components/ktb-stage-overview/ktb-stage-overview.component';
-import { KtbStageDetailsComponent } from './_components/ktb-stage-details/ktb-stage-details.component';
-import { KtbSequenceViewComponent } from './_views/ktb-sequence-view/ktb-sequence-view.component';
-import { KtbServiceViewComponent } from './_views/ktb-service-view/ktb-service-view.component';
-import { KeptnUrlPipe } from './_pipes/keptn-url.pipe';
-import { KtbSliBreakdownCriteriaItemComponent } from './_components/ktb-sli-breakdown-criteria-item/ktb-sli-breakdown-criteria-item.component';
-import { KtbServicesListComponent } from './_components/ktb-services-list/ktb-services-list.component';
-import { KtbStageBadgeComponent } from './_components/ktb-stage-badge/ktb-stage-badge.component';
-import { KtbKeptnServicesListComponent } from './_components/ktb-keptn-services-list/ktb-keptn-services-list.component';
-import { DtFilterFieldModule } from '@dynatrace/barista-components/filter-field';
-import { KtbDeploymentListComponent } from './_components/ktb-deployment-list/ktb-deployment-list.component';
-import { KtbUserComponent } from './_components/ktb-user/ktb-user.component';
-import { KtbServiceDetailsComponent } from './_components/ktb-service-details/ktb-service-details.component';
-import { KtbSettingsViewComponent } from './_views/ktb-settings-view/ktb-settings-view.component';
-import { KtbDeploymentStageTimelineComponent } from './_components/ktb-deployment-stage-timeline/ktb-deployment-stage-timeline.component';
-import { KtbSequenceListComponent } from './_components/ktb-sequence-list/ktb-sequence-list.component';
-import { KtbUniformRegistrationLogsComponent } from './_components/ktb-uniform-registration-logs/ktb-uniform-registration-logs.component';
-import { AppInitService } from './_services/app.init';
-import { KtbSecretsListComponent } from './_components/ktb-secrets-list/ktb-secrets-list.component';
-import { KtbCreateSecretFormComponent } from './_components/ktb-create-secret-form/ktb-create-secret-form.component';
-import { KtbNoServiceInfoComponent } from './_components/ktb-no-service-info/ktb-no-service-info.component';
-import { KtbSequenceStateListComponent } from './_components/ktb-sequence-state-list/ktb-sequence-state-list.component';
-import { KtbProjectSettingsGitComponent } from './_components/ktb-project-settings-git/ktb-project-settings-git.component';
-import { KtbProjectSettingsShipyardComponent } from './_components/ktb-project-settings-shipyard/ktb-project-settings-shipyard.component';
-import { KtbDragAndDropDirective } from './_directives/ktb-drag-and-drop/ktb-drag-and-drop.directive';
-import { KtbDangerZoneComponent } from './_components/ktb-danger-zone/ktb-danger-zone.component';
-import { KtbDeletionDialogComponent } from './_components/_dialogs/ktb-deletion-dialog/ktb-deletion-dialog.component';
-import { EventService } from './_services/event.service';
-import { ToType } from './_pipes/to-type';
-import { KtbUniformSubscriptionsComponent } from './_components/ktb-uniform-subscriptions/ktb-uniform-subscriptions.component';
-import { ToDatePipe } from './_pipes/to-date.pipe';
-import { KtbDeleteConfirmationComponent } from './_components/_dialogs/ktb-delete-confirmation/ktb-delete-confirmation.component';
-import { KtbModifyUniformSubscriptionComponent } from './_components/ktb-modify-uniform-subscription/ktb-modify-uniform-subscription.component';
-import { DtThemingModule } from '@dynatrace/barista-components/theming';
-import { KtbSubscriptionItemComponent } from './_components/ktb-subscription-item/ktb-subscription-item.component';
-import { KtbConfirmationDialogComponent } from './_components/_dialogs/ktb-confirmation-dialog/ktb-confirmation-dialog.component';
-import { POLLING_INTERVAL_MILLIS, RETRY_ON_HTTP_ERROR } from './_utils/app.utils';
 import { KtbSequenceControlsComponent } from './_components/ktb-sequence-controls/ktb-sequence-controls.component';
-import { environment } from '../environments/environment';
-import { KtbProjectSettingsComponent } from './_components/ktb-project-settings/ktb-project-settings.component';
-import { KtbWebhookSettingsComponent } from './_components/ktb-webhook-settings/ktb-webhook-settings.component';
-import { KtbServiceSettingsComponent } from './_components/ktb-service-settings/ktb-service-settings.component';
-import { KtbCreateServiceComponent } from './_components/ktb-create-service/ktb-create-service.component';
-import { KtbServiceSettingsOverviewComponent } from './_components/ktb-service-settings-overview/ktb-service-settings-overview.component';
+import { KtbSequenceListComponent } from './_components/ktb-sequence-list/ktb-sequence-list.component';
+import { KtbSequenceStateInfoComponent } from './_components/ktb-sequence-state-info/ktb-sequence-state-info.component';
+import { KtbSequenceStateListComponent } from './_components/ktb-sequence-state-list/ktb-sequence-state-list.component';
+import { KtbSequenceTasksListComponent } from './_components/ktb-sequence-tasks-list/ktb-sequence-tasks-list.component';
+import { KtbSequenceTimelineComponent } from './_components/ktb-sequence-timeline/ktb-sequence-timeline.component';
+import { KtbServiceDetailsComponent } from './_components/ktb-service-details/ktb-service-details.component';
 import { KtbServiceSettingsListComponent } from './_components/ktb-service-settings-list/ktb-service-settings-list.component';
-import { KtbEditServiceComponent } from './_components/ktb-edit-service/ktb-edit-service.component';
-import { DtAlertModule } from '@dynatrace/barista-components/alert';
-import { KtbEditServiceFileListComponent } from './_components/ktb-edit-service-file-list/ktb-edit-service-file-list.component';
-import { DtTreeTableModule } from '@dynatrace/barista-components/tree-table';
+import { KtbServiceSettingsOverviewComponent } from './_components/ktb-service-settings-overview/ktb-service-settings-overview.component';
+import { KtbServiceSettingsComponent } from './_components/ktb-service-settings/ktb-service-settings.component';
+import { KtbServicesListComponent } from './_components/ktb-services-list/ktb-services-list.component';
+import { KtbSliBreakdownCriteriaItemComponent } from './_components/ktb-sli-breakdown-criteria-item/ktb-sli-breakdown-criteria-item.component';
+import { KtbSliBreakdownComponent } from './_components/ktb-sli-breakdown/ktb-sli-breakdown.component';
+import { KtbStageBadgeComponent } from './_components/ktb-stage-badge/ktb-stage-badge.component';
+import { KtbStageDetailsComponent } from './_components/ktb-stage-details/ktb-stage-details.component';
+import { KtbStageOverviewComponent } from './_components/ktb-stage-overview/ktb-stage-overview.component';
+import { KtbSubscriptionItemComponent } from './_components/ktb-subscription-item/ktb-subscription-item.component';
+import { KtbTaskItemComponent, KtbTaskItemDetailDirective } from './_components/ktb-task-item/ktb-task-item.component';
+import { KtbTimeInputComponent } from './_components/ktb-time-input/ktb-time-input.component';
 import {
   KtbTreeListSelectComponent,
   KtbTreeListSelectDirective,
 } from './_components/ktb-tree-list-select/ktb-tree-list-select.component';
-import { OverlayModule } from '@angular/cdk/overlay';
-import { KtbSequenceStateInfoComponent } from './_components/ktb-sequence-state-info/ktb-sequence-state-info.component';
-import { KtbPayloadViewerComponent } from './_components/ktb-payload-viewer/ktb-payload-viewer.component';
-import { DtRadioModule } from '@dynatrace/barista-components/radio';
-import { NotFoundComponent } from './not-found/not-found.component';
-import { KtbVariableSelectorComponent } from './_components/ktb-variable-selector/ktb-variable-selector.component';
-import { KtbNotificationComponent } from './_components/ktb-notification/ktb-notification.component';
-import { KtbProjectCreateMessageComponent } from './_components/_status-messages/ktb-project-create-message/ktb-project-create-message.component';
-import { PendingChangesGuard } from './_guards/pending-changes.guard';
-import { ArrayToStringPipe } from './_pipes/array-to-string';
 import { KtbTriggerSequenceComponent } from './_components/ktb-trigger-sequence/ktb-trigger-sequence.component';
-import { KtbTimeInputComponent } from './_components/ktb-time-input/ktb-time-input.component';
-import {
-  KtbDatetimePickerComponent,
-  KtbDatetimePickerDirective,
-} from './_components/ktb-datetime-picker/ktb-datetime-picker.component';
-import { DtDatepickerModule } from '@dynatrace/barista-components/experimental/datepicker';
+import { KtbUniformRegistrationLogsComponent } from './_components/ktb-uniform-registration-logs/ktb-uniform-registration-logs.component';
+import { KtbUniformSubscriptionsComponent } from './_components/ktb-uniform-subscriptions/ktb-uniform-subscriptions.component';
+import { KtbUserComponent } from './_components/ktb-user/ktb-user.component';
+import { KtbVariableSelectorComponent } from './_components/ktb-variable-selector/ktb-variable-selector.component';
+import { KtbWebhookSettingsComponent } from './_components/ktb-webhook-settings/ktb-webhook-settings.component';
+import { KtbDragAndDropDirective } from './_directives/ktb-drag-and-drop/ktb-drag-and-drop.directive';
+import { KtbHideHttpLoadingDirective } from './_directives/ktb-hide-http-loading/ktb-hide-http-loading.directive';
+import { KtbShowHttpLoadingDirective } from './_directives/ktb-show-http-loading/ktb-show-http-loading.directive';
+import { PendingChangesGuard } from './_guards/pending-changes.guard';
+import { HttpDefaultInterceptor } from './_interceptors/http-default-interceptor';
+import { HttpErrorInterceptor } from './_interceptors/http-error-interceptor';
+import { HttpLoadingInterceptor } from './_interceptors/http-loading-interceptor';
+import { ArrayToStringPipe } from './_pipes/array-to-string';
+import { KeptnUrlPipe } from './_pipes/keptn-url.pipe';
+import { ToDatePipe } from './_pipes/to-date.pipe';
+import { ToType } from './_pipes/to-type';
 import { TruncateNumberPipe } from './_pipes/truncate-number';
+import { AppInitService } from './_services/app.init';
+import { EventService } from './_services/event.service';
+import { POLLING_INTERVAL_MILLIS, RETRY_ON_HTTP_ERROR } from './_utils/app.utils';
+import { KtbEnvironmentViewComponent } from './_views/ktb-environment-view/ktb-environment-view.component';
+import { KtbIntegrationViewComponent } from './_views/ktb-integration-view/ktb-integration-view.component';
+import { KtbSequenceViewComponent } from './_views/ktb-sequence-view/ktb-sequence-view.component';
+import { KtbServiceViewComponent } from './_views/ktb-service-view/ktb-service-view.component';
+import { KtbSettingsViewComponent } from './_views/ktb-settings-view/ktb-settings-view.component';
+import { AppHeaderComponent } from './app-header/app-header.component';
+import { AppComponent } from './app.component';
+import { AppRouting } from './app.routing';
+import { DashboardComponent } from './dashboard/dashboard.component';
+import { EvaluationBoardComponent } from './evaluation-board/evaluation-board.component';
+import { NotFoundComponent } from './not-found/not-found.component';
+import { ProjectBoardComponent } from './project-board/project-board.component';
 import { KtbErrorViewComponent } from './_views/ktb-error-view/ktb-error-view.component';
 import { KtbRootComponent } from './ktb-root/ktb-root.component';
 import { KtbLogoutViewComponent } from './_views/ktb-logout-view/ktb-logout-view.component';
@@ -165,8 +166,6 @@ import { KtbIntegerInputDirective } from './_directives/ktb-integer-input/ktb-in
 import { KtbCertificateInputComponent } from './_components/ktb-certificate-input/ktb-certificate-input.component';
 import { KtbSshKeyInputComponent } from './_components/ktb-ssh-key-input/ktb-ssh-key-input.component';
 import { KtbProjectSettingsGitSshInputComponent } from './_components/ktb-project-settings-git-ssh-input/ktb-project-settings-git-ssh-input.component';
-import { KtbLoadingDistractorComponent } from './_components/ktb-loading-distractor/ktb-loading-distractor.component';
-import { KtbLoadingSpinnerComponent } from './_components/ktb-loading-spinner/ktb-loading-spinner.component';
 import { SanitizeHtmlPipe } from './_pipes/sanitize-html.pipe';
 
 registerLocaleData(localeEn, 'en');
@@ -299,7 +298,6 @@ export function init_app(appLoadService: AppInitService): () => Promise<unknown>
     DtTileModule,
     DtInfoGroupModule,
     DtProgressBarModule,
-    DtLoadingDistractorModule,
     DtTableModule,
     DtTagModule,
     DtExpandableTextModule,

--- a/bridge/client/app/dashboard/dashboard.component.html
+++ b/bridge/client/app/dashboard/dashboard.component.html
@@ -1,22 +1,13 @@
-<div class="container" uitestid="keptn-dashboard-projectList">
-  <ng-container *ngIf="projects$ | async as projects">
-    <div
-      *ngIf="!projects"
-      fxLayout="row"
-      fxLayoutAlign="start center"
-      fxLayoutGap="15px"
-      uitestid="keptn-dashboard-loading"
-    >
-      <dt-loading-spinner></dt-loading-spinner>
-      <p>Loading ...</p>
-    </div>
-
+<div class="container" fxFlexFill uitestid="keptn-dashboard-projectList">
+  <ng-container *ngIf="projects$ | async as projects; else loading">
     <div fxLayout="row" fxLayoutAlign="start" class="p-3 project-dashboard-actions">
-      <a [routerLink]="'/create/project'"><button dt-button>Create a new project</button></a>
+      <a [routerLink]="'/create/project'">
+        <button dt-button>Create a new project</button>
+      </a>
       <div class="new-project-overlay p-3 animation-pulse" *ngIf="projects?.length === 0">
         <div fxLayout="row">
-          <dt-icon name="information" class="event-icon mr-2"></dt-icon
-          ><span>Ready for your automation journey?<br />Start here by creating your first project.</span>
+          <dt-icon name="information" class="event-icon mr-2"></dt-icon>
+          <span>Ready for your automation journey?<br />Start here by creating your first project.</span>
         </div>
       </div>
     </div>
@@ -26,7 +17,7 @@
         <dt-empty-state-item-img>
           <img alt="Logo" class="mt-2" [src]="logoInvertedUrl" />
         </dt-empty-state-item-img>
-        <dt-empty-state-item-title class="mt-2" aria-level="2"> No projects existing </dt-empty-state-item-title>
+        <dt-empty-state-item-title class="mt-2" aria-level="2"> No projects existing</dt-empty-state-item-title>
         <p>
           There are no projects available.<br />
           Create a new project by using the "Create a new project" button or check out the
@@ -55,4 +46,10 @@
       <ktb-project-list [projects]="projects"></ktb-project-list>
     </div>
   </ng-container>
+
+  <ng-template #loading>
+    <div fxFlexFill fxLayoutAlign="center center">
+      <ktb-loading-distractor>Loading ...</ktb-loading-distractor>
+    </div>
+  </ng-template>
 </div>

--- a/bridge/client/app/evaluation-board/evaluation-board.component.html
+++ b/bridge/client/app/evaluation-board/evaluation-board.component.html
@@ -63,8 +63,8 @@
       <ng-container [ngSwitch]="error">
         <ng-container *ngSwitchCase="'contextError'">
           <dt-empty-state-item-title class="mt-2" aria-level="2"
-            >Traces for <span class="italic" [textContent]="contextId"></span> not found</dt-empty-state-item-title
-          >
+            >Traces for <span class="italic" [textContent]="contextId"></span> not found
+          </dt-empty-state-item-title>
           <p>
             Sorry, traces with this shkeptncontext could not be loaded. Check out the
             <a href="https://keptn.sh/docs/quickstart/" target="_blank" rel="noopener">Quick Start</a> instructions on
@@ -87,7 +87,6 @@
 </div>
 <div class="container" *ngIf="!error && !evaluations">
   <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="15px">
-    <dt-loading-spinner></dt-loading-spinner>
-    <p>Loading ...</p>
+    <ktb-loading-distractor>Loading ...</ktb-loading-distractor>
   </div>
 </div>

--- a/bridge/client/app/project-board/project-board.component.html
+++ b/bridge/client/app/project-board/project-board.component.html
@@ -20,8 +20,8 @@
         </ng-container>
         <ng-container *ngSwitchCase="'trace'">
           <dt-empty-state-item-title class="mt-2" aria-level="2"
-            >Traces for <span class="italic" [textContent]="contextId"></span> not found</dt-empty-state-item-title
-          >
+            >Traces for <span class="italic" [textContent]="contextId"></span> not found
+          </dt-empty-state-item-title>
           <p>
             Sorry, traces with this shkeptncontext could not be loaded. Check out the
             <a href="https://keptn.sh/docs/quickstart/" target="_blank" rel="noopener noreferrer">Quick Start</a>
@@ -55,8 +55,7 @@
   *ngIf="(isCreateMode$ | async) === false && (error$ | async) === undefined && (hasProject$ | async) === undefined"
 >
   <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="15px">
-    <dt-loading-spinner></dt-loading-spinner>
-    <p>Loading ...</p>
+    <ktb-loading-distractor>Loading ...</ktb-loading-distractor>
   </div>
 </div>
 <div class="project-board" fxLayout="row" *ngIf="(hasProject$ | async) || (isCreateMode$ | async)">

--- a/bridge/client/assets/default-branding/keptn-theme.css
+++ b/bridge/client/assets/default-branding/keptn-theme.css
@@ -85,7 +85,7 @@
   stroke: var(--dt-theme-main-active-color) !important;
 }
 
-.dt-button.dt-button-nested .dt-loading-spinner-svg {
+.dt-button.dt-button-nested .ktb-loading-spinner-svg {
   stroke: var(--dt-neutral-active-color) !important;
 }
 

--- a/bridge/client/styles.scss
+++ b/bridge/client/styles.scss
@@ -102,13 +102,13 @@ ktb-loading-distractor.smaller .ktb-loading-distractor-label {
   color: $gray-700;
 }
 
-ktb-loading-distractor.smaller {
-  .ktb-loading-spinner {
-    --ktb-loading-distractor-color: #{$gray-700};
+ktb-loading-spinner.smaller,
+ktb-loading-distractor.smaller .ktb-loading-spinner {
+  --ktb-loading-distractor-color: #{$gray-700};
 
-    height: 20px;
-    width: 20px;
-  }
+  height: 16px;
+  width: 16px;
+  vertical-align: text-top;
 }
 
 p.small,

--- a/bridge/client/styles.scss
+++ b/bridge/client/styles.scss
@@ -8,13 +8,10 @@ $fonts-dir: '^./assets/fonts';
 @import '~@dynatrace/barista-components/style/main';
 @import '~@dynatrace/barista-components/style/index';
 
-dt-loading-spinner.gray-loading svg {
-  stroke: #898989 !important;
-}
-
 .relative {
   position: relative;
 }
+
 .notification-indicator, .notification-indicator-text {
   border-radius: 11px;
   background-color: $red-500;
@@ -97,11 +94,21 @@ ktb-root,
 }
 
 p.smaller,
-span.smaller {
+span.smaller,
+ktb-loading-distractor.smaller .ktb-loading-distractor-label {
   font-family: BerninaSansWeb, OpenSans, sans-serif;
   font-weight: 400;
   font-size: 13px;
   color: $gray-700;
+}
+
+ktb-loading-distractor.smaller {
+  .ktb-loading-spinner {
+    --ktb-loading-distractor-color: #{$gray-700};
+
+    height: 20px;
+    width: 20px;
+  }
 }
 
 p.small,

--- a/bridge/cypress/support/pageobjects/EnvironmentPage.ts
+++ b/bridge/cypress/support/pageobjects/EnvironmentPage.ts
@@ -34,7 +34,7 @@ class EnvironmentPage {
 
   public assertEvaluationHistoryLoadingCount(service: string, count: number): this {
     this.getServiceDetailsContainer(service)
-      .find('ktb-evaluation-info dt-tag-list[aria-label="evaluation-history"] dt-tag dt-loading-spinner')
+      .find('ktb-evaluation-info dt-tag-list[aria-label="evaluation-history"] dt-tag ktb-loading-spinner')
       .should('have.length', count);
     return this;
   }
@@ -69,4 +69,5 @@ class EnvironmentPage {
     return cy.get('ktb-stage-details ktb-expandable-tile h2').contains(service).parentsUntil('ktb-expandable-tile');
   }
 }
+
 export default EnvironmentPage;

--- a/bridge/cypress/support/pageobjects/SequencesPage.ts
+++ b/bridge/cypress/support/pageobjects/SequencesPage.ts
@@ -1,5 +1,5 @@
-import { interceptMain, interceptSequencesPage } from '../intercept';
 import { EventTypes } from '../../../shared/interfaces/event-types';
+import { interceptMain, interceptSequencesPage } from '../intercept';
 
 export class SequencesPage {
   private readonly sequenceWaitingMessage = ' Sequence is waiting for previous sequences to finish. ';
@@ -222,7 +222,7 @@ export class SequencesPage {
     cy.get('.stage-info')
       .contains(stage)
       .parentsUntilTestId(`keptn-sequence-timeline-stage-${stage}`)
-      .find('dt-loading-spinner')
+      .find('ktb-loading-spinner')
       .should(exists ? 'exist' : 'not.exist');
     return this;
   }


### PR DESCRIPTION
## This PR

- Uses the new loading components instead of dt-loading-*
- Fixes some styling
- Removes usage of `DtLoadingDistratorModule`

### Related Issues

Resolves #5568

### Notes

Some screenshots on how they would look like if the PR gets merged.

![loading-distractor-create-secret-button](https://user-images.githubusercontent.com/34232562/164219662-220f4286-f59d-4869-8cd0-889b3217b40e.png)
![loading-distractor-create-project](https://user-images.githubusercontent.com/34232562/164219667-540ca607-f6f1-4600-a7f9-d71af0798215.png)
![loading-distractor-sequence-fetching-events](https://user-images.githubusercontent.com/34232562/164219668-b2417610-56d4-4692-985e-24b1502308f3.png)
![loading-distractor-create-service](https://user-images.githubusercontent.com/34232562/164219669-ff9c01d3-e683-4ca3-8694-052356be9727.png)
![loading-distractor-delete-service](https://user-images.githubusercontent.com/34232562/164219670-d1be5563-f37d-4fec-be8b-3a968b0da302.png)
![loading-distractor-create-secret](https://user-images.githubusercontent.com/34232562/164219671-16a68eb9-8816-4cdf-8106-d1529311c3cb.png)
![loading-distractor-integrations-error-events](https://user-images.githubusercontent.com/34232562/164219673-53c685c2-7a8e-4f79-837f-879087ff47fb.png)
![loading-distractor-integrations](https://user-images.githubusercontent.com/34232562/164219676-a3e67f0a-fde3-4a2d-8520-136e983e2abe.png)
![loading-distractor-services](https://user-images.githubusercontent.com/34232562/164219678-aa66cc8a-d0e4-45ed-841e-fe444ae70e65.png)
![loading-distractor-edit-service](https://user-images.githubusercontent.com/34232562/164219681-36cae2b6-fd45-4be0-8c2f-b74482669d0a.png)
![loading-distractor-add-subscription](https://user-images.githubusercontent.com/34232562/164219731-d408adfe-3b99-4b9e-af0c-2c14531c73be.png)
![loading-distractor-loading-custom-sequences](https://user-images.githubusercontent.com/34232562/164219735-066b199a-c83f-4b68-b9ab-9f7d9620930c.png)
![loading-distractor-sequence-timeline](https://user-images.githubusercontent.com/34232562/164219738-8890b798-1b1c-4654-bee7-6e974392f7a0.png)

### Follow-up Tasks

Nothing.

### How to test

Open dev tools in browser and enable network throttling. Go through the screens and watch the fancy new loading indicators. Enjoy :)