### PR TITLE
test(bridge): Fix flaky sequence UI test

### DIFF
--- a/bridge/cypress/integration/sequences.spec.ts
+++ b/bridge/cypress/integration/sequences.spec.ts
@@ -35,7 +35,6 @@ describe('Sequences', () => {
 
   it('should show a filtered list if filters are applied', () => {
     sequencePage.visit('sockshop');
-    cy.wait('@SequencesMetadata');
     cy.wait('@Sequences');
     cy.wait(500);
 
@@ -162,7 +161,6 @@ describe('Sequences', () => {
 
   it('should filter waiting sequences', () => {
     sequencePage.visit('sockshop');
-    cy.wait('@SequencesMetadata');
     cy.wait('@Sequences');
     cy.wait(500);
 

--- a/bridge/cypress/support/pageobjects/SequencesPage.ts
+++ b/bridge/cypress/support/pageobjects/SequencesPage.ts
@@ -10,7 +10,7 @@ export class SequencesPage {
   }
 
   public visit(projectName: string): this {
-    cy.visit(`/project/${projectName}/sequence`).wait('@metadata');
+    cy.visit(`/project/${projectName}/sequence`).wait('@metadata').wait('@SequencesMetadata');
     return this;
   }
 


### PR DESCRIPTION
The test `should filter waiting sequences` in `sequence.spec.ts` was flaky (detached from DOM error). This was most likely related to a re-render after the sequence metadata has been fetched. The fix is to wait until the metadata is fetched.

Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>