### PR TITLE
feat(bridge): Introduce automaticprovisioning flag to metadata

### DIFF
--- a/bridge/client/app/_models/metadata.ts
+++ b/bridge/client/app/_models/metadata.ts
@@ -4,4 +4,5 @@ export interface Metadata {
   keptnlabel: string;
   bridgeversion: string;
   shipyardversion: string;
+  automaticprovisioning?: boolean;
 }


### PR DESCRIPTION
Adds the automaticprovisioning to the metadata interface.
To be backwards compatible to configuration-service, the property has to be optional. This will only be set if resource-service is already configured in the Keptn installation.
