### PR TITLE
fix(api): Allow to enable/disable rate limit 

### DIFF
--- a/api/middleware/ratelimiter_test.go
+++ b/api/middleware/ratelimiter_test.go
@@ -2,15 +2,16 @@ package middleware
 
 import (
 	"errors"
-	"github.com/benbjohnson/clock"
-	middleware_mock "github.com/keptn/keptn/api/middleware/fake"
-	"github.com/keptn/keptn/api/models"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"net/http/httptest"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/benbjohnson/clock"
+	middleware_mock "github.com/keptn/keptn/api/middleware/fake"
+	"github.com/keptn/keptn/api/models"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_extractIPFromRemoteAddress(t *testing.T) {
@@ -95,7 +96,7 @@ func TestRateLimiter(t *testing.T) {
 	tokenValidator := &middleware_mock.TokenValidatorMock{ValidateTokenFunc: func(token string) (*models.Principal, error) {
 		return nil, errors.New("oops")
 	}}
-	rl := NewRateLimiter(1.0, 1, tokenValidator, mockClock)
+	rl := NewRateLimiter(true, 1.0, 1, tokenValidator, mockClock)
 
 	mh := &MockHttpHandler{}
 	req, err := http.NewRequest(http.MethodGet, "", nil)
@@ -142,6 +143,39 @@ func TestRateLimiter(t *testing.T) {
 	// proceed the internal clock of the limiter and check if the visitors are being cleaned up
 	mockClock.Add(2 * time.Minute)
 	require.Empty(t, rl.visitors)
+}
+
+func TestRateLimiterDisabled(t *testing.T) {
+	mockClock := clock.NewMock()
+	tokenValidator := &middleware_mock.TokenValidatorMock{ValidateTokenFunc: func(token string) (*models.Principal, error) {
+		return nil, errors.New("oops")
+	}}
+	rl := NewRateLimiter(false, 1.0, 1, tokenValidator, mockClock)
+
+	mh := &MockHttpHandler{}
+	req, err := http.NewRequest(http.MethodGet, "", nil)
+	require.Nil(t, err)
+
+	// send one request
+	rl.Apply(&httptest.ResponseRecorder{}, req, mh)
+	require.Equal(t, 1, mh.calls)
+
+	// send a couple of requests at once
+	wg := &sync.WaitGroup{}
+	wg.Add(6)
+
+	for i := 0; i <= 5; i++ {
+		go func() {
+			defer wg.Done()
+			req, err := http.NewRequest(http.MethodGet, "", nil)
+			require.Nil(t, err)
+
+			rl.Apply(&httptest.ResponseRecorder{}, req, mh)
+		}()
+	}
+	wg.Wait()
+	// 1 initial + 6 burst
+	require.Equal(t, 7, mh.calls)
 }
 
 type MockHttpHandler struct {

--- a/api/restapi/configure_keptn.go
+++ b/api/restapi/configure_keptn.go
@@ -90,8 +90,11 @@ func configureAPI(api *operations.KeptnAPI) http.Handler {
 
 	//api.EvaluationTriggerEvaluationHandler = evaluation.TriggerEvaluationHandlerFunc(handlers.TriggerEvaluationHandlerFunc)
 
-	rateLimiter := custommiddleware.NewRateLimiter(env.AuthEnabled, env.AuthRequestsPerSecond, env.AuthRequestMaxBurst, tokenValidator, clock.New())
-	api.AddMiddlewareFor(http.MethodPost, "/auth", rateLimiter.Handle)
+	if env.AuthEnabled {
+		rateLimiter := custommiddleware.NewRateLimiter(env.AuthRequestsPerSecond, env.AuthRequestMaxBurst, tokenValidator, clock.New())
+		api.AddMiddlewareFor(http.MethodPost, "/auth", rateLimiter.Handle)
+	}
+
 	api.ServerShutdown = func() {}
 
 	return setupGlobalMiddleware(api.Serve(setupMiddlewares))

--- a/api/restapi/configure_keptn.go
+++ b/api/restapi/configure_keptn.go
@@ -5,13 +5,14 @@ package restapi
 import (
 	"crypto/tls"
 	"fmt"
-	"github.com/benbjohnson/clock"
-	"github.com/kelseyhightower/envconfig"
-	log "github.com/sirupsen/logrus"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
+
+	"github.com/benbjohnson/clock"
+	"github.com/kelseyhightower/envconfig"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
@@ -31,6 +32,7 @@ import (
 const envVarLogLevel = "LOG_LEVEL"
 
 type EnvConfig struct {
+	AuthEnabled           bool    `envconfig:"MAX_AUTH_ENABLED" default:"true"`
 	AuthRequestsPerSecond float64 `envconfig:"MAX_AUTH_REQUESTS_PER_SECOND" default:"1"`
 	AuthRequestMaxBurst   int     `envconfig:"MAX_AUTH_REQUESTS_BURST" default:"2"`
 }
@@ -88,7 +90,7 @@ func configureAPI(api *operations.KeptnAPI) http.Handler {
 
 	//api.EvaluationTriggerEvaluationHandler = evaluation.TriggerEvaluationHandlerFunc(handlers.TriggerEvaluationHandlerFunc)
 
-	rateLimiter := custommiddleware.NewRateLimiter(env.AuthRequestsPerSecond, env.AuthRequestMaxBurst, tokenValidator, clock.New())
+	rateLimiter := custommiddleware.NewRateLimiter(env.AuthEnabled, env.AuthRequestsPerSecond, env.AuthRequestMaxBurst, tokenValidator, clock.New())
 	api.AddMiddlewareFor(http.MethodPost, "/auth", rateLimiter.Handle)
 	api.ServerShutdown = func() {}
 

--- a/api/restapi/configure_keptn.go
+++ b/api/restapi/configure_keptn.go
@@ -32,9 +32,9 @@ import (
 const envVarLogLevel = "LOG_LEVEL"
 
 type EnvConfig struct {
-	AuthEnabled           bool    `envconfig:"MAX_AUTH_ENABLED" default:"true"`
-	AuthRequestsPerSecond float64 `envconfig:"MAX_AUTH_REQUESTS_PER_SECOND" default:"1"`
-	AuthRequestMaxBurst   int     `envconfig:"MAX_AUTH_REQUESTS_BURST" default:"2"`
+	MaxAuthEnabled           bool    `envconfig:"MAX_AUTH_ENABLED" default:"true"`
+	MaxAuthRequestsPerSecond float64 `envconfig:"MAX_AUTH_REQUESTS_PER_SECOND" default:"1"`
+	MaxAuthRequestBurst      int     `envconfig:"MAX_AUTH_REQUESTS_BURST" default:"2"`
 }
 
 func configureFlags(api *operations.KeptnAPI) {
@@ -90,8 +90,8 @@ func configureAPI(api *operations.KeptnAPI) http.Handler {
 
 	//api.EvaluationTriggerEvaluationHandler = evaluation.TriggerEvaluationHandlerFunc(handlers.TriggerEvaluationHandlerFunc)
 
-	if env.AuthEnabled {
-		rateLimiter := custommiddleware.NewRateLimiter(env.AuthRequestsPerSecond, env.AuthRequestMaxBurst, tokenValidator, clock.New())
+	if env.MaxAuthEnabled {
+		rateLimiter := custommiddleware.NewRateLimiter(env.MaxAuthRequestsPerSecond, env.MaxAuthRequestBurst, tokenValidator, clock.New())
 		api.AddMiddlewareFor(http.MethodPost, "/auth", rateLimiter.Handle)
 	}
 

--- a/api/restapi/configure_keptn_test.go
+++ b/api/restapi/configure_keptn_test.go
@@ -17,15 +17,15 @@ func Test_getEnvConfig(t *testing.T) {
 
 	config, err := getEnvConfig()
 	require.Nil(t, err)
-	require.Equal(t, false, config.AuthEnabled)
-	require.Equal(t, 0.5, config.AuthRequestsPerSecond)
-	require.Equal(t, 1, config.AuthRequestMaxBurst)
+	require.Equal(t, false, config.MaxAuthEnabled)
+	require.Equal(t, 0.5, config.MaxAuthRequestsPerSecond)
+	require.Equal(t, 1, config.MaxAuthRequestBurst)
 }
 
 func Test_getEnvConfigUseDefaults(t *testing.T) {
 	config, err := getEnvConfig()
 	require.Nil(t, err)
-	require.Equal(t, true, config.AuthEnabled)
-	require.Equal(t, float64(1), config.AuthRequestsPerSecond)
-	require.Equal(t, 2, config.AuthRequestMaxBurst)
+	require.Equal(t, true, config.MaxAuthEnabled)
+	require.Equal(t, float64(1), config.MaxAuthRequestsPerSecond)
+	require.Equal(t, 2, config.MaxAuthRequestBurst)
 }

--- a/api/restapi/configure_keptn_test.go
+++ b/api/restapi/configure_keptn_test.go
@@ -8,13 +8,16 @@ import (
 )
 
 func Test_getEnvConfig(t *testing.T) {
+	defer os.Unsetenv("MAX_AUTH_ENABLED")
 	defer os.Unsetenv("MAX_AUTH_REQUESTS_PER_SECOND")
 	defer os.Unsetenv("MAX_AUTH_REQUESTS_BURST")
+	_ = os.Setenv("MAX_AUTH_ENABLED", "false")
 	_ = os.Setenv("MAX_AUTH_REQUESTS_PER_SECOND", "0.5")
 	_ = os.Setenv("MAX_AUTH_REQUESTS_BURST", "1")
 
 	config, err := getEnvConfig()
 	require.Nil(t, err)
+	require.Equal(t, false, config.AuthEnabled)
 	require.Equal(t, 0.5, config.AuthRequestsPerSecond)
 	require.Equal(t, 1, config.AuthRequestMaxBurst)
 }
@@ -22,6 +25,7 @@ func Test_getEnvConfig(t *testing.T) {
 func Test_getEnvConfigUseDefaults(t *testing.T) {
 	config, err := getEnvConfig()
 	require.Nil(t, err)
+	require.Equal(t, true, config.AuthEnabled)
 	require.Equal(t, float64(1), config.AuthRequestsPerSecond)
 	require.Equal(t, 2, config.AuthRequestMaxBurst)
 }

--- a/installer/manifests/keptn/charts/control-plane/templates/api-service.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/api-service.yaml
@@ -74,11 +74,11 @@ spec:
             - name: AUTOMATIC_PROVISIONING_URL
               value: {{ (.Values.features).automaticProvisioningURL | default "" }}
             - name: MAX_AUTH_ENABLED
-              value: {{ (.Values.apiService.config.maxAuth).enabled | default true }}
+              value: {{ (.Values.apiService.maxAuth).enabled | default true }}
             - name: MAX_AUTH_REQUESTS_PER_SECOND
-              value: '{{ (.Values.apiService.config.maxAuth).requestsPerSecond | default "1.0"}}'
+              value: '{{ (.Values.apiService.maxAuth).requestsPerSecond | default "1.0"}}'
             - name: MAX_AUTH_REQUESTS_BURST
-              value: '{{ (.Values.apiService.config.maxAuth).requestBurst | default "2"}}'
+              value: '{{ (.Values.apiService.maxAuth).requestBurst | default "2"}}'
             - name: LOG_LEVEL
               value: {{ .Values.logLevel | default "info" }}
           {{- include "control-plane.common.container-security-context" . | nindent 10 }}

--- a/installer/manifests/keptn/charts/control-plane/templates/api-service.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/api-service.yaml
@@ -74,11 +74,11 @@ spec:
             - name: AUTOMATIC_PROVISIONING_URL
               value: {{ (.Values.features).automaticProvisioningURL | default "" }}
             - name: MAX_AUTH_ENABLED
-              value: {{ (.Values.apiService.config).maxAuthEnabled | default true }}
+              value: {{ (.Values.apiService.config.maxAuth).enabled | default true }}
             - name: MAX_AUTH_REQUESTS_PER_SECOND
-              value: '{{ .Values.apiService.config.maxAuthRequestsPerSecond | default "1.0"}}'
+              value: '{{ (.Values.apiService.config.maxAuth).requestsPerSecond | default "1.0"}}'
             - name: MAX_AUTH_REQUESTS_BURST
-              value: '{{ .Values.apiService.config.maxAuthRequestBurst | default "2"}}'
+              value: '{{ (.Values.apiService.config.maxAuth).requestBurst | default "2"}}'
             - name: LOG_LEVEL
               value: {{ .Values.logLevel | default "info" }}
           {{- include "control-plane.common.container-security-context" . | nindent 10 }}

--- a/installer/manifests/keptn/charts/control-plane/templates/api-service.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/api-service.yaml
@@ -71,8 +71,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: AUTOMATIC_PROVISIONING_URL 
+            - name: AUTOMATIC_PROVISIONING_URL
               value: {{ (.Values.features).automaticProvisioningURL | default "" }}
+            - name: MAX_AUTH_ENABLED
+              value: {{ (.Values.apiService.config).maxAuthEnabled | default true }}
             - name: MAX_AUTH_REQUESTS_PER_SECOND
               value: '{{ .Values.apiService.config.maxAuthRequestsPerSecond | default "1.0"}}'
             - name: MAX_AUTH_REQUESTS_BURST

--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -86,9 +86,10 @@ apiService:
     repository: docker.io/keptn/api
     tag: ""
   config:
-    maxAuthEnabled: true
-    maxAuthRequestsPerSecond: "1.0"
-    maxAuthRequestBurst: "2"
+    maxAuth:
+      enabled: true
+      requestsPerSecond: "1.0"
+      requestBurst: "2"
   nodeSelector: {}
 
 bridge:

--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -86,6 +86,7 @@ apiService:
     repository: docker.io/keptn/api
     tag: ""
   config:
+    maxAuthEnabled: true
     maxAuthRequestsPerSecond: "1.0"
     maxAuthRequestBurst: "2"
   nodeSelector: {}

--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -85,11 +85,10 @@ apiService:
   image:
     repository: docker.io/keptn/api
     tag: ""
-  config:
-    maxAuth:
-      enabled: true
-      requestsPerSecond: "1.0"
-      requestBurst: "2"
+  maxAuth:
+    enabled: true
+    requestsPerSecond: "1.0"
+    requestBurst: "2"
   nodeSelector: {}
 
 bridge:


### PR DESCRIPTION
Signed-off-by: Giovanni Liva <giovanni.liva@dynatrace.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- add a helm value to enable/disable the rate limit

### Notes
<!-- any additional notes for this PR -->

I also observed that `X-Forwarded-For` is more reliable to detect the request IP address

