### PR TITLE
refactor(installer): Make use of common chart

### DIFF
--- a/helm-service/chart/Chart.yaml
+++ b/helm-service/chart/Chart.yaml
@@ -21,3 +21,8 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 appVersion: latest
+
+dependencies:
+  - name: common
+    repository: https://charts-dev.keptn.sh
+    version: 0.15.0-dev

--- a/helm-service/chart/Chart.yaml
+++ b/helm-service/chart/Chart.yaml
@@ -24,5 +24,5 @@ appVersion: latest
 
 dependencies:
   - name: common
-    repository: https://charts-dev.keptn.sh
-    version: 0.15.0-dev
+    repository: "file://../../installer/manifests/common"
+    version: 0.1.0

--- a/helm-service/chart/templates/_helpers.tpl
+++ b/helm-service/chart/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Expand the name of the chart.
 */}}
 {{- define "helm-service.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- include "common.names.name" . -}}
 {{- end }}
 
 {{/*
@@ -11,44 +11,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "helm-service.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
+{{- include "common.names.fullname" . -}}
 {{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "helm-service.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
-{{- end }}
-
-{{/*
-Common labels
-*/}}
-{{- define "helm-service.labels" -}}
-helm.sh/chart: {{ include "helm-service.chart" . }}
-{{ include "helm-service.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end }}
-
-
-{{/*
-Selector labels
-*/}}
-{{- define "helm-service.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "helm-service.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+{{- include "common.names.chart" . -}}
 {{- end }}
 
 {{/*

--- a/helm-service/chart/templates/deployment.yaml
+++ b/helm-service/chart/templates/deployment.yaml
@@ -2,22 +2,18 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "helm-service.fullname" . }}
-  labels:
-    {{- include "helm-service.labels" . | nindent 4 }}
-
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
-    matchLabels:
-      {{- include "helm-service.selectorLabels" . | nindent 6 }}
+    matchLabels: {{- include "common.labels.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      labels:
-        {{- include "helm-service.labels" . | nindent 8 }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/helm-service/chart/templates/deployment.yaml
+++ b/helm-service/chart/templates/deployment.yaml
@@ -3,10 +3,12 @@ kind: Deployment
 metadata:
   name: {{ include "helm-service.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: helm-service
 spec:
   replicas: 1
   selector:
     matchLabels: {{- include "common.labels.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: helm-service
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -14,6 +16,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
+        app.kubernetes.io/component: helm-service
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/helm-service/chart/templates/service.yaml
+++ b/helm-service/chart/templates/service.yaml
@@ -3,13 +3,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "helm-service.fullname" . }}
-  labels:
-    {{- include "helm-service.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   type: ClusterIP
   ports:
     - port: 8080
       protocol: TCP
-  selector:
-    {{- include "helm-service.selectorLabels" . | nindent 4 }}
+  selector: {{- include "common.labels.selectorLabels" . | nindent 4 }}
   {{- end }}

--- a/helm-service/chart/templates/service.yaml
+++ b/helm-service/chart/templates/service.yaml
@@ -4,10 +4,12 @@ kind: Service
 metadata:
   name: {{ include "helm-service.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: helm-service
 spec:
   type: ClusterIP
   ports:
     - port: 8080
       protocol: TCP
   selector: {{- include "common.labels.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: helm-service
   {{- end }}

--- a/helm-service/chart/templates/serviceaccount.yaml
+++ b/helm-service/chart/templates/serviceaccount.yaml
@@ -2,8 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "helm-service.serviceAccountName" . }}
-  labels:
-    {{- include "helm-service.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
@@ -14,8 +13,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: keptn-{{ .Release.Namespace }}-helm-service-cluster-admin
-  labels:
-    {{- include "helm-service.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}

--- a/helm-service/chart/templates/serviceaccount.yaml
+++ b/helm-service/chart/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ kind: ServiceAccount
 metadata:
   name: {{ include "helm-service.serviceAccountName" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: helm-service
   {{- with .Values.serviceAccount.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
@@ -14,6 +15,7 @@ kind: ClusterRoleBinding
 metadata:
   name: keptn-{{ .Release.Namespace }}-helm-service-cluster-admin
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: helm-service
   {{- with .Values.serviceAccount.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}

--- a/helm-service/chart/templates/tests/test-api-connection.yaml
+++ b/helm-service/chart/templates/tests/test-api-connection.yaml
@@ -3,8 +3,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "helm-service.fullname" . }}-test-api-connection"
-  labels:
-  {{- include "helm-service.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
   annotations:
     "helm.sh/hook": test
 spec:

--- a/installer/.gitignore
+++ b/installer/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
 # ignore generated files
 manifests/keptn/Chart.lock
-manifests/keptn/charts/nats-*.tgz
+manifests/keptn/charts/*.tgz

--- a/installer/manifests/keptn/Chart.yaml
+++ b/installer/manifests/keptn/Chart.yaml
@@ -48,5 +48,5 @@ dependencies:
     version: 0.13.2
     repository: https://nats-io.github.io/k8s/helm/charts/
   - name: common
-    repository: https://charts-dev.keptn.sh
-    version: 0.15.0-dev
+    repository: "file://../common"
+    version: 0.1.0

--- a/installer/manifests/keptn/Chart.yaml
+++ b/installer/manifests/keptn/Chart.yaml
@@ -47,3 +47,6 @@ dependencies:
   - name: nats
     version: 0.13.2
     repository: https://nats-io.github.io/k8s/helm/charts/
+  - name: common
+    repository: https://charts-dev.keptn.sh
+    version: 0.15.0-dev

--- a/installer/manifests/keptn/templates/_helpers.tpl
+++ b/installer/manifests/keptn/templates/_helpers.tpl
@@ -58,7 +58,7 @@ livenessProbe:
   httpGet:
     path: /health
     port: {{.port | default 8080}}
-  initialDelaySeconds: {{ .initialDelaySeconds | default 10}}
+  initialDelaySeconds: {{ .initialDelaySeconds | default 10 }}
   periodSeconds: 5
 {{- end }}
 
@@ -67,7 +67,7 @@ readinessProbe:
   httpGet:
     path: /health
     port: {{.port | default 8080}}
-  initialDelaySeconds: {{ .initialDelaySeconds | default 5}}
+  initialDelaySeconds: {{ .initialDelaySeconds | default 5 }}
   periodSeconds: 5
 {{- end }}
 

--- a/installer/manifests/keptn/templates/_helpers.tpl
+++ b/installer/manifests/keptn/templates/_helpers.tpl
@@ -155,7 +155,7 @@ securityContext:
 {{- range $key, $value := omit .Values.bridge.podSecurityContext "enabled" "defaultSeccompProfile" }}
   {{ $key }}: {{- toYaml $value | nindent 4 }}
 {{- end -}}
-{{- if not .Values.bridge.podSecurityContext.defaultSeccompProfile }}
+{{- if not .Values.bridge.podSecurityContext.seccompProfile }}
 {{- if .Values.bridge.podSecurityContext.defaultSeccompProfile -}}
 {{- include "keptn.common.security-context-seccomp" . }}
 {{- end -}}
@@ -193,7 +193,7 @@ securityContext:
 {{- range $key, $value := omit .Values.apiGatewayNginx.podSecurityContext "enabled" "defaultSeccompProfile" }}
   {{ $key }}: {{- toYaml $value | nindent 4 }}
 {{- end -}}
-{{- if not .Values.apiGatewayNginx.podSecurityContext.defaultSeccompProfile -}}
+{{- if not .Values.apiGatewayNginx.podSecurityContext.seccompProfile -}}
 {{- if .Values.apiGatewayNginx.podSecurityContext.defaultSeccompProfile -}}
 {{- include "keptn.common.security-context-seccomp" . }}
 {{- end -}}
@@ -231,7 +231,7 @@ securityContext:
 {{- range $key, $value := omit .Values.podSecurityContext "enabled" "defaultSeccompProfile" }}
   {{ $key }}: {{- toYaml $value | nindent 4 }}
 {{- end -}}
-{{- if not .Values.podSecurityContext.defaultSeccompProfile -}}
+{{- if not .Values.podSecurityContext.seccompProfile -}}
 {{- if .Values.apiGatewayNginx.podSecurityContext.defaultSeccompProfile -}}
 {{- include "keptn.common.security-context-seccomp" . -}}
 {{- end -}}

--- a/installer/manifests/keptn/templates/_helpers.tpl
+++ b/installer/manifests/keptn/templates/_helpers.tpl
@@ -3,7 +3,7 @@
 Expand the name of the chart.
 */}}
 {{- define "keptn.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- include "common.names.name" . -}}
 {{- end }}
 
 {{/*
@@ -12,23 +12,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "keptn.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
+{{- include "common.names.fullname" . -}}
 {{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "keptn.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- include "common.names.chart" . -}}
 {{- end }}
 
 {{/*
@@ -47,6 +38,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "keptn.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "keptn.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 

--- a/installer/manifests/keptn/templates/_helpers.tpl
+++ b/installer/manifests/keptn/templates/_helpers.tpl
@@ -22,37 +22,6 @@ Create chart name and version as used by the chart label.
 {{- include "common.names.chart" . -}}
 {{- end }}
 
-{{/*
-Common labels
-*/}}
-{{- define "keptn.labels" -}}
-helm.sh/chart: {{ include "keptn.chart" . }}
-{{ include "keptn.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end }}
-
-{{/*
-Selector labels
-*/}}
-{{- define "keptn.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "keptn.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
-
-{{/*
-Create the name of the service account to use
-*/}}
-{{- define "keptn.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "keptn.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
-{{- end }}
-
 {{- define "keptn.dist.livenessProbe" -}}
 livenessProbe:
   httpGet:
@@ -303,21 +272,9 @@ Usage:
 */}}
 {{- define "keptn.tpl-value-or-default" -}}
   {{- if .value }}
-    {{- include "keptn.tpl-value" ( dict "value" .value "context" .context ) }}
+    {{- include "common.tplvalues.render" ( dict "value" .value "context" .context ) }}
   {{- else }}
-    {{- include "keptn.tpl-value" ( dict "value" .default "context" .context ) }}
+    {{- include "common.tplvalues.render" ( dict "value" .default "context" .context ) }}
   {{- end }}
 {{- end -}}
 
-{{/*
-Renders a value that contains a template. value can be a string, map or array
-Usage:
-{{ include "keptn.tpl-value" ( dict "value" .my-value.to-template "context" $ ) }}
-*/}}
-{{- define "keptn.tpl-value" -}}
-  {{- if typeIs "string" .value }}
-    {{- tpl .value .context }}
-  {{- else }}
-    {{- tpl (.value | toYaml) .context }}
-  {{- end }}
-{{- end -}}

--- a/installer/manifests/keptn/templates/_helpers.tpl
+++ b/installer/manifests/keptn/templates/_helpers.tpl
@@ -225,13 +225,13 @@ securityContext:
 {{- end -}}
 
 {{- define "keptn.common.pod-security-context" -}}
-{{- if (.Values.common).podSecurityContext -}}
-{{- if .Values.common.podSecurityContext.enabled -}}
+{{- if (.Values.).podSecurityContext -}}
+{{- if .Values..podSecurityContext.enabled -}}
 securityContext:
-{{- range $key, $value := omit .Values.common.podSecurityContext "enabled" "defaultSeccompProfile" }}
+{{- range $key, $value := omit .Values..podSecurityContext "enabled" "defaultSeccompProfile" }}
   {{ $key }}: {{- toYaml $value | nindent 4 }}
 {{- end -}}
-{{- if not .Values.common.podSecurityContext.seccompProfile -}}
+{{- if not .Values..podSecurityContext.seccompProfile -}}
 {{- if .Values.apiGatewayNginx.podSecurityContext.defaultSeccompProfile -}}
 {{- include "keptn.common.security-context-seccomp" . -}}
 {{- end -}}
@@ -245,10 +245,10 @@ securityContext:
 {{- end -}}
 
 {{- define "keptn.common.container-security-context" -}}
-{{- if (.Values.common).containerSecurityContext -}}
-{{- if .Values.common.containerSecurityContext.enabled -}}
+{{- if (.Values.).containerSecurityContext -}}
+{{- if .Values..containerSecurityContext.enabled -}}
 securityContext:
-{{- range $key, $value := omit .Values.common.containerSecurityContext "enabled" }}
+{{- range $key, $value := omit .Values..containerSecurityContext "enabled" }}
   {{ $key }}: {{- toYaml $value | nindent 4 }}
 {{- end -}}
 {{- end -}}
@@ -266,9 +266,9 @@ securityContext:
 rollingUpdate upgrade strategy for control plane deployments
 */}}
 {{- define "keptn.common.update-strategy" -}}
-{{- if (.Values.common).strategy -}}
+{{- if (.Values.).strategy -}}
 strategy:
-{{- toYaml .Values.common.strategy | nindent 2 -}}
+{{- toYaml .Values..strategy | nindent 2 -}}
 {{- else -}}
 strategy:
   type: RollingUpdate

--- a/installer/manifests/keptn/templates/_helpers.tpl
+++ b/installer/manifests/keptn/templates/_helpers.tpl
@@ -58,7 +58,7 @@ livenessProbe:
   httpGet:
     path: /health
     port: {{.port | default 8080}}
-  initialDelaySeconds: {{.initialDelaySeconds | default 10}}
+  initialDelaySeconds: {{ .initialDelaySeconds | default 10}}
   periodSeconds: 5
 {{- end }}
 
@@ -67,7 +67,7 @@ readinessProbe:
   httpGet:
     path: /health
     port: {{.port | default 8080}}
-  initialDelaySeconds: {{.initialDelaySeconds | default 5}}
+  initialDelaySeconds: {{ .initialDelaySeconds | default 5}}
   periodSeconds: 5
 {{- end }}
 
@@ -155,7 +155,7 @@ securityContext:
 {{- range $key, $value := omit .Values.bridge.podSecurityContext "enabled" "defaultSeccompProfile" }}
   {{ $key }}: {{- toYaml $value | nindent 4 }}
 {{- end -}}
-{{- if not .Values.bridge.podSecurityContext.seccompProfile }}
+{{- if not .Values.bridge.podSecurityContext.defaultSeccompProfile }}
 {{- if .Values.bridge.podSecurityContext.defaultSeccompProfile -}}
 {{- include "keptn.common.security-context-seccomp" . }}
 {{- end -}}
@@ -193,7 +193,7 @@ securityContext:
 {{- range $key, $value := omit .Values.apiGatewayNginx.podSecurityContext "enabled" "defaultSeccompProfile" }}
   {{ $key }}: {{- toYaml $value | nindent 4 }}
 {{- end -}}
-{{- if not .Values.apiGatewayNginx.podSecurityContext.seccompProfile -}}
+{{- if not .Values.apiGatewayNginx.podSecurityContext.defaultSeccompProfile -}}
 {{- if .Values.apiGatewayNginx.podSecurityContext.defaultSeccompProfile -}}
 {{- include "keptn.common.security-context-seccomp" . }}
 {{- end -}}
@@ -225,13 +225,13 @@ securityContext:
 {{- end -}}
 
 {{- define "keptn.common.pod-security-context" -}}
-{{- if (.Values.).podSecurityContext -}}
-{{- if .Values..podSecurityContext.enabled -}}
+{{- if .Values.podSecurityContext -}}
+{{- if .Values.podSecurityContext.enabled -}}
 securityContext:
-{{- range $key, $value := omit .Values..podSecurityContext "enabled" "defaultSeccompProfile" }}
+{{- range $key, $value := omit .Values.podSecurityContext "enabled" "defaultSeccompProfile" }}
   {{ $key }}: {{- toYaml $value | nindent 4 }}
 {{- end -}}
-{{- if not .Values..podSecurityContext.seccompProfile -}}
+{{- if not .Values.podSecurityContext.defaultSeccompProfile -}}
 {{- if .Values.apiGatewayNginx.podSecurityContext.defaultSeccompProfile -}}
 {{- include "keptn.common.security-context-seccomp" . -}}
 {{- end -}}
@@ -245,10 +245,10 @@ securityContext:
 {{- end -}}
 
 {{- define "keptn.common.container-security-context" -}}
-{{- if (.Values.).containerSecurityContext -}}
-{{- if .Values..containerSecurityContext.enabled -}}
+{{- if .Values.containerSecurityContext -}}
+{{- if .Values.containerSecurityContext.enabled -}}
 securityContext:
-{{- range $key, $value := omit .Values..containerSecurityContext "enabled" }}
+{{- range $key, $value := omit .Values.containerSecurityContext "enabled" }}
   {{ $key }}: {{- toYaml $value | nindent 4 }}
 {{- end -}}
 {{- end -}}
@@ -266,9 +266,9 @@ securityContext:
 rollingUpdate upgrade strategy for control plane deployments
 */}}
 {{- define "keptn.common.update-strategy" -}}
-{{- if (.Values.).strategy -}}
+{{- if .Values.strategy -}}
 strategy:
-{{- toYaml .Values..strategy | nindent 2 -}}
+{{- toYaml .Values.strategy | nindent 2 -}}
 {{- else -}}
 strategy:
   type: RollingUpdate

--- a/installer/manifests/keptn/templates/api-gateway-nginx.yaml
+++ b/installer/manifests/keptn/templates/api-gateway-nginx.yaml
@@ -408,20 +408,20 @@ spec:
               readOnly: true
               name: api-nginx-config
             {{- if .Values.apiGatewayNginx.extraVolumeMounts }}
-            {{- include "keptn.tpl-value" ( dict "value" .Values.apiGatewayNginx.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- include "common.tplvalues.render" ( dict "value" .Values.apiGatewayNginx.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
           resources:
             {{- toYaml .Values.apiGatewayNginx.resources | nindent 12 }}
           {{- include "keptn.apiGatewayNginx.container-security-context" . | nindent 10 }}
         {{- with .Values.apiGatewayNginx.sidecars }}
-        {{- include "keptn.tpl-value" ( dict "value" . "context" $ ) | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8 }}
         {{- end }}
       volumes:
         - name: api-nginx-config
           configMap:
             name: api-nginx-config # place ConfigMap `api-nginx-config` on /etc/nginx
         {{- if .Values.apiGatewayNginx.extraVolumes }}
-        {{- include "keptn.tpl-value" ( dict "value" .Values.apiGatewayNginx.extraVolumes "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.apiGatewayNginx.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
       serviceAccountName: keptn-default
       {{- include "keptn.nodeSelector" (dict "value" .Values.apiGatewayNginx.nodeSelector "default" .Values.nodeSelector "indent" 6 "context" . )}}

--- a/installer/manifests/keptn/templates/api-gateway-nginx.yaml
+++ b/installer/manifests/keptn/templates/api-gateway-nginx.yaml
@@ -4,13 +4,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: api-nginx-config
-  labels:
-    app.kubernetes.io/name: api-nginx-config-cm
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 data:
   nginx.conf: |
     worker_processes  3;
@@ -356,14 +352,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: api-gateway-nginx
-  labels:
-    app.kubernetes.io/name: api-gateway-nginx
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
     app.kubernetes.io/version: {{ .Values.apiGatewayNginx.image.tag }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 spec:
   selector:
     matchLabels:
@@ -373,14 +365,9 @@ spec:
   {{- include "keptn.common.update-strategy" . | nindent 2 }}
   template:
     metadata:
-      labels:
-        app.kubernetes.io/name: api-gateway-nginx
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
         app.kubernetes.io/component: {{ include "keptn.name" . }}
-        app.kubernetes.io/version: {{ .Values.apiGatewayNginx.image.tag }}
-        helm.sh/chart: {{ include "keptn.chart" . }}
       annotations: # add randomizer to restart the deployment if anything changes - see https://github.com/keptn/keptn/issues/3320
         rollme: {{ randAlphaNum 5 | quote }}
     spec:
@@ -439,19 +426,15 @@ spec:
         {{- include "keptn.tpl-value" ( dict "value" .Values.apiGatewayNginx.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
       serviceAccountName: keptn-default
-      {{- include "keptn.nodeSelector" (dict "value" .Values.apiGatewayNginx.nodeSelector "default" .Values.common.nodeSelector "indent" 6 "context" . )}}
+      {{- include "keptn.nodeSelector" (dict "value" .Values.apiGatewayNginx.nodeSelector "default" .Values.nodeSelector "indent" 6 "context" . )}}
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: api-gateway-nginx
-  labels:
-    app.kubernetes.io/name: api-gateway-nginx
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 spec:
   type: {{ .Values.apiGatewayNginx.type }}
   ports:
@@ -462,6 +445,4 @@ spec:
       nodePort: {{ .Values.apiGatewayNginx.nodePort }}
       {{- end }}
       protocol: TCP
-  selector:
-    app.kubernetes.io/name: api-gateway-nginx
-    app.kubernetes.io/instance: {{ .Release.Name }}
+  selector: {{- include "common.labels.selectorLabels" . | nindent 4 }}

--- a/installer/manifests/keptn/templates/api-gateway-nginx.yaml
+++ b/installer/manifests/keptn/templates/api-gateway-nginx.yaml
@@ -355,7 +355,6 @@ metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    app.kubernetes.io/version: {{ .Values.apiGatewayNginx.image.tag }}
 spec:
   selector:
     matchLabels:

--- a/installer/manifests/keptn/templates/api-gateway-nginx.yaml
+++ b/installer/manifests/keptn/templates/api-gateway-nginx.yaml
@@ -6,7 +6,7 @@ metadata:
   name: api-nginx-config
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: api-gateway-nginx
 data:
   nginx.conf: |
     worker_processes  3;
@@ -354,19 +354,18 @@ metadata:
   name: api-gateway-nginx
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: api-gateway-nginx
 spec:
   selector:
-    matchLabels:
-      app.kubernetes.io/name: api-gateway-nginx
-      app.kubernetes.io/instance: {{ .Release.Name }}
+    matchLabels: {{- include "common.labels.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: api-gateway-nginx
   replicas: 1
   {{- include "keptn.common.update-strategy" . | nindent 2 }}
   template:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-        app.kubernetes.io/component: {{ include "keptn.name" . }}
+        app.kubernetes.io/component: api-gateway-nginx
       annotations: # add randomizer to restart the deployment if anything changes - see https://github.com/keptn/keptn/issues/3320
         rollme: {{ randAlphaNum 5 | quote }}
     spec:
@@ -433,7 +432,7 @@ metadata:
   name: api-gateway-nginx
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: api-gateway-nginx
 spec:
   type: {{ .Values.apiGatewayNginx.type }}
   ports:
@@ -445,3 +444,4 @@ spec:
       {{- end }}
       protocol: TCP
   selector: {{- include "common.labels.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: api-gateway-nginx

--- a/installer/manifests/keptn/templates/api-service.yaml
+++ b/installer/manifests/keptn/templates/api-service.yaml
@@ -2,31 +2,19 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: api-service
-  labels:
-    app.kubernetes.io/name: api-service
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    app.kubernetes.io/version: {{ .Values.apiService.image.tag | default .Chart.AppVersion }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 spec:
   selector:
-    matchLabels:
-      app.kubernetes.io/name: api-service
-      app.kubernetes.io/instance: {{ .Release.Name }}
+    matchLabels: {{- include "common.labels.selectorLabels" . | nindent 6 }}
   replicas: 1
   {{- include "keptn.common.update-strategy" . | nindent 2 }}
   template:
     metadata:
-      labels:
-        app.kubernetes.io/name: api-service
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
         app.kubernetes.io/component: {{ include "keptn.name" . }}
-        app.kubernetes.io/version: {{ .Values.apiService.image.tag | default .Chart.AppVersion }}
-        helm.sh/chart: {{ include "keptn.chart" . }}
     spec:
       {{- include "keptn.common.pod-security-context" . | nindent 6 }}
       terminationGracePeriodSeconds: {{ .Values.apiService.gracePeriod | default 120 }}
@@ -105,25 +93,19 @@ spec:
       {{- include "keptn.tpl-value" ( dict "value" .Values.apiService.extraVolumes "context" $) | nindent 8 }}
       {{- end }}
       serviceAccountName: keptn-api-service
-      {{- include "keptn.nodeSelector" (dict "value" .Values.apiService.nodeSelector "default" .Values.common.nodeSelector "indent" 6 "context" . )}}
+      {{- include "keptn.nodeSelector" (dict "value" .Values.apiService.nodeSelector "default" .Values.nodeSelector "indent" 6 "context" . )}}
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: api-service
-  labels:
-    app.kubernetes.io/name: api-service
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 spec:
   ports:
     - port: 8080
       name: http
       targetPort: 8080
       protocol: TCP
-  selector:
-    app.kubernetes.io/name: api-service
-    app.kubernetes.io/instance: {{ .Release.Name }}
+  selector: {{- include "common.labels.selectorLabels" . | nindent 4 }}

--- a/installer/manifests/keptn/templates/api-service.yaml
+++ b/installer/manifests/keptn/templates/api-service.yaml
@@ -59,7 +59,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: AUTOMATIC_PROVISIONING_URL
-              value: {{ (.Values.features).automaticProvisioningURL | default "" }}
+              value: {{ (.Values.features).automaticProvisioningURL | default "" | quote }}
             - name: MAX_AUTH_ENABLED
               value: {{ (.Values.apiService.maxAuth).enabled | default true | quote }}
             - name: MAX_AUTH_REQUESTS_PER_SECOND

--- a/installer/manifests/keptn/templates/api-service.yaml
+++ b/installer/manifests/keptn/templates/api-service.yaml
@@ -72,7 +72,7 @@ spec:
           {{- include "keptn.common.container-security-context" . | nindent 10 }}
           {{- if .Values.apiService.extraVolumeMounts }}
           volumeMounts:
-          {{- include "keptn.tpl-value" ( dict "value" .Values.apiService.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- include "common.tplvalues.render" ( dict "value" .Values.apiService.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
         - name: distributor
           image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
@@ -87,11 +87,11 @@ spec:
           {{- include "keptn.dist.common.env.vars" . | nindent 12 }}
           {{- include "keptn.common.container-security-context" . | nindent 10 }}
         {{- with .Values.apiService.sidecars }}
-        {{- include "keptn.tpl-value" ( dict "value" . "context" $ ) | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8 }}
         {{- end }}
       {{- if .Values.apiService.extraVolumes }}
       volumes:
-      {{- include "keptn.tpl-value" ( dict "value" .Values.apiService.extraVolumes "context" $) | nindent 8 }}
+      {{- include "common.tplvalues.render" ( dict "value" .Values.apiService.extraVolumes "context" $) | nindent 8 }}
       {{- end }}
       serviceAccountName: keptn-api-service
       {{- include "keptn.nodeSelector" (dict "value" .Values.apiService.nodeSelector "default" .Values.nodeSelector "indent" 6 "context" . )}}

--- a/installer/manifests/keptn/templates/api-service.yaml
+++ b/installer/manifests/keptn/templates/api-service.yaml
@@ -4,17 +4,18 @@ metadata:
   name: api-service
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: api-service
 spec:
   selector:
     matchLabels: {{- include "common.labels.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: api-service
   replicas: 1
   {{- include "keptn.common.update-strategy" . | nindent 2 }}
   template:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-        app.kubernetes.io/component: {{ include "keptn.name" . }}
+        app.kubernetes.io/component: api-service
     spec:
       {{- include "keptn.common.pod-security-context" . | nindent 6 }}
       terminationGracePeriodSeconds: {{ .Values.apiService.gracePeriod | default 120 }}
@@ -101,7 +102,7 @@ metadata:
   name: api-service
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: api-service
 spec:
   ports:
     - port: 8080
@@ -109,3 +110,4 @@ spec:
       targetPort: 8080
       protocol: TCP
   selector: {{- include "common.labels.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: api-service

--- a/installer/manifests/keptn/templates/approval-service.yaml
+++ b/installer/manifests/keptn/templates/approval-service.yaml
@@ -2,31 +2,19 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: approval-service
-  labels:
-    app.kubernetes.io/name: approval-service
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    app.kubernetes.io/version: {{ .Values.approvalService.image.tag | default .Chart.AppVersion }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 spec:
   selector:
-    matchLabels:
-      app.kubernetes.io/name: approval-service
-      app.kubernetes.io/instance: {{ .Release.Name }}
+    matchLabels: {{- include "common.labels.selectorLabels" . | nindent 6 }}
   replicas: 1
   {{- include "keptn.common.update-strategy" . | nindent 2 }}
   template:
     metadata:
-      labels:
-        app.kubernetes.io/name: approval-service
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
         app.kubernetes.io/component: {{ include "keptn.name" . }}
-        app.kubernetes.io/version: {{ .Values.approvalService.image.tag | default .Chart.AppVersion }}
-        helm.sh/chart: {{ include "keptn.chart" . }}
     spec:
       {{- include "keptn.common.pod-security-context" . | nindent 6 }}
       terminationGracePeriodSeconds: {{ .Values.approvalService.gracePeriod | default 120 }}
@@ -94,17 +82,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: approval-service
-  labels:
-    app.kubernetes.io/name: approval-service
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 spec:
   ports:
     - port: 8080
       protocol: TCP
-  selector:
-    app.kubernetes.io/name: approval-service
-    app.kubernetes.io/instance: {{ .Release.Name }}
+  selector: {{- include "common.labels.selectorLabels" . | nindent 4 }}

--- a/installer/manifests/keptn/templates/approval-service.yaml
+++ b/installer/manifests/keptn/templates/approval-service.yaml
@@ -4,17 +4,18 @@ metadata:
   name: approval-service
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: approval-service
 spec:
   selector:
     matchLabels: {{- include "common.labels.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: approval-service
   replicas: 1
   {{- include "keptn.common.update-strategy" . | nindent 2 }}
   template:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-        app.kubernetes.io/component: {{ include "keptn.name" . }}
+        app.kubernetes.io/component: approval-service
     spec:
       {{- include "keptn.common.pod-security-context" . | nindent 6 }}
       terminationGracePeriodSeconds: {{ .Values.approvalService.gracePeriod | default 120 }}
@@ -84,9 +85,10 @@ metadata:
   name: approval-service
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: approval-service
 spec:
   ports:
     - port: 8080
       protocol: TCP
   selector: {{- include "common.labels.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: approval-service

--- a/installer/manifests/keptn/templates/approval-service.yaml
+++ b/installer/manifests/keptn/templates/approval-service.yaml
@@ -52,7 +52,7 @@ spec:
           {{- include "keptn.common.container-security-context" . | nindent 10 }}
           {{- if .Values.approvalService.extraVolumeMounts }}
           volumeMounts:
-          {{- include "keptn.tpl-value" ( dict "value" .Values.approvalService.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- include "common.tplvalues.render" ( dict "value" .Values.approvalService.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
         - name: distributor
           image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
@@ -71,11 +71,11 @@ spec:
           {{- include "keptn.dist.common.env.vars" . | nindent 12 }}
           {{- include "keptn.common.container-security-context" . | nindent 10 }}
         {{- with .Values.approvalService.sidecars }}
-        {{- include "keptn.tpl-value" ( dict "value" . "context" $ ) | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8 }}
         {{- end }}
       {{- if .Values.approvalService.extraVolumes }}
       volumes:
-      {{- include "keptn.tpl-value" ( dict "value" .Values.approvalService.extraVolumes "context" $) | nindent 8 }}
+      {{- include "common.tplvalues.render" ( dict "value" .Values.approvalService.extraVolumes "context" $) | nindent 8 }}
       {{- end }}
       {{- include "keptn.nodeSelector" (dict "value" .Values.approvalService.nodeSelector "default" .Values.nodeSelector "indent" 6 "context" . )}}
 ---

--- a/installer/manifests/keptn/templates/approval-service.yaml
+++ b/installer/manifests/keptn/templates/approval-service.yaml
@@ -76,7 +76,7 @@ spec:
       volumes:
       {{- include "keptn.tpl-value" ( dict "value" .Values.approvalService.extraVolumes "context" $) | nindent 8 }}
       {{- end }}
-      {{- include "keptn.nodeSelector" (dict "value" .Values.approvalService.nodeSelector "default" .Values.common.nodeSelector "indent" 6 "context" . )}}
+      {{- include "keptn.nodeSelector" (dict "value" .Values.approvalService.nodeSelector "default" .Values..nodeSelector "indent" 6 "context" . )}}
 ---
 apiVersion: v1
 kind: Service

--- a/installer/manifests/keptn/templates/approval-service.yaml
+++ b/installer/manifests/keptn/templates/approval-service.yaml
@@ -76,7 +76,7 @@ spec:
       volumes:
       {{- include "keptn.tpl-value" ( dict "value" .Values.approvalService.extraVolumes "context" $) | nindent 8 }}
       {{- end }}
-      {{- include "keptn.nodeSelector" (dict "value" .Values.approvalService.nodeSelector "default" .Values..nodeSelector "indent" 6 "context" . )}}
+      {{- include "keptn.nodeSelector" (dict "value" .Values.approvalService.nodeSelector "default" .Values.nodeSelector "indent" 6 "context" . )}}
 ---
 apiVersion: v1
 kind: Service

--- a/installer/manifests/keptn/templates/bridge.yaml
+++ b/installer/manifests/keptn/templates/bridge.yaml
@@ -2,18 +2,12 @@ apiVersion: v1
 kind: Service
 metadata:
   name: bridge
-  labels:
-    app.kubernetes.io/name: bridge
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 spec:
   ports:
     - port: 8080
       targetPort: 3000
       protocol: TCP
-  selector:
-    app.kubernetes.io/name: bridge
-    app.kubernetes.io/instance: {{ .Release.Name }}
+  selector: {{- include "common.labels.selectorLabels" . | nindent 4 }}

--- a/installer/manifests/keptn/templates/bridge.yaml
+++ b/installer/manifests/keptn/templates/bridge.yaml
@@ -4,10 +4,11 @@ metadata:
   name: bridge
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: bridge
 spec:
   ports:
     - port: 8080
       targetPort: 3000
       protocol: TCP
   selector: {{- include "common.labels.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: bridge

--- a/installer/manifests/keptn/templates/configuration-service.yaml
+++ b/installer/manifests/keptn/templates/configuration-service.yaml
@@ -2,25 +2,15 @@ apiVersion: v1
 kind: Service
 metadata:
   name: configuration-service
-  labels:
-    app.kubernetes.io/name: configuration-service
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 spec:
   ports:
     - port: 8080
       targetPort: 8080
       protocol: TCP
-  selector:
-    {{- if .Values.resourceService.enabled }}
-    app.kubernetes.io/name: resource-service
-    {{- else }}
-    app.kubernetes.io/name: configuration-service
-    {{- end }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+  selector: {{- include "common.labels.selectorLabels" . | nindent 4 }}
 ---
 # resource-service
 {{- if .Values.resourceService.enabled }}
@@ -28,31 +18,19 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: resource-service
-  labels:
-    app.kubernetes.io/name: resource-service
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    app.kubernetes.io/version: {{ .Values.resourceService.image.tag | default .Chart.AppVersion }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 spec:
   selector:
-    matchLabels:
-      app.kubernetes.io/name: resource-service
-      app.kubernetes.io/instance: {{ .Release.Name }}
+    matchLabels: {{- include "common.labels.selectorLabels" . | nindent 6 }}
   replicas: {{ .Values.resourceService.replicas }}
   {{- include "keptn.common.update-strategy" . | nindent 2 }}
   template:
     metadata:
-      labels:
-        app.kubernetes.io/name: resource-service
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
         app.kubernetes.io/component: {{ include "keptn.name" . }}
-        app.kubernetes.io/version: {{ .Values.resourceService.image.tag | default .Chart.AppVersion }}
-        helm.sh/chart: {{ include "keptn.chart" . }}
     spec:
       securityContext:
         fsGroup: {{ .Values.configurationService.fsGroup | default 1001 }}
@@ -117,19 +95,15 @@ spec:
         {{- include "keptn.tpl-value" ( dict "value" .Values.resourceService.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
       serviceAccountName: keptn-configuration-service
-      {{- include "keptn.nodeSelector" (dict "value" .Values.resourceService.nodeSelector "default" .Values.common.nodeSelector "indent" 6 "context" . )}}
+      {{- include "keptn.nodeSelector" (dict "value" .Values.resourceService.nodeSelector "default" .Values.nodeSelector "indent" 6 "context" . )}}
 {{- else }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: configuration-volume
-  labels:
-    app.kubernetes.io/name: configuration-volume
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 spec:
   accessModes:
     - ReadWriteOnce
@@ -144,32 +118,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: configuration-service
-  labels:
-    app.kubernetes.io/name: configuration-service
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    app.kubernetes.io/version: {{ .Values.configurationService.image.tag | default .Chart.AppVersion }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 spec:
   selector:
-    matchLabels:
-      app.kubernetes.io/name: configuration-service
-      app.kubernetes.io/instance: {{ .Release.Name }}
+    matchLabels: {{- include "common.labels.selectorLabels" . | nindent 6 }}
   replicas: 1
   strategy:
     type: Recreate
   template:
     metadata:
-      labels:
-        app.kubernetes.io/name: configuration-service
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
         app.kubernetes.io/component: {{ include "keptn.name" . }}
-        app.kubernetes.io/version: {{ .Values.configurationService.image.tag | default .Chart.AppVersion }}
-        helm.sh/chart: {{ include "keptn.chart" . }}
     spec:
       securityContext:
         fsGroup: {{ .Values.configurationService.fsGroup | default 1001 }}
@@ -250,5 +212,5 @@ spec:
         {{- include "keptn.tpl-value" ( dict "value" .Values.configurationService.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
       serviceAccountName: keptn-configuration-service
-      {{- include "keptn.nodeSelector" (dict "value" .Values.configurationService.nodeSelector "default" .Values.common.nodeSelector "indent" 6 "context" . )}}
+      {{- include "keptn.nodeSelector" (dict "value" .Values.configurationService.nodeSelector "default" .Values.nodeSelector "indent" 6 "context" . )}}
 {{- end }}

--- a/installer/manifests/keptn/templates/configuration-service.yaml
+++ b/installer/manifests/keptn/templates/configuration-service.yaml
@@ -4,7 +4,12 @@ metadata:
   name: configuration-service
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    {{- if .Values.resourceService.enabled }}
+    app.kubernetes.io/component: resource-service
+    {{- else }}
+    app.kubernetes.io/component: configuration-service
+    {{- end }}
+
 spec:
   ports:
     - port: 8080
@@ -20,17 +25,18 @@ metadata:
   name: resource-service
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: resource-service
 spec:
   selector:
     matchLabels: {{- include "common.labels.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: resource-service
   replicas: {{ .Values.resourceService.replicas }}
   {{- include "keptn.common.update-strategy" . | nindent 2 }}
   template:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-        app.kubernetes.io/component: {{ include "keptn.name" . }}
+        app.kubernetes.io/component: resource-service
     spec:
       securityContext:
         fsGroup: {{ .Values.configurationService.fsGroup | default 1001 }}
@@ -97,13 +103,18 @@ spec:
       serviceAccountName: keptn-configuration-service
       {{- include "keptn.nodeSelector" (dict "value" .Values.resourceService.nodeSelector "default" .Values.nodeSelector "indent" 6 "context" . )}}
 {{- else }}
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: configuration-volume
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    {{- if .Values.resourceService.enabled }}
+    app.kubernetes.io/component: resource-service
+    {{- else }}
+    app.kubernetes.io/component: configuration-service
+    {{- end }}
 spec:
   accessModes:
     - ReadWriteOnce
@@ -120,10 +131,11 @@ metadata:
   name: configuration-service
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: configuration-service
 spec:
   selector:
     matchLabels: {{- include "common.labels.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: configuration-service
   replicas: 1
   strategy:
     type: Recreate
@@ -131,7 +143,7 @@ spec:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-        app.kubernetes.io/component: {{ include "keptn.name" . }}
+        app.kubernetes.io/component: configuration-service
     spec:
       securityContext:
         fsGroup: {{ .Values.configurationService.fsGroup | default 1001 }}

--- a/installer/manifests/keptn/templates/configuration-service.yaml
+++ b/installer/manifests/keptn/templates/configuration-service.yaml
@@ -107,8 +107,8 @@ spec:
         {{- end }}
       serviceAccountName: keptn-configuration-service
       {{- include "keptn.nodeSelector" (dict "value" .Values.resourceService.nodeSelector "default" .Values.nodeSelector "indent" 6 "context" . )}}
-{{- else }}
 ---
+{{- else }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/installer/manifests/keptn/templates/configuration-service.yaml
+++ b/installer/manifests/keptn/templates/configuration-service.yaml
@@ -16,6 +16,11 @@ spec:
       targetPort: 8080
       protocol: TCP
   selector: {{- include "common.labels.selectorLabels" . | nindent 4 }}
+    {{- if .Values.resourceService.enabled }}
+    app.kubernetes.io/component: resource-service
+    {{- else }}
+    app.kubernetes.io/component: configuration-service
+    {{- end }}
 ---
 # resource-service
 {{- if .Values.resourceService.enabled }}

--- a/installer/manifests/keptn/templates/configuration-service.yaml
+++ b/installer/manifests/keptn/templates/configuration-service.yaml
@@ -94,16 +94,16 @@ spec:
             privileged: false
           {{- if .Values.resourceService.extraVolumeMounts }}
           volumeMounts:
-          {{- include "keptn.tpl-value" ( dict "value" .Values.resourceService.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- include "common.tplvalues.render" ( dict "value" .Values.resourceService.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
         {{- with .Values.resourceService.sidecars }}
-        {{- include "keptn.tpl-value" ( dict "value" . "context" $ ) | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8 }}
         {{- end }}
       volumes:
         - name: resource-volume
           emptyDir: {}
         {{- if .Values.resourceService.extraVolumes }}
-        {{- include "keptn.tpl-value" ( dict "value" .Values.resourceService.extraVolumes "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.resourceService.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
       serviceAccountName: keptn-configuration-service
       {{- include "keptn.nodeSelector" (dict "value" .Values.resourceService.nodeSelector "default" .Values.nodeSelector "indent" 6 "context" . )}}
@@ -210,7 +210,7 @@ spec:
             - mountPath: /data/config
               name: configuration-volume
             {{- if .Values.configurationService.extraVolumeMounts }}
-            {{- include "keptn.tpl-value" ( dict "value" .Values.configurationService.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- include "common.tplvalues.render" ( dict "value" .Values.configurationService.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
           securityContext:
             runAsNonRoot: true
@@ -219,14 +219,14 @@ spec:
             allowPrivilegeEscalation: false
             privileged: false
         {{- with .Values.configurationService.sidecars }}
-        {{- include "keptn.tpl-value" ( dict "value" . "context" $ ) | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8 }}
         {{- end }}
       volumes:
         - name: configuration-volume
           persistentVolumeClaim:
             claimName: configuration-volume
         {{- if .Values.configurationService.extraVolumes }}
-        {{- include "keptn.tpl-value" ( dict "value" .Values.configurationService.extraVolumes "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.configurationService.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
       serviceAccountName: keptn-configuration-service
       {{- include "keptn.nodeSelector" (dict "value" .Values.configurationService.nodeSelector "default" .Values.nodeSelector "indent" 6 "context" . )}}

--- a/installer/manifests/keptn/templates/configuration-service.yaml
+++ b/installer/manifests/keptn/templates/configuration-service.yaml
@@ -9,7 +9,6 @@ metadata:
     {{- else }}
     app.kubernetes.io/component: configuration-service
     {{- end }}
-
 spec:
   ports:
     - port: 8080

--- a/installer/manifests/keptn/templates/core.yaml
+++ b/installer/manifests/keptn/templates/core.yaml
@@ -51,7 +51,7 @@ metadata:
   name: bridge-credentials
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: bridge
 type: Opaque
 data:
   BASIC_AUTH_USERNAME: {{ "keptn" | b64enc | quote }}
@@ -64,7 +64,7 @@ metadata:
   name: bridge-oauth
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: bridge
 type: Opaque
 data:
   session_secret: {{ $bridgeSessionSecret }}
@@ -76,7 +76,7 @@ metadata:
   name: bridge-oauth-mongodb-credentials
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: bridge
 type: Opaque
 data:
   external_connection_string: {{ $bridgeMongoConnectionString }}
@@ -88,16 +88,17 @@ metadata:
   name: bridge
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: bridge
 spec:
   selector:
     matchLabels: {{- include "common.labels.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: bridge
   replicas: 1
   template:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-        app.kubernetes.io/component: {{ include "keptn.name" . }}
+        app.kubernetes.io/component: bridge
     spec:
       {{- include "keptn.bridge.pod-security-context" . | nindent 6 }}
       containers:

--- a/installer/manifests/keptn/templates/core.yaml
+++ b/installer/manifests/keptn/templates/core.yaml
@@ -197,11 +197,11 @@ spec:
             - name: bridge-oauth-mongodb-credentials
               mountPath: /config/oauth_mongodb
             {{- if .Values.bridge.extraVolumeMounts }}
-            {{- include "keptn.tpl-value" ( dict "value" .Values.bridge.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- include "common.tplvalues.render" ( dict "value" .Values.bridge.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
           {{- include "keptn.bridge.container-security-context" . | nindent 10 }}
           {{- with .Values.bridge.sidecars }}
-          {{- include "keptn.tpl-value" ( dict "value" . "context" $ ) | nindent 8 }}
+          {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8 }}
           {{- end }}
       serviceAccountName: keptn-default
       volumes:
@@ -216,6 +216,6 @@ spec:
             secretName: bridge-oauth-mongodb-credentials
             defaultMode: 0400
         {{- if .Values.bridge.extraVolumes }}
-        {{- include "keptn.tpl-value" ( dict "value" .Values.bridge.extraVolumes "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.bridge.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
       {{- include "keptn.nodeSelector" (dict "value" .Values.bridge.nodeSelector "default" .Values.nodeSelector "indent" 6 "context" . )}}

--- a/installer/manifests/keptn/templates/core.yaml
+++ b/installer/manifests/keptn/templates/core.yaml
@@ -36,13 +36,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: keptn-api-token
-  labels:
-    app.kubernetes.io/name: keptn-api-token
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 type: Opaque
 data:
   keptn-api-token: {{ $apiToken }}
@@ -53,16 +49,12 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: bridge-credentials
-  labels:
-    app.kubernetes.io/name: bridge-credentials
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 type: Opaque
 data:
-  BASIC_AUTH_USERNAME: 'a2VwdG4='
+  BASIC_AUTH_USERNAME: {{ "keptn" | b64enc | quote }}
   BASIC_AUTH_PASSWORD: {{ $bridgePassword }}
 ---
 {{- end }}
@@ -70,13 +62,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: bridge-oauth
-  labels:
-    app.kubernetes.io/name: bridge-oauth
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 type: Opaque
 data:
   session_secret: {{ $bridgeSessionSecret }}
@@ -86,13 +74,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: bridge-oauth-mongodb-credentials
-  labels:
-    app.kubernetes.io/name: bridge-oauth-mongodb-credentials
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 type: Opaque
 data:
   external_connection_string: {{ $bridgeMongoConnectionString }}
@@ -102,30 +86,18 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: bridge
-  labels:
-    app.kubernetes.io/name: bridge
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    app.kubernetes.io/version: {{ .Values.bridge.image.tag | default .Chart.AppVersion }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 spec:
   selector:
-    matchLabels:
-      app.kubernetes.io/name: bridge
-      app.kubernetes.io/instance: {{ .Release.Name }}
+    matchLabels: {{- include "common.labels.selectorLabels" . | nindent 6 }}
   replicas: 1
   template:
     metadata:
-      labels:
-        app.kubernetes.io/name: bridge
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
         app.kubernetes.io/component: {{ include "keptn.name" . }}
-        app.kubernetes.io/version: {{ .Values.bridge.image.tag | default .Chart.AppVersion }}
-        helm.sh/chart: {{ include "keptn.chart" . }}
     spec:
       {{- include "keptn.bridge.pod-security-context" . | nindent 6 }}
       containers:
@@ -245,4 +217,4 @@ spec:
         {{- if .Values.bridge.extraVolumes }}
         {{- include "keptn.tpl-value" ( dict "value" .Values.bridge.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
-      {{- include "keptn.nodeSelector" (dict "value" .Values.bridge.nodeSelector "default" .Values.common.nodeSelector "indent" 6 "context" . )}}
+      {{- include "keptn.nodeSelector" (dict "value" .Values.bridge.nodeSelector "default" .Values.nodeSelector "indent" 6 "context" . )}}

--- a/installer/manifests/keptn/templates/ingress-config.yaml
+++ b/installer/manifests/keptn/templates/ingress-config.yaml
@@ -16,13 +16,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: ingress-config
-  labels:
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/name: {{ include "keptn.name" . }}-cm
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 data:
   ingress_hostname_suffix: "{{ $ingressHostnameSuffix }}"
   ingress_protocol: "{{ $ingressProtocol }}"

--- a/installer/manifests/keptn/templates/ingress.yaml
+++ b/installer/manifests/keptn/templates/ingress.yaml
@@ -14,13 +14,9 @@ metadata:
 {{- end }}
   name: keptn-ingress
   namespace: {{ .Release.Namespace }}
-  labels:
-    app.kubernetes.io/name: ingress
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ .Values.ingress.className }}

--- a/installer/manifests/keptn/templates/lighthouse-service.yaml
+++ b/installer/manifests/keptn/templates/lighthouse-service.yaml
@@ -86,7 +86,7 @@ spec:
       {{- end }}
       serviceAccountName: keptn-lighthouse-service
       terminationGracePeriodSeconds: {{ .Values.lighthouseService.gracePeriod | default 120 }}
-      {{- include "keptn.nodeSelector" (dict "value" .Values.lighthouseService.nodeSelector "default" .Values..nodeSelector "indent" 6 "context" . )}}
+      {{- include "keptn.nodeSelector" (dict "value" .Values.lighthouseService.nodeSelector "default" .Values.nodeSelector "indent" 6 "context" . )}}
 ---
 apiVersion: v1
 kind: Service

--- a/installer/manifests/keptn/templates/lighthouse-service.yaml
+++ b/installer/manifests/keptn/templates/lighthouse-service.yaml
@@ -6,17 +6,18 @@ metadata:
   name: lighthouse-service
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: lighthouse-service
 spec:
   selector:
     matchLabels: {{- include "common.labels.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: lighthouse-service
   replicas: 1
   {{- include "keptn.common.update-strategy" . | nindent 2 }}
   template:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-        app.kubernetes.io/component: {{ include "keptn.name" . }}
+        app.kubernetes.io/component: lighthouse-service
     spec:
       {{- include "keptn.common.pod-security-context" . | nindent 6 }}
       containers:
@@ -94,9 +95,10 @@ metadata:
   name: lighthouse-service
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: lighthouse-service
 spec:
   ports:
     - port: 8080
       protocol: TCP
   selector: {{- include "common.labels.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: lighthouse-service

--- a/installer/manifests/keptn/templates/lighthouse-service.yaml
+++ b/installer/manifests/keptn/templates/lighthouse-service.yaml
@@ -60,7 +60,7 @@ spec:
           {{- include "keptn.common.container-security-context" . | nindent 10 }}
           {{- if .Values.lighthouseService.extraVolumeMounts }}
           volumeMounts:
-          {{- include "keptn.tpl-value" ( dict "value" .Values.lighthouseService.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- include "common.tplvalues.render" ( dict "value" .Values.lighthouseService.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
         - name: distributor
           image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
@@ -79,11 +79,11 @@ spec:
           {{- include "keptn.dist.common.env.vars" . | nindent 12 }}
           {{- include "keptn.common.container-security-context" . | nindent 10 }}
         {{- with .Values.lighthouseService.sidecars }}
-        {{- include "keptn.tpl-value" ( dict "value" . "context" $ ) | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8 }}
         {{- end }}
       {{- if .Values.lighthouseService.extraVolumes }}
       volumes:
-      {{- include "keptn.tpl-value" ( dict "value" .Values.lighthouseService.extraVolumes "context" $) | nindent 8 }}
+      {{- include "common.tplvalues.render" ( dict "value" .Values.lighthouseService.extraVolumes "context" $) | nindent 8 }}
       {{- end }}
       serviceAccountName: keptn-lighthouse-service
       terminationGracePeriodSeconds: {{ .Values.lighthouseService.gracePeriod | default 120 }}

--- a/installer/manifests/keptn/templates/lighthouse-service.yaml
+++ b/installer/manifests/keptn/templates/lighthouse-service.yaml
@@ -4,31 +4,19 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: lighthouse-service
-  labels:
-    app.kubernetes.io/name: lighthouse-service
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    app.kubernetes.io/version: {{ .Values.lighthouseService.image.tag | default .Chart.AppVersion }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 spec:
   selector:
-    matchLabels:
-      app.kubernetes.io/name: lighthouse-service
-      app.kubernetes.io/instance: {{ .Release.Name }}
+    matchLabels: {{- include "common.labels.selectorLabels" . | nindent 6 }}
   replicas: 1
   {{- include "keptn.common.update-strategy" . | nindent 2 }}
   template:
     metadata:
-      labels:
-        app.kubernetes.io/name: lighthouse-service
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
         app.kubernetes.io/component: {{ include "keptn.name" . }}
-        app.kubernetes.io/version: {{ .Values.lighthouseService.image.tag | default .Chart.AppVersion }}
-        helm.sh/chart: {{ include "keptn.chart" . }}
     spec:
       {{- include "keptn.common.pod-security-context" . | nindent 6 }}
       containers:
@@ -104,17 +92,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: lighthouse-service
-  labels:
-    app.kubernetes.io/name: lighthouse-service
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 spec:
   ports:
     - port: 8080
       protocol: TCP
-  selector:
-    app.kubernetes.io/name: lighthouse-service
-    app.kubernetes.io/instance: {{ .Release.Name }}
+  selector: {{- include "common.labels.selectorLabels" . | nindent 4 }}

--- a/installer/manifests/keptn/templates/lighthouse-service.yaml
+++ b/installer/manifests/keptn/templates/lighthouse-service.yaml
@@ -86,7 +86,7 @@ spec:
       {{- end }}
       serviceAccountName: keptn-lighthouse-service
       terminationGracePeriodSeconds: {{ .Values.lighthouseService.gracePeriod | default 120 }}
-      {{- include "keptn.nodeSelector" (dict "value" .Values.lighthouseService.nodeSelector "default" .Values.common.nodeSelector "indent" 6 "context" . )}}
+      {{- include "keptn.nodeSelector" (dict "value" .Values.lighthouseService.nodeSelector "default" .Values..nodeSelector "indent" 6 "context" . )}}
 ---
 apiVersion: v1
 kind: Service

--- a/installer/manifests/keptn/templates/mongodb-credentials.yaml
+++ b/installer/manifests/keptn/templates/mongodb-credentials.yaml
@@ -53,13 +53,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: mongodb-credentials
-  labels:
-    app.kubernetes.io/name: mongodb-credentials
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 type: Opaque
 data:
   mongodb-user: {{ $mongoUser }}

--- a/installer/manifests/keptn/templates/mongodb-datastore.yaml
+++ b/installer/manifests/keptn/templates/mongodb-datastore.yaml
@@ -101,7 +101,7 @@ spec:
       volumes:
       {{- include "keptn.tpl-value" ( dict "value" .Values.mongodbDatastore.extraVolumes "context" $) | nindent 8 }}
       {{- end }}
-      {{- include "keptn.nodeSelector" (dict "value" .Values.mongodbDatastore.nodeSelector "default" .Values..nodeSelector "indent" 8 "context" . )}}
+      {{- include "keptn.nodeSelector" (dict "value" .Values.mongodbDatastore.nodeSelector "default" .Values.nodeSelector "indent" 8 "context" . )}}
 ---
 apiVersion: v1
 kind: Service

--- a/installer/manifests/keptn/templates/mongodb-datastore.yaml
+++ b/installer/manifests/keptn/templates/mongodb-datastore.yaml
@@ -23,78 +23,85 @@ spec:
       serviceAccountName: keptn-default
       terminationGracePeriodSeconds: {{ .Values.mongodbDatastore.gracePeriod | default 120 }}
       containers:
-      - name: mongodb-datastore
-        image: {{ .Values.mongodbDatastore.image.repository }}:{{ .Values.mongodbDatastore.image.tag | default .Chart.AppVersion }}
-        {{- $prestop := .Values.mongodbDatastore.preStopHookTime | default 90 | quote -}}
-        {{- include "keptn.prestop" $prestop | nindent 8 }}
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: 8080
-          initialDelaySeconds: 10
-          periodSeconds: 5
-        readinessProbe:
-          httpGet:
-            path: /health
-            port: 8080
-          initialDelaySeconds: 10
-          periodSeconds: 5
-        imagePullPolicy: IfNotPresent
-        ports:
-        - containerPort: 8080
-        resources:
-          requests:
-            memory: "32Mi"
-            cpu: "50m"
-          limits:
-            memory: "512Mi"
-            cpu: "300m"
-        env:
-        - name: PREFIX_PATH
-          value: "{{ .Values.prefixPath }}"
-        - name: MONGODB_HOST
-          value: '{{ .Release.Name }}-{{ .Values.mongo.service.nameOverride }}:{{ .Values.mongo.service.port }}'
-        - name: MONGODB_DATABASE
-          value: {{ .Values.mongo.auth.database | default "keptn" }}
-        - name: MONGODB_USER
-          valueFrom:
-            secretKeyRef:
-              name: mongodb-credentials
-              key: mongodb-user
-        - name: MONGODB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: mongodb-credentials
-              key: mongodb-passwords
-        - name: MONGODB_EXTERNAL_CONNECTION_STRING
-          valueFrom:
-            secretKeyRef:
-              name: mongodb-credentials
-              key: external_connection_string
-              optional: true
-        - name: LOG_LEVEL
-          value: {{ .Values.logLevel | default "info" }}
-        {{- include "keptn.common.container-security-context" . | nindent 8 }}
-      - name: distributor
-        image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
-        {{- include "keptn.dist.livenessProbe" . | nindent 8 }}
-        {{- include "keptn.dist.readinessProbe" . | nindent 8 }}
-        imagePullPolicy: IfNotPresent
-        ports:
-          - containerPort: 8080
-        {{- include "keptn.distributor.resources" . | nindent 8 }}
-        env:
-          - name: PUBSUB_IMPL
-            value: nats
-          - name: PUBSUB_TOPIC
-            value: 'sh.keptn.>'
-          - name: PUBSUB_RECIPIENT
-            value: '127.0.0.1'
-          - name: PUBSUB_RECIPIENT_PATH
-            value: '/event'
-          {{- include "keptn.dist.common.env.vars" . | nindent 10 }}
-        {{- include "keptn.common.container-security-context" . | nindent 8 }}
-      {{- include "keptn.nodeSelector" (dict "value" .Values.mongodbDatastore.nodeSelector "default" .Values.nodeSelector "indent" 6 "context" . )}}
+        - name: mongodb-datastore
+          image: {{ .Values.mongodbDatastore.image.repository }}:{{ .Values.mongodbDatastore.image.tag | default .Chart.AppVersion }}
+          {{- $prestop := .Values.mongodbDatastore.preStopHookTime | default 90 | quote -}}
+          {{- include "keptn.prestop" $prestop | nindent 10 }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          resources:
+            {{- toYaml .Values.mongodbDatastore.resources | nindent 12 }}
+          env:
+            - name: PREFIX_PATH
+              value: "{{ .Values.prefixPath }}"
+            - name: MONGODB_HOST
+              value: '{{ .Release.Name }}-{{ .Values.mongo.service.nameOverride }}:{{ .Values.mongo.service.port }}'
+            - name: MONGODB_DATABASE
+              value: {{ .Values.mongo.auth.database | default "keptn" }}
+            - name: MONGODB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: mongodb-credentials
+                  key: mongodb-user
+            - name: MONGODB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mongodb-credentials
+                  key: mongodb-passwords
+            - name: MONGODB_EXTERNAL_CONNECTION_STRING
+              valueFrom:
+                secretKeyRef:
+                  name: mongodb-credentials
+                  key: external_connection_string
+                  optional: true
+            - name: LOG_LEVEL
+              value: {{ .Values.logLevel | default "info" }}
+          {{- include "keptn.common.container-security-context" . | nindent 10 }}
+          {{- if .Values.mongodbDatastore.extraVolumeMounts }}
+          volumeMounts:
+          {{- include "keptn.tpl-value" ( dict "value" .Values.mongodbDatastore.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- end }}
+        - name: distributor
+          image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
+          {{- include "keptn.dist.livenessProbe" . | nindent 10 }}
+          {{- include "keptn.dist.readinessProbe" . | nindent 10 }}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          resources:
+            {{- toYaml .Values.distributor.resources | nindent 12 }}
+          env:
+            - name: PUBSUB_IMPL
+              value: nats
+            - name: PUBSUB_TOPIC
+              value: 'sh.keptn.>'
+            - name: PUBSUB_RECIPIENT
+              value: '127.0.0.1'
+            - name: PUBSUB_RECIPIENT_PATH
+              value: '/event'
+            {{- include "keptn.dist.common.env.vars" . | nindent 12 }}
+          {{- include "keptn.common.container-security-context" . | nindent 10 }}
+        {{- with .Values.mongodbDatastore.sidecars }}
+        {{- include "keptn.tpl-value" ( dict "value" . "context" $ ) | nindent 8 }}
+        {{- end }}
+      {{- if .Values.mongodbDatastore.extraVolumes }}
+      volumes:
+      {{- include "keptn.tpl-value" ( dict "value" .Values.mongodbDatastore.extraVolumes "context" $) | nindent 8 }}
+      {{- end }}
+      {{- include "keptn.nodeSelector" (dict "value" .Values.mongodbDatastore.nodeSelector "default" .Values..nodeSelector "indent" 8 "context" . )}}
 ---
 apiVersion: v1
 kind: Service

--- a/installer/manifests/keptn/templates/mongodb-datastore.yaml
+++ b/installer/manifests/keptn/templates/mongodb-datastore.yaml
@@ -35,85 +35,78 @@ spec:
       serviceAccountName: keptn-default
       terminationGracePeriodSeconds: {{ .Values.mongodbDatastore.gracePeriod | default 120 }}
       containers:
-        - name: mongodb-datastore
-          image: {{ .Values.mongodbDatastore.image.repository }}:{{ .Values.mongodbDatastore.image.tag | default .Chart.AppVersion }}
-          {{- $prestop := .Values.mongodbDatastore.preStopHookTime | default 90 | quote -}}
-          {{- include "keptn.prestop" $prestop | nindent 10 }}
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 8080
-            initialDelaySeconds: 10
-            periodSeconds: 5
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: 8080
-            initialDelaySeconds: 10
-            periodSeconds: 5
-          imagePullPolicy: IfNotPresent
-          ports:
-            - containerPort: 8080
-          resources:
-            {{- toYaml .Values.mongodbDatastore.resources | nindent 12 }}
-          env:
-            - name: PREFIX_PATH
-              value: "{{ .Values.prefixPath }}"
-            - name: MONGODB_HOST
-              value: '{{ .Release.Name }}-{{ .Values.mongo.service.nameOverride }}:{{ .Values.mongo.service.port }}'
-            - name: MONGODB_DATABASE
-              value: {{ .Values.mongo.auth.database | default "keptn" }}
-            - name: MONGODB_USER
-              valueFrom:
-                secretKeyRef:
-                  name: mongodb-credentials
-                  key: mongodb-user
-            - name: MONGODB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: mongodb-credentials
-                  key: mongodb-passwords
-            - name: MONGODB_EXTERNAL_CONNECTION_STRING
-              valueFrom:
-                secretKeyRef:
-                  name: mongodb-credentials
-                  key: external_connection_string
-                  optional: true
-            - name: LOG_LEVEL
-              value: {{ .Values.logLevel | default "info" }}
-          {{- include "keptn.common.container-security-context" . | nindent 10 }}
-          {{- if .Values.mongodbDatastore.extraVolumeMounts }}
-          volumeMounts:
-          {{- include "keptn.tpl-value" ( dict "value" .Values.mongodbDatastore.extraVolumeMounts "context" $) | nindent 12 }}
-          {{- end }}
-        - name: distributor
-          image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
-          {{- include "keptn.dist.livenessProbe" . | nindent 10 }}
-          {{- include "keptn.dist.readinessProbe" . | nindent 10 }}
-          imagePullPolicy: IfNotPresent
-          ports:
-            - containerPort: 8080
-          resources:
-            {{- toYaml .Values.distributor.resources | nindent 12 }}
-          env:
-            - name: PUBSUB_IMPL
-              value: nats
-            - name: PUBSUB_TOPIC
-              value: 'sh.keptn.>'
-            - name: PUBSUB_RECIPIENT
-              value: '127.0.0.1'
-            - name: PUBSUB_RECIPIENT_PATH
-              value: '/event'
-            {{- include "keptn.dist.common.env.vars" . | nindent 12 }}
-          {{- include "keptn.common.container-security-context" . | nindent 10 }}
-        {{- with .Values.mongodbDatastore.sidecars }}
-        {{- include "keptn.tpl-value" ( dict "value" . "context" $ ) | nindent 8 }}
-        {{- end }}
-      {{- if .Values.mongodbDatastore.extraVolumes }}
-      volumes:
-      {{- include "keptn.tpl-value" ( dict "value" .Values.mongodbDatastore.extraVolumes "context" $) | nindent 8 }}
-      {{- end }}
-      {{- include "keptn.nodeSelector" (dict "value" .Values.mongodbDatastore.nodeSelector "default" .Values.common.nodeSelector "indent" 8 "context" . )}}
+      - name: mongodb-datastore
+        image: {{ .Values.mongodbDatastore.image.repository }}:{{ .Values.mongodbDatastore.image.tag | default .Chart.AppVersion }}
+        {{- $prestop := .Values.mongodbDatastore.preStopHookTime | default 90 | quote -}}
+        {{- include "keptn.prestop" $prestop | nindent 8 }}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "50m"
+          limits:
+            memory: "512Mi"
+            cpu: "300m"
+        env:
+        - name: PREFIX_PATH
+          value: "{{ .Values.prefixPath }}"
+        - name: MONGODB_HOST
+          value: '{{ .Release.Name }}-{{ .Values.mongo.service.nameOverride }}:{{ .Values.mongo.service.port }}'
+        - name: MONGODB_DATABASE
+          value: {{ .Values.mongo.auth.database | default "keptn" }}
+        - name: MONGODB_USER
+          valueFrom:
+            secretKeyRef:
+              name: mongodb-credentials
+              key: mongodb-user
+        - name: MONGODB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mongodb-credentials
+              key: mongodb-passwords
+        - name: MONGODB_EXTERNAL_CONNECTION_STRING
+          valueFrom:
+            secretKeyRef:
+              name: mongodb-credentials
+              key: external_connection_string
+              optional: true
+        - name: LOG_LEVEL
+          value: {{ .Values.logLevel | default "info" }}
+        {{- include "keptn.common.container-security-context" . | nindent 8 }}
+      - name: distributor
+        image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
+        {{- include "keptn.dist.livenessProbe" . | nindent 8 }}
+        {{- include "keptn.dist.readinessProbe" . | nindent 8 }}
+        imagePullPolicy: IfNotPresent
+        ports:
+          - containerPort: 8080
+        {{- include "keptn.distributor.resources" . | nindent 8 }}
+        env:
+          - name: PUBSUB_IMPL
+            value: nats
+          - name: PUBSUB_TOPIC
+            value: 'sh.keptn.>'
+          - name: PUBSUB_RECIPIENT
+            value: '127.0.0.1'
+          - name: PUBSUB_RECIPIENT_PATH
+            value: '/event'
+          {{- include "keptn.dist.common.env.vars" . | nindent 10 }}
+        {{- include "keptn.common.container-security-context" . | nindent 8 }}
+      {{- include "keptn.nodeSelector" (dict "value" .Values.mongodbDatastore.nodeSelector "default" .Values.common.nodeSelector "indent" 6 "context" . )}}
 ---
 apiVersion: v1
 kind: Service
@@ -128,8 +121,8 @@ metadata:
     helm.sh/chart: {{ include "keptn.chart" . }}
 spec:
   ports:
-    - port: 8080
-      protocol: TCP
+  - port: 8080
+    protocol: TCP
   selector:
     app.kubernetes.io/name: mongodb-datastore
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/installer/manifests/keptn/templates/mongodb-datastore.yaml
+++ b/installer/manifests/keptn/templates/mongodb-datastore.yaml
@@ -5,31 +5,19 @@ metadata:
   name: mongodb-datastore
   annotations:
     fluentbit.io/exclude: "true"
-  labels:
-    app.kubernetes.io/name: mongodb-datastore
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    app.kubernetes.io/version: {{ .Values.mongodbDatastore.image.tag | default .Chart.AppVersion }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 spec:
   selector:
-    matchLabels:
-      app.kubernetes.io/name: mongodb-datastore
-      app.kubernetes.io/instance: {{ .Release.Name }}
+    matchLabels: {{- include "common.labels.selectorLabels" . | nindent 6 }}
   replicas: 1
   {{- include "keptn.common.update-strategy" . | nindent 2 }}
   template:
     metadata:
-      labels:
-        app.kubernetes.io/name: mongodb-datastore
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
         app.kubernetes.io/component: {{ include "keptn.name" . }}
-        app.kubernetes.io/version: {{ .Values.mongodbDatastore.image.tag | default .Chart.AppVersion }}
-        helm.sh/chart: {{ include "keptn.chart" . }}
     spec:
       {{- include "keptn.common.pod-security-context" . | nindent 6 }}
       serviceAccountName: keptn-default
@@ -106,23 +94,17 @@ spec:
             value: '/event'
           {{- include "keptn.dist.common.env.vars" . | nindent 10 }}
         {{- include "keptn.common.container-security-context" . | nindent 8 }}
-      {{- include "keptn.nodeSelector" (dict "value" .Values.mongodbDatastore.nodeSelector "default" .Values.common.nodeSelector "indent" 6 "context" . )}}
+      {{- include "keptn.nodeSelector" (dict "value" .Values.mongodbDatastore.nodeSelector "default" .Values.nodeSelector "indent" 6 "context" . )}}
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: mongodb-datastore
-  labels:
-    app.kubernetes.io/name: mongodb-datastore
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 spec:
   ports:
   - port: 8080
     protocol: TCP
-  selector:
-    app.kubernetes.io/name: mongodb-datastore
-    app.kubernetes.io/instance: {{ .Release.Name }}
+  selector: {{- include "common.labels.selectorLabels" . | nindent 4 }}

--- a/installer/manifests/keptn/templates/mongodb-datastore.yaml
+++ b/installer/manifests/keptn/templates/mongodb-datastore.yaml
@@ -5,17 +5,18 @@ metadata:
   name: mongodb-datastore
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: mongodb-datastore
 spec:
   selector:
     matchLabels: {{- include "common.labels.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: mongodb-datastore
   replicas: 1
   {{- include "keptn.common.update-strategy" . | nindent 2 }}
   template:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-        app.kubernetes.io/component: {{ include "keptn.name" . }}
+        app.kubernetes.io/component: mongodb-datastore
     spec:
       {{- include "keptn.common.pod-security-context" . | nindent 6 }}
       serviceAccountName: keptn-default
@@ -107,9 +108,10 @@ metadata:
   name: mongodb-datastore
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: mongodb-datastore
 spec:
   ports:
   - port: 8080
     protocol: TCP
   selector: {{- include "common.labels.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: mongodb-datastore

--- a/installer/manifests/keptn/templates/mongodb-datastore.yaml
+++ b/installer/manifests/keptn/templates/mongodb-datastore.yaml
@@ -3,8 +3,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mongodb-datastore
-  annotations:
-    fluentbit.io/exclude: "true"
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}

--- a/installer/manifests/keptn/templates/mongodb-datastore.yaml
+++ b/installer/manifests/keptn/templates/mongodb-datastore.yaml
@@ -71,7 +71,7 @@ spec:
           {{- include "keptn.common.container-security-context" . | nindent 10 }}
           {{- if .Values.mongodbDatastore.extraVolumeMounts }}
           volumeMounts:
-          {{- include "keptn.tpl-value" ( dict "value" .Values.mongodbDatastore.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- include "common.tplvalues.render" ( dict "value" .Values.mongodbDatastore.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
         - name: distributor
           image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
@@ -94,11 +94,11 @@ spec:
             {{- include "keptn.dist.common.env.vars" . | nindent 12 }}
           {{- include "keptn.common.container-security-context" . | nindent 10 }}
         {{- with .Values.mongodbDatastore.sidecars }}
-        {{- include "keptn.tpl-value" ( dict "value" . "context" $ ) | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8 }}
         {{- end }}
       {{- if .Values.mongodbDatastore.extraVolumes }}
       volumes:
-      {{- include "keptn.tpl-value" ( dict "value" .Values.mongodbDatastore.extraVolumes "context" $) | nindent 8 }}
+      {{- include "common.tplvalues.render" ( dict "value" .Values.mongodbDatastore.extraVolumes "context" $) | nindent 8 }}
       {{- end }}
       {{- include "keptn.nodeSelector" (dict "value" .Values.mongodbDatastore.nodeSelector "default" .Values.nodeSelector "indent" 8 "context" . )}}
 ---

--- a/installer/manifests/keptn/templates/mongodb-datastore.yaml
+++ b/installer/manifests/keptn/templates/mongodb-datastore.yaml
@@ -111,7 +111,7 @@ metadata:
     app.kubernetes.io/component: mongodb-datastore
 spec:
   ports:
-  - port: 8080
-    protocol: TCP
+    - port: 8080
+      protocol: TCP
   selector: {{- include "common.labels.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: mongodb-datastore

--- a/installer/manifests/keptn/templates/rbac.yaml
+++ b/installer/manifests/keptn/templates/rbac.yaml
@@ -13,7 +13,11 @@ metadata:
   name: keptn-configuration-service
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    {{- if .Values.resourceService.enabled }}
+    app.kubernetes.io/component: resource-service
+    {{- else }}
+    app.kubernetes.io/component: configuration-service
+    {{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -21,7 +25,7 @@ metadata:
   name: keptn-shipyard-controller
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: shipyard-controller
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -29,7 +33,7 @@ metadata:
   name: keptn-secret-service
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: secret-service
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -37,7 +41,7 @@ metadata:
   name: keptn-lighthouse-service
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: lighthouse-service
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -45,7 +49,7 @@ metadata:
   name: keptn-api-service
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: api-service
 ---
 {{- if .Values.webhookService.enabled }}
 apiVersion: v1
@@ -54,7 +58,7 @@ metadata:
   name: keptn-webhook-service
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: webhook-service
 ---
 {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -83,7 +87,11 @@ metadata:
   name: keptn-get-secrets
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    {{- if .Values.resourceService.enabled }}
+    app.kubernetes.io/component: resource-service
+    {{- else }}
+    app.kubernetes.io/component: configuration-service
+    {{- end }}
 rules:
   - apiGroups:
       - ""
@@ -99,7 +107,7 @@ metadata:
   name: keptn-manage-roles
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: secret-service
 rules:
   - apiGroups:
       - rbac.authorization.k8s.io
@@ -118,7 +126,7 @@ metadata:
   name: keptn-manage-rolebindings
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: secret-service
 rules:
   - apiGroups:
       - rbac.authorization.k8s.io
@@ -130,6 +138,7 @@ rules:
       - delete
       - update
       - deletecollection
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -137,7 +146,7 @@ metadata:
   name: keptn-read-metadata
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: api-service
 rules:
   - apiGroups:
       - extensions
@@ -155,7 +164,7 @@ metadata:
   name: keptn-manage-configmaps
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: lighthouse-service
 rules:
   - apiGroups:
       - ""
@@ -173,7 +182,7 @@ metadata:
   name: keptn-get-webhook-config
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: webhook-service
 rules:
   - apiGroups:
       - ""
@@ -188,28 +197,10 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: keptn-delete-bridge-pod
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - get
-      - delete
-      - deletecollection
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
   name: keptn-acquire-lease
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: shipyard-controller
 rules:
   - apiGroups:
       - "coordination.k8s.io"
@@ -230,7 +221,7 @@ metadata:
   name: keptn-lighthouse-service
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: lighthouse-service
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -246,7 +237,7 @@ metadata:
   name: keptn-webhook-service
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: webhook-service
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -262,7 +253,7 @@ metadata:
   name: keptn-api-service-metadata
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: api-service
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -278,7 +269,11 @@ metadata:
   name: keptn-configuration-service-get-secrets
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    {{- if .Values.resourceService.enabled }}
+    app.kubernetes.io/component: resource-service
+    {{- else }}
+    app.kubernetes.io/component: configuration-service
+    {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -294,7 +289,7 @@ metadata:
   name: keptn-shipyard-controller-manage-secrets
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: shipyard-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -310,7 +305,7 @@ metadata:
   name: keptn-secret-service-manage-secrets
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: secret-service
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -326,7 +321,7 @@ metadata:
   name: keptn-secret-service-manage-roles
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: secret-service
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -341,7 +336,7 @@ metadata:
   name: keptn-secret-service-manage-rolebindings
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: secret-service
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -357,7 +352,7 @@ metadata:
   name: keptn-shipyard-controller-acquire-lease
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: shipyard-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/installer/manifests/keptn/templates/rbac.yaml
+++ b/installer/manifests/keptn/templates/rbac.yaml
@@ -3,9 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: keptn-default
-  labels:
-    {{ include "keptn.labels" . | nindent 4 }}
-    app.kubernetes.io/name: keptn-default
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
 ---
@@ -13,9 +11,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: keptn-configuration-service
-  labels:
-    {{ include "keptn.labels" . | nindent 4 }}
-    app.kubernetes.io/name: keptn-configuration-service
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
 ---
@@ -23,9 +19,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: keptn-shipyard-controller
-  labels:
-    {{ include "keptn.labels" . | nindent 4 }}
-    app.kubernetes.io/name: keptn-shipyard-controller
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
 ---
@@ -33,9 +27,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: keptn-secret-service
-  labels:
-    {{ include "keptn.labels" . | nindent 4 }}
-    app.kubernetes.io/name: keptn-secret-service
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
 ---
@@ -43,9 +35,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: keptn-lighthouse-service
-  labels:
-    {{ include "keptn.labels" . | nindent 4 }}
-    app.kubernetes.io/name: keptn-lighthouse-service
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
 ---
@@ -53,9 +43,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: keptn-api-service
-  labels:
-    {{ include "keptn.labels" . | nindent 4 }}
-    app.kubernetes.io/name: keptn-api-service
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
 ---
@@ -64,9 +52,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: keptn-webhook-service
-  labels:
-    {{ include "keptn.labels" . | nindent 4 }}
-    app.kubernetes.io/name: keptn-api-service
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
 ---
@@ -75,9 +61,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: keptn-manage-secrets
-  labels:
-    {{ include "keptn.labels" . | nindent 4 }}
-    app.kubernetes.io/name: keptn-manage-secrets
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
 rules:
@@ -97,9 +81,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: keptn-get-secrets
-  labels:
-    {{ include "keptn.labels" . | nindent 4 }}
-    app.kubernetes.io/name: keptn-get-secrets
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
 rules:
@@ -115,9 +97,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: keptn-manage-roles
-  labels:
-    {{ include "keptn.labels" . | nindent 4 }}
-    app.kubernetes.io/name: keptn-manage-roles
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
 rules:
@@ -136,9 +116,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: keptn-manage-rolebindings
-  labels:
-    {{ include "keptn.labels" . | nindent 4 }}
-    app.kubernetes.io/name: keptn-manage-rolebindings
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
 rules:
@@ -157,9 +135,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: keptn-read-metadata
-  labels:
-    {{ include "keptn.labels" . | nindent 4 }}
-    app.kubernetes.io/name: keptn-read-metadata
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
 rules:
@@ -177,9 +153,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: keptn-manage-configmaps
-  labels:
-    {{ include "keptn.labels" . | nindent 4 }}
-    app.kubernetes.io/name: keptn-manage-configmaps
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
 rules:
@@ -217,9 +191,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: keptn-delete-bridge-pod
-  labels:
-    {{ include "keptn.labels" . | nindent 4 }}
-    app.kubernetes.io/name: keptn-delete-bridge-pod
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
 rules:
@@ -237,13 +209,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: keptn-acquire-lease
-  labels:
-    app.kubernetes.io/name: keptn-acquire-lease
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 rules:
   - apiGroups:
       - "coordination.k8s.io"
@@ -262,9 +230,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: keptn-lighthouse-service
-  labels:
-    {{ include "keptn.labels" . | nindent 4 }}
-    app.kubernetes.io/name: keptn-lighthouse-service
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
 roleRef:
@@ -298,9 +264,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: keptn-api-service-metadata
-  labels:
-    {{ include "keptn.labels" . | nindent 4 }}
-    app.kubernetes.io/name: keptn-api-service-metadata
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
 roleRef:
@@ -316,9 +280,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: keptn-configuration-service-get-secrets
-  labels:
-    {{ include "keptn.labels" . | nindent 4 }}
-    app.kubernetes.io/name: keptn-configuration-service-get-secrets
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
 roleRef:
@@ -334,9 +296,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: keptn-shipyard-controller-manage-secrets
-  labels:
-    {{ include "keptn.labels" . | nindent 4 }}
-    app.kubernetes.io/name: keptn-shipyard-controller-manage-secrets
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
 roleRef:
@@ -352,9 +312,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: keptn-secret-service-manage-secrets
-  labels:
-    {{ include "keptn.labels" . | nindent 4 }}
-    app.kubernetes.io/name: keptn-secret-service-manage-secrets
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
 roleRef:
@@ -370,9 +328,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: keptn-secret-service-manage-roles
-  labels:
-    {{ include "keptn.labels" . | nindent 4 }}
-    app.kubernetes.io/name: keptn-secret-service-manage-roles
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
 roleRef:
@@ -387,9 +343,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: keptn-secret-service-manage-rolebindings
-  labels:
-    {{ include "keptn.labels" . | nindent 4 }}
-    app.kubernetes.io/name: keptn-secret-service-manage-secrets
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
 roleRef:
@@ -405,13 +359,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: keptn-shipyard-controller-acquire-lease
-  labels:
-    app.kubernetes.io/name: keptn-shipyard-controller-acquire-lease
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/installer/manifests/keptn/templates/rbac.yaml
+++ b/installer/manifests/keptn/templates/rbac.yaml
@@ -173,7 +173,6 @@ metadata:
   name: keptn-get-webhook-config
   labels:
     {{ include "keptn.labels" . | nindent 4 }}
-    app.kubernetes.io/name: keptn-get-webhook-config
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
 rules:
@@ -248,7 +247,6 @@ metadata:
   name: keptn-webhook-service
   labels:
     {{ include "keptn.labels" . | nindent 4 }}
-    app.kubernetes.io/name: keptn-webhook-service
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
 roleRef:

--- a/installer/manifests/keptn/templates/rbac.yaml
+++ b/installer/manifests/keptn/templates/rbac.yaml
@@ -171,8 +171,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: keptn-get-webhook-config
-  labels:
-    {{ include "keptn.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
 rules:
@@ -245,8 +244,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: keptn-webhook-service
-  labels:
-    {{ include "keptn.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
 roleRef:

--- a/installer/manifests/keptn/templates/remediation-service.yaml
+++ b/installer/manifests/keptn/templates/remediation-service.yaml
@@ -6,17 +6,18 @@ metadata:
   name: remediation-service
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: remediation-service
 spec:
   selector:
     matchLabels: {{- include "common.labels.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: remediation-service
   replicas: 1
   {{- include "keptn.common.update-strategy" . | nindent 2 }}
   template:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-        app.kubernetes.io/component: {{ include "keptn.name" . }}
+        app.kubernetes.io/component: remediation-service
     spec:
       {{- include "keptn.common.pod-security-context" . | nindent 6 }}
       containers:
@@ -86,11 +87,12 @@ metadata:
   name: remediation-service
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: remediation-service
 spec:
   ports:
   - port: 8080
     targetPort: 8080
     protocol: TCP
   selector: {{- include "common.labels.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: remediation-service
 

--- a/installer/manifests/keptn/templates/remediation-service.yaml
+++ b/installer/manifests/keptn/templates/remediation-service.yaml
@@ -4,31 +4,19 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: remediation-service
-  labels:
-    app.kubernetes.io/name: remediation-service
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    app.kubernetes.io/version: {{ .Values.remediationService.image.tag | default .Chart.AppVersion }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 spec:
   selector:
-    matchLabels:
-      app.kubernetes.io/name: remediation-service
-      app.kubernetes.io/instance: {{ .Release.Name }}
+    matchLabels: {{- include "common.labels.selectorLabels" . | nindent 6 }}
   replicas: 1
   {{- include "keptn.common.update-strategy" . | nindent 2 }}
   template:
     metadata:
-      labels:
-        app.kubernetes.io/name: remediation-service
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
         app.kubernetes.io/component: {{ include "keptn.name" . }}
-        app.kubernetes.io/version: {{ .Values.remediationService.image.tag | default .Chart.AppVersion }}
-        helm.sh/chart: {{ include "keptn.chart" . }}
     spec:
       {{- include "keptn.common.pod-security-context" . | nindent 6 }}
       containers:
@@ -89,19 +77,13 @@ apiVersion: v1
 kind: Service
 metadata:
   name: remediation-service
-  labels:
-    app.kubernetes.io/name: remediation-service
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 spec:
   ports:
   - port: 8080
     targetPort: 8080
     protocol: TCP
-  selector:
-    app.kubernetes.io/name: remediation-service
-    app.kubernetes.io/instance: {{ .Release.Name }}
+  selector: {{- include "common.labels.selectorLabels" . | nindent 4 }}
 

--- a/installer/manifests/keptn/templates/remediation-service.yaml
+++ b/installer/manifests/keptn/templates/remediation-service.yaml
@@ -32,62 +32,55 @@ spec:
     spec:
       {{- include "keptn.common.pod-security-context" . | nindent 6 }}
       containers:
-        - name: remediation-service
-          image: {{ .Values.remediationService.image.repository }}:{{ .Values.remediationService.image.tag | default .Chart.AppVersion }}
-          {{- $prestop := .Values.remediationService.preStopHookTime | default 90 | quote -}}
-          {{- include "keptn.prestop" $prestop | nindent 10 }}
-          imagePullPolicy: IfNotPresent
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 8080
-            initialDelaySeconds: 10
-            periodSeconds: 5
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: 8080
-            initialDelaySeconds: 10
-            periodSeconds: 5
-          ports:
-            - containerPort: 8080
-          resources:
-            {{- toYaml .Values.remediationService.resources | nindent 12 }}
-          env:
-            - name: EVENTBROKER
-              value: 'http://localhost:8081/event'
-            - name: CONFIGURATION_SERVICE
-              value: 'http://configuration-service:8080'
-            - name: ENVIRONMENT
-              value: 'production'
-          {{- include "keptn.common.container-security-context" . | nindent 10 }}
-          {{- if .Values.remediationService.extraVolumeMounts }}
-          volumeMounts:
-          {{- include "keptn.tpl-value" ( dict "value" .Values.remediationService.extraVolumeMounts "context" $) | nindent 12 }}
-          {{- end }}
-        - name: distributor
-          image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
-          imagePullPolicy: IfNotPresent
-          {{- include "keptn.dist.livenessProbe" . | nindent 10 }}
-          {{- include "keptn.dist.readinessProbe" . | nindent 10 }}
-          ports:
-            - containerPort: 8080
-          resources:
-            {{- toYaml .Values.distributor.resources | nindent 12 }}
-          env:
-            - name: PUBSUB_TOPIC
-              value: 'sh.keptn.event.get-action.triggered'
-            - name: PUBSUB_RECIPIENT
-              value: '127.0.0.1'
-          {{- include "keptn.dist.common.env.vars" . | nindent 12 }}
-          {{- include "keptn.common.container-security-context" . | nindent 10 }}
-        {{- with .Values.remediationService.sidecars }}
-        {{- include "keptn.tpl-value" ( dict "value" . "context" $ ) | nindent 8 }}
-        {{- end }}
-      {{- if .Values.remediationService.extraVolumes }}
-      volumes:
-      {{- include "keptn.tpl-value" ( dict "value" .Values.remediationService.extraVolumes "context" $) | nindent 8 }}
-      {{- end }}
+      - name: remediation-service
+        image: {{ .Values.remediationService.image.repository }}:{{ .Values.remediationService.image.tag | default .Chart.AppVersion }}
+        {{- $prestop := .Values.remediationService.preStopHookTime | default 90 | quote -}}
+        {{- include "keptn.prestop" $prestop | nindent 8 }}
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
+        ports:
+        - containerPort: 8080
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "50m"
+          limits:
+            memory: "1Gi"
+            cpu: "200m"
+        env:
+          - name: EVENTBROKER
+            value: 'http://localhost:8081/event'
+          - name: CONFIGURATION_SERVICE
+            value: 'http://configuration-service:8080'
+          - name: ENVIRONMENT
+            value: 'production'
+        {{- include "keptn.common.container-security-context" . | nindent 8 }}
+      - name: distributor
+        image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
+        imagePullPolicy: IfNotPresent
+        {{- include "keptn.dist.livenessProbe" . | nindent 8 }}
+        {{- include "keptn.dist.readinessProbe" . | nindent 8 }}
+        ports:
+          - containerPort: 8080
+        {{- include "keptn.distributor.resources" . | nindent 8 }}
+        env:
+          - name: PUBSUB_TOPIC
+            value: 'sh.keptn.event.get-action.triggered'
+          - name: PUBSUB_RECIPIENT
+            value: '127.0.0.1'
+        {{- include "keptn.dist.common.env.vars" . | nindent 10 }}
+        {{- include "keptn.common.container-security-context" . | nindent 8 }}
       serviceAccountName: keptn-default
       terminationGracePeriodSeconds: {{ .Values.remediationService.gracePeriod | default 120 }}
       {{- include "keptn.nodeSelector" (dict "value" .Values.remediationService.nodeSelector "default" .Values.common.nodeSelector "indent" 6 "context" . )}}
@@ -105,9 +98,9 @@ metadata:
     helm.sh/chart: {{ include "keptn.chart" . }}
 spec:
   ports:
-    - port: 8080
-      targetPort: 8080
-      protocol: TCP
+  - port: 8080
+    targetPort: 8080
+    protocol: TCP
   selector:
     app.kubernetes.io/name: remediation-service
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/installer/manifests/keptn/templates/remediation-service.yaml
+++ b/installer/manifests/keptn/templates/remediation-service.yaml
@@ -20,58 +20,65 @@ spec:
     spec:
       {{- include "keptn.common.pod-security-context" . | nindent 6 }}
       containers:
-      - name: remediation-service
-        image: {{ .Values.remediationService.image.repository }}:{{ .Values.remediationService.image.tag | default .Chart.AppVersion }}
-        {{- $prestop := .Values.remediationService.preStopHookTime | default 90 | quote -}}
-        {{- include "keptn.prestop" $prestop | nindent 8 }}
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: 8080
-          initialDelaySeconds: 10
-          periodSeconds: 5
-        readinessProbe:
-          httpGet:
-            path: /health
-            port: 8080
-          initialDelaySeconds: 10
-          periodSeconds: 5
-        ports:
-        - containerPort: 8080
-        resources:
-          requests:
-            memory: "64Mi"
-            cpu: "50m"
-          limits:
-            memory: "1Gi"
-            cpu: "200m"
-        env:
-          - name: EVENTBROKER
-            value: 'http://localhost:8081/event'
-          - name: CONFIGURATION_SERVICE
-            value: 'http://configuration-service:8080'
-          - name: ENVIRONMENT
-            value: 'production'
-        {{- include "keptn.common.container-security-context" . | nindent 8 }}
-      - name: distributor
-        image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
-        imagePullPolicy: IfNotPresent
-        {{- include "keptn.dist.livenessProbe" . | nindent 8 }}
-        {{- include "keptn.dist.readinessProbe" . | nindent 8 }}
-        ports:
-          - containerPort: 8080
-        {{- include "keptn.distributor.resources" . | nindent 8 }}
-        env:
-          - name: PUBSUB_TOPIC
-            value: 'sh.keptn.event.get-action.triggered'
-          - name: PUBSUB_RECIPIENT
-            value: '127.0.0.1'
-        {{- include "keptn.dist.common.env.vars" . | nindent 10 }}
-        {{- include "keptn.common.container-security-context" . | nindent 8 }}
+        - name: remediation-service
+          image: {{ .Values.remediationService.image.repository }}:{{ .Values.remediationService.image.tag | default .Chart.AppVersion }}
+          {{- $prestop := .Values.remediationService.preStopHookTime | default 90 | quote -}}
+          {{- include "keptn.prestop" $prestop | nindent 10 }}
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          ports:
+            - containerPort: 8080
+          resources:
+            {{- toYaml .Values.remediationService.resources | nindent 12 }}
+          env:
+            - name: EVENTBROKER
+              value: 'http://localhost:8081/event'
+            - name: CONFIGURATION_SERVICE
+              value: 'http://configuration-service:8080'
+            - name: ENVIRONMENT
+              value: 'production'
+          {{- include "keptn.common.container-security-context" . | nindent 10 }}
+          {{- if .Values.remediationService.extraVolumeMounts }}
+          volumeMounts:
+          {{- include "keptn.tpl-value" ( dict "value" .Values.remediationService.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- end }}
+        - name: distributor
+          image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
+          imagePullPolicy: IfNotPresent
+          {{- include "keptn.dist.livenessProbe" . | nindent 10 }}
+          {{- include "keptn.dist.readinessProbe" . | nindent 10 }}
+          ports:
+            - containerPort: 8080
+          resources:
+            {{- toYaml .Values.distributor.resources | nindent 12 }}
+          env:
+            - name: PUBSUB_TOPIC
+              value: 'sh.keptn.event.get-action.triggered'
+            - name: PUBSUB_RECIPIENT
+              value: '127.0.0.1'
+          {{- include "keptn.dist.common.env.vars" . | nindent 12 }}
+          {{- include "keptn.common.container-security-context" . | nindent 10 }}
+        {{- with .Values.remediationService.sidecars }}
+        {{- include "keptn.tpl-value" ( dict "value" . "context" $ ) | nindent 8 }}
+        {{- end }}
+      {{- if .Values.remediationService.extraVolumes }}
+      volumes:
+      {{- include "keptn.tpl-value" ( dict "value" .Values.remediationService.extraVolumes "context" $) | nindent 8 }}
+      {{- end }}
       serviceAccountName: keptn-default
       terminationGracePeriodSeconds: {{ .Values.remediationService.gracePeriod | default 120 }}
-      {{- include "keptn.nodeSelector" (dict "value" .Values.remediationService.nodeSelector "default" .Values.common.nodeSelector "indent" 6 "context" . )}}
+      {{- include "keptn.nodeSelector" (dict "value" .Values.remediationService.nodeSelector "default" .Values..nodeSelector "indent" 6 "context" . )}}
 ---
 apiVersion: v1
 kind: Service

--- a/installer/manifests/keptn/templates/remediation-service.yaml
+++ b/installer/manifests/keptn/templates/remediation-service.yaml
@@ -52,7 +52,7 @@ spec:
           {{- include "keptn.common.container-security-context" . | nindent 10 }}
           {{- if .Values.remediationService.extraVolumeMounts }}
           volumeMounts:
-          {{- include "keptn.tpl-value" ( dict "value" .Values.remediationService.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- include "common.tplvalues.render" ( dict "value" .Values.remediationService.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
         - name: distributor
           image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
@@ -71,11 +71,11 @@ spec:
           {{- include "keptn.dist.common.env.vars" . | nindent 12 }}
           {{- include "keptn.common.container-security-context" . | nindent 10 }}
         {{- with .Values.remediationService.sidecars }}
-        {{- include "keptn.tpl-value" ( dict "value" . "context" $ ) | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8 }}
         {{- end }}
       {{- if .Values.remediationService.extraVolumes }}
       volumes:
-      {{- include "keptn.tpl-value" ( dict "value" .Values.remediationService.extraVolumes "context" $) | nindent 8 }}
+      {{- include "common.tplvalues.render" ( dict "value" .Values.remediationService.extraVolumes "context" $) | nindent 8 }}
       {{- end }}
       serviceAccountName: keptn-default
       terminationGracePeriodSeconds: {{ .Values.remediationService.gracePeriod | default 120 }}

--- a/installer/manifests/keptn/templates/remediation-service.yaml
+++ b/installer/manifests/keptn/templates/remediation-service.yaml
@@ -78,7 +78,7 @@ spec:
       {{- end }}
       serviceAccountName: keptn-default
       terminationGracePeriodSeconds: {{ .Values.remediationService.gracePeriod | default 120 }}
-      {{- include "keptn.nodeSelector" (dict "value" .Values.remediationService.nodeSelector "default" .Values..nodeSelector "indent" 6 "context" . )}}
+      {{- include "keptn.nodeSelector" (dict "value" .Values.remediationService.nodeSelector "default" .Values.nodeSelector "indent" 6 "context" . )}}
 ---
 apiVersion: v1
 kind: Service

--- a/installer/manifests/keptn/templates/remediation-service.yaml
+++ b/installer/manifests/keptn/templates/remediation-service.yaml
@@ -90,9 +90,9 @@ metadata:
     app.kubernetes.io/component: remediation-service
 spec:
   ports:
-  - port: 8080
-    targetPort: 8080
-    protocol: TCP
+    - port: 8080
+      targetPort: 8080
+      protocol: TCP
   selector: {{- include "common.labels.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: remediation-service
 

--- a/installer/manifests/keptn/templates/secret-service.yaml
+++ b/installer/manifests/keptn/templates/secret-service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: secret-service-config
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: secret-service
 data:
   scopes.yaml: |
     Scopes:
@@ -35,17 +35,18 @@ metadata:
   name: secret-service
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: secret-service
 spec:
   selector:
     matchLabels: {{- include "common.labels.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: secret-service
   replicas: 1
   {{- include "keptn.common.update-strategy" . | nindent 2 }}
   template:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-        app.kubernetes.io/component: {{ include "keptn.name" . }}
+        app.kubernetes.io/component: secret-service
     spec:
       {{- include "keptn.common.pod-security-context" . | nindent 6 }}
       serviceAccountName: keptn-secret-service
@@ -104,10 +105,11 @@ metadata:
   name: secret-service
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: secret-service
 spec:
   ports:
     - port: 8080
       targetPort: 8080
       protocol: TCP
   selector: {{- include "common.labels.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: secret-service

--- a/installer/manifests/keptn/templates/secret-service.yaml
+++ b/installer/manifests/keptn/templates/secret-service.yaml
@@ -2,13 +2,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: secret-service-config
-  labels:
-    app.kubernetes.io/name: secret-service-config-cm
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 data:
   scopes.yaml: |
     Scopes:
@@ -37,31 +33,19 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: secret-service
-  labels:
-    app.kubernetes.io/name: secret-service
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    app.kubernetes.io/version: {{ .Values.secretService.image.tag | default .Chart.AppVersion }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 spec:
   selector:
-    matchLabels:
-      app.kubernetes.io/name: secret-service
-      app.kubernetes.io/instance: {{ .Release.Name }}
+    matchLabels: {{- include "common.labels.selectorLabels" . | nindent 6 }}
   replicas: 1
   {{- include "keptn.common.update-strategy" . | nindent 2 }}
   template:
     metadata:
-      labels:
-        app.kubernetes.io/name: secret-service
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
         app.kubernetes.io/component: {{ include "keptn.name" . }}
-        app.kubernetes.io/version: {{ .Values.secretService.image.tag | default .Chart.AppVersion }}
-        helm.sh/chart: {{ include "keptn.chart" . }}
     spec:
       {{- include "keptn.common.pod-security-context" . | nindent 6 }}
       serviceAccountName: keptn-secret-service
@@ -112,24 +96,18 @@ spec:
         {{- if .Values.secretService.extraVolumes }}
         {{- include "keptn.tpl-value" ( dict "value" .Values.secretService.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
-      {{- include "keptn.nodeSelector" (dict "value" .Values.secretService.nodeSelector "default" .Values.common.nodeSelector "indent" 6 "context" . )}}
+      {{- include "keptn.nodeSelector" (dict "value" .Values.secretService.nodeSelector "default" .Values.nodeSelector "indent" 6 "context" . )}}
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: secret-service
-  labels:
-    app.kubernetes.io/name: secret-service
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 spec:
   ports:
     - port: 8080
       targetPort: 8080
       protocol: TCP
-  selector:
-    app.kubernetes.io/name: secret-service
-    app.kubernetes.io/instance: {{ .Release.Name }}
+  selector: {{- include "common.labels.selectorLabels" . | nindent 4 }}

--- a/installer/manifests/keptn/templates/secret-service.yaml
+++ b/installer/manifests/keptn/templates/secret-service.yaml
@@ -84,18 +84,18 @@ spec:
             - mountPath: /data
               name: secret-service-configmap-volume
             {{- if .Values.secretService.extraVolumeMounts }}
-            {{- include "keptn.tpl-value" ( dict "value" .Values.secretService.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- include "common.tplvalues.render" ( dict "value" .Values.secretService.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
           {{- include "keptn.common.container-security-context" . | nindent 10 }}
         {{- with .Values.secretService.sidecars }}
-        {{- include "keptn.tpl-value" ( dict "value" . "context" $ ) | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8 }}
         {{- end }}
       volumes:
         - name: secret-service-configmap-volume
           configMap:
             name: secret-service-config
         {{- if .Values.secretService.extraVolumes }}
-        {{- include "keptn.tpl-value" ( dict "value" .Values.secretService.extraVolumes "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.secretService.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
       {{- include "keptn.nodeSelector" (dict "value" .Values.secretService.nodeSelector "default" .Values.nodeSelector "indent" 6 "context" . )}}
 ---

--- a/installer/manifests/keptn/templates/shipyard-controller.yaml
+++ b/installer/manifests/keptn/templates/shipyard-controller.yaml
@@ -2,19 +2,12 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: shipyard-controller
-  labels:
-    app.kubernetes.io/name: shipyard-controller
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    app.kubernetes.io/version: {{ .Values.shipyardController.image.tag | default .Chart.AppVersion }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 spec:
   selector:
-    matchLabels:
-      app.kubernetes.io/name: shipyard-controller
-      app.kubernetes.io/instance: {{ .Release.Name }}
+    matchLabels: {{- include "common.labels.selectorLabels" . | nindent 6 }}
   {{- if or (lt .Capabilities.KubeVersion.Minor "14") (.Values.shipyardController.config.disableLeaderElection) }}
   replicas : 1
   {{- else }}
@@ -23,14 +16,9 @@ spec:
   {{- include "keptn.common.update-strategy" . | nindent 2 }}
   template:
     metadata:
-      labels:
-        app.kubernetes.io/name: shipyard-controller
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
         app.kubernetes.io/component: {{ include "keptn.name" . }}
-        app.kubernetes.io/version: {{ .Values.shipyardController.image.tag | default .Chart.AppVersion }}
-        helm.sh/chart: {{ include "keptn.chart" . }}
     spec:
       {{- include "keptn.common.pod-security-context" . | nindent 6 }}
       serviceAccountName: keptn-shipyard-controller
@@ -122,18 +110,12 @@ apiVersion: v1
 kind: Service
 metadata:
   name: shipyard-controller
-  labels:
-    app.kubernetes.io/name: shipyard-controller
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 spec:
   ports:
     - port: 8080
       targetPort: 8080
       protocol: TCP
-  selector:
-    app.kubernetes.io/name: shipyard-controller
-    app.kubernetes.io/instance: {{ .Release.Name }}
+  selector: {{- include "common.labels.selectorLabels" . | nindent 4 }}

--- a/installer/manifests/keptn/templates/shipyard-controller.yaml
+++ b/installer/manifests/keptn/templates/shipyard-controller.yaml
@@ -100,7 +100,7 @@ spec:
         {{- include "keptn.tpl-value" ( dict "value" . "context" $ ) | nindent 8 }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.shipyardController.gracePeriod | default 120 }}
-      {{- include "keptn.nodeSelector" (dict "value" .Values.shipyardController.nodeSelector "default" .Values.common.nodeSelector "indent" 6 "context" . )}}
+      {{- include "keptn.nodeSelector" (dict "value" .Values.shipyardController.nodeSelector "default" .Values..nodeSelector "indent" 6 "context" . )}}
       {{- if .Values.shipyardController.extraVolumes }}
       volumes:
       {{- include "keptn.tpl-value" ( dict "value" .Values.shipyardController.extraVolumes "context" $) | nindent 8 }}

--- a/installer/manifests/keptn/templates/shipyard-controller.yaml
+++ b/installer/manifests/keptn/templates/shipyard-controller.yaml
@@ -76,7 +76,7 @@ spec:
             - name: LOG_LEVEL
               value: {{ .Values.logLevel | default "info" }}
             - name: AUTOMATIC_PROVISIONING_URL
-              value: {{ (.Values.features).automaticProvisioningURL | default "" }}
+              value: {{ (.Values.features).automaticProvisioningURL | default "" | quote }}
             - name: DISABLE_LEADER_ELECTION
               {{- if  lt .Capabilities.KubeVersion.Minor "14"}}
               value: {{ true | quote }}

--- a/installer/manifests/keptn/templates/shipyard-controller.yaml
+++ b/installer/manifests/keptn/templates/shipyard-controller.yaml
@@ -4,10 +4,11 @@ metadata:
   name: shipyard-controller
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: shipyard-controller
 spec:
   selector:
     matchLabels: {{- include "common.labels.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: shipyard-controller
   {{- if or (lt .Capabilities.KubeVersion.Minor "14") (.Values.shipyardController.config.disableLeaderElection) }}
   replicas : 1
   {{- else }}
@@ -18,7 +19,7 @@ spec:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-        app.kubernetes.io/component: {{ include "keptn.name" . }}
+        app.kubernetes.io/component: shipyard-controller
     spec:
       {{- include "keptn.common.pod-security-context" . | nindent 6 }}
       serviceAccountName: keptn-shipyard-controller
@@ -112,10 +113,11 @@ metadata:
   name: shipyard-controller
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: shipyard-controller
 spec:
   ports:
     - port: 8080
       targetPort: 8080
       protocol: TCP
   selector: {{- include "common.labels.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: shipyard-controller

--- a/installer/manifests/keptn/templates/shipyard-controller.yaml
+++ b/installer/manifests/keptn/templates/shipyard-controller.yaml
@@ -100,7 +100,7 @@ spec:
         {{- include "keptn.tpl-value" ( dict "value" . "context" $ ) | nindent 8 }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.shipyardController.gracePeriod | default 120 }}
-      {{- include "keptn.nodeSelector" (dict "value" .Values.shipyardController.nodeSelector "default" .Values..nodeSelector "indent" 6 "context" . )}}
+      {{- include "keptn.nodeSelector" (dict "value" .Values.shipyardController.nodeSelector "default" .Values.nodeSelector "indent" 6 "context" . )}}
       {{- if .Values.shipyardController.extraVolumes }}
       volumes:
       {{- include "keptn.tpl-value" ( dict "value" .Values.shipyardController.extraVolumes "context" $) | nindent 8 }}

--- a/installer/manifests/keptn/templates/shipyard-controller.yaml
+++ b/installer/manifests/keptn/templates/shipyard-controller.yaml
@@ -95,16 +95,16 @@ spec:
           {{- include "keptn.common.container-security-context" . | nindent 10 }}
           {{- if .Values.shipyardController.extraVolumeMounts }}
           volumeMounts:
-          {{- include "keptn.tpl-value" ( dict "value" .Values.shipyardController.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- include "common.tplvalues.render" ( dict "value" .Values.shipyardController.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
         {{- with .Values.shipyardController.sidecars }}
-        {{- include "keptn.tpl-value" ( dict "value" . "context" $ ) | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8 }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.shipyardController.gracePeriod | default 120 }}
       {{- include "keptn.nodeSelector" (dict "value" .Values.shipyardController.nodeSelector "default" .Values.nodeSelector "indent" 6 "context" . )}}
       {{- if .Values.shipyardController.extraVolumes }}
       volumes:
-      {{- include "keptn.tpl-value" ( dict "value" .Values.shipyardController.extraVolumes "context" $) | nindent 8 }}
+      {{- include "common.tplvalues.render" ( dict "value" .Values.shipyardController.extraVolumes "context" $) | nindent 8 }}
       {{- end }}
 ---
 apiVersion: v1

--- a/installer/manifests/keptn/templates/statistics-service.yaml
+++ b/installer/manifests/keptn/templates/statistics-service.yaml
@@ -69,7 +69,7 @@ spec:
           {{- include "keptn.common.container-security-context" . | nindent 10 }}
           {{- if .Values.statisticsService.extraVolumeMounts }}
           volumeMounts:
-          {{- include "keptn.tpl-value" ( dict "value" .Values.statisticsService.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- include "common.tplvalues.render" ( dict "value" .Values.statisticsService.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
         - name: distributor
           image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
@@ -90,11 +90,11 @@ spec:
           {{- include "keptn.dist.common.env.vars" . | nindent 12 }}
           {{- include "keptn.common.container-security-context" . | nindent 10 }}
         {{- with .Values.statisticsService.sidecars }}
-        {{- include "keptn.tpl-value" ( dict "value" . "context" $ ) | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8 }}
         {{- end }}
       {{- if .Values.statisticsService.extraVolumes }}
       volumes:
-      {{- include "keptn.tpl-value" ( dict "value" .Values.statisticsService.extraVolumes "context" $) | nindent 8 }}
+      {{- include "common.tplvalues.render" ( dict "value" .Values.statisticsService.extraVolumes "context" $) | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.statisticsService.gracePeriod | default 120 }}
       {{- include "keptn.nodeSelector" (dict "value" .Values.statisticsService.nodeSelector "default" .Values.nodeSelector "indent" 6 "context" . )}}

--- a/installer/manifests/keptn/templates/statistics-service.yaml
+++ b/installer/manifests/keptn/templates/statistics-service.yaml
@@ -2,31 +2,19 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: statistics-service
-  labels:
-    app.kubernetes.io/name: statistics-service
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    app.kubernetes.io/version: {{ .Values.statisticsService.image.tag | default .Chart.AppVersion }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 spec:
   selector:
-    matchLabels:
-      app.kubernetes.io/name: statistics-service
-      app.kubernetes.io/instance: {{ .Release.Name }}
+    matchLabels: {{- include "common.labels.selectorLabels" . | nindent 6 }}
   replicas: 1
   {{- include "keptn.common.update-strategy" . | nindent 2 }}
   template:
     metadata:
-      labels:
-        app.kubernetes.io/name: statistics-service
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
         app.kubernetes.io/component: {{ include "keptn.name" . }}
-        app.kubernetes.io/version: {{ .Values.statisticsService.image.tag | default .Chart.AppVersion }}
-        helm.sh/chart: {{ include "keptn.chart" . }}
     spec:
       {{- include "keptn.common.pod-security-context" . | nindent 6 }}
       serviceAccountName: keptn-default
@@ -114,18 +102,12 @@ apiVersion: v1
 kind: Service
 metadata:
   name: statistics-service
-  labels:
-    app.kubernetes.io/name: statistics-service
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 spec:
   ports:
     - port: 8080
       targetPort: 8080
       protocol: TCP
-  selector:
-    app.kubernetes.io/name: statistics-service
-    app.kubernetes.io/instance: {{ .Release.Name }}
+  selector: {{- include "common.labels.selectorLabels" . | nindent 4 }}

--- a/installer/manifests/keptn/templates/statistics-service.yaml
+++ b/installer/manifests/keptn/templates/statistics-service.yaml
@@ -4,17 +4,18 @@ metadata:
   name: statistics-service
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: statistics-service
 spec:
   selector:
     matchLabels: {{- include "common.labels.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: statistics-service
   replicas: 1
   {{- include "keptn.common.update-strategy" . | nindent 2 }}
   template:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-        app.kubernetes.io/component: {{ include "keptn.name" . }}
+        app.kubernetes.io/component: statistics-service
     spec:
       {{- include "keptn.common.pod-security-context" . | nindent 6 }}
       serviceAccountName: keptn-default
@@ -104,10 +105,11 @@ metadata:
   name: statistics-service
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: statistics-service
 spec:
   ports:
     - port: 8080
       targetPort: 8080
       protocol: TCP
   selector: {{- include "common.labels.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: statistics-service

--- a/installer/manifests/keptn/templates/statistics-service.yaml
+++ b/installer/manifests/keptn/templates/statistics-service.yaml
@@ -96,7 +96,7 @@ spec:
       {{- include "keptn.tpl-value" ( dict "value" .Values.statisticsService.extraVolumes "context" $) | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.statisticsService.gracePeriod | default 120 }}
-      {{- include "keptn.nodeSelector" (dict "value" .Values.statisticsService.nodeSelector "default" .Values.common.nodeSelector "indent" 6 "context" . )}}
+      {{- include "keptn.nodeSelector" (dict "value" .Values.statisticsService.nodeSelector "default" .Values..nodeSelector "indent" 6 "context" . )}}
 ---
 apiVersion: v1
 kind: Service

--- a/installer/manifests/keptn/templates/statistics-service.yaml
+++ b/installer/manifests/keptn/templates/statistics-service.yaml
@@ -96,7 +96,7 @@ spec:
       {{- include "keptn.tpl-value" ( dict "value" .Values.statisticsService.extraVolumes "context" $) | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.statisticsService.gracePeriod | default 120 }}
-      {{- include "keptn.nodeSelector" (dict "value" .Values.statisticsService.nodeSelector "default" .Values..nodeSelector "indent" 6 "context" . )}}
+      {{- include "keptn.nodeSelector" (dict "value" .Values.statisticsService.nodeSelector "default" .Values.nodeSelector "indent" 6 "context" . )}}
 ---
 apiVersion: v1
 kind: Service

--- a/installer/manifests/keptn/templates/webhook-service.yaml
+++ b/installer/manifests/keptn/templates/webhook-service.yaml
@@ -53,7 +53,7 @@ spec:
           {{- include "keptn.common.container-security-context" . | nindent 10 }}
           {{- if .Values.webhookService.extraVolumeMounts }}
           volumeMounts:
-          {{- include "keptn.tpl-value" ( dict "value" .Values.webhookService.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- include "common.tplvalues.render" ( dict "value" .Values.webhookService.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
         - name: distributor
           image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
@@ -74,11 +74,11 @@ spec:
           {{- include "keptn.dist.common.env.vars" . | nindent 12 }}
           {{- include "keptn.common.container-security-context" . | nindent 10 }}
         {{- with .Values.webhookService.sidecars }}
-        {{- include "keptn.tpl-value" ( dict "value" . "context" $ ) | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8 }}
         {{- end }}
       {{- if .Values.webhookService.extraVolumes }}
       volumes:
-      {{- include "keptn.tpl-value" ( dict "value" .Values.webhookService.extraVolumes "context" $) | nindent 8 }}
+      {{- include "common.tplvalues.render" ( dict "value" .Values.webhookService.extraVolumes "context" $) | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.webhookService.gracePeriod | default 120 }}
       {{- include "keptn.nodeSelector" (dict "value" .Values.webhookService.nodeSelector "default" .Values.nodeSelector "indent" 6 "context" . )}}

--- a/installer/manifests/keptn/templates/webhook-service.yaml
+++ b/installer/manifests/keptn/templates/webhook-service.yaml
@@ -6,17 +6,18 @@ metadata:
   name: webhook-service
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: webhook-service
 spec:
   selector:
     matchLabels: {{- include "common.labels.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: webhook-service
   replicas: 1
   {{- include "keptn.common.update-strategy" . | nindent 2 }}
   template:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-        app.kubernetes.io/component: {{ include "keptn.name" . }}
+        app.kubernetes.io/component: webhook-service
     spec:
       {{- include "keptn.common.pod-security-context" . | nindent 6 }}
       serviceAccountName: keptn-webhook-service
@@ -88,12 +89,13 @@ metadata:
   name: webhook-service
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: webhook-service
 spec:
   ports:
     - port: 8080
       protocol: TCP
   selector: {{- include "common.labels.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: webhook-service
 {{- end }}
 ---
 apiVersion: v1
@@ -105,7 +107,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
-    app.kubernetes.io/component: {{ include "keptn.name" . }}
+    app.kubernetes.io/component: webhook-service
     helm.sh/chart: {{ include "keptn.chart" . }}
 data:
   denyList: |-

--- a/installer/manifests/keptn/templates/webhook-service.yaml
+++ b/installer/manifests/keptn/templates/webhook-service.yaml
@@ -4,31 +4,19 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: webhook-service
-  labels:
-    app.kubernetes.io/name: webhook-service
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    app.kubernetes.io/version: {{ .Values.webhookService.image.tag | default .Chart.AppVersion }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 spec:
   selector:
-    matchLabels:
-      app.kubernetes.io/name: webhook-service
-      app.kubernetes.io/instance: {{ .Release.Name }}
+    matchLabels: {{- include "common.labels.selectorLabels" . | nindent 6 }}
   replicas: 1
   {{- include "keptn.common.update-strategy" . | nindent 2 }}
   template:
     metadata:
-      labels:
-        app.kubernetes.io/name: webhook-service
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
         app.kubernetes.io/component: {{ include "keptn.name" . }}
-        app.kubernetes.io/version: {{ .Values.webhookService.image.tag | default .Chart.AppVersion }}
-        helm.sh/chart: {{ include "keptn.chart" . }}
     spec:
       {{- include "keptn.common.pod-security-context" . | nindent 6 }}
       serviceAccountName: keptn-webhook-service
@@ -98,20 +86,14 @@ apiVersion: v1
 kind: Service
 metadata:
   name: webhook-service
-  labels:
-    app.kubernetes.io/name: webhook-service
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: keptn-{{ .Release.Namespace }}
     app.kubernetes.io/component: {{ include "keptn.name" . }}
-    helm.sh/chart: {{ include "keptn.chart" . }}
 spec:
   ports:
     - port: 8080
       protocol: TCP
-  selector:
-    app.kubernetes.io/name: webhook-service
-    app.kubernetes.io/instance: {{ .Release.Name }}
+  selector: {{- include "common.labels.selectorLabels" . | nindent 4 }}
 {{- end }}
 ---
 apiVersion: v1

--- a/installer/manifests/keptn/templates/webhook-service.yaml
+++ b/installer/manifests/keptn/templates/webhook-service.yaml
@@ -80,7 +80,7 @@ spec:
       {{- include "keptn.tpl-value" ( dict "value" .Values.webhookService.extraVolumes "context" $) | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.webhookService.gracePeriod | default 120 }}
-      {{- include "keptn.nodeSelector" (dict "value" .Values.webhookService.nodeSelector "default" .Values.common.nodeSelector "indent" 6 "context" . )}}
+      {{- include "keptn.nodeSelector" (dict "value" .Values.webhookService.nodeSelector "default" .Values..nodeSelector "indent" 6 "context" . )}}
 ---
 apiVersion: v1
 kind: Service

--- a/installer/manifests/keptn/templates/webhook-service.yaml
+++ b/installer/manifests/keptn/templates/webhook-service.yaml
@@ -80,7 +80,7 @@ spec:
       {{- include "keptn.tpl-value" ( dict "value" .Values.webhookService.extraVolumes "context" $) | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.webhookService.gracePeriod | default 120 }}
-      {{- include "keptn.nodeSelector" (dict "value" .Values.webhookService.nodeSelector "default" .Values..nodeSelector "indent" 6 "context" . )}}
+      {{- include "keptn.nodeSelector" (dict "value" .Values.webhookService.nodeSelector "default" .Values.nodeSelector "indent" 6 "context" . )}}
 ---
 apiVersion: v1
 kind: Service

--- a/installer/manifests/keptn/values.yaml
+++ b/installer/manifests/keptn/values.yaml
@@ -291,7 +291,6 @@ configurationService:
 
 resourceService:
   enabled: false
-
   replicas: 1
   image:
     repository: docker.io/keptn/resource-service
@@ -417,21 +416,20 @@ ingress:
 
 logLevel: "info"
 
-common:
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
-  podSecurityContext:
-    enabled: true
-    defaultSeccompProfile: true
-    fsGroup: 65532
-  containerSecurityContext:
-    enabled: true
-    runAsNonRoot: true
-    runAsUser: 65532
-    readOnlyRootFilesystem: true
-    allowPrivilegeEscalation: false
-    privileged: false
-  nodeSelector: {}
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 1
+    maxUnavailable: 0
+podSecurityContext:
+  enabled: true
+  defaultSeccompProfile: true
+  fsGroup: 65532
+containerSecurityContext:
+  enabled: true
+  runAsNonRoot: true
+  runAsUser: 65532
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  privileged: false
+nodeSelector: {}

--- a/installer/manifests/keptn/values.yaml
+++ b/installer/manifests/keptn/values.yaml
@@ -291,6 +291,7 @@ configurationService:
 
 resourceService:
   enabled: false
+
   replicas: 1
   image:
     repository: docker.io/keptn/resource-service

--- a/jmeter-service/chart/Chart.yaml
+++ b/jmeter-service/chart/Chart.yaml
@@ -21,3 +21,8 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 appVersion: latest
+
+dependencies:
+  - name: common
+    repository: https://charts-dev.keptn.sh
+    version: 0.15.0-dev

--- a/jmeter-service/chart/Chart.yaml
+++ b/jmeter-service/chart/Chart.yaml
@@ -24,5 +24,5 @@ appVersion: latest
 
 dependencies:
   - name: common
-    repository: https://charts-dev.keptn.sh
-    version: 0.15.0-dev
+    repository: "file://../../installer/manifests/common"
+    version: 0.1.0

--- a/jmeter-service/chart/templates/_helpers.tpl
+++ b/jmeter-service/chart/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Expand the name of the chart.
 */}}
 {{- define "jmeter-service.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- include "common.names.name" . -}}
 {{- end }}
 
 {{/*
@@ -11,44 +11,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "jmeter-service.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
+{{- include "common.names.fullname" . -}}
 {{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "jmeter-service.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
-{{- end }}
-
-{{/*
-Common labels
-*/}}
-{{- define "jmeter-service.labels" -}}
-helm.sh/chart: {{ include "jmeter-service.chart" . }}
-{{ include "jmeter-service.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end }}
-
-
-{{/*
-Selector labels
-*/}}
-{{- define "jmeter-service.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "jmeter-service.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+{{- include "common.names.chart" . -}}
 {{- end }}
 
 {{/*

--- a/jmeter-service/chart/templates/deployment.yaml
+++ b/jmeter-service/chart/templates/deployment.yaml
@@ -2,22 +2,18 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "jmeter-service.fullname" . }}
-  labels:
-    {{- include "jmeter-service.labels" . | nindent 4 }}
-
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
-    matchLabels:
-      {{- include "jmeter-service.selectorLabels" . | nindent 6 }}
+    matchLabels: {{- include "common.labels.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      labels:
-        {{- include "jmeter-service.labels" . | nindent 8 }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/jmeter-service/chart/templates/deployment.yaml
+++ b/jmeter-service/chart/templates/deployment.yaml
@@ -3,10 +3,12 @@ kind: Deployment
 metadata:
   name: {{ include "jmeter-service.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: jmeter-service
 spec:
   replicas: 1
   selector:
     matchLabels: {{- include "common.labels.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: jmeter-service
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -14,6 +16,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
+        app.kubernetes.io/component: jmeter-service
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/jmeter-service/chart/templates/service.yaml
+++ b/jmeter-service/chart/templates/service.yaml
@@ -3,13 +3,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "jmeter-service.fullname" . }}
-  labels:
-    {{- include "jmeter-service.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   type: ClusterIP
   ports:
     - port: 8080
       protocol: TCP
-  selector:
-    {{- include "jmeter-service.selectorLabels" . | nindent 4 }}
+  selector: {{- include "common.labels.selectorLabels" . | nindent 4 }}
   {{- end }}

--- a/jmeter-service/chart/templates/service.yaml
+++ b/jmeter-service/chart/templates/service.yaml
@@ -4,10 +4,12 @@ kind: Service
 metadata:
   name: {{ include "jmeter-service.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: jmeter-service
 spec:
   type: ClusterIP
   ports:
     - port: 8080
       protocol: TCP
   selector: {{- include "common.labels.selectorLabels" . | nindent 4 }}
+      app.kubernetes.io/component: jmeter-service
   {{- end }}

--- a/jmeter-service/chart/templates/service.yaml
+++ b/jmeter-service/chart/templates/service.yaml
@@ -11,5 +11,5 @@ spec:
     - port: 8080
       protocol: TCP
   selector: {{- include "common.labels.selectorLabels" . | nindent 4 }}
-      app.kubernetes.io/component: jmeter-service
+    app.kubernetes.io/component: jmeter-service
   {{- end }}

--- a/jmeter-service/chart/templates/serviceaccount.yaml
+++ b/jmeter-service/chart/templates/serviceaccount.yaml
@@ -2,8 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "jmeter-service.serviceAccountName" . }}
-  labels:
-    {{- include "jmeter-service.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}

--- a/jmeter-service/chart/templates/serviceaccount.yaml
+++ b/jmeter-service/chart/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ kind: ServiceAccount
 metadata:
   name: {{ include "jmeter-service.serviceAccountName" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: jmeter-service
   {{- with .Values.serviceAccount.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
### This PR
- makes use of the new common chart
- removes the `common` key from the helm values in favor of moving all contained values out of it. This is to prevent name collisions with the `common` helm chart
- removes a few unused helper functions