### PR TITLE
test(bridge): Fixed flaky create project UI test

### DIFF
--- a/bridge/cypress/fixtures/create.project.request.body.json
+++ b/bridge/cypress/fixtures/create.project.request.body.json
@@ -2,6 +2,6 @@
   "gitRemoteUrl": "https://git-repo.com",
   "gitToken": "testtoken",
   "gitUser": "carpe-github-username",
-  "name": "test-project-bycypress-001",
+  "name": "sockshop",
   "shipyard": "YXBpVmVyc2lvbjogInNwZWMua2VwdG4uc2gvMC4yLjAiCmtpbmQ6ICJTaGlweWFyZCIKbWV0YWRhdGE6CiAgbmFtZTogInNoaXB5YXJkLXF1YWxpdHktZ2F0ZXMiCnNwZWM6CiAgc3RhZ2VzOgogICAgLSBuYW1lOiAicXVhbGl0eS1nYXRlLXRlc3QiCg=="
 }

--- a/bridge/cypress/integration/project-create.spec.ts
+++ b/bridge/cypress/integration/project-create.spec.ts
@@ -1,26 +1,25 @@
 /// <reference types="cypress" />
 import DashboardPage from '../support/pageobjects/DashboardPage';
+import NewProjectCreatePage from '../support/pageobjects/NewProjectCreatePage';
 
 describe('Create new project test', () => {
   it('test new project create', () => {
     const dashboardPage = new DashboardPage();
+    const createProjectPage = new NewProjectCreatePage();
     const GIT_USERNAME = 'carpe-github-username';
-    const PROJECT_NAME = 'test-project-bycypress-001';
+    const PROJECT_NAME = 'sockshop';
     const GIT_REMOTE_URL = 'https://git-repo.com';
     const GIT_TOKEN = 'testtoken';
-    cy.fixture('get.project.json').as('initProjectJSON');
-    cy.fixture('metadata.json').as('initmetadata');
 
-    cy.intercept('/api/bridgeInfo', { fixture: 'bridgeInfo.mock' });
-    cy.intercept('GET', 'api/v1/metadata', { fixture: 'metadata' }).as('metadataCmpl');
+    dashboardPage.intercept();
+    createProjectPage.intercept().interceptSettings();
+
+    cy.intercept('/api/project/sockshop', { fixture: 'project.mock' });
     cy.intercept('GET', 'api/controlPlane/v1/project?disableUpstreamSync=true&pageSize=50', {
-      fixture: 'get.project.json',
-    }).as('initProjects');
-
-    cy.intercept('POST', 'api/controlPlane/v1/project', {
-      statusCode: 200,
-      body: {},
-    }).as('createProjectUrl');
+      body: {
+        projects: [],
+      },
+    });
 
     // eslint-disable-next-line promise/catch-or-return,promise/always-return
     cy.fixture('create.project.request.body').then((reqBody) => {
@@ -30,19 +29,8 @@ describe('Create new project test', () => {
       });
     });
 
-    cy.intercept('GET', 'api/controlPlane/v1/sequence/dynatrace?pageSize=5', { fixture: 'project.sequences' });
-
-    cy.intercept('GET', 'api/project/testproject?approval=true&remediation=true', {
-      statusCode: 200,
-    }).as('projectApproval');
-
-    cy.intercept('GET', 'api/controlPlane/v1/project?disableUpstreamSync=true&pageSize=50', {
-      statusCode: 200,
-    }).as('disableUpstreamSync');
-
-    cy.visit('/');
-    cy.wait('@metadataCmpl');
     dashboardPage
+      .visit()
       .clickCreateNewProjectButton()
       .typeProjectName(PROJECT_NAME)
       .typeGitUrl(GIT_REMOTE_URL)

--- a/bridge/cypress/support/intercept.ts
+++ b/bridge/cypress/support/intercept.ts
@@ -80,6 +80,10 @@ export function interceptMain(): void {
   cy.intercept('/api/controlPlane/v1/project?disableUpstreamSync=true&pageSize=50', { fixture: 'projects.mock' });
 }
 
+export function interceptCreateProject(): void {
+  cy.intercept('/api/project/sockshop', { fixture: 'project.mock' });
+}
+
 export function interceptDashboard(): void {
   interceptMain();
   cy.intercept('/api/controlPlane/v1/sequence/sockshop?pageSize=5', { fixture: 'sequences.sockshop' }).as('sequences');

--- a/bridge/cypress/support/pageobjects/NewProjectCreatePage.ts
+++ b/bridge/cypress/support/pageobjects/NewProjectCreatePage.ts
@@ -1,6 +1,11 @@
 /// <reference types="cypress" />
 
-import { interceptMain, interceptMainResourceEnabled, interceptProjectBoard } from '../intercept';
+import {
+  interceptCreateProject,
+  interceptMain,
+  interceptMainResourceEnabled,
+  interceptProjectBoard,
+} from '../intercept';
 
 class NewProjectCreatePage {
   private validCertificateInput = '-----BEGIN CERTIFICATE-----\nmyCertificate\n-----END CERTIFICATE-----';
@@ -12,6 +17,7 @@ class NewProjectCreatePage {
     } else {
       interceptMain();
     }
+    interceptCreateProject();
     return this;
   }
 


### PR DESCRIPTION
There was a flaky test in `project-create.spec.ts`.
Fix: Added missing API mocks.

Cause: Missing API mocks.
On create, there were two calls that failed. Because nothing after the creation is validated the two calls sometimes came in and sometimes did not.


Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>