### PR TITLE
chore: Add @renepanzar as member

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -40,9 +40,10 @@ Christian Heckelmann, @checkelmann, ERT / Dynatrace
 Arthur Pitman, @arthurpitman, Dynatrace
 Gabriel Tanner, @tannergabriel, Dynatrace
 Gilbert Tanner, @TannerGilbert, Dynatrace
+Joerg Poecher, @j-poecher, Dynatrace
 Kavindu Dodanduwa, @kavindu-dodan, Dynatrace
 Paolo Chila, @pchila, Dynatrace
+Raphael Ludwig, @Raffy23, Dynatrace
+René Panzar, @renepanzar, Dynatrace
 Rob Jahn, @robertjahn, Dynatrace
 Suraj Banakar, @vadasambar, No Affiliation
-Raphael Ludwig, @Raffy23, Dynatrace
-Joerg Poecher, @j-poecher, Dynatrace


### PR DESCRIPTION
## This PR

- Adds @renepanzar as member
- Re-orders members to follow the ascending order rule

### Related Issues

https://github.com/keptn/community/issues/142

### Notes

### Follow-up Tasks


### How to test

