### PR TITLE
feat(bridge): Make git upstream optional when automatic provisioning url is provided

### DIFF
--- a/bridge/client/app/_components/ktb-project-settings-git-extended/ktb-project-settings-git-extended.component.html
+++ b/bridge/client/app/_components/ktb-project-settings-git-extended/ktb-project-settings-git-extended.component.html
@@ -1,73 +1,57 @@
-<h2 [class.required]="required" class="required">Git upstream repository</h2>
-<p class="mt-0 mb-3" *ngIf="required">
-  A Git upstream repository has to be set. You can connect your Git repository with HTTPS or SSH. Instructions, on how
-  to set up your Git provider can be found in the
-  <a [href]="'/manage/git_upstream/' | keptnUrl" target="_blank">Git-based upstream documentation</a>.
-</p>
-<p class="mt-0 mb-3" *ngIf="!required">
-  It is recommended to set a Git upstream repository. You can connect your Git repository with HTTPS or SSH.
-  Instructions, on how to set up your Git provider can be found in the
-  <a [href]="'/manage/git_upstream/' | keptnUrl" target="_blank">Git-based upstream documentation</a>.
-</p>
-
-<ktb-loading-distractor *ngIf="isLoading">Loading ...</ktb-loading-distractor>
-
-<ng-container *ngIf="!isLoading">
-  <dt-label [class.required]="required" class="dt-form-field-label">Connect via</dt-label>
-  <dt-radio-group (change)="setSelectedForm($event)" fxLayout="row">
-    <div [dtOverlay]="noUpstreamOverlay" [disabled]="isCreateMode || (!required && !upstreamConfigured)">
-      <dt-radio-button
-        *ngIf="!required"
-        [value]="FormType.NO_UPSTREAM"
-        [checked]="selectedForm === FormType.NO_UPSTREAM"
-        [disabled]="!isCreateMode && !required && upstreamConfigured"
-        class="mr-2"
-        uitestid="ktb-no-upstream-form-button"
-      >
-        No Upstream
-      </dt-radio-button>
-    </div>
-    <ng-template #noUpstreamOverlay
-      >This project has already an upstream configured. If an upstream is already configured, it can not be unset.
-    </ng-template>
+<dt-label [class.required]="required" class="dt-form-field-label">Connect via</dt-label>
+<dt-radio-group (change)="setSelectedForm($event)" fxLayout="row">
+  <div [dtOverlay]="noUpstreamOverlay" [disabled]="isCreateMode || (!required && !upstreamConfigured)">
     <dt-radio-button
-      [value]="FormType.HTTPS"
-      [checked]="selectedForm === FormType.HTTPS"
+      *ngIf="!required"
+      [value]="FormType.NO_UPSTREAM"
+      [checked]="selectedForm === FormType.NO_UPSTREAM"
+      [disabled]="!isCreateMode && !required && upstreamConfigured"
       class="mr-2"
-      uitestid="ktb-https-form-button"
+      uitestid="ktb-no-upstream-form-button"
     >
-      HTTPS
+      No Upstream
     </dt-radio-button>
-    <dt-radio-button [value]="FormType.SSH" [checked]="selectedForm === FormType.SSH" uitestid="ktb-ssh-form-button">
-      SSH
-    </dt-radio-button>
-  </dt-radio-group>
-  <div class="mt-3">
-    <!-- hidden instead of switch to keep the component instance and related data  -->
-    <ktb-project-settings-git-https
-      [hidden]="selectedForm !== FormType.HTTPS"
-      (dataChange)="dataChanged(FormType.HTTPS, $event)"
-      [gitInputData]="gitInputDataHttps"
-    ></ktb-project-settings-git-https>
-    <ktb-project-settings-git-ssh
-      [hidden]="selectedForm !== FormType.SSH"
-      (sshChange)="dataChanged(FormType.SSH, $event)"
-      [gitInputSshData]="gitInputDataSsh"
-    ></ktb-project-settings-git-ssh>
-    <div *ngIf="!isCreateMode && FormType.NO_UPSTREAM">
-      Currently there is no Git upstream configured. You can connect your Git repository with HTTPS or SSH.
-    </div>
   </div>
+  <ng-template #noUpstreamOverlay
+    >This project has already an upstream configured. If an upstream is already configured, it can not be unset.
+  </ng-template>
+  <dt-radio-button
+    [value]="FormType.HTTPS"
+    [checked]="selectedForm === FormType.HTTPS"
+    class="mr-2"
+    uitestid="ktb-https-form-button"
+  >
+    HTTPS
+  </dt-radio-button>
+  <dt-radio-button [value]="FormType.SSH" [checked]="selectedForm === FormType.SSH" uitestid="ktb-ssh-form-button">
+    SSH
+  </dt-radio-button>
+</dt-radio-group>
+<div class="mt-3">
+  <!-- hidden instead of switch to keep the component instance and related data  -->
+  <ktb-project-settings-git-https
+    [hidden]="selectedForm !== FormType.HTTPS"
+    (dataChange)="dataChanged(FormType.HTTPS, $event)"
+    [gitInputData]="gitInputDataHttps"
+  ></ktb-project-settings-git-https>
+  <ktb-project-settings-git-ssh
+    [hidden]="selectedForm !== FormType.SSH"
+    (sshChange)="dataChanged(FormType.SSH, $event)"
+    [gitInputSshData]="gitInputDataSsh"
+  ></ktb-project-settings-git-ssh>
+  <div *ngIf="!isCreateMode && selectedForm === FormType.NO_UPSTREAM">
+    Currently there is no Git upstream configured. You can connect your Git repository with HTTPS or SSH.
+  </div>
+</div>
 
-  <div class="mt-3" *ngIf="!isCreateMode">
-    <button
-      [disabled]="!gitData || (!isCreateMode && selectedForm === FormType.NO_UPSTREAM) || isGitUpstreamInProgress"
-      (click)="updateUpstream()"
-      dt-button
-      uitestid="ktb-project-update-button"
-    >
-      <dt-loading-spinner *ngIf="isGitUpstreamInProgress" aria-label="Saving Git upstream URL"></dt-loading-spinner>
-      Save Git upstream
-    </button>
-  </div>
-</ng-container>
+<div class="mt-3" *ngIf="!isCreateMode">
+  <button
+    [disabled]="!gitData || (!isCreateMode && selectedForm === FormType.NO_UPSTREAM) || isGitUpstreamInProgress"
+    (click)="updateUpstream()"
+    dt-button
+    uitestid="ktb-project-update-button"
+  >
+    <dt-loading-spinner *ngIf="isGitUpstreamInProgress" aria-label="Saving Git upstream URL"></dt-loading-spinner>
+    Save Git upstream
+  </button>
+</div>

--- a/bridge/client/app/_components/ktb-project-settings-git-extended/ktb-project-settings-git-extended.component.html
+++ b/bridge/client/app/_components/ktb-project-settings-git-extended/ktb-project-settings-git-extended.component.html
@@ -22,7 +22,7 @@
         [checked]="selectedForm === FormType.NO_UPSTREAM"
         [disabled]="!isCreateMode && !required && upstreamConfigured"
         class="mr-2"
-        uitestid="ktb-https-form-button"
+        uitestid="ktb-no-upstream-form-button"
       >
         No Upstream
       </dt-radio-button>

--- a/bridge/client/app/_components/ktb-project-settings-git-extended/ktb-project-settings-git-extended.component.html
+++ b/bridge/client/app/_components/ktb-project-settings-git-extended/ktb-project-settings-git-extended.component.html
@@ -1,47 +1,73 @@
-<h2 class="required">Git upstream repository</h2>
-<p class="mt-0 mb-3">
+<h2 [class.required]="required" class="required">Git upstream repository</h2>
+<p class="mt-0 mb-3" *ngIf="required">
   A Git upstream repository has to be set. You can connect your Git repository with HTTPS or SSH. Instructions, on how
   to set up your Git provider can be found in the
   <a [href]="'/manage/git_upstream/' | keptnUrl" target="_blank">Git-based upstream documentation</a>.
 </p>
-<dt-label class="required dt-form-field-label">Connect via</dt-label>
-<dt-radio-group (change)="setSelectedForm($event)">
-  <dt-radio-button
-    [value]="FormType.HTTPS"
-    [checked]="selectedForm === FormType.HTTPS"
-    class="mr-2"
-    uitestid="ktb-https-form-button"
-  >
-    HTTPS
-  </dt-radio-button>
-  <dt-radio-button [value]="FormType.SSH" [checked]="selectedForm === FormType.SSH" uitestid="ktb-ssh-form-button">
-    SSH
-  </dt-radio-button>
-</dt-radio-group>
-<div class="mt-3">
-  <!-- hidden instead of switch to keep the component instance and related data  -->
-  <ktb-project-settings-git-https
-    [hidden]="selectedForm !== FormType.HTTPS"
-    (dataChange)="dataChanged($event)"
-    [gitInputData]="gitInputDataHttps"
-    [isLoading]="isLoading"
-  ></ktb-project-settings-git-https>
-  <ktb-project-settings-git-ssh
-    [hidden]="selectedForm !== FormType.SSH"
-    (sshChange)="dataChanged($event)"
-    [gitInputSshData]="gitInputDataSsh"
-    [isLoading]="isLoading"
-  ></ktb-project-settings-git-ssh>
-</div>
+<p class="mt-0 mb-3" *ngIf="!required">
+  It is recommended to set a Git upstream repository. You can connect your Git repository with HTTPS or SSH.
+  Instructions, on how to set up your Git provider can be found in the
+  <a [href]="'/manage/git_upstream/' | keptnUrl" target="_blank">Git-based upstream documentation</a>.
+</p>
 
