### PR TITLE
feat: Make deployment resources customizable in helm charts

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -82,3 +82,4 @@ For a realtime overview of current contributors to the Keptn project, we refer t
 * [Eric Y. Kim](https://github.com/eyskim)
 * [Markus Lackner](https://github.com/markuslackner)
 * [René Panzar](https://github.com/renepanzar)
+* [Alberto Gil de Dios](https://github.com/albertogdd)

--- a/helm-service/chart/templates/deployment.yaml
+++ b/helm-service/chart/templates/deployment.yaml
@@ -92,7 +92,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.helmservice.resources | nindent 12 }}
         - name: distributor
           image: "{{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}"
           {{- include "helm-service.prestop" . | nindent 10 }}
@@ -112,12 +112,7 @@ spec:
           ports:
             - containerPort: 8080
           resources:
-            requests:
-              memory: "16Mi"
-              cpu: "25m"
-            limits:
-              memory: "32Mi"
-              cpu: "100m"
+            {{- toYaml .Values.distributor.resources | nindent 12 }}
           env:
             - name: PUBSUB_TOPIC
               value: 'sh.keptn.event.deployment.triggered,sh.keptn.event.rollback.triggered,sh.keptn.event.release.triggered,sh.keptn.event.action.triggered,sh.keptn.event.service.delete.finished'

--- a/helm-service/chart/values.yaml
+++ b/helm-service/chart/values.yaml
@@ -7,6 +7,13 @@ helmservice:
     enabled: true                            # Creates a Kubernetes Service for the helm-service
   gracePeriod: 90                            # PreStop hook time +30s
   preStopHookTime: 60
+  resources:                                 # Resource limits and requests
+    limits:
+      cpu: "1000m"
+      memory: "512Mi"
+    requests:
+      cpu: "50m"
+      memory: "128Mi"
 
 distributor:
   stageFilter: ""                            # Stage to which this helm service belongs; default=all; comma-separated list to filter for set of stages
@@ -25,6 +32,13 @@ distributor:
       discovery: ""
       tokenURL: ""
       scopes: ""
+  resources:
+    requests:
+      memory: "16Mi"
+      cpu: "25m"
+    limits:
+      memory: "32Mi"
+      cpu: "100m"
 
 remoteControlPlane:
   enabled: false                             # Enables remote execution plane mode
@@ -51,14 +65,6 @@ securityContext: {}                          # Set the security context (e.g. ru
 #  readOnlyRootFilesystem: true
 #  runAsNonRoot: true
 #  runAsUser: 1000
-
-resources:                                  # Resource limits and requests
-  limits:
-    cpu: 1000m
-    memory: 512Mi
-  requests:
-    cpu: 50m
-    memory: 128Mi
 
 nodeSelector: {}                             # Node selector configuration
 

--- a/installer/manifests/keptn/templates/_helpers.tpl
+++ b/installer/manifests/keptn/templates/_helpers.tpl
@@ -79,16 +79,6 @@ readinessProbe:
   periodSeconds: 5
 {{- end }}
 
-{{- define "keptn.distributor.resources" -}}
-resources:
-  requests:
-    memory: "16Mi"
-    cpu: "25m"
-  limits:
-    memory: "32Mi"
-    cpu: "100m"
-{{- end }}
-
 {{/*
 preStop hook for keptn deployments
 */}}

--- a/installer/manifests/keptn/templates/api-gateway-nginx.yaml
+++ b/installer/manifests/keptn/templates/api-gateway-nginx.yaml
@@ -423,12 +423,7 @@ spec:
               readOnly: true
               name: api-nginx-config
           resources:
-            requests:
-              memory: "64Mi"
-              cpu: "50m"
-            limits:
-              memory: "128Mi"
-              cpu: "100m"
+            {{- toYaml .Values.apiGatewayNginx.resources | nindent 12 }}
         {{- include "keptn.apiGatewayNginx.container-security-context" . | nindent 10 }}
       volumes:
         - name: api-nginx-config

--- a/installer/manifests/keptn/templates/api-service.yaml
+++ b/installer/manifests/keptn/templates/api-service.yaml
@@ -51,12 +51,7 @@ spec:
           ports:
             - containerPort: 8080
           resources:
-            requests:
-              memory: "32Mi"
-              cpu: "50m"
-            limits:
-              memory: "64Mi"
-              cpu: "100m"
+            {{- toYaml .Values.apiService.resources | nindent 12 }}
           env:
             - name: PREFIX_PATH
               value: "{{ .Values.prefixPath }}"
@@ -93,7 +88,8 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
-          {{- include "keptn.distributor.resources" . | nindent 10 }}
+          resources:
+            {{- toYaml .Values.distributor.resources | nindent 12 }}
           env:
           {{- include "keptn.dist.common.env.vars" . | nindent 12 }}
           {{- include "keptn.common.container-security-context" . | nindent 10 }}

--- a/installer/manifests/keptn/templates/approval-service.yaml
+++ b/installer/manifests/keptn/templates/approval-service.yaml
@@ -52,12 +52,7 @@ spec:
           ports:
             - containerPort: 8080
           resources:
-            requests:
-              memory: "32Mi"
-              cpu: "25m"
-            limits:
-              memory: "128Mi"
-              cpu: "100m"
+            {{- toYaml .Values.approvalService.resources | nindent 12 }}
           env:
             - name: CONFIGURATION_SERVICE
               value: 'http://configuration-service:8080'
@@ -73,7 +68,8 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
-          {{- include "keptn.distributor.resources" . | nindent 10 }}
+          resources:
+            {{- toYaml .Values.distributor.resources | nindent 12 }}
           env:
             - name: PUBSUB_TOPIC
               value: 'sh.keptn.event.approval.>'

--- a/installer/manifests/keptn/templates/configuration-service.yaml
+++ b/installer/manifests/keptn/templates/configuration-service.yaml
@@ -93,12 +93,7 @@ spec:
           ports:
             - containerPort: 8080
           resources:
-            requests:
-              memory: "32Mi"
-              cpu: "25m"
-            limits:
-              memory: "64Mi"
-              cpu: "100m"
+            {{- toYaml .Values.resourceService.resources | nindent 12 }}
           volumeMounts:
             - mountPath: /data/config
               name: resource-volume
@@ -221,12 +216,7 @@ spec:
           ports:
             - containerPort: 8080
           resources:
-            requests:
-              memory: "32Mi"
-              cpu: "25m"
-            limits:
-              memory: "64Mi"
-              cpu: "100m"
+            {{- toYaml .Values.configurationService.resources | nindent 12 }}
           volumeMounts:
             - mountPath: /data/config
               name: configuration-volume

--- a/installer/manifests/keptn/templates/core.yaml
+++ b/installer/manifests/keptn/templates/core.yaml
@@ -214,12 +214,7 @@ spec:
           ports:
             - containerPort: 3000
           resources:
-            requests:
-              memory: "64Mi"
-              cpu: "25m"
-            limits:
-              memory: "256Mi"
-              cpu: "200m"
+            {{- toYaml .Values.bridge.resources | nindent 12 }}
           volumeMounts:
             - name: assets
               mountPath: /usr/src/app/dist/assets/branding

--- a/installer/manifests/keptn/templates/lighthouse-service.yaml
+++ b/installer/manifests/keptn/templates/lighthouse-service.yaml
@@ -52,12 +52,7 @@ spec:
           ports:
             - containerPort: 8080
           resources:
-            requests:
-              memory: "128Mi"
-              cpu: "50m"
-            limits:
-              memory: "1Gi"
-              cpu: "200m"
+            {{- toYaml .Values.lighthouseService.resources | nindent 12 }}
           env:
             - name: EVENTBROKER
               value: 'http://localhost:8081/event'
@@ -81,7 +76,8 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
-          {{- include "keptn.distributor.resources" . | nindent 10 }}
+          resources:
+            {{- toYaml .Values.distributor.resources | nindent 12 }}
           env:
             - name: PUBSUB_TOPIC
               value: 'sh.keptn.event.evaluation.triggered,sh.keptn.event.get-sli.finished,sh.keptn.event.monitoring.configure'

--- a/installer/manifests/keptn/templates/mongodb-datastore.yaml
+++ b/installer/manifests/keptn/templates/mongodb-datastore.yaml
@@ -55,12 +55,7 @@ spec:
         ports:
         - containerPort: 8080
         resources:
-          requests:
-            memory: "32Mi"
-            cpu: "50m"
-          limits:
-            memory: "512Mi"
-            cpu: "300m"
+          {{- toYaml .Values.mongodbDatastore.resources | nindent 10 }}
         env:
         - name: PREFIX_PATH
           value: "{{ .Values.prefixPath }}"
@@ -94,7 +89,8 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 8080
-        {{- include "keptn.distributor.resources" . | nindent 8 }}
+        resources:
+            {{- toYaml .Values.distributor.resources | nindent 12 }}
         env:
           - name: PUBSUB_IMPL
             value: nats

--- a/installer/manifests/keptn/templates/remediation-service.yaml
+++ b/installer/manifests/keptn/templates/remediation-service.yaml
@@ -52,12 +52,7 @@ spec:
         ports:
         - containerPort: 8080
         resources:
-          requests:
-            memory: "64Mi"
-            cpu: "50m"
-          limits:
-            memory: "1Gi"
-            cpu: "200m"
+          {{- toYaml .Values.remediationService.resources | nindent 10 }}
         env:
           - name: EVENTBROKER
             value: 'http://localhost:8081/event'
@@ -73,7 +68,8 @@ spec:
         {{- include "keptn.dist.readinessProbe" . | nindent 8 }}
         ports:
           - containerPort: 8080
-        {{- include "keptn.distributor.resources" . | nindent 8 }}
+        resources:
+          {{- toYaml .Values.distributor.resources | nindent 10 }}
         env:
           - name: PUBSUB_TOPIC
             value: 'sh.keptn.event.get-action.triggered'

--- a/installer/manifests/keptn/templates/secret-service.yaml
+++ b/installer/manifests/keptn/templates/secret-service.yaml
@@ -94,12 +94,7 @@ spec:
           ports:
             - containerPort: 8080
           resources:
-            requests:
-              memory: "32Mi"
-              cpu: "25m"
-            limits:
-              memory: "64Mi"
-              cpu: "200m"
+            {{- toYaml .Values.secretService.resources | nindent 12 }}
           volumeMounts:
             - mountPath: /data
               name: secret-service-configmap-volume

--- a/installer/manifests/keptn/templates/shipyard-controller.yaml
+++ b/installer/manifests/keptn/templates/shipyard-controller.yaml
@@ -102,12 +102,7 @@ spec:
           ports:
             - containerPort: 8080
           resources:
-            requests:
-              memory: "32Mi"
-              cpu: "50m"
-            limits:
-              memory: "128Mi"
-              cpu: "100m"
+            {{- toYaml .Values.shipyardController.resources | nindent 12 }}
           {{- include "keptn.common.container-security-context" . | nindent 10 }}
       terminationGracePeriodSeconds: {{ .Values.shipyardController.gracePeriod | default 120 }}
       {{- include "keptn.nodeSelector" (dict "value" .Values.shipyardController.nodeSelector "default" .Values.common.nodeSelector "indent" 6 "context" . )}}

--- a/installer/manifests/keptn/templates/statistics-service.yaml
+++ b/installer/manifests/keptn/templates/statistics-service.yaml
@@ -76,12 +76,7 @@ spec:
           ports:
             - containerPort: 8080
           resources:
-            requests:
-              memory: "32Mi"
-              cpu: "25m"
-            limits:
-              memory: "64Mi"
-              cpu: "100m"
+            {{- toYaml .Values.statisticsService.resources | nindent 12 }}
           {{- include "keptn.common.container-security-context" . | nindent 10 }}
         - name: distributor
           image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}
@@ -90,7 +85,8 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
-          {{- include "keptn.distributor.resources" . | nindent 10 }}
+          resources:
+            {{- toYaml .Values.distributor.resources | nindent 12 }}
           env:
             - name: PUBSUB_TOPIC
               value: 'sh.keptn.>'

--- a/installer/manifests/keptn/templates/webhook-service.yaml
+++ b/installer/manifests/keptn/templates/webhook-service.yaml
@@ -53,12 +53,7 @@ spec:
           ports:
             - containerPort: 8080
           resources:
-            requests:
-              memory: "32Mi"
-              cpu: "25m"
-            limits:
-              memory: "64Mi"
-              cpu: "100m"
+            {{- toYaml .Values.webhookService.resources | nindent 12 }}
           env:
             - name: POD_NAMESPACE
               valueFrom:
@@ -74,7 +69,8 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
-          {{- include "keptn.distributor.resources" . | nindent 10 }}
+          resources:
+            {{- toYaml .Values.distributor.resources | nindent 12 }}
           env:
             - name: PUBSUB_TOPIC
               value: ''

--- a/installer/manifests/keptn/values.yaml
+++ b/installer/manifests/keptn/values.yaml
@@ -84,6 +84,13 @@ apiGatewayNginx:
   nodeSelector: {}
   gracePeriod: 120     # gracePeriod set to preStop hook time +30s
   preStopHookTime: 90
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "50m"
+    limits:
+      memory: "128Mi"
+      cpu: "100m"
 
 remediationService:
   image:
@@ -92,6 +99,13 @@ remediationService:
   nodeSelector: {}
   gracePeriod: 120     # gracePeriod set to preStop hook time +30s
   preStopHookTime: 90
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "50m"
+    limits:
+      memory: "1Gi"
+      cpu: "200m"
 
 apiService:
   tokenSecretName:
@@ -105,6 +119,13 @@ apiService:
   nodeSelector: {}
   gracePeriod: 120     # gracePeriod set to preStop hook time +30s
   preStopHookTime: 90
+  resources:
+    requests:
+      memory: "32Mi"
+      cpu: "50m"
+    limits:
+      memory: "64Mi"
+      cpu: "100m"
 
 bridge:
   image:
@@ -146,6 +167,13 @@ bridge:
     userIdentifier: ""
     mongoConnectionString: ""
   nodeSelector: {}
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "25m"
+    limits:
+      memory: "256Mi"
+      cpu: "200m"
 
 distributor:
   metadata:
@@ -163,6 +191,13 @@ distributor:
       discovery: ""
       tokenURL: ""
       scopes: ""
+  resources:
+    requests:
+      memory: "16Mi"
+      cpu: "25m"
+    limits:
+      memory: "32Mi"
+      cpu: "100m"
 
 shipyardController:
   image:
@@ -187,6 +222,13 @@ shipyardController:
   nodeSelector: {}
   gracePeriod: 120     # gracePeriod set to preStop hook time +30s
   preStopHookTime: 90
+  resources:
+    requests:
+      memory: "32Mi"
+      cpu: "50m"
+    limits:
+      memory: "128Mi"
+      cpu: "100m"
 
 secretService:
   image:
@@ -195,6 +237,13 @@ secretService:
   nodeSelector: {}
   gracePeriod: 120     # gracePeriod set to preStop hook time +30s
   preStopHookTime: 90
+  resources:
+    requests:
+      memory: "32Mi"
+      cpu: "25m"
+    limits:
+      memory: "64Mi"
+      cpu: "200m"
 
 configurationService:
   image:
@@ -211,6 +260,13 @@ configurationService:
   nodeSelector: {}
   gracePeriod: 120     # gracePeriod set to preStop hook time +30s
   preStopHookTime: 90
+  resources:
+    requests:
+      memory: "32Mi"
+      cpu: "25m"
+    limits:
+      memory: "64Mi"
+      cpu: "100m"
 
 resourceService:
   enabled: false
@@ -225,6 +281,13 @@ resourceService:
   nodeSelector: {}
   gracePeriod: 120     # gracePeriod set to preStop hook time +30s
   preStopHookTime: 90
+  resources:
+    requests:
+      memory: "32Mi"
+      cpu: "25m"
+    limits:
+      memory: "64Mi"
+      cpu: "100m"
 
 mongodbDatastore:
   image:
@@ -233,6 +296,13 @@ mongodbDatastore:
   nodeSelector: {}
   gracePeriod: 120     # gracePeriod set to preStop hook time +30s
   preStopHookTime: 90
+  resources:
+    requests:
+      memory: "32Mi"
+      cpu: "50m"
+    limits:
+      memory: "512Mi"
+      cpu: "300m"
 
 lighthouseService:
   image:
@@ -241,6 +311,13 @@ lighthouseService:
   nodeSelector: {}
   gracePeriod: 120     # gracePeriod set to preStop hook time +30s
   preStopHookTime: 90
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "50m"
+    limits:
+      memory: "1Gi"
+      cpu: "200m"
 
 statisticsService:
   image:
@@ -249,6 +326,13 @@ statisticsService:
   nodeSelector: {}
   gracePeriod: 120     # gracePeriod set to preStop hook time +30s
   preStopHookTime: 90
+  resources:
+    requests:
+      memory: "32Mi"
+      cpu: "25m"
+    limits:
+      memory: "64Mi"
+      cpu: "100m"
 
 approvalService:
   image:
@@ -257,6 +341,13 @@ approvalService:
   nodeSelector: {}
   gracePeriod: 120     # gracePeriod set to preStop hook time +30s
   preStopHookTime: 90
+  resources:
+    requests:
+      memory: "32Mi"
+      cpu: "25m"
+    limits:
+      memory: "128Mi"
+      cpu: "100m"
 
 webhookService:
   enabled: true
@@ -266,6 +357,13 @@ webhookService:
   nodeSelector: {}
   gracePeriod: 120     # gracePeriod set to preStop hook time +30s
   preStopHookTime: 90
+  resources:
+    requests:
+      memory: "32Mi"
+      cpu: "25m"
+    limits:
+      memory: "64Mi"
+      cpu: "100m"
 
 ingress:
   enabled: false

--- a/jmeter-service/chart/templates/deployment.yaml
+++ b/jmeter-service/chart/templates/deployment.yaml
@@ -58,7 +58,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.jmeterservice.resources | nindent 12 }}
         - name: distributor
           image: "{{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag | default .Chart.AppVersion }}"
           {{- include "jmeter-service.prestop" . | nindent 10 }}
