### PR TITLE
feat: Change default values of preStop hook time and grace period

### DIFF
--- a/helm-service/chart/values.yaml
+++ b/helm-service/chart/values.yaml
@@ -5,8 +5,8 @@ helmservice:
     tag: ""                                  # Container Tag
   service:
     enabled: true                            # Creates a Kubernetes Service for the helm-service
-  gracePeriod: 90                            # PreStop hook time +30s
-  preStopHookTime: 60
+  gracePeriod: 60
+  preStopHookTime: 5
 
 distributor:
   stageFilter: ""                            # Stage to which this helm service belongs; default=all; comma-separated list to filter for set of stages

--- a/installer/manifests/keptn/charts/control-plane/templates/shipyard-controller.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/shipyard-controller.yaml
@@ -37,7 +37,6 @@ spec:
       containers:
         - name: shipyard-controller
           image: {{ .Values.shipyardController.image.repository }}:{{ .Values.shipyardController.image.tag | default .Chart.AppVersion }}
-          {{- $prestop := .Values.shipyardController.preStopHookTime | default 90 | quote -}}
           lifecycle:
             preStop:
               httpGet:

--- a/installer/manifests/keptn/charts/control-plane/templates/shipyard-controller.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/shipyard-controller.yaml
@@ -38,7 +38,12 @@ spec:
         - name: shipyard-controller
           image: {{ .Values.shipyardController.image.repository }}:{{ .Values.shipyardController.image.tag | default .Chart.AppVersion }}
           {{- $prestop := .Values.shipyardController.preStopHookTime | default 90 | quote -}}
-          {{- include "control-plane.prestop" $prestop | nindent 10 }}
+          lifecycle:
+            preStop:
+              httpGet:
+                port: 8081
+                path: /operations/v1/pre-stop
+                host: localhost
           livenessProbe:
             httpGet:
               path: /health
@@ -85,6 +90,8 @@ spec:
               value: {{ .Values.shipyardController.config.taskStartedWaitDuration | default "10m"}}
             - name: UNIFORM_INTEGRATION_TTL
               value: {{ .Values.shipyardController.config.uniformIntegrationTTL | default "2m" }}
+            - name: PRE_STOP_HOOK_TIME
+              value: {{ .Values.shipyardController.preStopHookTime | default 5 | quote }}
             - name: LOG_LEVEL
               value: {{ .Values.logLevel | default "info" }}
             - name: AUTOMATIC_PROVISIONING_URL

--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -184,7 +184,7 @@ secretService:
     repository: docker.io/keptn/secret-service
     tag: ""
   nodeSelector: {}
-  gracePeriod: 60     # gracePeriod set to preStop hook time +30s
+  gracePeriod: 60
   preStopHookTime: 5
 
 configurationService:

--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -73,16 +73,16 @@ apiGatewayNginx:
     repository: docker.io/nginxinc/nginx-unprivileged
     tag: 1.21.6-alpine
   nodeSelector: {}
-  gracePeriod: 120     # gracePeriod set to preStop hook time +30s
-  preStopHookTime: 90
+  gracePeriod: 60
+  preStopHookTime: 5
 
 remediationService:
   image:
     repository: docker.io/keptn/remediation-service
     tag: ""
   nodeSelector: {}
-  gracePeriod: 120     # gracePeriod set to preStop hook time +30s
-  preStopHookTime: 90
+  gracePeriod: 60
+  preStopHookTime: 5
 
 apiService:
   tokenSecretName:
@@ -94,8 +94,8 @@ apiService:
     requestsPerSecond: "1.0"
     requestBurst: "2"
   nodeSelector: {}
-  gracePeriod: 120     # gracePeriod set to preStop hook time +30s
-  preStopHookTime: 90
+  gracePeriod: 60
+  preStopHookTime: 5
 
 bridge:
   image:
@@ -176,16 +176,16 @@ shipyardController:
       # If the helm chart generation for blue/green deployments is not needed, and this value is too small, it can be adapted here
       serviceNameMaxSize: 43
   nodeSelector: {}
-  gracePeriod: 120     # gracePeriod set to preStop hook time +30s
-  preStopHookTime: 90
+  gracePeriod: 60
+  preStopHookTime: 15 # 15s instead of 5s to give background jobs such as sequence dispatcher or jetstream client enough time to complete their tasks
 
 secretService:
   image:
     repository: docker.io/keptn/secret-service
     tag: ""
   nodeSelector: {}
-  gracePeriod: 120     # gracePeriod set to preStop hook time +30s
-  preStopHookTime: 90
+  gracePeriod: 60     # gracePeriod set to preStop hook time +30s
+  preStopHookTime: 5
 
 configurationService:
   image:
@@ -200,8 +200,8 @@ configurationService:
     GIT_KEPTN_USER: "keptn"
     GIT_KEPTN_EMAIL: "keptn@keptn.sh"
   nodeSelector: {}
-  gracePeriod: 120     # gracePeriod set to preStop hook time +30s
-  preStopHookTime: 90
+  gracePeriod: 60
+  preStopHookTime: 5
 
 resourceService:
   enabled: false
@@ -214,40 +214,40 @@ resourceService:
     GIT_KEPTN_EMAIL: "keptn@keptn.sh"
     DIRECTORY_STAGE_STRUCTURE: "false"
   nodeSelector: {}
-  gracePeriod: 120     # gracePeriod set to preStop hook time +30s
-  preStopHookTime: 90
+  gracePeriod: 60
+  preStopHookTime: 5
 
 mongodbDatastore:
   image:
     repository: docker.io/keptn/mongodb-datastore
     tag: ""
   nodeSelector: {}
