### PR TITLE
fix(approval-service): Use deployment name for registration name to fix queue group functionality

### DIFF
--- a/approval-service/main.go
+++ b/approval-service/main.go
@@ -22,8 +22,6 @@ import (
 	"github.com/keptn/keptn/cp-connector/pkg/nats"
 )
 
-const envVarLogLevel = "LOG_LEVEL"
-
 type envConfig struct {
 	K8SDeploymentName      string `envconfig:"K8S_DEPLOYMENT_NAME" default:""`
 	K8SDeploymentVersion   string `envconfig:"K8S_DEPLOYMENT_VERSION" default:""`

--- a/approval-service/main.go
+++ b/approval-service/main.go
@@ -122,7 +122,7 @@ func (as ApprovalService) OnEvent(ctx context.Context, event models.KeptnContext
 
 func (l ApprovalService) RegistrationData() controlplane.RegistrationData {
 	return controlplane.RegistrationData{
-		Name: l.env.K8SPodName,
+		Name: l.env.K8SDeploymentName,
 		MetaData: models.MetaData{
 			Hostname:           l.env.K8SNodeName,
 			IntegrationVersion: l.env.K8SDeploymentVersion,


### PR DESCRIPTION
Since the nats event source uses the `registrationData.Name` property as the queue group identified, this needs to be set to the name of the deployment, instead of the pod name. Otherwise, each pod of the approval-service deployment would receive a copy of every event.