### PR TITLE
feat: Introduce WriteConcern to MongoDB connection string

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/templates/mongodb-datastore.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/mongodb-datastore.yaml
@@ -68,6 +68,8 @@ spec:
           value: '{{ .Release.Name }}-{{ .Values.mongo.service.nameOverride }}:{{ .Values.mongo.service.port }}'
         - name: MONGODB_DATABASE
           value: {{ .Values.mongo.auth.database | default "keptn" }}
+        - name: MONGODB_WRITECONCERN_TIMEOUT
+          value: '{{ .Values.mongo.writeconcernTimeout | default 30 }}'
         - name: MONGODB_USER
           valueFrom:
             secretKeyRef:

--- a/installer/manifests/keptn/charts/control-plane/templates/shipyard-controller.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/shipyard-controller.yaml
@@ -73,6 +73,8 @@ spec:
                   key: mongodb-passwords
             - name: MONGODB_DATABASE
               value: {{ .Values.mongo.auth.database | default "keptn" }}
+            - name: MONGODB_WRITECONCERN_TIMEOUT
+              value: '{{ .Values.mongo.writeconcernTimeout | default 30 }}'
             - name: MONGODB_EXTERNAL_CONNECTION_STRING
               valueFrom:
                 secretKeyRef:

--- a/installer/manifests/keptn/charts/control-plane/templates/statistics-service.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/statistics-service.yaml
@@ -65,6 +65,8 @@ spec:
                   key: mongodb-passwords
             - name: MONGODB_DATABASE
               value: {{ .Values.mongo.auth.database | default "keptn" }}
+            - name: MONGODB_WRITECONCERN_TIMEOUT
+              value: '{{ .Values.mongo.writeconcernTimeout | default 30 }}'
             - name: MONGODB_EXTERNAL_CONNECTION_STRING
               valueFrom:
                 secretKeyRef:

--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -5,6 +5,7 @@ mongo:
   service:
     nameOverride: 'mongo'
     port: 27017
+  writeconcernTimeout: 30
   auth:
     databases:
       - 'keptn'

--- a/mongodb-datastore/README.md
+++ b/mongodb-datastore/README.md
@@ -36,7 +36,7 @@ If you are using VS Code for your development, you can use the following launch 
             "mode": "auto",
             "program": "${workspaceFolder}/cmd/mongo-db-datastore-server/main.go",
             "env": {
-                "MONGO_DB_CONNECTION_STRING":"mongodb://user:password@localhost:27017/keptn",
+                "MONGO_DB_CONNECTION_STRING":"mongodb://user:password@localhost:27017/keptn?w=majority&wtimeoutMS=30000",
                 "MONGODB_DATABASE":"keptn"
             },
             "args": ["--port=8080"]

