### PR TITLE
fix(installer): Revert configuration-service back to update strategy recreate

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/templates/configuration-service.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/configuration-service.yaml
@@ -153,7 +153,8 @@ spec:
       app.kubernetes.io/name: configuration-service
       app.kubernetes.io/instance: {{ .Release.Name }}
   replicas: 1
-  {{- include "control-plane.common.update-strategy" . | nindent 2 }}
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- reverts the configuration service to use the recreate update strategy instead of rollingUpdate. Rolling updates cannot be done here, because the attached volume is set to acecssMode `ReadWriteOnce`

