### PR TITLE
test: Retrieve pod names using kubectl library

### DIFF
--- a/test/go-tests/test_backuprestore.go
+++ b/test/go-tests/test_backuprestore.go
@@ -238,11 +238,9 @@ func BackupRestoreTestGeneric(t *testing.T, serviceUnderTestName string) {
 	_, err = ExecuteCommandf("kubectl cp %s/%s:/tmp/dump ./%s/ -c mongodb", keptnNamespace, mongoDbPod, mongoDBBackupFolder)
 
 	if backupGit {
-
 		//backup git-credentials
-
 		t.Logf("Executing backup of git-credentials")
-		secret, err := ExecuteCommandf("kubectl get secret -n %s git-credentials-%s -oyaml", keptnNamespace, projectName)
+		secret, err := ExecuteCommandf("kubectl get secret -n %s git-credentials-%s -oyaml 2>/dev/null", keptnNamespace, projectName)
 		require.Nil(t, err)
 		err = os.WriteFile(secretFileName, []byte(secret), 0644)
 		require.Nil(t, err)

--- a/test/go-tests/test_backuprestore.go
+++ b/test/go-tests/test_backuprestore.go
@@ -221,14 +221,8 @@ func BackupRestoreTestGeneric(t *testing.T, serviceUnderTestName string) {
 	require.Nil(t, err)
 
 	t.Logf("Execute MongoDb database dump")
-	mongoDbRootUser, err := ExecuteCommandf("kubectl get secret mongodb-credentials -n %s -ojsonpath={.data.mongodb-root-user}", keptnNamespace)
-	require.Nil(t, err)
-	mongoDbRootUser, err = decodeBase64(removeQuotes(mongoDbRootUser))
-	require.Nil(t, err)
+	mongoDbRootUser, mongoDbRootPassword, err := GetMongoDBCredentials()
 
-	mongoDbRootPassword, err := ExecuteCommandf("kubectl get secret mongodb-credentials -n %s -ojsonpath={.data.mongodb-root-password}", keptnNamespace)
-	require.Nil(t, err)
-	mongoDbRootPassword, err = decodeBase64(removeQuotes(mongoDbRootPassword))
 	require.Nil(t, err)
 
 	_, err = ExecuteCommandf("kubectl exec svc/keptn-mongo -n %s -- mongodump --authenticationDatabase admin --username %s --password %s -d keptn -h localhost --out=/tmp/dump", keptnNamespace, mongoDbRootUser, mongoDbRootPassword)

--- a/test/go-tests/test_utils.go
+++ b/test/go-tests/test_utils.go
@@ -793,6 +793,25 @@ func SetShipyardControllerEnvVar(t *testing.T, envVarName, envVarValue string) e
 	return nil
 }
 
+func GetPodNamesOfDeployment(labelSelector string) ([]string, error) {
+	k8sClient, err := keptnkubeutils.GetClientset(false)
+	if err != nil {
+		return nil, err
+	}
+
+	get, err := k8sClient.CoreV1().Pods(GetKeptnNameSpaceFromEnv()).List(context.TODO(), v1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		return nil, nil
+	}
+
+	podNames := []string{}
+
+	for _, pod := range get.Items {
+		podNames = append(podNames, pod.Name)
+	}
+	return podNames, nil
+}
+
 // SetRecreateUpgradeStrategyForDeployment sets the upgrade strategy of a deployment to "Recreate".
 // Needed for our minishift tests right now, as there are problems with the RollingUpdate strategy of the shipyard-controller
 // Should become obsolete when we switch to testing on an OpenShift 4.x cluster instead.

--- a/test/go-tests/test_utils.go
+++ b/test/go-tests/test_utils.go
@@ -888,6 +888,31 @@ func GetGiteaToken() (string, error) {
 	return token, nil
 }
 
+// GetMongoDBCredentials retrieves the credentials of the mongodb user from the mongodb credentials secret
+func GetMongoDBCredentials() (string, string, error) {
+	clientset, err := keptnkubeutils.GetClientset(false)
+	if err != nil {
+		return "", "", err
+	}
+
+	mongoDBSecret, err := clientset.CoreV1().Secrets(GetKeptnNameSpaceFromEnv()).Get(context.TODO(), "mongodb-credentials", v1.GetOptions{})
+	if err != nil {
+		return "", "", err
+	}
+
+	user := string(mongoDBSecret.Data["mongodb-root-user"])
+	if user == "" {
+		return "", "", errors.New("no mongodb user found")
+	}
+
+	password := string(mongoDBSecret.Data["mongodb-root-password"])
+	if password == "" {
+		return "", "", errors.New("no mongodb password found")
+	}
+
+	return user, password, nil
+}
+
 func GetGiteaUser() string {
 	if os.Getenv("GITEA_ADMIN_USER") != "" {
 		return os.Getenv("GITEA_ADMIN_USER")


### PR DESCRIPTION
Closes #7654 

At some points in the tests, we were using the kubectl CLI to retrieve the names of pods. Due to a deprecation notice regarding GCP, the output of the `kubectl get pods` command was polluted.

To reduce the risk of that happening again, pod names in the backup tests are now retrieved using the kubernetes lib