### PR TITLE
fix(installer): Custom readiness probe for MongoDB to fix default one

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -15,6 +15,27 @@ mongo:
     rootUser: 'admin'
     rootPassword: null
     bridgeAuthDatabase: 'keptn'
+  readinessProbe:
+    enabled: false
+  customReadinessProbe:
+    # custom readiness probe was introduced because the default one had issues
+    # reference: https://github.com/bitnami/charts/pull/9916
+    exec:
+      command:
+        - bash
+        - -ec
+        - |
+          # Run the proper check depending on the version
+          [[ $(mongosh --version) =~ ([0-9]+\.[0-9]+\.[0-9]+) ]] && VERSION=${BASH_REMATCH[1]}
+          . /opt/bitnami/scripts/libversion.sh
+          VERSION_MAJOR="$(get_sematic_version "$VERSION" 1)"
+          VERSION_MINOR="$(get_sematic_version "$VERSION" 2)"
+          VERSION_PATCH="$(get_sematic_version "$VERSION" 3)"
+          if [[ "$VERSION_MAJOR" -ge 4 ]] && [[ "$VERSION_MINOR" -ge 4 ]] && [[ "$VERSION_PATCH" -ge 2 ]]; then
+              mongosh  $TLS_OPTIONS --eval 'db.hello().isWritablePrimary' | grep -q 'true'
+          else
+              mongosh  $TLS_OPTIONS --eval 'db.isMaster().ismaster' | grep -q 'true'
+          fi
   external:
     connectionString:
 


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- adds a custom readiness probe for mongodb since the default one has error in keptn
- the probe was copied from bitnami/mongodb and simplified since we don't have a secondary DB

References:
https://github.com/bitnami/charts/pull/9916
https://github.com/bitnami/charts/blob/master/bitnami/mongodb/templates/common-scripts-cm.yaml#L33-L35