-<div class="mt-3" *ngIf="!isCreateMode">
-  <button
-    [disabled]="!gitData || isGitUpstreamInProgress"
-    (click)="updateUpstream()"
-    dt-button
-    uitestid="ktb-project-update-button"
-  >
-    <dt-loading-spinner *ngIf="isGitUpstreamInProgress" aria-label="Setting Git upstream URL"></dt-loading-spinner>
-    Set Git upstream
-  </button>
-</div>
+<ktb-loading-distractor *ngIf="isLoading">Loading ...</ktb-loading-distractor>
+
+<ng-container *ngIf="!isLoading">
+  <dt-label [class.required]="required" class="dt-form-field-label">Connect via</dt-label>
+  <dt-radio-group (change)="setSelectedForm($event)" fxLayout="row">
+    <div [dtOverlay]="noUpstreamOverlay" [disabled]="isCreateMode || (!required && !upstreamConfigured)">
+      <dt-radio-button
+        *ngIf="!required"
+        [value]="FormType.NO_UPSTREAM"
+        [checked]="selectedForm === FormType.NO_UPSTREAM"
+        [disabled]="!isCreateMode && !required && upstreamConfigured"
+        class="mr-2"
+        uitestid="ktb-https-form-button"
+      >
+        No Upstream
+      </dt-radio-button>
+    </div>
+    <ng-template #noUpstreamOverlay
+      >This project has already an upstream configured. If an upstream is already configured, it can not be unset.
+    </ng-template>
+    <dt-radio-button
+      [value]="FormType.HTTPS"
+      [checked]="selectedForm === FormType.HTTPS"
+      class="mr-2"
+      uitestid="ktb-https-form-button"
+    >
+      HTTPS
+    </dt-radio-button>
+    <dt-radio-button [value]="FormType.SSH" [checked]="selectedForm === FormType.SSH" uitestid="ktb-ssh-form-button">
+      SSH
+    </dt-radio-button>
+  </dt-radio-group>
+  <div class="mt-3">
+    <!-- hidden instead of switch to keep the component instance and related data  -->
+    <ktb-project-settings-git-https
+      [hidden]="selectedForm !== FormType.HTTPS"
+      (dataChange)="dataChanged(FormType.HTTPS, $event)"
+      [gitInputData]="gitInputDataHttps"
+    ></ktb-project-settings-git-https>
+    <ktb-project-settings-git-ssh
+      [hidden]="selectedForm !== FormType.SSH"
+      (sshChange)="dataChanged(FormType.SSH, $event)"
+      [gitInputSshData]="gitInputDataSsh"
+    ></ktb-project-settings-git-ssh>
+    <div *ngIf="!isCreateMode && FormType.NO_UPSTREAM">
+      Currently there is no Git upstream configured. You can connect your Git repository with HTTPS or SSH.
+    </div>
+  </div>
+
+  <div class="mt-3" *ngIf="!isCreateMode">
+    <button
+      [disabled]="!gitData || (!isCreateMode && selectedForm === FormType.NO_UPSTREAM) || isGitUpstreamInProgress"
+      (click)="updateUpstream()"
+      dt-button
+      uitestid="ktb-project-update-button"
+    >
+      <dt-loading-spinner *ngIf="isGitUpstreamInProgress" aria-label="Saving Git upstream URL"></dt-loading-spinner>
+      Save Git upstream
+    </button>
+  </div>
+</ng-container>

--- a/bridge/client/app/_components/ktb-project-settings-git-extended/ktb-project-settings-git-extended.component.html
+++ b/bridge/client/app/_components/ktb-project-settings-git-extended/ktb-project-settings-git-extended.component.html
@@ -9,7 +9,7 @@
       class="mr-2"
       uitestid="ktb-no-upstream-form-button"
     >
-      No Upstream
+      No upstream
     </dt-radio-button>
   </div>
   <ng-template #noUpstreamOverlay

--- a/bridge/client/app/_components/ktb-project-settings-git-extended/ktb-project-settings-git-extended.component.spec.ts
+++ b/bridge/client/app/_components/ktb-project-settings-git-extended/ktb-project-settings-git-extended.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { GitFormType, KtbProjectSettingsGitExtendedComponent } from './ktb-project-settings-git-extended.component';
 import { AppModule } from '../../app.module';
@@ -32,8 +32,6 @@ describe('KtbProjectSettingsGitExtendedComponent', () => {
     }).compileComponents();
     fixture = TestBed.createComponent(KtbProjectSettingsGitExtendedComponent);
     component = fixture.componentInstance;
-    component.required = true;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
@@ -41,19 +39,31 @@ describe('KtbProjectSettingsGitExtendedComponent', () => {
   });
 
   it('should default select HTTPS', () => {
+    // given, when
+    fixture.detectChanges();
+
+    // then
     expect(component.selectedForm).toBe(GitFormType.HTTPS);
   });
 
   it('should default select NO_UPSTREAM if git upstream is not required', () => {
+    // given
     component.required = false;
-    component.ngOnInit();
+
+    // when
+    fixture.detectChanges();
+
+    // then
     expect(component.selectedForm).toBe(GitFormType.NO_UPSTREAM);
   });
 
   it('should select HTTPS form on init with https data given', () => {
     // given
     component.gitInputData = getDefaultHttpsData();
-    component.ngOnInit();
+
+    // when
+    fixture.detectChanges();
+
     // then
     expect(component.selectedForm).toBe(GitFormType.HTTPS);
   });