@@ -78,12 +78,7 @@ spec:
           ports:
             - containerPort: 8080
           resources:
-            requests:
-              memory: "16Mi"
-              cpu: "25m"
-            limits:
-              memory: "32Mi"
-              cpu: "100m"
+            {{- toYaml .Values.distributor.resources | nindent 12 }}
           env:
             - name: PUBSUB_TOPIC
               value: 'sh.keptn.event.test.triggered'

--- a/jmeter-service/chart/values.yaml
+++ b/jmeter-service/chart/values.yaml
@@ -7,6 +7,17 @@ jmeterservice:
     enabled: true                              # Creates a Kubernetes Service for the jmeter-service
   gracePeriod: 120                             # PreStop hook time +30s
   preStopHookTime: 90
+  resources:                                   # Resource limits and requests
+    requests:
+      cpu: "100m"
+      memory: "128Mi"
+# We usually recommend not to specify default resources and to leave this as a conscious
+# choice for the user. This also increases chances charts run on environments with little
+# resources, such as Minikube. If you want to limit the resources, you can uncomment the following lines
+# but be aware that JMeter needs  lots of resources while running load tests.
+#    limits:
+#      cpu: "2"
+#      memory: "2Gi"
 
 distributor:
   stageFilter: ""                            # Sets the stage this helm service belongs to
