### PR TITLE
fix(shipyard-controller): Fix order of merging properties for event payload

### DIFF
--- a/shipyard-controller/common/utils.go
+++ b/shipyard-controller/common/utils.go
@@ -28,29 +28,35 @@ func Stringp(s string) *string {
 	return &s
 }
 
+// Merge merges together the two provided objects.
+// If any of the two objects' properties do not have matching types, the property of in2 will override the one of in1
 func Merge(in1, in2 interface{}) interface{} {
 	switch in1 := in1.(type) {
 	case []interface{}:
-		in2, ok := in2.([]interface{})
-		if !ok {
-			return in1
+		in2Slice, ok := in2.([]interface{})
+		if !ok && in2 != nil {
+			return in2
 		}
-		return append(in1, in2...)
+		// as defined in https://github.com/keptn/keptn/issues/7627, the slice should start with the entries of the second property
+		return append(in2Slice, in1...)
 	case map[string]interface{}:
-		in2, ok := in2.(map[string]interface{})
-		if !ok {
-			return in1
+		in2Map, ok := in2.(map[string]interface{})
+		if !ok && in2 != nil {
+			return in2
 		}
-		mergeMaps(in1, in2)
+		mergeMaps(in1, in2Map)
 	case string:
-		if in2, ok := in2.(string); ok {
+		in2String, ok := in2.(string)
+		if !ok && in2 != nil {
 			return in2
 		}
+		return in2String
 	case nil:
-		in2, ok := in2.(map[string]interface{})
-		if ok {
+		in2Map, ok := in2.(map[string]interface{})
+		if !ok && in2 != nil {
 			return in2
 		}
+		return in2Map
 	}
 	return in1
 }

--- a/shipyard-controller/common/utils_test.go
+++ b/shipyard-controller/common/utils_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"github.com/stretchr/testify/require"
 	"reflect"
 	"testing"
 	"time"
@@ -77,6 +78,20 @@ func TestMerge(t *testing.T) {
 			},
 		},
 		{
+			name: "merge map - string property of in2 should override property with same name in in1",
+			args: args{
+				in1: map[string]interface{}{
+					"foo": "bar",
+				},
+				in2: map[string]interface{}{
+					"foo": "foo",
+				},
+			},
+			want: map[string]interface{}{
+				"foo": "foo",
+			},
+		},
+		{
 			name: "merge different structures",
 			args: args{
 				in1: map[string]interface{}{
@@ -101,14 +116,90 @@ func TestMerge(t *testing.T) {
 				in1: []interface{}{"item1", "item2"},
 				in2: []interface{}{"item3"},
 			},
-			want: []interface{}{"item1", "item2", "item3"},
+			want: []interface{}{"item3", "item1", "item2"},
+		},
+		{
+			name: "merge different structures 3",
+			args: args{
+				in1: []interface{}{"item1", map[string]interface{}{"x": "y", "b": []interface{}{1, "b", []string{"hello"}}}},
+				in2: []interface{}{"item3"},
+			},
+			want: []interface{}{"item3", "item1", map[string]interface{}{"x": "y", "b": []interface{}{1, "b", []string{"hello"}}}},
+		},
+		{
+			name: "merge structures with different types for same property names: map vs string",
+			args: args{
+				in1: map[string]interface{}{
+					"foo": map[string]interface{}{
+						"bar": "xyz",
+					},
+				},
+				in2: map[string]interface{}{
+					"foo": "bar",
+				},
+			},
+			want: map[string]interface{}{
+				"foo": "bar",
+			},
+		},
+		{
+			name: "merge structures with different types for same property names: slice vs string",
+			args: args{
+				in1: map[string]interface{}{
+					"foo": []interface{}{"bar"},
+				},
+				in2: map[string]interface{}{
+					"foo": "bar",
+				},
+			},
+			want: map[string]interface{}{
+				"foo": "bar",
+			},
+		},
+		{
+			name: "merge structures with different types for same property names: string vs slice",
+			args: args{
+				in1: map[string]interface{}{
+					"foo": "bar",
+				},
+				in2: map[string]interface{}{
+					"foo": []interface{}{"bar"},
+				},
+			},
+			want: map[string]interface{}{
+				"foo": []interface{}{"bar"},
+			},
+		},
+		{
+			name: "merge structures with different types: nil vs map",
+			args: args{
+				in1: nil,
+				in2: map[string]interface{}{
+					"foo": map[string]interface{}{
+						"bar": "xyz",
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"foo": map[string]interface{}{
+					"bar": "xyz",
+				},
+			},
+		},
+		{
+			name: "merge structures with different types: nil vs string",
+			args: args{
+				in1: nil,
+				in2: "foo",
+			},
+			want: "foo",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := Merge(tt.args.in1, tt.args.in2); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Merge() = %v, want %v", got, tt.want)
-			}
+			got := Merge(tt.args.in1, tt.args.in2)
+
+			require.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/shipyard-controller/models/sequence_execution.go
+++ b/shipyard-controller/models/sequence_execution.go
@@ -129,7 +129,8 @@ func (e *SequenceExecution) GetNextTriggeredEventData() map[string]interface{} {
 	eventPayload := map[string]interface{}{}
 
 	if e.InputProperties != nil {
-		eventPayload = common.CopyMap(e.InputProperties)
+		inputProperties := common.CopyMap(e.InputProperties)
+		eventPayload = common.Merge(eventPayload, inputProperties).(map[string]interface{})
 	}
 
 	eventPayload["project"] = e.Scope.Project
@@ -148,6 +149,11 @@ func (e *SequenceExecution) GetNextTriggeredEventData() map[string]interface{} {
 	nextTask := e.GetNextTaskOfSequence()
 	if nextTask != nil && nextTask.Properties != nil {
 		eventPayload[nextTask.Name] = common.Merge(eventPayload[nextTask.Name], nextTask.Properties)
+	}
+
+	// remove any messages set by previous task executors
+	if eventPayload["message"] != nil {
+		eventPayload["message"] = ""
 	}
 
 	return eventPayload

--- a/shipyard-controller/models/sequence_execution_test.go
+++ b/shipyard-controller/models/sequence_execution_test.go
@@ -175,6 +175,104 @@ func TestSequenceExecution_GetNextTriggeredEventData(t *testing.T) {
 				"status": keptnv2.StatusSucceeded,
 			},
 		},
+		{
+			name: "get next triggered event - with input data and completed tasks with same properties",
+			fields: fields{
+				Sequence: keptnv2.Sequence{
+					Name: "delivery",
+					Tasks: []keptnv2.Task{
+						{
+							Name: "deployment",
+							Properties: map[string]interface{}{
+								"foo": "bar",
+							},
+						},
+						{
+							Name: "my-second-task",
+						},
+					},
+				},
+				Status: SequenceExecutionStatus{
+					PreviousTasks: []TaskExecutionResult{
+						{
+							Name:   "deployment",
+							Result: keptnv2.ResultPass,
+							Status: keptnv2.StatusSucceeded,
+							Properties: map[string]interface{}{
+								"deployment": map[string]interface{}{
+									"deploymentURIsLocal": []interface{}{
+										"http://carts.sockshop-dev:80",
+									},
+									"deploymentURIsPublic": []interface{}{
+										"http://carts.sockshop-staging.svc.cluster.local:80",
+									},
+								},
+								"message": "task finished",
+							},
+						},
+						{
+							Name:   "test",
+							Result: keptnv2.ResultPass,
+							Status: keptnv2.StatusSucceeded,
+							Properties: map[string]interface{}{
+								"test": map[string]interface{}{
+									"start": "3",
+									"end":   "4",
+								},
+								"message": "task finished",
+							},
+						},
+					},
+					CurrentTask: TaskExecutionState{},
+				},
+				Scope: EventScope{
+					EventData: keptnv2.EventData{
+						Project: "my-project",
+						Stage:   "my-stage",
+						Service: "my-service",
+					},
+				},
+				InputProperties: map[string]interface{}{
+					"configurationChange": map[string]interface{}{
+						"image": "1.0",
+					},
+					"deployment": map[string]interface{}{
+						"deploymentURIsLocal": nil,
+						"deploymentURIsPublic": []interface{}{
+							"http://carts.sockshop-dev.svc.cluster.local:80",
+						},
+					},
+					"test": map[string]interface{}{
+						"start": "1",
+						"end":   "2",
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"project": "my-project",
+				"stage":   "my-stage",
+				"service": "my-service",
+				"configurationChange": map[string]interface{}{
+					"image": "1.0",
+				},
+				"deployment": map[string]interface{}{
+					"deploymentURIsLocal": []interface{}{
+						"http://carts.sockshop-dev:80",
+					},
+					"deploymentURIsPublic": []interface{}{
+						"http://carts.sockshop-staging.svc.cluster.local:80",
+						"http://carts.sockshop-dev.svc.cluster.local:80",
+					},
+				},
+				"test": map[string]interface{}{
+					"start": "3",
+					"end":   "4",
+				},
+				"result":  keptnv2.ResultPass,
+				"status":  keptnv2.StatusSucceeded,
+				"message": "",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Port of https://github.com/keptn/keptn/pull/7631

Closes https://github.com/keptn/keptn/issues/7627
Closes https://github.com/keptn/keptn/issues/7633
Closes https://github.com/keptn/keptn/issues/7642

Integration test run: https://github.com/keptn/keptn/runs/6301278126?check_suite_focus=true

note: the failing tests on GKE are related to a different problem regarding the usage of the kubectl library in our tests, and will be tackled in a separate PR shortly, as the changes in this PR are not related to that other issue)