--- a/mongodb-datastore/db/mongodb_connection.go
+++ b/mongodb-datastore/db/mongodb_connection.go
@@ -44,7 +44,7 @@ func getMongoDBWriteConcernTimeout() time.Duration {
 	timeoutString := os.Getenv("MONGODB_WRITECONCERN_TIMEOUT")
 	timeout, err := strconv.Atoi(timeoutString)
 	if err != nil {
-		logger.Errorf("failed to read MongoDB WriteConcern Timeout from env variable: %w", err)
+		logger.Errorf("failed to read MongoDB WriteConcern Timeout from env variable: %v", err.Error())
 		return 30 * time.Second
 	}
 	return time.Duration(timeout) * time.Second

--- a/mongodb-datastore/db/mongodb_connection.go
+++ b/mongodb-datastore/db/mongodb_connection.go
@@ -90,8 +90,8 @@ func (m *MongoDBConnection) connectMongoDBClient() error {
 		logger.Errorf(clientCreationFailed, err)
 		return fmt.Errorf(clientCreationFailed, err)
 	}
-	clientOptions := options.Client()
-	clientOptions = clientOptions.ApplyURI(connectionString).SetWriteConcern(writeconcern.New(writeconcern.WMajority(), writeconcern.WTimeout(getMongoDBWriteConcernTimeout())))
+	clientOptions := options.Client().SetWriteConcern(writeconcern.New(writeconcern.WMajority(), writeconcern.WTimeout(getMongoDBWriteConcernTimeout())))
+	clientOptions = clientOptions.ApplyURI(connectionString)
 	clientOptions = clientOptions.SetConnectTimeout(30 * time.Second)
 	m.client, err = mongo.NewClient(clientOptions)
 	if err != nil {

--- a/mongodb-datastore/db/mongodb_connection.go
+++ b/mongodb-datastore/db/mongodb_connection.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	logger "github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/mongo/writeconcern"
 )
 
 var mutex = &sync.Mutex{}
@@ -36,6 +38,16 @@ func GetMongoDBConnectionInstance() *MongoDBConnection {
 
 func getDatabaseName() string {
 	return os.Getenv("MONGODB_DATABASE")
+}
+
+func getMongoDBWriteConcernTimeout() time.Duration {
+	timeoutString := os.Getenv("MONGODB_WRITECONCERN_TIMEOUT")
+	timeout, err := strconv.Atoi(timeoutString)
+	if err != nil {
+		logger.Errorf("failed to read MongoDB WriteConcern Timeout from env variable: %w", err)
+		return 30 * time.Second
+	}
+	return time.Duration(timeout) * time.Second
 }
 
 func (m *MongoDBConnection) GetClient() (*mongo.Client, error) {
@@ -79,7 +91,7 @@ func (m *MongoDBConnection) connectMongoDBClient() error {
 		return fmt.Errorf(clientCreationFailed, err)
 	}
 	clientOptions := options.Client()
-	clientOptions = clientOptions.ApplyURI(connectionString)
+	clientOptions = clientOptions.ApplyURI(connectionString).SetWriteConcern(writeconcern.New(writeconcern.WMajority().WTimeout(getMongoDBWriteConcernTimeout())))
 	clientOptions = clientOptions.SetConnectTimeout(30 * time.Second)
 	m.client, err = mongo.NewClient(clientOptions)
 	if err != nil {

--- a/mongodb-datastore/db/mongodb_connection.go
+++ b/mongodb-datastore/db/mongodb_connection.go
@@ -91,7 +91,7 @@ func (m *MongoDBConnection) connectMongoDBClient() error {
 		return fmt.Errorf(clientCreationFailed, err)
 	}
 	clientOptions := options.Client()
-	clientOptions = clientOptions.ApplyURI(connectionString).SetWriteConcern(writeconcern.New(writeconcern.WMajority().WTimeout(getMongoDBWriteConcernTimeout())))
+	clientOptions = clientOptions.ApplyURI(connectionString).SetWriteConcern(writeconcern.New(writeconcern.WMajority(), writeconcern.WTimeout(getMongoDBWriteConcernTimeout())))
 	clientOptions = clientOptions.SetConnectTimeout(30 * time.Second)
 	m.client, err = mongo.NewClient(clientOptions)
 	if err != nil {

--- a/mongodb-datastore/deploy/mongodb-datastore.yaml
+++ b/mongodb-datastore/deploy/mongodb-datastore.yaml
@@ -49,6 +49,8 @@ spec:
           value: 'keptn-mongo:27017'
         - name: MONGODB_DATABASE
           value: 'keptn'
+        - name: MONGODB_WRITECONCERN_TIMEOUT
+          value: "30"
         - name: MONGODB_USER
           valueFrom:
             secretKeyRef:

--- a/shipyard-controller/db/mongodb_connection.go
+++ b/shipyard-controller/db/mongodb_connection.go
@@ -44,7 +44,7 @@ func getMongoDBWriteConcernTimeout() time.Duration {
 	timeoutString := os.Getenv("MONGODB_WRITECONCERN_TIMEOUT")
 	timeout, err := strconv.Atoi(timeoutString)
 	if err != nil {
-		logger.Errorf("failed to read MongoDB WriteConcern Timeout from env variable: %w", err)
+		logger.Errorf("failed to read MongoDB WriteConcern Timeout from env variable: %v", err.Error())
 		return 30 * time.Second
 	}
 	return time.Duration(timeout) * time.Second

--- a/shipyard-controller/db/mongodb_connection.go
+++ b/shipyard-controller/db/mongodb_connection.go
@@ -82,8 +82,8 @@ func (m *MongoDBConnection) connectMongoDBClient() error {
 		logger.Errorf(clientCreationFailed, err)
 		return fmt.Errorf(clientCreationFailed, err)
 	}
-	clientOptions := options.Client()
-	clientOptions = clientOptions.ApplyURI(connectionString).SetWriteConcern(writeconcern.New(writeconcern.WMajority(), writeconcern.WTimeout(getMongoDBWriteConcernTimeout())))
+	clientOptions := options.Client().SetWriteConcern(writeconcern.New(writeconcern.WMajority(), writeconcern.WTimeout(getMongoDBWriteConcernTimeout())))
+	clientOptions = clientOptions.ApplyURI(connectionString)
 	clientOptions = clientOptions.SetConnectTimeout(30 * time.Second)
 	m.Client, err = mongo.NewClient(clientOptions)
 	if err != nil {

--- a/shipyard-controller/db/mongodb_connection.go
+++ b/shipyard-controller/db/mongodb_connection.go
@@ -83,7 +83,7 @@ func (m *MongoDBConnection) connectMongoDBClient() error {
 		return fmt.Errorf(clientCreationFailed, err)
 	}
 	clientOptions := options.Client()
-	clientOptions = clientOptions.ApplyURI(connectionString).SetWriteConcern(writeconcern.New(writeconcern.WMajority().WTimeout(getMongoDBWriteConcernTimeout())))
+	clientOptions = clientOptions.ApplyURI(connectionString).SetWriteConcern(writeconcern.New(writeconcern.WMajority(), writeconcern.WTimeout(getMongoDBWriteConcernTimeout())))
 	clientOptions = clientOptions.SetConnectTimeout(30 * time.Second)
 	m.Client, err = mongo.NewClient(clientOptions)
 	if err != nil {

--- a/shipyard-controller/deploy/service.yaml
+++ b/shipyard-controller/deploy/service.yaml
@@ -55,6 +55,8 @@ spec:
                 key: mongodb-password
           - name: MONGODB_DATABASE
             value: "keptn"
+          - name: MONGODB_WRITECONCERN_TIMEOUT
+            value: "30"
           - name: MONGODB_EXTERNAL_CONNECTION_STRING
             valueFrom:
               secretKeyRef:

--- a/statistics-service/db/mongodb_connection.go
+++ b/statistics-service/db/mongodb_connection.go
@@ -32,7 +32,7 @@ func getMongoDBWriteConcernTimeout() time.Duration {
 	timeoutString := os.Getenv("MONGODB_WRITECONCERN_TIMEOUT")
 	timeout, err := strconv.Atoi(timeoutString)
 	if err != nil {
-		logger.Errorf("failed to read MongoDB WriteConcern Timeout from env variable: %w", err)
+		logger.Errorf("failed to read MongoDB WriteConcern Timeout from env variable: %v", err.Error())
 		return 30 * time.Second
 	}
 	return time.Duration(timeout) * time.Second

--- a/statistics-service/db/mongodb_connection.go
+++ b/statistics-service/db/mongodb_connection.go
@@ -72,8 +72,8 @@ func (m *MongoDBConnection) connectMongoDBClient() error {
 		return fmt.Errorf(clientCreationFailed, err)
 	}
 	databaseName = dbName
-	clientOptions := options.Client()
-	clientOptions = clientOptions.ApplyURI(connectionString).SetWriteConcern(writeconcern.New(writeconcern.WMajority(), writeconcern.WTimeout(getMongoDBWriteConcernTimeout())))
+	clientOptions := options.Client().SetWriteConcern(writeconcern.New(writeconcern.WMajority(), writeconcern.WTimeout(getMongoDBWriteConcernTimeout())))
+	clientOptions = clientOptions.ApplyURI(connectionString)
 	clientOptions = clientOptions.SetConnectTimeout(30 * time.Second)
 	m.Client, err = mongo.NewClient(clientOptions)
 	if err != nil {

--- a/statistics-service/db/mongodb_connection.go
+++ b/statistics-service/db/mongodb_connection.go
@@ -73,7 +73,7 @@ func (m *MongoDBConnection) connectMongoDBClient() error {
 	}
 	databaseName = dbName
 	clientOptions := options.Client()
-	clientOptions = clientOptions.ApplyURI(connectionString).SetWriteConcern(writeconcern.New(writeconcern.WMajority().WTimeout(getMongoDBWriteConcernTimeout())))
+	clientOptions = clientOptions.ApplyURI(connectionString).SetWriteConcern(writeconcern.New(writeconcern.WMajority(), writeconcern.WTimeout(getMongoDBWriteConcernTimeout())))
 	clientOptions = clientOptions.SetConnectTimeout(30 * time.Second)
 	m.Client, err = mongo.NewClient(clientOptions)
 	if err != nil {

--- a/statistics-service/deploy/service.yaml
+++ b/statistics-service/deploy/service.yaml
@@ -45,6 +45,8 @@ spec:
                   key: password
             - name: MONGODB_DATABASE
               value: 'keptn'
+            - name: MONGODB_WRITECONCERN_TIMEOUT
+              value: "30"
         - name: distributor
           image: keptndev/distributor:latest
           ports:


### PR DESCRIPTION
Signed-off-by: odubajDT <ondrej.dubaj@dynatrace.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- adds WriteConcern to MongoDB connection string
- introduces helm value `mongo.writeconcernTimeout` to configure the WriteConcern timeout, default value is set to 30s
- updates README in mongodb-datastore with the new parameters

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #6811 

### Integration tests