@@ -25,6 +36,13 @@ distributor:
       discovery: ""
       tokenURL: ""
       scopes: ""
+  resources:                                 # Resource limits and requests
+    requests:
+      memory: "16Mi"
+      cpu: "25m"
+    limits:
+      memory: "32Mi"
+      cpu: "100m"
 
 remoteControlPlane:
   enabled: false                             # Enables remote execution plane mode
@@ -51,18 +69,6 @@ securityContext: {}                          # Set the security context (e.g. ru
 #  readOnlyRootFilesystem: true
 #  runAsNonRoot: true
 #  runAsUser: 1000
-
-resources:                                 # Resource limits and requests
-# We usually recommend not to specify default resources and to leave this as a conscious
-# choice for the user. This also increases chances charts run on environments with little
-# resources, such as Minikube. If you want to limit the resources, you can uncomment the following lines
-# but be aware that JMeter needs  lots of resources while running load tests.
-#  limits:
-#    cpu: 2
-#    memory: 2Gi
-  requests:
-    cpu: 100m
-    memory: 128Mi
 
 nodeSelector: {}                                # Node selector configuration
 


### PR DESCRIPTION
## This PR treats with #6981 
<!-- add the description of the PR here -->

Makes possible to inject your own custom resources values using the Helm Charts in the following pods:

from /helm-service
- `helm-service`

from /jmeter-service
- `jmeter-service`

from /installer
- `api-gateway-nginx`
- `approval-service`
- `resource-service`
- `configuration-service`
- `remediation-service`
- `bridge`
- `mongodb-datastore`
- `secret-service`
- `shipyard-controller`
- `statistics-service`
- `webhook-service`

This resources values were hardcoded before in the templates.

### Related Issues
Closes #6981 

### Notes
Init Containers aren't included in the changes, as they had no specified resources. Hence, they use the [default K8s values](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#resources).

All `control-plane` distributor pods use the same resources properties (they all use the same `keptn.distributor.resources` function). Now the value of this function is customizable (see `keptn/installer/manifests/keptn/values.yaml`)

### Follow-up Tasks
No further changes are needed, as the template resource values now are in values.yaml, the templating engine should generate the exact same output as before.

### How to test
Comparing the templates generated in this feature branch with the ones from `charts-features`. 
[diff in keptn installer generated templates](https://www.diffchecker.com/yweJ6VZM)
[diff in jmeter-service generated templates](https://www.diffchecker.com/aYYrlStf)
[diff in helm-service generated templates](https://www.diffchecker.com/rWb2UI0r)

There's a difference in the order of the lines inside the generated resources, my guess is that `toYaml` orders them alphabetically. Also, the quotes `""` are removed in some cases.
```
// keptn/installer/manifests/keptn
helm template . --output-dir ../../../temp/test-templates/installer
```
```
// before
          resources:	
            requests:	
              memory: "32Mi"	
              cpu: "25m"	
            limits:	
              memory: "64Mi"	
              cpu: "100m"
// after:
          resources:
            limits:
              cpu: 100m
              memory: 64Mi
            requests:
              cpu: 25m
              memory: 32Mi
```
Injecting a custom value for resources and seeing it reflected in the generated template
```
// keptn/helm-service/chart
helm template . --output-dir ../../temp/test-templates/with-values/helm-service --set helmservice.resources.limits.cpu=2000m
```