### PR TITLE
feat(cp-connector): Added `FixedSubscriptionSource`

### DIFF
--- a/cp-connector/pkg/controlplane/subscriptionsource.go
+++ b/cp-connector/pkg/controlplane/subscriptionsource.go
@@ -73,7 +73,7 @@ type FixedSubscriptionSource struct {
 }
 
 // WithFixedSubscriptions adds a fixed list of subscriptions to the FixedSubscriptionSource
-func WithFixedSubscriptions(subscriptions []models.EventSubscription) func(s *FixedSubscriptionSource) {
+func WithFixedSubscriptions(subscriptions ...models.EventSubscription) func(s *FixedSubscriptionSource) {
 	return func(s *FixedSubscriptionSource) {
 		s.fixedSubscriptions = subscriptions
 	}

--- a/cp-connector/pkg/controlplane/subscriptionsource.go
+++ b/cp-connector/pkg/controlplane/subscriptionsource.go
@@ -63,3 +63,32 @@ func (s *UniformSubscriptionSource) Start(ctx context.Context, registrationData 
 	}()
 	return nil
 }
+
+// FixedSubscriptionSource can be used to use a fixed list of subscriptions rather than
+// consulting the Keptn API for subscriptions.
+// This is useful when you want to consume events from an event source, but NOT register
+// as an Keptn integration to the control plane
+type FixedSubscriptionSource struct {
+	fixedSubscriptions []models.EventSubscription
+}
+
+// WithFixedSubscriptions adds a fixed list of subscriptions to the FixedSubscriptionSource
+func WithFixedSubscriptions(subscriptions []models.EventSubscription) func(s *FixedSubscriptionSource) {
+	return func(s *FixedSubscriptionSource) {
+		s.fixedSubscriptions = subscriptions
+	}
+}
+
+// NewFixedSubscriptionSource creates a new instance of FixedSubscriptionSource
+func NewFixedSubscriptionSource(options ...func(source *FixedSubscriptionSource)) *FixedSubscriptionSource {
+	fss := &FixedSubscriptionSource{fixedSubscriptions: []models.EventSubscription{}}
+	for _, o := range options {
+		o(fss)
+	}
+	return fss
+}
+
+func (s FixedSubscriptionSource) Start(ctx context.Context, data RegistrationData, c chan []models.EventSubscription) error {
+	go func() { c <- s.fixedSubscriptions }()
+	return nil
+}

--- a/cp-connector/pkg/controlplane/subscriptionsource_test.go
+++ b/cp-connector/pkg/controlplane/subscriptionsource_test.go
@@ -208,3 +208,22 @@ func TestSubscriptionSource(t *testing.T) {
 	subs = <-subscriptionUpdates
 	require.Equal(t, 1, len(subs))
 }
+
+func TestFixedSubscriptionSource_WithSubscriptions(t *testing.T) {
+	fss := NewFixedSubscriptionSource(WithFixedSubscriptions([]models.EventSubscription{{Event: "some.event"}}))
+	subchan := make(chan []models.EventSubscription)
+	err := fss.Start(context.TODO(), RegistrationData{}, subchan)
+	require.NoError(t, err)
+	updates := <-subchan
+	require.Equal(t, 1, len(updates))
+	require.Equal(t, []models.EventSubscription{{Event: "some.event"}}, updates)
+}
+
+func TestFixedSubscriptionSourcer_WithNoSubscriptions(t *testing.T) {
+	fss := NewFixedSubscriptionSource()
+	subchan := make(chan []models.EventSubscription)
+	err := fss.Start(context.TODO(), RegistrationData{}, subchan)
+	require.NoError(t, err)
+	updates := <-subchan
+	require.Equal(t, 0, len(updates))
+}

--- a/cp-connector/pkg/controlplane/subscriptionsource_test.go
+++ b/cp-connector/pkg/controlplane/subscriptionsource_test.go
@@ -210,7 +210,7 @@ func TestSubscriptionSource(t *testing.T) {
 }
 
 func TestFixedSubscriptionSource_WithSubscriptions(t *testing.T) {
-	fss := NewFixedSubscriptionSource(WithFixedSubscriptions([]models.EventSubscription{{Event: "some.event"}}))
+	fss := NewFixedSubscriptionSource(WithFixedSubscriptions(models.EventSubscription{Event: "some.event"}))
 	subchan := make(chan []models.EventSubscription)
 	err := fss.Start(context.TODO(), RegistrationData{}, subchan)
 	require.NoError(t, err)


### PR DESCRIPTION
This PR adds a `FixedSubscriptionSource` , an implementation of `SubscriptionSource` that allows to skip registering to or getting subscriptions from an actual keptn control plane. This is useful when you just want to process (known types of) events **without** actually registering as an integration to Keptn.

Usage:
```go
...
fss := cp.NewFixedSubscriptionSource(cp.WithFixedSubscriptions(models.EventSubscription{Event: "sh.keptn.>"}))
controlPlane := cp.New(fss, eventSource)
...
```
