### PR TITLE
ci: Changed integration tests schedule from 3 AM to 1 AM UTC

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -2,7 +2,7 @@ name: Integration Tests
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron: '0 3 * * 1-5' # run integration tests at 3 AM, monday to friday (1-5)
+    - cron: '0 1 * * 1-5' # run integration tests at 1 AM (UTC), monday to friday (1-5)
 
   workflow_dispatch: # run integration tests only when triggered manually
     inputs:


### PR DESCRIPTION
Lets trigger our nightly integration tests a bit earlier....