-  gracePeriod: 120     # gracePeriod set to preStop hook time +30s
-  preStopHookTime: 90
+  gracePeriod: 60
+  preStopHookTime: 5
 
 lighthouseService:
   image:
     repository: docker.io/keptn/lighthouse-service
     tag: ""
   nodeSelector: {}
-  gracePeriod: 120     # gracePeriod set to preStop hook time +30s
-  preStopHookTime: 90
+  gracePeriod: 60
+  preStopHookTime: 5
 
 statisticsService:
   image:
     repository: docker.io/keptn/statistics-service
     tag: ""
   nodeSelector: {}
-  gracePeriod: 120     # gracePeriod set to preStop hook time +30s
-  preStopHookTime: 90
+  gracePeriod: 60
+  preStopHookTime: 5
 
 approvalService:
   image:
     repository: docker.io/keptn/approval-service
     tag: ""
   nodeSelector: {}
-  gracePeriod: 120     # gracePeriod set to preStop hook time +30s
-  preStopHookTime: 90
+  gracePeriod: 60
+  preStopHookTime: 5
 
 webhookService:
   enabled: true
@@ -255,8 +255,8 @@ webhookService:
     repository: docker.io/keptn/webhook-service
     tag: ""
   nodeSelector: {}
-  gracePeriod: 120     # gracePeriod set to preStop hook time +30s
-  preStopHookTime: 90
+  gracePeriod: 60
+  preStopHookTime: 5
 
 ingress:
   enabled: false

--- a/jmeter-service/chart/values.yaml
+++ b/jmeter-service/chart/values.yaml
@@ -5,8 +5,8 @@ jmeterservice:
     tag: ""                                    # Container Tag
   service:
     enabled: true                              # Creates a Kubernetes Service for the jmeter-service
-  gracePeriod: 120                             # PreStop hook time +30s
-  preStopHookTime: 90
+  gracePeriod: 60
+  preStopHookTime: 5
 
 distributor:
   stageFilter: ""                            # Sets the stage this helm service belongs to

--- a/shipyard-controller/config/envconfig.go
+++ b/shipyard-controller/config/envconfig.go
@@ -16,4 +16,7 @@ type EnvConfig struct {
 	// AutomaticProvisioningURL is a URL to a REST API to provision
 	// git credentials if they are not set by the user
 	AutomaticProvisioningURL string `envconfig:"AUTOMATIC_PROVISIONING_URL" default:""`
+	// PreStopHookTime is the duration of the preStop hook. The duration defined via this value will be the duration between signaling the
+	// termination of the shipyard-controller's pod and the reception of the SIGTERM signal
+	PreStopHookTime int `envconfig:"PRE_STOP_HOOK_TIME" default:"5"`
 }

--- a/shipyard-controller/main.go
+++ b/shipyard-controller/main.go
@@ -329,7 +329,7 @@ func main() {
 		}
 	}()
 
-	GracefulShutdown(wg, srv, func() {})
+	GracefulShutdown(wg, srv)
 }
 
 func LeaderElection(client v1.CoordinationV1Interface, ctx context.Context, start func(ctx context.Context, mode common.SDMode), stop func()) {
@@ -384,15 +384,13 @@ func LeaderElection(client v1.CoordinationV1Interface, ctx context.Context, star
 	})
 }
 
-func GracefulShutdown(wg *sync.WaitGroup, srv *http.Server, onSigTerm func()) {
+func GracefulShutdown(wg *sync.WaitGroup, srv *http.Server) {
 	// Wait for interrupt signal to gracefully shut down the server
 	quit := make(chan os.Signal, 1)
 
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	<-quit
 	log.Println("Shutting down server...")
-
-	go onSigTerm()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/shipyard-controller/main.go
+++ b/shipyard-controller/main.go
@@ -308,6 +308,9 @@ func main() {
 
 	operationsV1.GET("/pre-stop", func(c *gin.Context) {
 		log.Debug("PreStop hook has been called.")
+		// invoke the cancel() function to shut down the periodically executed
+		// tasks such as nats subscription, sequence watcher, sequence dispatcher, event dispatcher
+		// this should ensure that no iteration of either of these tasks is attempted to be started right before the termination of the pod
 		cancel()
 		log.Debugf("PreStop: Sleeping for %d seconds", env.PreStopHookTime)
 		<-time.After(time.Duration(env.PreStopHookTime) * time.Second)
@@ -326,12 +329,7 @@ func main() {
 		}
 	}()
 
-	GracefulShutdown(wg, srv, func() {
-		// invoke the cancel() function to shut down the periodically executed
-		// tasks such as nats subscription, sequence watcher, sequence dispatcher, event dispatcher
-		// this should ensure that no iteration of either of these tasks is attempted to be started right before the termination of the pod
-		//cancel()
-	})
+	GracefulShutdown(wg, srv, func() {})
 }
 
 func LeaderElection(client v1.CoordinationV1Interface, ctx context.Context, start func(ctx context.Context, mode common.SDMode), stop func()) {


### PR DESCRIPTION
Part of #7613

This PR changes the default values of the preStop hook time and grace period to 5s/60s respectively.

For the shipyard-controller, an internal preStop hook endpoint is introduced, which will take care of unsubscribing from nats and shutting down background tasks, such as the sequence dispatcher/event dispatcher, as well as waiting a defined number of seconds before the sigterm signal is sent to the container

Integration test run: https://github.com/keptn/keptn/actions/runs/2304981277