### PR TITLE
chore(bridge): Remove dev-dependency jest-fetch-mock

### DIFF
--- a/bridge/client/app/_services/api.service.ts
+++ b/bridge/client/app/_services/api.service.ts
@@ -30,6 +30,8 @@ import { IScopesResult } from '../_interfaces/scopes-result';
 import { SecretScope } from '../../../shared/interfaces/secret-scope';
 import { IGitHttps, IGitSsh } from '../_interfaces/git-upstream';
 import { ICustomSequences } from '../../../shared/interfaces/custom-sequences';
+import { environment } from '../../environments/environment';
+import { WindowConfig } from '../../environments/environment.dynamic';
 
 @Injectable({
   providedIn: 'root',
@@ -533,5 +535,9 @@ export class ApiService {
 
   public getSecretScopes(): Observable<IScopesResult> {
     return this.http.get<IScopesResult>(`${this._baseUrl}/secrets/v1/scope`);
+  }
+
+  public getLookAndFeelConfig(): Observable<WindowConfig | undefined> {
+    return this.http.get<WindowConfig | undefined>(environment.appConfigUrl);
   }
 }

--- a/bridge/client/app/_services/app.init.ts
+++ b/bridge/client/app/_services/app.init.ts
@@ -1,46 +1,39 @@
 import { Injectable } from '@angular/core';
-import { environment } from '../../environments/environment';
 import { WindowConfig } from '../../environments/environment.dynamic';
-
-declare global {
-  interface Window {
-    config: WindowConfig;
-  }
-}
+import { ApiService } from './api.service';
+import { environment } from '../../environments/environment';
 
 @Injectable()
 export class AppInitService {
-  public init(): Promise<null | string> {
-    return new Promise((resolve) => {
-      fetch(environment.appConfigUrl)
-        .then((response) => response.text())
-        .then((config) => {
-          try {
-            if (config) {
-              Object.defineProperty(window, 'config', {
-                value: JSON.parse(config),
-              });
+  constructor(private apiService: ApiService) {}
 
-              if (window.config?.stylesheetUrl) {
-                const body = document.getElementsByTagName('body')[0];
-                const link = document.createElement('link');
-                link.setAttribute('rel', 'stylesheet');
-                link.setAttribute('type', 'text/css');
-                link.setAttribute('href', window.config.stylesheetUrl);
-                link.setAttribute('media', 'all');
-                body.appendChild(link);
-              }
-            }
-          } catch (err) {
-            console.error('Error parsing app-config.json:', err);
+  public init(): Promise<null | WindowConfig> {
+    return new Promise((resolve) => {
+      this.apiService.getLookAndFeelConfig().subscribe(
+        (config) => {
+          if (!config) {
+            return;
           }
+          environment.config = config;
+
+          if (!config.stylesheetUrl) {
+            return;
+          }
+          const body = document.getElementsByTagName('body')[0];
+          const link = document.createElement('link');
+          link.setAttribute('rel', 'stylesheet');
+          link.setAttribute('type', 'text/css');
+          link.setAttribute('href', config.stylesheetUrl);
+          link.setAttribute('media', 'all');
+          body.appendChild(link);
 
           return resolve(config);
-        })
-        .catch((err) => {
+        },
+        (err) => {
           console.error('Error loading app-config.json.', err);
-          return resolve(null);
-        });
+          resolve(null);
+        }
+      );
     });
   }
 }

--- a/bridge/client/app/_services/app.init.ts
+++ b/bridge/client/app/_services/app.init.ts
@@ -12,11 +12,13 @@ export class AppInitService {
       this.apiService.getLookAndFeelConfig().subscribe(
         (config) => {
           if (!config) {
+            resolve(null);
             return;
           }
           environment.config = config;
 
           if (!config.stylesheetUrl) {
+            resolve(config);
             return;
           }
           const body = document.getElementsByTagName('body')[0];
@@ -27,7 +29,7 @@ export class AppInitService {
           link.setAttribute('media', 'all');
           body.appendChild(link);
 
-          return resolve(config);
+          resolve(config);
         },
         (err) => {
           console.error('Error loading app-config.json.', err);

--- a/bridge/client/app/app-header/app-header.component.ts
+++ b/bridge/client/app/app-header/app-header.component.ts
@@ -27,15 +27,15 @@ export class AppHeaderComponent implements OnInit, OnDestroy {
   public projects: Observable<Project[] | undefined>;
   public selectedProject: string | undefined;
   public projectBoardView = '';
-  public appTitle = environment?.config?.appTitle;
-  public logoUrl = environment?.config?.logoUrl;
-  public logoInvertedUrl = environment?.config?.logoInvertedUrl;
+  public appTitle = environment.config.appTitle;
+  public logoUrl = environment.config.logoUrl;
+  public logoInvertedUrl = environment.config.logoInvertedUrl;
   public keptnInfo?: KeptnInfo;
   public versionCheckDialogState: string | null = null;
   public versionCheckReference = '/reference/version_check/';
 
   constructor(
-    @Inject(DOCUMENT) private _document: HTMLDocument,
+    @Inject(DOCUMENT) private _document: Document,
     private router: Router,
     private dataService: DataService,
     private notificationsService: NotificationsService,

--- a/bridge/client/app/app.module.ts
+++ b/bridge/client/app/app.module.ts
@@ -167,11 +167,12 @@ import { KtbCertificateInputComponent } from './_components/ktb-certificate-inpu
 import { KtbSshKeyInputComponent } from './_components/ktb-ssh-key-input/ktb-ssh-key-input.component';
 import { KtbProjectSettingsGitSshInputComponent } from './_components/ktb-project-settings-git-ssh-input/ktb-project-settings-git-ssh-input.component';
 import { SanitizeHtmlPipe } from './_pipes/sanitize-html.pipe';
+import { WindowConfig } from '../environments/environment.dynamic';
 
 registerLocaleData(localeEn, 'en');
 
 export function init_app(appLoadService: AppInitService): () => Promise<unknown> {
-  return (): Promise<string | null> => appLoadService.init();
+  return (): Promise<WindowConfig | null> => appLoadService.init();
 }
 
 @NgModule({

--- a/bridge/client/environments/environment.dynamic.ts
+++ b/bridge/client/environments/environment.dynamic.ts
@@ -5,34 +5,20 @@ export interface WindowConfig {
   stylesheetUrl?: string;
 }
 
-declare global {
-  interface Window {
-    config: WindowConfig;
-  }
-}
-
 export class DynamicEnvironment {
-  public appTitle?: string;
-  public logoUrl?: string;
-  public logoInvertedUrl?: string;
   public production: boolean;
   public appConfigUrl: string;
   public baseUrl: string;
   public pollingIntervalMillis?: number;
+  public config: WindowConfig = {
+    appTitle: 'keptn',
+    logoUrl: 'assets/default-branding/logo.png',
+    logoInvertedUrl: 'assets/default-branding/logo_inverted.png',
+  };
 
   constructor() {
     this.production = false;
     this.appConfigUrl = 'assets/default-branding/app-config.json';
     this.baseUrl = '/';
-  }
-
-  public get config(): WindowConfig {
-    return (
-      window.config || {
-        appTitle: 'keptn',
-        logoUrl: 'assets/default-branding/logo.png',
-        logoInvertedUrl: 'assets/default-branding/logo_inverted.png',
-      }
-    );
   }
 }

--- a/bridge/client/environments/environment.dynamic.ts
+++ b/bridge/client/environments/environment.dynamic.ts
@@ -11,7 +11,7 @@ export class DynamicEnvironment {
   public baseUrl: string;
   public pollingIntervalMillis?: number;
   public config: WindowConfig = {
-    appTitle: 'keptn',
+    appTitle: 'Keptn',
     logoUrl: 'assets/default-branding/logo.png',
     logoInvertedUrl: 'assets/default-branding/logo_inverted.png',
   };

--- a/bridge/jest.setup.ts
+++ b/bridge/jest.setup.ts
@@ -1,6 +1,15 @@
 import 'jest-preset-angular';
 import 'jest-preset-angular/setup-jest';
+import { Injectable } from '@angular/core';
+import { WindowConfig } from './client/environments/environment.dynamic';
 import { TestUtils } from './client/app/_utils/test.utils';
+
+@Injectable()
+class AppInitServiceMock {
+  public init(): Promise<null | WindowConfig> {
+    return Promise.resolve(null);
+  }
+}
 
 Object.defineProperty(window, 'DragEvent', {
   value: class DragEvent {},
@@ -9,3 +18,4 @@ Object.defineProperty(window, 'DragEvent', {
 TestUtils.mockWindowMatchMedia();
 
 jest.setTimeout(30000);
+jest.mock('./client/app/_services/app.init', () => ({ AppInitService: AppInitServiceMock }));

--- a/bridge/jest.setup.ts
+++ b/bridge/jest.setup.ts
@@ -1,9 +1,6 @@
 import 'jest-preset-angular';
 import 'jest-preset-angular/setup-jest';
-import fetchMock from 'jest-fetch-mock';
 import { TestUtils } from './client/app/_utils/test.utils';
-
-fetchMock.enableMocks();
 
 Object.defineProperty(window, 'DragEvent', {
   value: class DragEvent {},

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -104,7 +104,6 @@
     "eslint-plugin-prettier": "4.0.0",
     "eslint-plugin-promise": "6.0.0",
     "jest": "27.5.1",
-    "jest-fetch-mock": "3.0.3",
     "jest-preset-angular": "11.1.2",
     "minimist": "1.2.6",
     "npm-run-all": "4.1.5",

--- a/bridge/server/app.ts
+++ b/bridge/server/app.ts
@@ -257,15 +257,19 @@ function setupLookAndFeel(url: string): void {
         response.pipe(file);
         file.on('finish', () => {
           file.end();
-          const zip = new AdmZip(destFile);
-          zip.extractAllToAsync(destDir, true, false, (error?: Error) => {
-            unlinkSync(destFile);
-            if (error) {
-              console.error(`[ERROR] Error while extracting custom Look-and-Feel file. ${error}`);
-              return;
-            }
-            console.log('Custom Look-and-Feel downloaded and extracted successfully');
-          });
+          try {
+            const zip = new AdmZip(destFile); // throws an error if unsupported format
+            zip.extractAllToAsync(destDir, true, false, (error?: Error) => {
+              unlinkSync(destFile);
+              if (error) {
+                console.error(`[ERROR] Error while extracting custom Look-and-Feel file. ${error}`);
+                return;
+              }
+              console.log('Custom Look-and-Feel downloaded and extracted successfully');
+            });
+          } catch (error) {
+            console.error(`[ERROR] Error while extracting custom Look-and-Feel file. ${error}`);
+          }
         });
         file.on('error', async (err) => {
           file.end();

--- a/bridge/yarn.lock
+++ b/bridge/yarn.lock
@@ -4447,13 +4447,6 @@ critters@0.0.12:
     postcss "^8.3.7"
     pretty-bytes "^5.3.0"
 
-cross-fetch@^3.0.4:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.4.tgz#9723f3a3a247bf8b89039f3a380a9244e8fa2f39"
-  integrity sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==
-  dependencies:
-    node-fetch "2.6.1"
-
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -7677,14 +7670,6 @@ jest-environment-node@^27.5.1:
     jest-mock "^27.5.1"
     jest-util "^27.5.1"
 
-jest-fetch-mock@3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz#31749c456ae27b8919d69824f1c2bd85fe0a1f3b"
-  integrity sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
-  dependencies:
-    cross-fetch "^3.0.4"
-    promise-polyfill "^8.1.3"
-
 jest-get-type@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.5.1.tgz#3cd613c507b0f7ace013df407a1c1cd578bcb4f1"
@@ -8938,11 +8923,6 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-fetch@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
-
 node-forge@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
@@ -10141,11 +10121,6 @@ promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
-
-promise-polyfill@^8.1.3:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.2.0.tgz#367394726da7561457aba2133c9ceefbd6267da0"
-  integrity sha512-k/TC0mIcPVF6yHhUvwAp7cvL6I2fFV7TzF1DuGPI8mBh4QQazf36xCKEHKTZKRysEoTQoQdKyP25J8MPJp7j5g==
 
 promise-retry@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
- Removes dev dependency `jest-fetch-mock`
- Adapted fetching the config for the look and feel (with `HttpClient` instead of `fetch`)
- Removed data stored in `window.config` and instead correctly save it in the environment file
- Additional error check for fetching the look and feel zip file

Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>