### PR TITLE
fix: Do not require git user being set when updating project upstream credentials

### DIFF
--- a/configuration-service/common/git.go
+++ b/configuration-service/common/git.go
@@ -72,7 +72,7 @@ func (K8sCredentialReader) GetCredentials(project string) (*common_models.GitCre
 	if err != nil {
 		return nil, fmt.Errorf(unmarshalGitCredentialsFail)
 	}
-	if credentials.User != "" && credentials.Token != "" && credentials.RemoteURI != "" {
+	if credentials.Token != "" && credentials.RemoteURI != "" {
 		return &credentials, nil
 	}
 	return nil, nil
@@ -544,7 +544,7 @@ func GetCredentials(project string) (*common_models.GitCredentials, error) {
 	if err != nil {
 		return nil, fmt.Errorf(unmarshalGitCredentialsFail)
 	}
-	if credentials.User != "" && credentials.Token != "" && credentials.RemoteURI != "" {
+	if credentials.Token != "" && credentials.RemoteURI != "" {
 		return &credentials, nil
 	}
 	return nil, nil

--- a/configuration-service/common/git.go
+++ b/configuration-service/common/git.go
@@ -67,9 +67,12 @@ func (K8sCredentialReader) GetCredentials(project string) (*common_models.GitCre
 	}
 
 	// secret found -> unmarshal it
+	return unmarshalGitCredentials(secret.Data["git-credentials"])
+}
+
+func unmarshalGitCredentials(data []byte) (*common_models.GitCredentials, error) {
 	var credentials common_models.GitCredentials
-	err = json.Unmarshal(secret.Data["git-credentials"], &credentials)
-	if err != nil {
+	if err := json.Unmarshal(data, &credentials); err != nil {
 		return nil, fmt.Errorf(unmarshalGitCredentialsFail)
 	}
 	if credentials.Token != "" && credentials.RemoteURI != "" {
@@ -398,7 +401,7 @@ func isNoRemoteHeadFoundError(err error) bool {
 
 func getRepoURI(uri string, user string, token string) string {
 	if user == "" {
-		user = "keptn"
+		user = gitKeptnUserDefault
 	}
 	if strings.Contains(user, "@") {
 		// username contains an @, probably an e-mail; need to encode it

--- a/configuration-service/common/git.go
+++ b/configuration-service/common/git.go
@@ -397,6 +397,9 @@ func isNoRemoteHeadFoundError(err error) bool {
 }
 
 func getRepoURI(uri string, user string, token string) string {
+	if user == "" {
+		user = "keptn"
+	}
 	if strings.Contains(user, "@") {
 		// username contains an @, probably an e-mail; need to encode it
 		// see https://stackoverflow.com/a/29356143

--- a/configuration-service/common/git_test.go
+++ b/configuration-service/common/git_test.go
@@ -819,6 +819,17 @@ func Test_unmarshalGitCredentials(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "get secret",
+			args: args{
+				data: []byte(`{"token":"token","remoteURI":"http://remote-url.git"}`),
+			},
+			want: &common_models.GitCredentials{
+				Token:     "token",
+				RemoteURI: "http://remote-url.git",
+			},
+			wantErr: false,
+		},
+		{
 			name: "no token and remote URI",
 			args: args{
 				data: []byte(`{"user":"user","token":"","remoteURI":""}`),

--- a/shipyard-controller/handler/projectmanager.go
+++ b/shipyard-controller/handler/projectmanager.go
@@ -216,7 +216,7 @@ func (pm *ProjectManager) Update(params *models.UpdateProjectParams) (error, com
 
 	decodedPemCertificate, _ := base64.StdEncoding.DecodeString(params.GitPemCertificate)
 
-	if params.GitUser != "" && params.GitRemoteURL != "" {
+	if params.GitRemoteURL != "" {
 		// try to update git repository secret
 		err = pm.updateGITRepositorySecret(*params.Name, &gitCredentials{
 			User:              params.GitUser,

--- a/shipyard-controller/handler/projectmanager_test.go
+++ b/shipyard-controller/handler/projectmanager_test.go
@@ -1002,6 +1002,110 @@ func TestUpdate(t *testing.T) {
 	assert.Equal(t, expectedUpdateShipyardResourceData, configStore.UpdateProjectResourceCalls()[0].Resource)
 }
 
+func TestUpdate_ShouldWorkWithEmptyGitUser(t *testing.T) {
+
+	secretStore := &common_mock.SecretStoreMock{}
+	projectMVRepo := &db_mock.ProjectMVRepoMock{}
+	eventRepo := &db_mock.EventRepoMock{}
+	configStore := &common_mock.ConfigurationStoreMock{}
+	sequenceQueueRepo := &db_mock.SequenceQueueRepoMock{}
+	eventQueueRepo := &db_mock.EventQueueRepoMock{}
+	sequenceExecutionRepo := &db_mock.SequenceExecutionRepoMock{}
+
+	oldSecretsData, _ := json.Marshal(gitCredentials{
+		User:      "my-old-user",
+		Token:     "my-old-token",
+		RemoteURI: "http://my-old-remote.uri",
+	})
+
+	updateSecretsData, _ := json.Marshal(gitCredentials{
+		User:            "",
+		Token:           "git-token",
+		RemoteURI:       "git-url",
+		GitProxyURL:     "some-url",
+		GitProxyScheme:  "http",
+		GitProxyUser:    "proxy-user",
+		InsecureSkipTLS: false,
+	})
+
+	oldProjectData := &apimodels.ExpandedProject{
+		CreationDate:    "old-creationdate",
+		GitRemoteURI:    "http://my-old-remote.uri",
+		GitUser:         "my-old-user",
+		ProjectName:     "my-project",
+		Shipyard:        "",
+		ShipyardVersion: "v1",
+	}
+
+	secretStore.GetSecretFunc = func(name string) (map[string][]byte, error) {
+
+		return map[string][]byte{"git-credentials": oldSecretsData}, nil
+	}
+
+	secretStore.UpdateSecretFunc = func(name string, content map[string][]byte) error {
+		return nil
+	}
+	projectMVRepo.GetProjectFunc = func(projectName string) (*apimodels.ExpandedProject, error) {
+		return oldProjectData, nil
+	}
+
+	configStore.UpdateProjectFunc = func(project apimodels.Project) error {
+		return nil
+	}
+
+	configStore.UpdateProjectResourceFunc = func(projectName string, resource *apimodels.Resource) error {
+		return nil
+	}
+
+	projectMVRepo.UpdateProjectFunc = func(prj *apimodels.ExpandedProject) error {
+		return nil
+	}
+
+	instance := NewProjectManager(configStore, secretStore, projectMVRepo, sequenceExecutionRepo, eventRepo, sequenceQueueRepo, eventQueueRepo)
+	myShipyard := "my-shipyard"
+	params := &models.UpdateProjectParams{
+		GitRemoteURL:    "git-url",
+		GitToken:        "git-token",
+		GitUser:         "",
+		Name:            common.Stringp("my-project"),
+		GitProxyURL:     "some-url",
+		GitProxyScheme:  "http",
+		GitProxyUser:    "proxy-user",
+		InsecureSkipTLS: false,
+		Shipyard:        &myShipyard,
+	}
+	err, rollback := instance.Update(params)
+	assert.Nil(t, err)
+	rollback()
+
+	projectUpdateData := apimodels.Project{
+		ProjectName: *params.Name,
+	}
+
+	projectDBUpdateData := &apimodels.ExpandedProject{
+		CreationDate:    "old-creationdate",
+		GitRemoteURI:    "git-url",
+		GitUser:         "",
+		ProjectName:     "my-project",
+		Shipyard:        "my-shipyard",
+		GitProxyURL:     "some-url",
+		GitProxyScheme:  "http",
+		GitProxyUser:    "proxy-user",
+		InsecureSkipTLS: false,
+		ShipyardVersion: "v1",
+	}
+
+	expectedUpdateShipyardResourceData := &apimodels.Resource{
+		ResourceContent: *params.Shipyard,
+		ResourceURI:     common.Stringp("shipyard.yaml")}
+
+	assert.Equal(t, projectUpdateData, configStore.UpdateProjectCalls()[0].Project)
+	assert.Equal(t, "git-credentials-my-project", secretStore.UpdateSecretCalls()[0].Name)
+	assert.Equal(t, updateSecretsData, secretStore.UpdateSecretCalls()[0].Content["git-credentials"])
+	assert.Equal(t, projectDBUpdateData, projectMVRepo.UpdateProjectCalls()[0].Prj)
+	assert.Equal(t, expectedUpdateShipyardResourceData, configStore.UpdateProjectResourceCalls()[0].Resource)
+}
+
 func TestUpdateNoInsecureParameter(t *testing.T) {
 
 	secretStore := &common_mock.SecretStoreMock{}


### PR DESCRIPTION
Closes #7496 

A couple of adjustments had to be made in the shipyard-controller, as well as the configuration service in order to support setting the upstream without a user. 