### PR TITLE
feat(bridge): Stop event propergation when clicking on external link

### DIFF
--- a/bridge/client/app/_components/ktb-task-item/ktb-task-item.component.html
+++ b/bridge/client/app/_components/ktb-task-item/ktb-task-item.component.html
@@ -77,7 +77,7 @@
               *ngFor="let deploymentURIPublic of finishedEvent.data?.deployment?.deploymentURIsPublic"
               [href]="deploymentURIPublic"
               target="_blank"
-              (click)="$event.stopPropagation();"
+              (click)="$event.stopPropagation()"
             >
               <button dt-icon-button variant="nested" [title]="'View ' + task.service + ' in ' + task.stage">
                 <dt-icon name="externallink"></dt-icon>

--- a/bridge/client/app/_components/ktb-task-item/ktb-task-item.component.html
+++ b/bridge/client/app/_components/ktb-task-item/ktb-task-item.component.html
@@ -77,6 +77,7 @@
               *ngFor="let deploymentURIPublic of finishedEvent.data?.deployment?.deploymentURIsPublic"
               [href]="deploymentURIPublic"
               target="_blank"
+              (click)="$event.stopPropagation();"
             >
               <button dt-icon-button variant="nested" [title]="'View ' + task.service + ' in ' + task.stage">
                 <dt-icon name="externallink"></dt-icon>


### PR DESCRIPTION
## This PR

- Stop event propergation when clicking on external link to prevent opening/closing of expandable tile

### Related Issues

Fixes #5284 

