### PR TITLE
feat(approval-service): Consider nats connection in readiness probe

### DIFF
--- a/approval-service/main.go
+++ b/approval-service/main.go
@@ -143,7 +143,6 @@ func (l ApprovalService) RegistrationData() controlplane.RegistrationData {
 }
 
 func getGracefulContext() context.Context {
-
 	ch := make(chan os.Signal)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
 	wg := &sync.WaitGroup{}
@@ -151,13 +150,11 @@ func getGracefulContext() context.Context {
 	ctx = cloudevents.WithEncodingStructured(ctx)
 	go func() {
 		<-ch
-		logger.Info("Container termination triggered, starting graceful shutdown")
-		logger.Info("Cancelling context")
+		logger.Info("Container termination triggered, starting graceful shutdown and cancelling context")
 		cancel()
 		logger.Info("Waiting for event handlers to finish")
 		wg.Wait()
 		logger.Info("All handlers finished - ready to shut down")
-
 	}()
 	return ctx
 }

--- a/approval-service/main.go
+++ b/approval-service/main.go
@@ -152,11 +152,11 @@ func getGracefulContext() context.Context {
 	go func() {
 		<-ch
 		logger.Info("Container termination triggered, starting graceful shutdown")
-		logger.Info("cancelling context")
+		logger.Info("Cancelling context")
 		cancel()
-		logger.Info("waiting for event handlers to finish")
+		logger.Info("Waiting for event handlers to finish")
 		wg.Wait()
-		logger.Info("all handlers finished - ready to shut down")
+		logger.Info("All handlers finished - ready to shut down")
 
 	}()
 	return ctx


### PR DESCRIPTION
Part of #7613
This PR modifies the readiness probe of the approval service to consider the current state of the control plane connector. The service will now be considered ready, only when it's connected to the controlplane. Until that is the case, previous pods of the approval-service will not be terminated. This will ensure that there is always at least one replica available that is ready to receive events.

Integration test run: https://github.com/keptn/keptn/actions/runs/2313756860