@@ -61,7 +71,10 @@ describe('KtbProjectSettingsGitExtendedComponent', () => {
   it('should select SSH form on init with ssh data given', () => {
     // given
     component.gitInputData = getDefaultSshData();
-    component.ngOnInit();
+
+    // when
+    fixture.detectChanges();
+
     // then
     expect(component.selectedForm).toBe(GitFormType.SSH);
   });
@@ -69,7 +82,12 @@ describe('KtbProjectSettingsGitExtendedComponent', () => {
   it('should select NO_UPSTREAM form on init if not data given and git upstream is not required', () => {
     // given
     component.required = false;
-    component.ngOnInit();
+    component.gitInputData = getDefaultHttpsData();
+    component.gitInputData.https.gitRemoteURL = '';
+
+    // when
+    fixture.detectChanges();
+
     // then
     expect(component.selectedForm).toBe(GitFormType.NO_UPSTREAM);
   });
@@ -77,7 +95,7 @@ describe('KtbProjectSettingsGitExtendedComponent', () => {
   it('should select another form and data should be invalidated', () => {
     // given
     const emitSpy = jest.spyOn(component.gitDataChange, 'emit');
-    expect(component.selectedForm).toBe(GitFormType.HTTPS);
+    fixture.detectChanges();
 
     // when
     setSelectedForm(GitFormType.SSH);
@@ -91,6 +109,7 @@ describe('KtbProjectSettingsGitExtendedComponent', () => {
   it('should correctly update and emit data', () => {
     // given
     const emitSpy = jest.spyOn(component.gitDataChange, 'emit');
+    fixture.detectChanges();
 
     // when
     component.dataChanged(GitFormType.SSH, getDefaultSshData());
@@ -103,6 +122,7 @@ describe('KtbProjectSettingsGitExtendedComponent', () => {
     // given
     const dataService = TestBed.inject(DataService);
     const updateUpstreamSpy = jest.spyOn(dataService, 'updateGitUpstream');
+    fixture.detectChanges();
 
     // when
     component.updateUpstream();
@@ -111,30 +131,25 @@ describe('KtbProjectSettingsGitExtendedComponent', () => {
     expect(updateUpstreamSpy).not.toHaveBeenCalled();
   });
 
-  it('should update gitUpstream', fakeAsync(() => {
+  it('should update gitUpstream', () => {
     // given
+    fixture.detectChanges();
     const dataService = TestBed.inject(DataService);
     const updateUpstreamSpy = jest.spyOn(dataService, 'updateGitUpstream');
-    const inProgressSpy = jest.fn();
-    Object.defineProperty(component, 'isGitUpstreamInProgress', {
-      get: jest.fn(() => true),
-      set: inProgressSpy,
-    });
+    const data = getDefaultSshData();
 
     // when
     setSelectedForm(GitFormType.SSH);
-    component.dataChanged(GitFormType.SSH, getDefaultSshData());
+    component.dataChanged(GitFormType.SSH, data);
     component.updateUpstream();
 
     // then
-    expect(inProgressSpy).toHaveBeenCalledWith(true);
-    tick();
-    expect(inProgressSpy).toHaveBeenCalledWith(false);
-    expect(updateUpstreamSpy).toHaveBeenCalled();
-  }));
+    expect(updateUpstreamSpy).toHaveBeenCalledWith('sockshop', data);
+  });
 
-  it('should update gitUpstream and set inProgress to false on error', fakeAsync(() => {
+  it('should update gitUpstream and set inProgress to false on error', () => {
     // given
+    fixture.detectChanges();
     const dataService = TestBed.inject(DataService);
     jest.spyOn(dataService, 'updateGitUpstream').mockReturnValue(throwError('error'));
     const updateUpstreamSpy = jest.spyOn(dataService, 'updateGitUpstream');
@@ -150,44 +165,64 @@ describe('KtbProjectSettingsGitExtendedComponent', () => {
     component.updateUpstream();
 
     // then
-    expect(inProgressSpy).toHaveBeenCalledWith(true);
-    tick();
     expect(inProgressSpy).toHaveBeenCalledWith(false);
     expect(updateUpstreamSpy).toHaveBeenCalled();
-  }));
+  });
 
   it('should correctly return data if input is HTTPS', () => {
+    // given
     component.gitInputData = getDefaultHttpsData();
-    component.ngOnInit();
-    expect(component.gitInputDataHttps).toEqual(getDefaultHttpsData());
 
+    // when
+    fixture.detectChanges();
+
+    // then
+    expect(component.gitInputDataHttps).toEqual(getDefaultHttpsData());
     expect(component.gitInputDataSsh).toBe(undefined);
   });
 
   it('should correctly return data if input is SSH', () => {
+    // given
     component.gitInputData = getDefaultSshData();
-    component.ngOnInit();
+
+    // when
+    fixture.detectChanges();
+
+    // then
     expect(component.gitInputDataSsh).toEqual(getDefaultSshData());
     expect(component.gitInputDataHttps).toBe(undefined);
   });
 
   it('should correctly return data if no upstream is selected', () => {
+    // given
     const spy = jest.spyOn(component.gitDataChange, 'emit');
     component.required = false;
+    fixture.detectChanges();
+
+    // when
     setSelectedForm(GitFormType.NO_UPSTREAM);
+
+    // then
     expect(component.gitInputDataSsh).toEqual(undefined);
     expect(component.gitInputDataHttps).toBe(undefined);
     expect(spy).toHaveBeenCalledWith({ noupstream: '' });
   });
 
   it('should return undefined if input is undefined', () => {
+    // given
     component.gitInputData = undefined;
+
+    // when
+    fixture.detectChanges();
+
+    // then
     expect(component.gitInputDataSsh).toBe(undefined);
     expect(component.gitInputDataHttps).toBe(undefined);
   });
 
   it('should emit cached https data if it switched back', () => {
     // given
+    fixture.detectChanges();
     component.dataChanged(GitFormType.HTTPS, getDefaultHttpsData());
 
     // when
@@ -204,6 +239,7 @@ describe('KtbProjectSettingsGitExtendedComponent', () => {
 
   it('should emit cached ssh data if it switched back', () => {
     // given
+    fixture.detectChanges();
     setSelectedForm(GitFormType.SSH);
     component.dataChanged(GitFormType.SSH, getDefaultSshData());
 

--- a/bridge/client/app/_components/ktb-project-settings-git-extended/ktb-project-settings-git-extended.component.spec.ts
+++ b/bridge/client/app/_components/ktb-project-settings-git-extended/ktb-project-settings-git-extended.component.spec.ts
@@ -50,30 +50,26 @@ describe('KtbProjectSettingsGitExtendedComponent', () => {
     expect(component.selectedForm).toBe(GitFormType.NO_UPSTREAM);
   });
 
-  it('should update selected form to SSH and back to HTTPS', () => {
+  it('should select HTTPS form on init with https data given', () => {
     // given
-    component.gitInputData = getDefaultSshData();
-    // then
-    expect(component.selectedForm).toBe(GitFormType.SSH);
-
-    // when
-    component.gitInputData = undefined;
-
+    component.gitInputData = getDefaultHttpsData();
+    component.ngOnInit();
     // then
     expect(component.selectedForm).toBe(GitFormType.HTTPS);
   });
 
-  it('should update selected form to SSH and back to NO_UPSTREAM if git upstream is not required', () => {
+  it('should select SSH form on init with ssh data given', () => {
+    // given
+    component.gitInputData = getDefaultSshData();
+    component.ngOnInit();
+    // then
+    expect(component.selectedForm).toBe(GitFormType.SSH);
+  });
+
+  it('should select NO_UPSTREAM form on init if not data given and git upstream is not required', () => {
     // given
     component.required = false;
     component.ngOnInit();
-    component.gitInputData = getDefaultSshData();
-    // then
-    expect(component.selectedForm).toBe(GitFormType.SSH);
-
-    // when
-    component.gitInputData = undefined;
-
     // then
     expect(component.selectedForm).toBe(GitFormType.NO_UPSTREAM);
   });
@@ -162,6 +158,7 @@ describe('KtbProjectSettingsGitExtendedComponent', () => {
 
   it('should correctly return data if input is HTTPS', () => {
     component.gitInputData = getDefaultHttpsData();
+    component.ngOnInit();
     expect(component.gitInputDataHttps).toEqual(getDefaultHttpsData());
 
     expect(component.gitInputDataSsh).toBe(undefined);
@@ -169,6 +166,7 @@ describe('KtbProjectSettingsGitExtendedComponent', () => {
 
   it('should correctly return data if input is SSH', () => {
     component.gitInputData = getDefaultSshData();
+    component.ngOnInit();
     expect(component.gitInputDataSsh).toEqual(getDefaultSshData());
     expect(component.gitInputDataHttps).toBe(undefined);
   });
@@ -229,7 +227,7 @@ describe('KtbProjectSettingsGitExtendedComponent', () => {
       ssh: {
         gitPrivateKeyPass: '',
         gitPrivateKey: '',
-        gitRemoteURL: '',
+        gitRemoteURL: 'ssh://git@github.com/keptn/keptn',
       },
     };
   }

--- a/bridge/client/app/_components/ktb-project-settings-git-extended/ktb-project-settings-git-extended.component.spec.ts
+++ b/bridge/client/app/_components/ktb-project-settings-git-extended/ktb-project-settings-git-extended.component.spec.ts
@@ -45,9 +45,8 @@ describe('KtbProjectSettingsGitExtendedComponent', () => {
   });
 
   it('should default select NO_UPSTREAM if git upstream is not required', () => {
-    fixture = TestBed.createComponent(KtbProjectSettingsGitExtendedComponent);
-    component = fixture.componentInstance;
     component.required = false;
+    component.ngOnInit();
     expect(component.selectedForm).toBe(GitFormType.NO_UPSTREAM);
   });
 
@@ -66,9 +65,8 @@ describe('KtbProjectSettingsGitExtendedComponent', () => {
 
   it('should update selected form to SSH and back to NO_UPSTREAM if git upstream is not required', () => {
     // given
-    fixture = TestBed.createComponent(KtbProjectSettingsGitExtendedComponent);
-    component = fixture.componentInstance;
     component.required = false;
+    component.ngOnInit();
     component.gitInputData = getDefaultSshData();
     // then
     expect(component.selectedForm).toBe(GitFormType.SSH);

--- a/bridge/client/app/_components/ktb-project-settings-git-extended/ktb-project-settings-git-extended.component.spec.ts
+++ b/bridge/client/app/_components/ktb-project-settings-git-extended/ktb-project-settings-git-extended.component.spec.ts
@@ -32,6 +32,7 @@ describe('KtbProjectSettingsGitExtendedComponent', () => {
     }).compileComponents();
     fixture = TestBed.createComponent(KtbProjectSettingsGitExtendedComponent);
     component = fixture.componentInstance;
+    component.required = true;
     fixture.detectChanges();
   });
 
@@ -41,6 +42,13 @@ describe('KtbProjectSettingsGitExtendedComponent', () => {
 
   it('should default select HTTPS', () => {
     expect(component.selectedForm).toBe(GitFormType.HTTPS);
+  });
+
+  it('should default select NO_UPSTREAM if git upstream is not required', () => {
+    fixture = TestBed.createComponent(KtbProjectSettingsGitExtendedComponent);
+    component = fixture.componentInstance;
+    component.required = false;
+    expect(component.selectedForm).toBe(GitFormType.NO_UPSTREAM);
   });
 
   it('should update selected form to SSH and back to HTTPS', () => {
@@ -54,6 +62,22 @@ describe('KtbProjectSettingsGitExtendedComponent', () => {
 
     // then
     expect(component.selectedForm).toBe(GitFormType.HTTPS);
+  });
+
+  it('should update selected form to SSH and back to NO_UPSTREAM if git upstream is not required', () => {
+    // given
+    fixture = TestBed.createComponent(KtbProjectSettingsGitExtendedComponent);
+    component = fixture.componentInstance;
+    component.required = false;
+    component.gitInputData = getDefaultSshData();
+    // then
+    expect(component.selectedForm).toBe(GitFormType.SSH);
+
+    // when
+    component.gitInputData = undefined;
+
+    // then
+    expect(component.selectedForm).toBe(GitFormType.NO_UPSTREAM);
   });
 
   it('should select another form and data should be invalidated', () => {
@@ -75,7 +99,7 @@ describe('KtbProjectSettingsGitExtendedComponent', () => {
     const emitSpy = jest.spyOn(component.gitDataChange, 'emit');
 
     // when
-    component.dataChanged(getDefaultSshData());
+    component.dataChanged(GitFormType.SSH, getDefaultSshData());
 
     // then
     expect(emitSpy).toHaveBeenCalledWith(getDefaultSshData());
@@ -105,7 +129,7 @@ describe('KtbProjectSettingsGitExtendedComponent', () => {
 
     // when
     setSelectedForm(GitFormType.SSH);
-    component.dataChanged(getDefaultSshData());
+    component.dataChanged(GitFormType.SSH, getDefaultSshData());
     component.updateUpstream();
 
     // then
@@ -128,7 +152,7 @@ describe('KtbProjectSettingsGitExtendedComponent', () => {
 
     // when
     setSelectedForm(GitFormType.SSH);
-    component.dataChanged(getDefaultSshData());
+    component.dataChanged(GitFormType.SSH, getDefaultSshData());
     component.updateUpstream();
 
     // then
@@ -151,6 +175,15 @@ describe('KtbProjectSettingsGitExtendedComponent', () => {
     expect(component.gitInputDataHttps).toBe(undefined);
   });
 
+  it('should correctly return data if no upstream is selected', () => {
+    const spy = jest.spyOn(component.gitDataChange, 'emit');
+    component.required = false;
+    setSelectedForm(GitFormType.NO_UPSTREAM);
+    expect(component.gitInputDataSsh).toEqual(undefined);
+    expect(component.gitInputDataHttps).toBe(undefined);
+    expect(spy).toHaveBeenCalledWith({ noupstream: '' });
+  });
+
   it('should return undefined if input is undefined', () => {
     component.gitInputData = undefined;
     expect(component.gitInputDataSsh).toBe(undefined);
@@ -159,7 +192,7 @@ describe('KtbProjectSettingsGitExtendedComponent', () => {
 
   it('should emit cached https data if it switched back', () => {
     // given
-    component.dataChanged(getDefaultHttpsData());
+    component.dataChanged(GitFormType.HTTPS, getDefaultHttpsData());
 
     // when
     setSelectedForm(GitFormType.SSH);
@@ -176,7 +209,7 @@ describe('KtbProjectSettingsGitExtendedComponent', () => {
   it('should emit cached ssh data if it switched back', () => {
     // given
     setSelectedForm(GitFormType.SSH);
-    component.dataChanged(getDefaultSshData());
+    component.dataChanged(GitFormType.SSH, getDefaultSshData());
 
     // when
     setSelectedForm(GitFormType.HTTPS);
@@ -206,7 +239,7 @@ describe('KtbProjectSettingsGitExtendedComponent', () => {
   function getDefaultHttpsData(): IGitHttps {
     return {
       https: {
-        gitRemoteURL: '',
+        gitRemoteURL: 'https://github.com/keptn/keptn',
         gitToken: '',
       },
     };

--- a/bridge/client/app/_components/ktb-project-settings-git-extended/ktb-project-settings-git-extended.component.ts
+++ b/bridge/client/app/_components/ktb-project-settings-git-extended/ktb-project-settings-git-extended.component.ts
@@ -4,7 +4,7 @@ import { IGitDataExtended, IGitHttps, IGitSsh } from '../../_interfaces/git-upst
 import { DataService } from '../../_services/data.service';
 import { ActivatedRoute, ParamMap } from '@angular/router';
 import { filter, map } from 'rxjs/operators';
-import { isGitHTTPS, isGitSSH } from '../../_utils/git-upstream.utils';
+import { isGitHTTPS, isGitSSH, isRemoteUrlEmpty } from '../../_utils/git-upstream.utils';
 
 export enum GitFormType {
   SSH,
@@ -59,7 +59,7 @@ export class KtbProjectSettingsGitExtendedComponent implements OnInit {
   }
 
   public ngOnInit(): void {
-    if (!this.gitInputData || this.isRemoteUrlEmpty(this.gitInputData)) {
+    if (!this.gitInputData || isRemoteUrlEmpty(this.gitInputData)) {
       this.selectedForm = this.required ? GitFormType.HTTPS : GitFormType.NO_UPSTREAM;
 
       if (this.selectedForm === GitFormType.NO_UPSTREAM) {
@@ -92,13 +92,6 @@ export class KtbProjectSettingsGitExtendedComponent implements OnInit {
       .subscribe((projectName: string) => {
         this.projectName = projectName;
       });
-  }
-
-  private isRemoteUrlEmpty(gitInputData: IGitDataExtended): boolean {
-    return (
-      (isGitHTTPS(gitInputData) && !gitInputData.https.gitRemoteURL) ||
-      (isGitSSH(gitInputData) && !gitInputData.ssh.gitRemoteURL)
-    );
   }
 
   public setSelectedForm($event: DtRadioChange<GitFormType>): void {

--- a/bridge/client/app/_components/ktb-project-settings-git-extended/ktb-project-settings-git-extended.component.ts
+++ b/bridge/client/app/_components/ktb-project-settings-git-extended/ktb-project-settings-git-extended.component.ts
@@ -59,24 +59,27 @@ export class KtbProjectSettingsGitExtendedComponent implements OnInit {
   }
 
   public ngOnInit(): void {
-    if (this.gitInputData) {
-      if (isGitHTTPS(this.gitInputData) && this.gitInputData.https.gitRemoteURL) {
-        this.gitInputDataHttps = this.gitInputData;
-        this.selectedForm = GitFormType.HTTPS;
-        this.upstreamConfigured = true;
-      } else if (isGitSSH(this.gitInputData) && this.gitInputData.ssh.gitRemoteURL) {
-        this.gitInputDataSsh = this.gitInputData;
-        this.selectedForm = GitFormType.SSH;
-        this.upstreamConfigured = true;
-      } else {
-        this.selectedForm = this.required ? GitFormType.HTTPS : GitFormType.NO_UPSTREAM;
-      }
-    } else {
+    if (!this.gitInputData || this.isRemoteUrlEmpty()) {
       this.selectedForm = this.required ? GitFormType.HTTPS : GitFormType.NO_UPSTREAM;
+
+      if (this.selectedForm === GitFormType.NO_UPSTREAM) {
+        this.dataChanged(this.selectedForm, this.gitData);
+      }
+
+      return;
     }
 
-    if (this.selectedForm === GitFormType.NO_UPSTREAM) {
-      this.dataChanged(this.selectedForm, this.gitData);
+    if (isGitHTTPS(this.gitInputData)) {
+      this.gitInputDataHttps = this.gitInputData;
+      this.selectedForm = GitFormType.HTTPS;
+      this.upstreamConfigured = true;
+      return;
+    }
+
+    if (isGitSSH(this.gitInputData)) {
+      this.gitInputDataSsh = this.gitInputData;
+      this.selectedForm = GitFormType.SSH;
+      this.upstreamConfigured = true;
     }
   }
 
@@ -89,6 +92,16 @@ export class KtbProjectSettingsGitExtendedComponent implements OnInit {
       .subscribe((projectName: string) => {
         this.projectName = projectName;
       });
+  }
+
+  private isRemoteUrlEmpty(): boolean {
+    if (!this.gitInputData) {
+      return true;
+    }
+    return (
+      (isGitHTTPS(this.gitInputData) && !this.gitInputData.https.gitRemoteURL) ||
+      (isGitSSH(this.gitInputData) && !this.gitInputData.ssh.gitRemoteURL)
+    );
   }
 
   public setSelectedForm($event: DtRadioChange<GitFormType>): void {

--- a/bridge/client/app/_components/ktb-project-settings-git-extended/ktb-project-settings-git-extended.component.ts
+++ b/bridge/client/app/_components/ktb-project-settings-git-extended/ktb-project-settings-git-extended.component.ts
@@ -28,9 +28,6 @@ export class KtbProjectSettingsGitExtendedComponent implements OnInit {
   public upstreamConfigured = false;
 
   @Input()
-  public isLoading = false;
-
-  @Input()
   public isCreateMode = false;
 
   @Input()
@@ -40,25 +37,7 @@ export class KtbProjectSettingsGitExtendedComponent implements OnInit {
   public required = true;
 
   @Input()
-  public set gitInputData(gitData: IGitDataExtended | undefined) {
-    if (gitData) {
-      if (isGitHTTPS(gitData) && gitData.https.gitRemoteURL) {
-        this.gitInputDataHttps = gitData;
-        this.selectedForm = GitFormType.HTTPS;
-        this.upstreamConfigured = true;
-      } else if (isGitSSH(gitData)) {
-        this.gitInputDataSsh = gitData;
-        this.selectedForm = GitFormType.SSH;
-        this.upstreamConfigured = true;
-      } else {
-        this.selectedForm = this.required ? GitFormType.HTTPS : GitFormType.NO_UPSTREAM;
-        this.upstreamConfigured = false;
-      }
-    } else {
-      this.selectedForm = this.required ? GitFormType.HTTPS : GitFormType.NO_UPSTREAM;
-      this.upstreamConfigured = false;
-    }
-  }
+  public gitInputData: IGitDataExtended | undefined;
 
   @Output()
   public gitDataChange = new EventEmitter<IGitDataExtended | undefined>();
@@ -74,11 +53,28 @@ export class KtbProjectSettingsGitExtendedComponent implements OnInit {
         return this.gitDataSsh;
       case GitFormType.NO_UPSTREAM:
         return { noupstream: '' };
+      default:
+        return undefined;
     }
   }
 
   public ngOnInit(): void {
-    this.selectedForm = this.required ? GitFormType.HTTPS : GitFormType.NO_UPSTREAM;
+    if (this.gitInputData) {
+      if (isGitHTTPS(this.gitInputData) && this.gitInputData.https.gitRemoteURL) {
+        this.gitInputDataHttps = this.gitInputData;
+        this.selectedForm = GitFormType.HTTPS;
+        this.upstreamConfigured = true;
+      } else if (isGitSSH(this.gitInputData) && this.gitInputData.ssh.gitRemoteURL) {
+        this.gitInputDataSsh = this.gitInputData;
+        this.selectedForm = GitFormType.SSH;
+        this.upstreamConfigured = true;
+      } else {
+        this.selectedForm = this.required ? GitFormType.HTTPS : GitFormType.NO_UPSTREAM;
+      }
+    } else {
+      this.selectedForm = this.required ? GitFormType.HTTPS : GitFormType.NO_UPSTREAM;
+    }
+
     if (this.selectedForm === GitFormType.NO_UPSTREAM) {
       this.dataChanged(this.selectedForm, this.gitData);
     }

--- a/bridge/client/app/_components/ktb-project-settings-git-extended/ktb-project-settings-git-extended.component.ts
+++ b/bridge/client/app/_components/ktb-project-settings-git-extended/ktb-project-settings-git-extended.component.ts
@@ -59,7 +59,7 @@ export class KtbProjectSettingsGitExtendedComponent implements OnInit {
   }
 
   public ngOnInit(): void {
-    if (!this.gitInputData || this.isRemoteUrlEmpty()) {
+    if (!this.gitInputData || this.isRemoteUrlEmpty(this.gitInputData)) {
       this.selectedForm = this.required ? GitFormType.HTTPS : GitFormType.NO_UPSTREAM;
 
       if (this.selectedForm === GitFormType.NO_UPSTREAM) {
@@ -94,19 +94,16 @@ export class KtbProjectSettingsGitExtendedComponent implements OnInit {
       });
   }
 
-  private isRemoteUrlEmpty(): boolean {
-    if (!this.gitInputData) {
-      return true;
-    }
+  private isRemoteUrlEmpty(gitInputData: IGitDataExtended): boolean {
     return (
-      (isGitHTTPS(this.gitInputData) && !this.gitInputData.https.gitRemoteURL) ||
-      (isGitSSH(this.gitInputData) && !this.gitInputData.ssh.gitRemoteURL)
+      (isGitHTTPS(gitInputData) && !gitInputData.https.gitRemoteURL) ||
+      (isGitSSH(gitInputData) && !gitInputData.ssh.gitRemoteURL)
     );
   }
 
   public setSelectedForm($event: DtRadioChange<GitFormType>): void {
     this.selectedForm = $event.value ?? GitFormType.HTTPS;
-    this.dataChanged($event.value ?? GitFormType.HTTPS, this.gitData);
+    this.dataChanged(this.selectedForm, this.gitData);
   }
 
   public updateUpstream(): void {

--- a/bridge/client/app/_components/ktb-project-settings-git-extended/ktb-project-settings-git-extended.component.ts
+++ b/bridge/client/app/_components/ktb-project-settings-git-extended/ktb-project-settings-git-extended.component.ts
@@ -7,9 +7,9 @@ import { filter, map } from 'rxjs/operators';
 import { isGitHTTPS, isGitSSH } from '../../_utils/git-upstream.utils';
 
 export enum GitFormType {
-  SSH = 'SSH',
-  HTTPS = 'HTTPS',
-  NO_UPSTREAM = 'NO_UPSTREAM',
+  SSH,
+  HTTPS,
+  NO_UPSTREAM,
 }
 
 @Component({

--- a/bridge/client/app/_components/ktb-project-settings-git-extended/ktb-project-settings-git-extended.component.ts
+++ b/bridge/client/app/_components/ktb-project-settings-git-extended/ktb-project-settings-git-extended.component.ts
@@ -51,7 +51,7 @@ export class KtbProjectSettingsGitExtendedComponent implements OnInit {
         this.selectedForm = GitFormType.SSH;
         this.upstreamConfigured = true;
       } else {
-        this.selectedForm = GitFormType.NO_UPSTREAM;
+        this.selectedForm = this.required ? GitFormType.HTTPS : GitFormType.NO_UPSTREAM;
         this.upstreamConfigured = false;
       }
     }
@@ -75,12 +75,10 @@ export class KtbProjectSettingsGitExtendedComponent implements OnInit {
   }
 
   public ngOnInit(): void {
-    if (this.required && this.isCreateMode) {
-      this.selectedForm = GitFormType.HTTPS;
+    this.selectedForm = this.required ? GitFormType.HTTPS : GitFormType.NO_UPSTREAM;
+    if (this.selectedForm === GitFormType.NO_UPSTREAM) {
+      this.dataChanged(this.selectedForm, this.gitData);
     }
-
-    this.selectedForm = GitFormType.NO_UPSTREAM;
-    this.dataChanged(GitFormType.NO_UPSTREAM, this.gitData);
   }
 
   constructor(private readonly dataService: DataService, readonly routes: ActivatedRoute) {

--- a/bridge/client/app/_components/ktb-project-settings-git-extended/ktb-project-settings-git-extended.component.ts
+++ b/bridge/client/app/_components/ktb-project-settings-git-extended/ktb-project-settings-git-extended.component.ts
@@ -54,6 +54,9 @@ export class KtbProjectSettingsGitExtendedComponent implements OnInit {
         this.selectedForm = this.required ? GitFormType.HTTPS : GitFormType.NO_UPSTREAM;
         this.upstreamConfigured = false;
       }
+    } else {
+      this.selectedForm = this.required ? GitFormType.HTTPS : GitFormType.NO_UPSTREAM;
+      this.upstreamConfigured = false;
     }
   }
 
@@ -125,8 +128,11 @@ export class KtbProjectSettingsGitExtendedComponent implements OnInit {
           break;
       }
     } else {
-      this.gitDataHttps = undefined;
-      this.gitDataSsh = undefined;
+      if (this.selectedForm === GitFormType.HTTPS) {
+        this.gitDataHttps = undefined;
+      } else if (this.selectedForm === GitFormType.SSH) {
+        this.gitDataSsh = undefined;
+      }
     }
     this.gitDataChange.emit(data);
   }

--- a/bridge/client/app/_components/ktb-project-settings-git-https/ktb-project-settings-git-https.component.html
+++ b/bridge/client/app/_components/ktb-project-settings-git-https/ktb-project-settings-git-https.component.html
@@ -5,7 +5,7 @@
   [isLoading]="isLoading"
   (gitDataChanged)="gitUpstreamChanged($event); inputChanged()"
 ></ktb-project-settings-git>
-<h2>Certificate</h2>
+<h3>Certificate</h3>
 <p class="mt-0">
   If a certificate is needed for the Git repository connection, upload the certificate file or add it directly as text.
 </p>
@@ -17,13 +17,13 @@
     certificate = $event; isCertificateValid = certificateInputElement.certificateForm.valid; inputChanged()
   "
 ></ktb-certificate-input>
-<h2 class="mt-3">Proxy</h2>
+<h3 class="mt-3">Proxy</h3>
 <dt-switch
   (change)="proxyEnabled = $event.checked; inputChanged()"
   [checked]="proxyEnabled"
   uitestid="ktb-enable-git-proxy"
-  >Use proxy</dt-switch
->
+  >Use proxy
+</dt-switch>
 <dt-loading-spinner *ngIf="isLoading" class="gray-loading" aria-label="Loading data"></dt-loading-spinner>
 <ktb-proxy-input
   [hidden]="!proxyEnabled"

--- a/bridge/client/app/_components/ktb-project-settings-git-ssh/ktb-project-settings-git-ssh.component.html
+++ b/bridge/client/app/_components/ktb-project-settings-git-ssh/ktb-project-settings-git-ssh.component.html
@@ -4,7 +4,7 @@
   [isLoading]="isLoading"
 ></ktb-project-settings-git-ssh-input>
 
-<h2 class="required mt-3">SSH private key</h2>
+<h3 class="required mt-3">SSH private key</h3>
 <p class="mt-0">
   For SSH the private key is needed to connect to the repository. Provide it as file or directly as text.
 </p>

--- a/bridge/client/app/_components/ktb-project-settings/ktb-project-settings.component.html
+++ b/bridge/client/app/_components/ktb-project-settings/ktb-project-settings.component.html
@@ -27,9 +27,12 @@
           </dt-error>
         </dt-form-field>
       </div>
-      <div class="mb-3 settings-section" *ngIf="resourceServiceEnabled !== undefined">
+      <h2 [class.required]="gitUpstreamRequired">Git upstream repository</h2>
+      <ng-template #loading>
+        <ktb-loading-distractor>Loading ...</ktb-loading-distractor>
+      </ng-template>
+      <div class="mb-3 settings-section" *ngIf="resourceServiceEnabled !== undefined; else loading">
         <ng-container *ngIf="resourceServiceEnabled; else defaultGit">
-          <h2 [class.required]="gitUpstreamRequired" class="required">Git upstream repository</h2>
           <p class="mt-0 mb-3" *ngIf="gitUpstreamRequired">
             A Git upstream repository has to be set. You can connect your Git repository with HTTPS or SSH.
             Instructions, on how to set up your Git provider can be found in the
@@ -51,9 +54,7 @@
             (gitDataChange)="updateGitDataExtended($event)"
           ></ktb-project-settings-git-extended>
         </ng-container>
-        <ng-template #loading>
-          <ktb-loading-distractor>Loading ...</ktb-loading-distractor>
-        </ng-template>
+
         <ng-template #defaultGit>
           <ktb-project-settings-git
             [isLoading]="isProjectLoading"

--- a/bridge/client/app/_components/ktb-project-settings/ktb-project-settings.component.html
+++ b/bridge/client/app/_components/ktb-project-settings/ktb-project-settings.component.html
@@ -1,4 +1,4 @@
-<div class="container" fxFlexFill>
+<div class="container" fxFlexFill *ngIf="state$ | async as state">
   <div fxLayout="column" fxFlexFill fxLayoutAlign="space-between" class="pb-3">
     <div>
       <div [formGroup]="projectNameForm" *ngIf="isCreateMode" class="mb-3 settings-section">
@@ -27,18 +27,18 @@
           </dt-error>
         </dt-form-field>
       </div>
-      <h2 [class.required]="gitUpstreamRequired">Git upstream repository</h2>
+      <h2 [class.required]="state.gitUpstreamRequired">Git upstream repository</h2>
       <ng-template #loading>
         <ktb-loading-distractor>Loading ...</ktb-loading-distractor>
       </ng-template>
       <div class="mb-3 settings-section" *ngIf="resourceServiceEnabled !== undefined; else loading">
         <ng-container *ngIf="resourceServiceEnabled; else defaultGit">
-          <p class="mt-0 mb-3" *ngIf="gitUpstreamRequired">
+          <p class="mt-0 mb-3" *ngIf="state.gitUpstreamRequired">
             A Git upstream repository has to be set. You can connect your Git repository with HTTPS or SSH.
             Instructions, on how to set up your Git provider can be found in the
             <a [href]="'/manage/git_upstream/' | keptnUrl" target="_blank">Git-based upstream documentation</a>.
           </p>
-          <p class="mt-0 mb-3" *ngIf="!gitUpstreamRequired">
+          <p class="mt-0 mb-3" *ngIf="!state.gitUpstreamRequired">
             It is recommended to set a Git upstream repository. You can connect your Git repository with HTTPS or SSH.
             Instructions, on how to set up your Git provider can be found in the
             <a [href]="'/manage/git_upstream/' | keptnUrl" target="_blank">Git-based upstream documentation</a>.
@@ -49,7 +49,7 @@
             [isCreateMode]="isCreateMode"
             [isGitUpstreamInProgress]="isGitUpstreamInProgress"
             [gitInputData]="gitInputDataExtended"
-            [required]="gitUpstreamRequired"
+            [required]="state.gitUpstreamRequired"
             (resetTouched)="isProjectFormTouched = false"
             (gitDataChange)="updateGitDataExtended($event)"
           ></ktb-project-settings-git-extended>

--- a/bridge/client/app/_components/ktb-project-settings/ktb-project-settings.component.html
+++ b/bridge/client/app/_components/ktb-project-settings/ktb-project-settings.component.html
@@ -45,7 +45,7 @@
           </p>
 
           <ktb-project-settings-git-extended
-            *ngIf="!isProjectLoading; else loading"
+            *ngIf="!isProjectLoading && state.gitUpstreamRequired; else loading"
             [isCreateMode]="isCreateMode"
             [isGitUpstreamInProgress]="isGitUpstreamInProgress"
             [gitInputData]="gitInputDataExtended"

--- a/bridge/client/app/_components/ktb-project-settings/ktb-project-settings.component.html
+++ b/bridge/client/app/_components/ktb-project-settings/ktb-project-settings.component.html
@@ -45,7 +45,7 @@
           </p>
 
           <ktb-project-settings-git-extended
-            *ngIf="!isProjectLoading && state.gitUpstreamRequired; else loading"
+            *ngIf="!isProjectLoading && state.gitUpstreamRequired !== undefined; else loading"
             [isCreateMode]="isCreateMode"
             [isGitUpstreamInProgress]="isGitUpstreamInProgress"
             [gitInputData]="gitInputDataExtended"

--- a/bridge/client/app/_components/ktb-project-settings/ktb-project-settings.component.html
+++ b/bridge/client/app/_components/ktb-project-settings/ktb-project-settings.component.html
@@ -34,6 +34,7 @@
           [isCreateMode]="isCreateMode"
           [isGitUpstreamInProgress]="isGitUpstreamInProgress"
           [gitInputData]="gitInputDataExtended"
+          [required]="gitUpstreamRequired"
           (resetTouched)="isProjectFormTouched = false"
           (gitDataChange)="updateGitDataExtended($event)"
         ></ktb-project-settings-git-extended>

--- a/bridge/client/app/_components/ktb-project-settings/ktb-project-settings.component.html
+++ b/bridge/client/app/_components/ktb-project-settings/ktb-project-settings.component.html
@@ -28,16 +28,32 @@
         </dt-form-field>
       </div>
       <div class="mb-3 settings-section" *ngIf="resourceServiceEnabled !== undefined">
-        <ktb-project-settings-git-extended
-          *ngIf="resourceServiceEnabled; else defaultGit"
-          [isLoading]="!!isProjectLoading"
-          [isCreateMode]="isCreateMode"
-          [isGitUpstreamInProgress]="isGitUpstreamInProgress"
-          [gitInputData]="gitInputDataExtended"
-          [required]="gitUpstreamRequired"
-          (resetTouched)="isProjectFormTouched = false"
-          (gitDataChange)="updateGitDataExtended($event)"
-        ></ktb-project-settings-git-extended>
+        <ng-container *ngIf="resourceServiceEnabled; else defaultGit">
+          <h2 [class.required]="gitUpstreamRequired" class="required">Git upstream repository</h2>
+          <p class="mt-0 mb-3" *ngIf="gitUpstreamRequired">
+            A Git upstream repository has to be set. You can connect your Git repository with HTTPS or SSH.
+            Instructions, on how to set up your Git provider can be found in the
+            <a [href]="'/manage/git_upstream/' | keptnUrl" target="_blank">Git-based upstream documentation</a>.
+          </p>
+          <p class="mt-0 mb-3" *ngIf="!gitUpstreamRequired">
+            It is recommended to set a Git upstream repository. You can connect your Git repository with HTTPS or SSH.
+            Instructions, on how to set up your Git provider can be found in the
+            <a [href]="'/manage/git_upstream/' | keptnUrl" target="_blank">Git-based upstream documentation</a>.
+          </p>
+
+          <ktb-project-settings-git-extended
+            *ngIf="!isProjectLoading; else loading"
+            [isCreateMode]="isCreateMode"
+            [isGitUpstreamInProgress]="isGitUpstreamInProgress"
+            [gitInputData]="gitInputDataExtended"
+            [required]="gitUpstreamRequired"
+            (resetTouched)="isProjectFormTouched = false"
+            (gitDataChange)="updateGitDataExtended($event)"
+          ></ktb-project-settings-git-extended>
+        </ng-container>
+        <ng-template #loading>
+          <ktb-loading-distractor>Loading ...</ktb-loading-distractor>
+        </ng-template>
         <ng-template #defaultGit>
           <ktb-project-settings-git
             [isLoading]="isProjectLoading"

--- a/bridge/client/app/_components/ktb-project-settings/ktb-project-settings.component.ts
+++ b/bridge/client/app/_components/ktb-project-settings/ktb-project-settings.component.ts
@@ -19,6 +19,7 @@ import { IClientFeatureFlags } from '../../../../shared/interfaces/feature-flags
 import { IGitData, IGitDataExtended } from '../../_interfaces/git-upstream';
 import { AppUtils } from '../../_utils/app.utils';
 import { FeatureFlagsService } from '../../_services/feature-flags.service';
+import { KeptnInfo } from '../../_models/keptn-info';
 
 type DialogState = null | 'unsaved';
 
@@ -50,6 +51,7 @@ export class KtbProjectSettingsComponent implements OnInit, OnDestroy, PendingCh
     gitFormValid: true,
   };
   private gitDataExtended?: IGitDataExtended;
+  public gitUpstreamRequired = true;
   public projectNameControl = new FormControl('');
   public projectNameForm = new FormGroup({
     projectName: this.projectNameControl,
@@ -72,6 +74,16 @@ export class KtbProjectSettingsComponent implements OnInit, OnDestroy, PendingCh
       .pipe(takeUntil(this.unsubscribe$))
       .subscribe((featureFlags: IClientFeatureFlags) => {
         this.resourceServiceEnabled = featureFlags.RESOURCE_SERVICE_ENABLED;
+      });
+
+    this.dataService.keptnInfo
+      .pipe(
+        filter((keptnInfo: KeptnInfo | undefined): keptnInfo is KeptnInfo => !!keptnInfo),
+        takeUntil(this.unsubscribe$)
+      )
+      .subscribe((keptnInfo) => {
+        // if automaticprovisioning is false or undefined, git is required
+        this.gitUpstreamRequired = !keptnInfo.metadata.automaticprovisioning;
       });
   }
 

--- a/bridge/client/app/_components/ktb-project-settings/ktb-project-settings.component.ts
+++ b/bridge/client/app/_components/ktb-project-settings/ktb-project-settings.component.ts
@@ -9,7 +9,7 @@ import { DataService } from '../../_services/data.service';
 import { DtToast } from '@dynatrace/barista-components/toast';
 import { NotificationsService } from '../../_services/notifications.service';
 import { EventService } from '../../_services/event.service';
-import { filter, map, startWith, takeUntil } from 'rxjs/operators';
+import { filter, map, takeUntil } from 'rxjs/operators';
 import { Project } from '../../_models/project';
 import { FormUtils } from '../../_utils/form.utils';
 import { KtbProjectCreateMessageComponent } from '../_status-messages/ktb-project-create-message/ktb-project-create-message.component';
@@ -66,8 +66,7 @@ export class KtbProjectSettingsComponent implements OnInit, OnDestroy, PendingCh
 
   readonly state$: Observable<ProjectSettingsState> = this.dataService.keptnInfo.pipe(
     filter((keptnInfo: KeptnInfo | undefined): keptnInfo is KeptnInfo => !!keptnInfo),
-    map((keptnInfo: KeptnInfo) => ({ gitUpstreamRequired: !keptnInfo.metadata.automaticprovisioning })),
-    startWith({ gitUpstreamRequired: true })
+    map((keptnInfo: KeptnInfo) => ({ gitUpstreamRequired: !keptnInfo.metadata.automaticprovisioning }))
   );
 
   constructor(

--- a/bridge/client/app/_components/ktb-project-settings/ktb-project-settings.component.ts
+++ b/bridge/client/app/_components/ktb-project-settings/ktb-project-settings.component.ts
@@ -9,7 +9,7 @@ import { DataService } from '../../_services/data.service';
 import { DtToast } from '@dynatrace/barista-components/toast';
 import { NotificationsService } from '../../_services/notifications.service';
 import { EventService } from '../../_services/event.service';
-import { filter, map, takeUntil } from 'rxjs/operators';
+import { filter, map, startWith, takeUntil } from 'rxjs/operators';
 import { Project } from '../../_models/project';
 import { FormUtils } from '../../_utils/form.utils';
 import { KtbProjectCreateMessageComponent } from '../_status-messages/ktb-project-create-message/ktb-project-create-message.component';
@@ -24,7 +24,7 @@ import { KeptnInfo } from '../../_models/keptn-info';
 type DialogState = null | 'unsaved';
 
 interface ProjectSettingsState {
-  gitUpstreamRequired: boolean;
+  gitUpstreamRequired: boolean | undefined;
 }
 
 @Component({
@@ -66,7 +66,8 @@ export class KtbProjectSettingsComponent implements OnInit, OnDestroy, PendingCh
 
   readonly state$: Observable<ProjectSettingsState> = this.dataService.keptnInfo.pipe(
     filter((keptnInfo: KeptnInfo | undefined): keptnInfo is KeptnInfo => !!keptnInfo),
-    map((keptnInfo: KeptnInfo) => ({ gitUpstreamRequired: !keptnInfo.metadata.automaticprovisioning }))
+    map((keptnInfo: KeptnInfo) => ({ gitUpstreamRequired: !keptnInfo.metadata.automaticprovisioning })),
+    startWith({ gitUpstreamRequired: undefined })
   );
 
   constructor(

--- a/bridge/client/app/_interfaces/git-upstream.ts
+++ b/bridge/client/app/_interfaces/git-upstream.ts
@@ -45,6 +45,10 @@ export interface IGitSsh {
   ssh: IGitSshData & ISshKeyData;
 }
 
+export interface IGitNoUpstream {
+  noupstream: string;
+}
+
 export type IGitHttps = IGitHttpsWithoutProxy | IGitHTTPSProxy;
 
-export type IGitDataExtended = IGitHttps | IGitSsh;
+export type IGitDataExtended = IGitHttps | IGitSsh | IGitNoUpstream;

--- a/bridge/client/app/_services/api.service.ts
+++ b/bridge/client/app/_services/api.service.ts
@@ -138,7 +138,7 @@ export class ApiService {
   public createProjectExtended(
     projectName: string,
     shipyard: string,
-    data: IGitHttps['https'] | IGitSsh['ssh']
+    data?: IGitHttps['https'] | IGitSsh['ssh']
   ): Observable<unknown> {
     const url = `${this._baseUrl}/controlPlane/v1/project`;
     return this.http.post<unknown>(url, {
@@ -383,7 +383,7 @@ export class ApiService {
 
   public updateGitUpstreamExtended(
     projectName: string,
-    data: IGitHttps['https'] | IGitSsh['ssh']
+    data?: IGitHttps['https'] | IGitSsh['ssh']
   ): Observable<unknown> {
     const url = `${this._baseUrl}/controlPlane/v1/project`;
     return this.http.put<unknown>(url, {

--- a/bridge/client/app/_services/data.service.ts
+++ b/bridge/client/app/_services/data.service.ts
@@ -32,7 +32,7 @@ import { TriggerResponse, TriggerSequenceData } from '../_models/trigger-sequenc
 import { EventData } from '../_components/ktb-evaluation-info/ktb-evaluation-info.component';
 import { SecretScope } from '../../../shared/interfaces/secret-scope';
 import { IGitDataExtended } from '../_interfaces/git-upstream';
-import { isGitHTTPS } from '../_utils/git-upstream.utils';
+import { getGitData } from '../_utils/git-upstream.utils';
 
 @Injectable({
   providedIn: 'root',
@@ -132,7 +132,7 @@ export class DataService {
   }
 
   public createProjectExtended(projectName: string, shipyard: string, data: IGitDataExtended): Observable<unknown> {
-    return this.apiService.createProjectExtended(projectName, shipyard, isGitHTTPS(data) ? data.https : data.ssh);
+    return this.apiService.createProjectExtended(projectName, shipyard, getGitData(data));
   }
 
   public createService(projectName: string, serviceName: string): Observable<Record<string, unknown>> {
@@ -247,7 +247,7 @@ export class DataService {
   }
 
   public updateGitUpstream(projectName: string, data: IGitDataExtended): Observable<unknown> {
-    return this.apiService.updateGitUpstreamExtended(projectName, isGitHTTPS(data) ? data.https : data.ssh);
+    return this.apiService.updateGitUpstreamExtended(projectName, getGitData(data));
   }
 
   public loadKeptnInfo(): void {

--- a/bridge/client/app/_utils/git-upstream.utils.spec.ts
+++ b/bridge/client/app/_utils/git-upstream.utils.spec.ts
@@ -130,4 +130,52 @@ describe('GitUpstreamUtils', () => {
       } as Project)
     ).toBe(false);
   });
+
+  it('should return true if the https git remote url is empty', () => {
+    expect(
+      gitUtils.isRemoteUrlEmpty({
+        https: {
+          gitToken: '',
+          gitRemoteURL: '',
+        },
+      })
+    ).toBe(true);
+  });
+
+  it('should return false if the https git remote url is not empty', () => {
+    expect(
+      gitUtils.isRemoteUrlEmpty({
+        https: {
+          gitToken: '',
+          gitRemoteURL: 'https://myGitUrl',
+        },
+      })
+    ).toBe(false);
+  });
+
+  it('should return true if the ssh git remote url is empty', () => {
+    expect(
+      gitUtils.isRemoteUrlEmpty({
+        ssh: {
+          gitRemoteURL: '',
+          gitPrivateKey: '',
+        },
+      })
+    ).toBe(true);
+  });
+
+  it('should return false if the ssh git remote url is not empty', () => {
+    expect(
+      gitUtils.isRemoteUrlEmpty({
+        ssh: {
+          gitRemoteURL: 'ssh://myGitUrl',
+          gitPrivateKey: '',
+        },
+      })
+    ).toBe(false);
+  });
+
+  it('should return true if it is not a https or an ssh configuration', () => {
+    expect(gitUtils.isRemoteUrlEmpty({ noupstream: '' })).toBe(true);
+  });
 });

--- a/bridge/client/app/_utils/git-upstream.utils.ts
+++ b/bridge/client/app/_utils/git-upstream.utils.ts
@@ -41,6 +41,7 @@ export function getGitData(data: IGitDataExtended): IGitHttps['https'] | IGitSsh
 export function isRemoteUrlEmpty(gitInputData: IGitDataExtended): boolean {
   return (
     (isGitHTTPS(gitInputData) && !gitInputData.https.gitRemoteURL) ||
-    (isGitSSH(gitInputData) && !gitInputData.ssh.gitRemoteURL)
+    (isGitSSH(gitInputData) && !gitInputData.ssh.gitRemoteURL) ||
+    (!isGitHTTPS(gitInputData) && !isGitSSH(gitInputData))
   );
 }

--- a/bridge/client/app/_utils/git-upstream.utils.ts
+++ b/bridge/client/app/_utils/git-upstream.utils.ts
@@ -1,8 +1,19 @@
 import { Project } from '../_models/project';
-import { IGitData, IGitDataExtended, IGitHttps, IGitHTTPSProxy, IRequiredGitData } from '../_interfaces/git-upstream';
+import {
+  IGitData,
+  IGitDataExtended,
+  IGitHttps,
+  IGitHTTPSProxy,
+  IGitSsh,
+  IRequiredGitData,
+} from '../_interfaces/git-upstream';
 
 export function isGitHTTPS(data: IGitDataExtended): data is IGitHttps {
   return data.hasOwnProperty('https');
+}
+
+export function isGitSSH(data: IGitDataExtended): data is IGitSsh {
+  return data.hasOwnProperty('ssh');
 }
 
 export function isGitWithProxy(data: IGitHttps): data is IGitHTTPSProxy {
@@ -15,4 +26,14 @@ export function isGitInputWithHTTPS(project: Project): boolean {
 
 export function isGitUpstreamValidSet(gitUpstream: IGitData): gitUpstream is IRequiredGitData {
   return !!(gitUpstream.gitToken && gitUpstream.gitRemoteURL);
+}
+
+export function getGitData(data: IGitDataExtended): IGitHttps['https'] | IGitSsh['ssh'] | undefined {
+  if (isGitHTTPS(data)) {
+    return data.https;
+  }
+  if (isGitSSH(data)) {
+    return data.ssh;
+  }
+  return undefined;
 }

--- a/bridge/client/app/_utils/git-upstream.utils.ts
+++ b/bridge/client/app/_utils/git-upstream.utils.ts
@@ -37,3 +37,10 @@ export function getGitData(data: IGitDataExtended): IGitHttps['https'] | IGitSsh
   }
   return undefined;
 }
+
+export function isRemoteUrlEmpty(gitInputData: IGitDataExtended): boolean {
+  return (
+    (isGitHTTPS(gitInputData) && !gitInputData.https.gitRemoteURL) ||
+    (isGitSSH(gitInputData) && !gitInputData.ssh.gitRemoteURL)
+  );
+}

--- a/bridge/cypress/fixtures/metadata.ap-disabled.mock.json
+++ b/bridge/cypress/fixtures/metadata.ap-disabled.mock.json
@@ -1,0 +1,8 @@
+{
+  "bridgeversion": "docker.io/keptn/bridge2:0.9.0",
+  "keptnlabel": "keptn",
+  "keptnversion": "0.9.0",
+  "namespace": "keptn",
+  "shipyardversion": "0.2.0",
+  "automaticprovisioning": false
+}

--- a/bridge/cypress/fixtures/metadata.ap-enabled.mock.json
+++ b/bridge/cypress/fixtures/metadata.ap-enabled.mock.json
@@ -1,0 +1,8 @@
+{
+  "bridgeversion": "docker.io/keptn/bridge2:0.9.0",
+  "keptnlabel": "keptn",
+  "keptnversion": "0.9.0",
+  "namespace": "keptn",
+  "shipyardversion": "0.2.0",
+  "automaticprovisioning": true
+}

--- a/bridge/cypress/integration/project-create-extended.spec.ts
+++ b/bridge/cypress/integration/project-create-extended.spec.ts
@@ -83,7 +83,6 @@ describe('Create extended project https test', () => {
 
   it('should have enabled create button if invalid proxy form is disabled', () => {
     createProjectPage.enterBasicValidProjectHttps().setEnableProxy(true).assertCreateButtonEnabled(false);
-    cy.wait(200);
     createProjectPage.setEnableProxy(false).assertCreateButtonEnabled(true);
   });
 
@@ -275,7 +274,7 @@ describe('Create extended project test ssh and https', () => {
   });
 });
 
-describe('Create extended project with and with automatic provisioned git upstream', () => {
+describe('Create extended project with automatic provisioned git upstream', () => {
   const createProjectPage = new NewProjectCreatePage();
 
   beforeEach(() => {

--- a/bridge/cypress/integration/project-create-extended.spec.ts
+++ b/bridge/cypress/integration/project-create-extended.spec.ts
@@ -82,8 +82,12 @@ describe('Create extended project https test', () => {
   });
 
   it('should have enabled create button if invalid proxy form is disabled', () => {
-    createProjectPage.enterBasicValidProjectHttps().setEnableProxy(true).assertCreateButtonEnabled(false);
-    createProjectPage.setEnableProxy(false).assertCreateButtonEnabled(true);
+    createProjectPage
+      .enterBasicValidProjectHttps()
+      .setEnableProxy(true)
+      .assertCreateButtonEnabled(false)
+      .setEnableProxy(false)
+      .assertCreateButtonEnabled(true);
   });
 
   it('should not change validity to false of proxy form if username or password is entered', () => {

--- a/bridge/cypress/integration/project-create-extended.spec.ts
+++ b/bridge/cypress/integration/project-create-extended.spec.ts
@@ -277,3 +277,38 @@ describe('Create extended project test ssh and https', () => {
       .assertCreateButtonEnabled(true);
   });
 });
+
+describe('Create extended project with and with automatic provisioned git upstream', () => {
+  const createProjectPage = new NewProjectCreatePage();
+
+  beforeEach(() => {
+    createProjectPage.intercept(true, true).visit();
+  });
+
+  it('should show the no upstream option as default', () => {
+    createProjectPage.assertNoUpstreamSelected(true);
+  });
+
+  it('should enable the create button, if everything is filled and no upstream is selected', () => {
+    createProjectPage.enterBasicValidProjectWithoutGitUpstream().assertCreateButtonEnabled(true);
+  });
+
+  it('should disable the create button, if invalid https or ssh data is entered, and enable it again after no upstream is selected', () => {
+    createProjectPage
+      .assertNoUpstreamSelected(true)
+      .selectHttpsForm()
+      .enterBasicValidProjectHttps()
+      .assertCreateButtonEnabled(true)
+      .clearGitToken()
+      .assertCreateButtonEnabled(false);
+
+    createProjectPage
+      .selectSshForm()
+      .enterBasicValidProjectSsh()
+      .assertCreateButtonEnabled(true)
+      .clearSshPrivateKey()
+      .assertCreateButtonEnabled(false);
+
+    createProjectPage.selectNoUpstreamForm().assertCreateButtonEnabled(true);
+  });
+});

--- a/bridge/cypress/integration/project-create-extended.spec.ts
+++ b/bridge/cypress/integration/project-create-extended.spec.ts
@@ -82,12 +82,9 @@ describe('Create extended project https test', () => {
   });
 
   it('should have enabled create button if invalid proxy form is disabled', () => {
-    createProjectPage
-      .enterBasicValidProjectHttps()
-      .setEnableProxy(true)
-      .assertCreateButtonEnabled(false)
-      .setEnableProxy(false)
-      .assertCreateButtonEnabled(true);
+    createProjectPage.enterBasicValidProjectHttps().setEnableProxy(true).assertCreateButtonEnabled(false);
+    cy.wait(200);
+    createProjectPage.setEnableProxy(false).assertCreateButtonEnabled(true);
   });
 
   it('should not change validity to false of proxy form if username or password is entered', () => {

--- a/bridge/cypress/integration/project-settings.spec.ts
+++ b/bridge/cypress/integration/project-settings.spec.ts
@@ -70,7 +70,6 @@ describe('Git upstream extended settings project https test', () => {
     });
     projectSettingsPage.interceptSettings(true).visitSettings('sockshop');
 
-    cy.wait(200);
     projectSettingsPage.assertSshFormVisible(true).assertGitUsernameSsh('myGitUser');
   });
 

--- a/bridge/cypress/integration/project-settings.spec.ts
+++ b/bridge/cypress/integration/project-settings.spec.ts
@@ -83,7 +83,6 @@ describe('Automatic provisioning enabled test', () => {
 
   beforeEach(() => {
     projectSettingsPage.interceptSettings(true, true);
-    projectSettingsPage.visitSettings('sockshop');
   });
 
   it('should select no upstream radio button as default when no upstream was configured for a project', () => {
@@ -101,6 +100,7 @@ describe('Automatic provisioning enabled test', () => {
       body: project,
     }).as('project');
 
+    projectSettingsPage.visitSettings('sockshop');
     cy.wait('@metadata').wait('@project');
 
     projectSettingsPage.assertNoUpstreamSelected(true);
@@ -121,6 +121,7 @@ describe('Automatic provisioning enabled test', () => {
       body: project,
     }).as('project');
 
+    projectSettingsPage.visitSettings('sockshop');
     cy.wait('@metadata').wait('@project');
 
     projectSettingsPage.assertHttpsFormVisible(true).assertNoUpstreamSelected(false).assertNoUpstreamEnabled(false);
@@ -145,6 +146,7 @@ describe('Automatic provisioning enabled test', () => {
       body: project,
     }).as('project');
 
+    projectSettingsPage.visitSettings('sockshop');
     cy.wait('@metadata').wait('@project');
 
     projectSettingsPage.assertSshFormVisible(true).assertNoUpstreamSelected(false).assertNoUpstreamEnabled(false);

--- a/bridge/cypress/integration/project-settings.spec.ts
+++ b/bridge/cypress/integration/project-settings.spec.ts
@@ -122,11 +122,7 @@ describe('Automatic provisioning enabled test', () => {
       body: project,
     }).as('project');
 
-    // eslint-disable-next-line promise/catch-or-return
-    cy.wait('@metadata').then(() => {
-      cy.wait('@project');
-      return;
-    });
+    cy.wait('@metadata').wait('@project');
 
     projectSettingsPage.assertHttpsFormVisible(true).assertNoUpstreamSelected(false).assertNoUpstreamEnabled(false);
 
@@ -150,11 +146,7 @@ describe('Automatic provisioning enabled test', () => {
       body: project,
     }).as('project');
 
-    // eslint-disable-next-line promise/catch-or-return
-    cy.wait('@metadata').then(() => {
-      cy.wait('@project');
-      return;
-    });
+    cy.wait('@metadata').wait('@project');
 
     projectSettingsPage.assertSshFormVisible(true).assertNoUpstreamSelected(false).assertNoUpstreamEnabled(false);
 

--- a/bridge/cypress/support/intercept.ts
+++ b/bridge/cypress/support/intercept.ts
@@ -54,7 +54,13 @@ function getEvaluationUrls(project: string, service: string): string[] {
 }
 
 export function interceptMainResourceEnabled(): void {
-  cy.intercept('/api/v1/metadata', { fixture: 'metadata.mock' }).as('metadata');
+  cy.intercept('/api/v1/metadata', { fixture: 'metadata.ap-disabled.mock' }).as('metadata');
+  cy.intercept('/api/bridgeInfo', { fixture: 'bridgeInfoEnableResourceService.mock' });
+  cy.intercept('/api/controlPlane/v1/project?disableUpstreamSync=true&pageSize=50', { fixture: 'projects.mock' });
+}
+
+export function interceptMainResourceApEnabled(): void {
+  cy.intercept('/api/v1/metadata', { fixture: 'metadata.ap-enabled.mock' }).as('metadata');
   cy.intercept('/api/bridgeInfo', { fixture: 'bridgeInfoEnableResourceService.mock' });
   cy.intercept('/api/controlPlane/v1/project?disableUpstreamSync=true&pageSize=50', { fixture: 'projects.mock' });
 }

--- a/bridge/cypress/support/pageobjects/NewProjectCreatePage.ts
+++ b/bridge/cypress/support/pageobjects/NewProjectCreatePage.ts
@@ -24,10 +24,14 @@ class NewProjectCreatePage {
     return this;
   }
 
-  public interceptSettings(resourceServiceEnabled = false): this {
+  public interceptSettings(resourceServiceEnabled = false, automaticProvisioningEnabled = false): this {
     interceptProjectBoard();
     if (resourceServiceEnabled) {
-      interceptMainResourceEnabled();
+      if (!automaticProvisioningEnabled) {
+        interceptMainResourceEnabled();
+      } else {
+        interceptMainResourceApEnabled();
+      }
     } else {
       interceptMain();
     }
@@ -283,6 +287,10 @@ class NewProjectCreatePage {
     return this.typeProjectName('my-project').setShipyardFile();
   }
 
+  public enterBasicSsh(): this {
+    return this.typeGitUrlSsh('ssh://example.com').typeValidSshPrivateKey();
+  }
+
   public enterBasicValidProjectSsh(fillPrivateKey = true): this {
     this.typeProjectName('my-project').setShipyardFile().typeGitUrlSsh('ssh://example.com');
     if (fillPrivateKey) {
@@ -305,11 +313,12 @@ class NewProjectCreatePage {
       .assertSshPrivateKeyPassphrase('myPassphrase');
   }
 
+  public enterBasicHttps(): this {
+    return this.typeGitUrl('https://example.com').typeGitToken('myToken');
+  }
+
   public enterBasicValidProjectHttps(): this {
-    return this.typeProjectName('my-project')
-      .setShipyardFile()
-      .typeGitUrl('https://example.com')
-      .typeGitToken('myToken');
+    return this.typeProjectName('my-project').setShipyardFile().enterBasicHttps();
   }
 
   public enterFullValidProjectHttps(): this {
@@ -379,6 +388,13 @@ class NewProjectCreatePage {
     return this;
   }
 
+  public assertNoUpstreamEnabled(status: boolean): this {
+    cy.byTestId('ktb-no-upstream-form-button')
+      .get('input')
+      .should(status ? 'be.enabled' : 'be.disabled');
+    return this;
+  }
+
   public selectHttpsForm(): this {
     cy.byTestId('ktb-https-form-button').click();
     return this;
@@ -401,6 +417,11 @@ class NewProjectCreatePage {
 
   public assertUpdateButtonExists(status: boolean): this {
     cy.byTestId('ktb-project-update-button').should(status ? 'exist' : 'not.exist');
+    return this;
+  }
+
+  public assertUpdateButtonEnabled(status: boolean): this {
+    cy.byTestId('ktb-project-update-button').should(status ? 'be.enabled' : 'be.disabled');
     return this;
   }
 }

--- a/bridge/cypress/support/pageobjects/NewProjectCreatePage.ts
+++ b/bridge/cypress/support/pageobjects/NewProjectCreatePage.ts
@@ -1,14 +1,23 @@
 /// <reference types="cypress" />
 
-import { interceptMain, interceptMainResourceEnabled, interceptProjectBoard } from '../intercept';
+import {
+  interceptMain,
+  interceptMainResourceApEnabled,
+  interceptMainResourceEnabled,
+  interceptProjectBoard,
+} from '../intercept';
 
 class NewProjectCreatePage {
   private validCertificateInput = '-----BEGIN CERTIFICATE-----\nmyCertificate\n-----END CERTIFICATE-----';
   private validPrivateKeyInput = '-----BEGIN OPENSSH PRIVATE KEY-----\nmyPrivateKey\n-----END OPENSSH PRIVATE KEY-----';
 
-  public intercept(resourceServiceEnabled = false): this {
+  public intercept(resourceServiceEnabled = false, automaticProvisioningEnabled = false): this {
     if (resourceServiceEnabled) {
-      interceptMainResourceEnabled();
+      if (!automaticProvisioningEnabled) {
+        interceptMainResourceEnabled();
+      } else {
+        interceptMainResourceApEnabled();
+      }
     } else {
       interceptMain();
     }
@@ -92,6 +101,11 @@ class NewProjectCreatePage {
 
   public assertGitToken(token: string): this {
     cy.byTestId('ktb-git-token-input').should('have.value', token);
+    return this;
+  }
+
+  public clearGitToken(): this {
+    cy.byTestId('ktb-git-token-input').clear();
     return this;
   }
 
@@ -183,6 +197,11 @@ class NewProjectCreatePage {
     return this;
   }
 
+  public clearSshPrivateKey(): this {
+    cy.byTestId('ktb-ssh-private-key-input').clear();
+    return this;
+  }
+
   public typeSshPrivateKeyPassphrase(passphrase: string): this {
     cy.byTestId('ktb-ssh-private-key-passphrase-input').type(passphrase);
     return this;
@@ -258,6 +277,10 @@ class NewProjectCreatePage {
       .find('input')
       .should(status ? 'be.checked' : 'not.be.checked');
     return this;
+  }
+
+  public enterBasicValidProjectWithoutGitUpstream(): this {
+    return this.typeProjectName('my-project').setShipyardFile();
   }
 
   public enterBasicValidProjectSsh(fillPrivateKey = true): this {
@@ -351,6 +374,11 @@ class NewProjectCreatePage {
     return this;
   }
 
+  public assertNoUpstreamSelected(status: boolean): this {
+    cy.byTestId('ktb-no-upstream-form-button').should(status ? 'have.class' : 'not.have.class', 'dt-radio-checked');
+    return this;
+  }
+
   public selectHttpsForm(): this {
     cy.byTestId('ktb-https-form-button').click();
     return this;
@@ -358,6 +386,11 @@ class NewProjectCreatePage {
 
   public selectSshForm(): this {
     cy.byTestId('ktb-ssh-form-button').click();
+    return this;
+  }
+
+  public selectNoUpstreamForm(): this {
+    cy.byTestId('ktb-no-upstream-form-button').click();
     return this;
   }
 


### PR DESCRIPTION
Add the option for the git extended forms (create project & project settings) to configure no upstream when automation provisioning is true.
<img width="640" alt="image" src="https://user-images.githubusercontent.com/2674029/167116925-f6221b6f-e04e-45f1-83e2-2cc2d2f41d2a.png">
