### PR TITLE
fix: Reverted to GKE 21

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -78,7 +78,7 @@ jobs:
             REMOTE_EXECUTION_PLANE: "true"
             COLLECT_RESOURCE_LIMITS: "false"
           - CLOUD_PROVIDER: "GKE"
-            PLATFORM_VERSION: "1.22"
+            PLATFORM_VERSION: "1.21"
             CLUSTER_NAME: "keptn-integration-test-2"
             KUBECONFIG: ""
             PLATFORM: "kubernetes"

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         include:
           - CLOUD_PROVIDER: "GKE"
-            PLATFORM_VERSION: "1.22"
+            PLATFORM_VERSION: "1.21"
             CLUSTER_NAME: "keptn-integration-test-2"
             KUBECONFIG: ""
             PLATFORM: "kubernetes"

--- a/cli/main.go
+++ b/cli/main.go
@@ -14,7 +14,7 @@ var (
 
 const (
 	// DefaultKubeServerVersionConstraints is used when no version is passed by ldflags
-	DefaultKubeServerVersionConstraints = ">= 1.14, <= 1.22"
+	DefaultKubeServerVersionConstraints = ">= 1.14, <= 1.21"
 )
 
 func init() {


### PR DESCRIPTION
Signed-off-by: RealAnna <anna.reale@dynatrace.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- temporary reverts integration tests and CLI checks to  1.21

