### PR TITLE
test: increase wait time for scaling down deployments to adapt to newly introduced termination grace period

### DIFF
--- a/test/go-tests/test_sequencequeue.go
+++ b/test/go-tests/test_sequencequeue.go
@@ -436,7 +436,7 @@ func executeSequenceAndVerifyCompletion(t *testing.T, projectName, serviceName, 
 		}
 		taskTriggeredEvent = event
 		return true
-	}, 5*time.Minute, 10*time.Second)
+	}, 10*time.Minute, 10*time.Second)
 	require.NotNil(t, taskTriggeredEvent)
 
 	cloudEvent := keptnv2.ToCloudEvent(*taskTriggeredEvent)

--- a/test/go-tests/test_uniform.go
+++ b/test/go-tests/test_uniform.go
@@ -325,7 +325,7 @@ func Test_UniformRegistration_TestAPI(t *testing.T) {
 			return false
 		}
 		return true
-	}, 3*time.Minute, 10*time.Second)
+	}, 5*time.Minute, 10*time.Second)
 }
 
 // Test_UniformRegistration_RegistrationOfKeptnIntegration tests whether a deployed Keptn Integration gets correctly

--- a/test/go-tests/test_utils.go
+++ b/test/go-tests/test_utils.go
@@ -868,7 +868,7 @@ func WaitForDeploymentToBeScaledDown(deploymentName string) error {
 			}
 		}
 		return nil
-	})
+	}, retry.NumberOfRetries(40))
 
 	return err
 }

--- a/test/go-tests/test_zerodowntime.go
+++ b/test/go-tests/test_zerodowntime.go
@@ -54,6 +54,13 @@ func Test_ZeroDownTimeTriggerSequence(t *testing.T) {
 	// scale down the shipyard controller
 	err = ScaleDownUniform([]string{"shipyard-controller"})
 
+	defer func() {
+		if err := ScaleUpUniform([]string{"shipyard-controller"}, 1); err != nil {
+			t.Errorf("could not scale up shipyard-controller: %v", err)
+		}
+
+	}()
+
 	require.Nil(t, err)
 
 	err = WaitForDeploymentToBeScaledDown("shipyard-controller")

--- a/test/go-tests/test_zerodowntime.go
+++ b/test/go-tests/test_zerodowntime.go
@@ -55,6 +55,7 @@ func Test_ZeroDownTimeTriggerSequence(t *testing.T) {
 	err = ScaleDownUniform([]string{"shipyard-controller"})
 
 	defer func() {
+		// make sure the shipyard-controller deployment is scaled back up in any case, even when there is an unexpected error during the test
 		if err := ScaleUpUniform([]string{"shipyard-controller"}, 1); err != nil {
 			t.Errorf("could not scale up shipyard-controller: %v", err)
 		}


### PR DESCRIPTION
Closes #7545

Integration test run: https://github.com/keptn/keptn/actions/runs/2207581509