### PR TITLE
feat: Make deployment resources customizable in helm charts

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -82,3 +82,4 @@ For a realtime overview of current contributors to the Keptn project, we refer t
 * [Eric Y. Kim](https://github.com/eyskim)
 * [Markus Lackner](https://github.com/markuslackner)
 * [René Panzar](https://github.com/renepanzar)
+* [Alberto Gil de Dios](https://github.com/albertogdd)

--- a/helm-service/chart/templates/deployment.yaml
+++ b/helm-service/chart/templates/deployment.yaml
@@ -92,7 +92,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.helmservice.resources | nindent 12 }}
         - name: distributor
           image: "{{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}"
           {{- include "helm-service.prestop" . | nindent 10 }}
@@ -112,12 +112,7 @@ spec:
           ports:
             - containerPort: 8080
           resources:
-            requests:
-              memory: "16Mi"
-              cpu: "25m"
-            limits:
-              memory: "32Mi"
-              cpu: "100m"
+            {{- toYaml .Values.distributor.resources | nindent 12 }}
           env:
             - name: PUBSUB_TOPIC
               value: 'sh.keptn.event.deployment.triggered,sh.keptn.event.rollback.triggered,sh.keptn.event.release.triggered,sh.keptn.event.action.triggered,sh.keptn.event.service.delete.finished'

--- a/helm-service/chart/values.yaml
+++ b/helm-service/chart/values.yaml
@@ -7,6 +7,13 @@ helmservice:
     enabled: true                            # Creates a Kubernetes Service for the helm-service
   gracePeriod: 90                            # PreStop hook time +30s
   preStopHookTime: 60
+  resources:                                 # Resource limits and requests
+    limits:
+      cpu: 1000m
+      memory: 512Mi
+    requests:
+      cpu: 50m
+      memory: 128Mi
 
 distributor:
   stageFilter: ""                            # Stage to which this helm service belongs; default=all; comma-separated list to filter for set of stages
@@ -25,6 +32,13 @@ distributor:
       discovery: ""
       tokenURL: ""
       scopes: ""
+  resources:                                 # Resource limits and requests
+    requests:
+      memory: "16Mi"
+      cpu: "25m"
+    limits:
+      memory: "32Mi"
+      cpu: "100m"
 
 remoteControlPlane:
   enabled: false                             # Enables remote execution plane mode
@@ -51,14 +65,6 @@ securityContext: {}                          # Set the security context (e.g. ru
 #  readOnlyRootFilesystem: true
 #  runAsNonRoot: true
 #  runAsUser: 1000
-
-resources:                                  # Resource limits and requests
-  limits:
-    cpu: 1000m
-    memory: 512Mi
-  requests:
-    cpu: 50m
-    memory: 128Mi
 
 nodeSelector: {}                             # Node selector configuration
 

--- a/installer/manifests/keptn/charts/control-plane/templates/api-gateway-nginx.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/api-gateway-nginx.yaml
@@ -423,12 +423,7 @@ spec:
               readOnly: true
               name: api-nginx-config
           resources:
-            requests:
-              memory: "64Mi"
-              cpu: "50m"
-            limits:
-              memory: "128Mi"
-              cpu: "100m"
+            {{- toYaml .Values.apiGatewayNginx.resources | nindent 12 }}
         {{- include "control-plane.apiGatewayNginx.container-security-context" . | nindent 10 }}
       volumes:
         - name: api-nginx-config

--- a/installer/manifests/keptn/charts/control-plane/templates/api-service.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/api-service.yaml
@@ -51,12 +51,7 @@ spec:
           ports:
             - containerPort: 8080
           resources:
-            requests:
-              memory: "32Mi"
-              cpu: "50m"
-            limits:
-              memory: "64Mi"
-              cpu: "100m"
+            {{- toYaml .Values.apiService.resources | nindent 12 }}
           env:
             - name: PREFIX_PATH
               value: "{{ .Values.prefixPath }}"

--- a/installer/manifests/keptn/charts/control-plane/templates/approval-service.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/approval-service.yaml
@@ -52,12 +52,7 @@ spec:
           ports:
             - containerPort: 8080
           resources:
-            requests:
-              memory: "32Mi"
-              cpu: "25m"
-            limits:
-              memory: "128Mi"
-              cpu: "100m"
+            {{- toYaml .Values.approvalService.resources | nindent 12 }}
           env:
             - name: CONFIGURATION_SERVICE
               value: 'http://configuration-service:8080'

--- a/installer/manifests/keptn/charts/control-plane/templates/configuration-service.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/configuration-service.yaml
@@ -93,12 +93,7 @@ spec:
           ports:
             - containerPort: 8080
           resources:
-            requests:
-              memory: "32Mi"
-              cpu: "25m"
-            limits:
-              memory: "64Mi"
-              cpu: "100m"
+            {{- toYaml .Values.resourceService.resources | nindent 12 }}
           volumeMounts:
             - mountPath: /data/config
               name: resource-volume
@@ -220,12 +215,7 @@ spec:
           ports:
             - containerPort: 8080
           resources:
-            requests:
-              memory: "32Mi"
-              cpu: "25m"
-            limits:
-              memory: "64Mi"
-              cpu: "100m"
+            {{- toYaml .Values.configurationService.resources | nindent 12 }}
           volumeMounts:
             - mountPath: /data/config
               name: configuration-volume

--- a/installer/manifests/keptn/charts/control-plane/templates/continuous-operations.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/continuous-operations.yaml
@@ -52,12 +52,7 @@ spec:
         ports:
         - containerPort: 8080
         resources:
-          requests:
-            memory: "64Mi"
-            cpu: "50m"
-          limits:
-            memory: "1Gi"
-            cpu: "200m"
+          {{- toYaml .Values.remediationService.resources | nindent 10 }}
         env:
           - name: EVENTBROKER
             value: 'http://localhost:8081/event'

--- a/installer/manifests/keptn/charts/control-plane/templates/core.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/core.yaml
@@ -214,12 +214,7 @@ spec:
           ports:
             - containerPort: 3000
           resources:
-            requests:
-              memory: "64Mi"
-              cpu: "25m"
-            limits:
-              memory: "256Mi"
-              cpu: "200m"
+            {{- toYaml .Values.bridge.resources | nindent 12 }}
           volumeMounts:
             - name: assets
               mountPath: /usr/src/app/dist/assets/branding

--- a/installer/manifests/keptn/charts/control-plane/templates/mongodb-datastore.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/mongodb-datastore.yaml
@@ -55,12 +55,7 @@ spec:
         ports:
         - containerPort: 8080
         resources:
-          requests:
-            memory: "32Mi"
-            cpu: "50m"
-          limits:
-            memory: "512Mi"
-            cpu: "300m"
+          {{- toYaml .Values.mongodbDatastore.resources | nindent 10 }}
         env:
         - name: PREFIX_PATH
           value: "{{ .Values.prefixPath }}"

--- a/installer/manifests/keptn/charts/control-plane/templates/secret-service.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/secret-service.yaml
@@ -94,12 +94,7 @@ spec:
           ports:
             - containerPort: 8080
           resources:
-            requests:
-              memory: "32Mi"
-              cpu: "25m"
-            limits:
-              memory: "64Mi"
-              cpu: "200m"
+            {{- toYaml .Values.secretService.resources | nindent 12 }}
           volumeMounts:
             - mountPath: /data
               name: secret-service-configmap-volume

--- a/installer/manifests/keptn/charts/control-plane/templates/shipyard-controller.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/shipyard-controller.yaml
@@ -102,12 +102,7 @@ spec:
           ports:
             - containerPort: 8080
           resources:
-            requests:
-              memory: "32Mi"
-              cpu: "50m"
-            limits:
-              memory: "128Mi"
-              cpu: "100m"
+            {{- toYaml .Values.shipyardController.resources | nindent 12 }}
           {{- include "control-plane.common.container-security-context" . | nindent 10 }}
       terminationGracePeriodSeconds: {{ .Values.shipyardController.gracePeriod | default 120 }}
       {{- include "keptn.nodeSelector" (dict "value" .Values.shipyardController.nodeSelector "default" .Values.common.nodeSelector "indent" 6 "context" . )}}

--- a/installer/manifests/keptn/charts/control-plane/templates/statistics-service.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/statistics-service.yaml
@@ -76,12 +76,7 @@ spec:
           ports:
             - containerPort: 8080
           resources:
-            requests:
-              memory: "32Mi"
-              cpu: "25m"
-            limits:
-              memory: "64Mi"
-              cpu: "100m"
+            {{- toYaml .Values.statisticsService.resources | nindent 12 }}
           {{- include "control-plane.common.container-security-context" . | nindent 10 }}
         - name: distributor
           image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}

--- a/installer/manifests/keptn/charts/control-plane/templates/webhook-service.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/webhook-service.yaml
@@ -53,12 +53,7 @@ spec:
           ports:
             - containerPort: 8080
           resources:
-            requests:
-              memory: "32Mi"
-              cpu: "25m"
-            limits:
-              memory: "64Mi"
-              cpu: "100m"
+            {{- toYaml .Values.webhookService.resources | nindent 12 }}
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -75,6 +75,13 @@ apiGatewayNginx:
   nodeSelector: {}
   gracePeriod: 120     # gracePeriod set to preStop hook time +30s
   preStopHookTime: 90
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "50m"
+    limits:
+      memory: "128Mi"
+      cpu: "100m"
 
 remediationService:
   image:
@@ -83,6 +90,13 @@ remediationService:
   nodeSelector: {}
   gracePeriod: 120     # gracePeriod set to preStop hook time +30s
   preStopHookTime: 90
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "50m"
+    limits:
+      memory: "1Gi"
+      cpu: "200m"
 
 apiService:
   tokenSecretName:
@@ -96,6 +110,13 @@ apiService:
   nodeSelector: {}
   gracePeriod: 120     # gracePeriod set to preStop hook time +30s
   preStopHookTime: 90
+  resources:
+    requests:
+      memory: "32Mi"
+      cpu: "50m"
+    limits:
+      memory: "64Mi"
+      cpu: "100m"
 
 bridge:
   image:
@@ -137,6 +158,13 @@ bridge:
     userIdentifier: ""
     mongoConnectionString: ""
   nodeSelector: {}
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "25m"
+    limits:
+      memory: "256Mi"
+      cpu: "200m"
 
 distributor:
   metadata:
@@ -178,6 +206,13 @@ shipyardController:
   nodeSelector: {}
   gracePeriod: 120     # gracePeriod set to preStop hook time +30s
   preStopHookTime: 90
+  resources:
+    requests:
+      memory: "32Mi"
+      cpu: "50m"
+    limits:
+      memory: "128Mi"
+      cpu: "100m"
 
 secretService:
   image:
@@ -186,6 +221,13 @@ secretService:
   nodeSelector: {}
   gracePeriod: 120     # gracePeriod set to preStop hook time +30s
   preStopHookTime: 90
+  resources:
+    requests:
+      memory: "32Mi"
+      cpu: "25m"
+    limits:
+      memory: "64Mi"
+      cpu: "200m"
 
 configurationService:
   image:
@@ -202,6 +244,13 @@ configurationService:
   nodeSelector: {}
   gracePeriod: 120     # gracePeriod set to preStop hook time +30s
   preStopHookTime: 90
+  resources:
+    requests:
+      memory: "32Mi"
+      cpu: "25m"
+    limits:
+      memory: "64Mi"
+      cpu: "100m"
 
 resourceService:
   enabled: false
@@ -216,6 +265,13 @@ resourceService:
   nodeSelector: {}
   gracePeriod: 120     # gracePeriod set to preStop hook time +30s
   preStopHookTime: 90
+  resources:
+    requests:
+      memory: "32Mi"
+      cpu: "25m"
+    limits:
+      memory: "64Mi"
+      cpu: "100m"
 
 mongodbDatastore:
   image:
@@ -224,6 +280,13 @@ mongodbDatastore:
   nodeSelector: {}
   gracePeriod: 120     # gracePeriod set to preStop hook time +30s
   preStopHookTime: 90
+  resources:
+    requests:
+      memory: "32Mi"
+      cpu: "50m"
+    limits:
+      memory: "512Mi"
+      cpu: "300m"
 
 lighthouseService:
   image:
@@ -240,6 +303,13 @@ statisticsService:
   nodeSelector: {}
   gracePeriod: 120     # gracePeriod set to preStop hook time +30s
   preStopHookTime: 90
+  resources:
+    requests:
+      memory: "32Mi"
+      cpu: "25m"
+    limits:
+      memory: "64Mi"
+      cpu: "100m"
 
 approvalService:
   image:
@@ -248,6 +318,13 @@ approvalService:
   nodeSelector: {}
   gracePeriod: 120     # gracePeriod set to preStop hook time +30s
   preStopHookTime: 90
+  resources:
+    requests:
+      memory: "32Mi"
+      cpu: "25m"
+    limits:
+      memory: "128Mi"
+      cpu: "100m"
 
 webhookService:
   enabled: true
@@ -257,6 +334,13 @@ webhookService:
   nodeSelector: {}
   gracePeriod: 120     # gracePeriod set to preStop hook time +30s
   preStopHookTime: 90
+  resources:
+    requests:
+      memory: "32Mi"
+      cpu: "25m"
+    limits:
+      memory: "64Mi"
+      cpu: "100m"
 
 ingress:
   enabled: false

--- a/installer/manifests/keptn/templates/_helpers.tpl
+++ b/installer/manifests/keptn/templates/_helpers.tpl
@@ -64,12 +64,7 @@ Create the name of the service account to use
 
 {{- define "keptn.distributor.resources" -}}
 resources:
-  requests:
-    memory: "16Mi"
-    cpu: "25m"
-  limits:
-    memory: "32Mi"
-    cpu: "100m"
+  {{- toYaml .Values.distributor.resources | nindent 2 }}
 {{- end }}
 
 {{/*

--- a/installer/manifests/keptn/values.yaml
+++ b/installer/manifests/keptn/values.yaml
@@ -3,6 +3,14 @@ control-plane:
   apiGatewayNginx:
     type: ClusterIP
     port: 80
+  distributor:  
+    resources:
+      requests:
+        memory: "16Mi"
+        cpu: "25m"
+      limits:
+        memory: "32Mi"
+        cpu: "100m"
 
 continuous-delivery:
   enabled: false

--- a/jmeter-service/chart/templates/deployment.yaml
+++ b/jmeter-service/chart/templates/deployment.yaml
@@ -58,7 +58,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.jmeterservice.resources | nindent 12 }}
         - name: distributor
           image: "{{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}"
           {{- include "jmeter-service.prestop" . | nindent 10 }}
@@ -78,12 +78,7 @@ spec:
           ports:
             - containerPort: 8080
           resources:
-            requests:
-              memory: "16Mi"
-              cpu: "25m"
-            limits:
-              memory: "32Mi"
-              cpu: "100m"
+            {{- toYaml .Values.distributor.resources | nindent 12 }}
           env:
             - name: PUBSUB_TOPIC
               value: 'sh.keptn.event.test.triggered'

--- a/jmeter-service/chart/values.yaml
+++ b/jmeter-service/chart/values.yaml
@@ -7,6 +7,17 @@ jmeterservice:
     enabled: true                              # Creates a Kubernetes Service for the jmeter-service
   gracePeriod: 120                             # PreStop hook time +30s
   preStopHookTime: 90
+  resources:                                   # Resource limits and requests
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you want to limit the resources, you can uncomment the following lines
+  # but be aware that JMeter needs  lots of resources while running load tests.
+  #  limits:
+  #    cpu: 2
+  #    memory: 2Gi
+    requests:
+      cpu: 100m
+      memory: 128Mi
 
 distributor:
   stageFilter: ""                            # Sets the stage this helm service belongs to
@@ -25,6 +36,13 @@ distributor:
       discovery: ""
       tokenURL: ""
       scopes: ""
+  resources:                                 # Resource limits and requests
+    requests:
+      memory: "16Mi"
+      cpu: "25m"
+    limits:
+      memory: "32Mi"
+      cpu: "100m"
 
 remoteControlPlane:
   enabled: false                             # Enables remote execution plane mode
@@ -51,18 +69,6 @@ securityContext: {}                          # Set the security context (e.g. ru
 #  readOnlyRootFilesystem: true
 #  runAsNonRoot: true
 #  runAsUser: 1000
-
-resources:                                 # Resource limits and requests
-# We usually recommend not to specify default resources and to leave this as a conscious
-# choice for the user. This also increases chances charts run on environments with little
-# resources, such as Minikube. If you want to limit the resources, you can uncomment the following lines
-# but be aware that JMeter needs  lots of resources while running load tests.
-#  limits:
-#    cpu: 2
-#    memory: 2Gi
-  requests:
-    cpu: 100m
-    memory: 128Mi
 
 nodeSelector: {}                                # Node selector configuration
 


### PR DESCRIPTION
## This PR treats with #6981 
<!-- add the description of the PR here -->

Makes possible to inject your own custom resources values using the Helm Charts in the following pods:

from /helm-service
- `helm-service`

from /jmeter-service
- `jmeter-service`

from /installer
- `api-gateway-nginx`
- `approval-service`
- `resource-service`
- `configuration-service`
- `remediation-service`
- `bridge`
- `mongodb-datastore`
- `secret-service`
- `shipyard-controller`
- `statistics-service`
- `webhook-service`

This resources values were hardcoded before in the templates.

### Related Issues
Closes #6981 

### Notes
Init Containers aren't included in the changes, as they had no specified resources. Hence, they use the [default K8s values](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#resources).

All `control-plane` distributor pods use the same resources properties (they all use the same `keptn.distributor.resources` function). Now the value of this function is customizable (see `keptn/installer/manifests/keptn/values.yaml`)

### Follow-up Tasks
No further changes are needed, as the template resource values now are in values.yaml, the templating engine should generate the exact same output as before.

### How to test
Comparing the templates generated in this branch with the ones from master. [You can check the diff here](https://www.diffchecker.com/clg1yomK). 
There's a difference in the order of the lines inside the generated resources, my guess is that `toYaml` orders them alphabetically. Also, it removes the `""` quotes.
```
// keptn/installer/manifests/keptn
helm template . --output-dir ../../../temp/test-templates/installer
```
```
// before
          resources:	
            requests:	
              memory: "32Mi"	
              cpu: "25m"	
            limits:	
              memory: "64Mi"	
              cpu: "100m"
// after:
          resources:
            limits:
              cpu: 100m
              memory: 64Mi
            requests:
              cpu: 25m
              memory: 32Mi
```
Injecting a custom value for resources and seeing it reflected in the generated template
```
// keptn/helm-service/chart
helm template . --output-dir ../../temp/test-templates/with-values/helm-service --set helmservice.resources.limits.cpu=2000m
```