### PR TITLE
feat: Add ability to customize client_max_body_size in the nginx gateway

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/templates/api-gateway-nginx.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/api-gateway-nginx.yaml
@@ -55,7 +55,9 @@ data:
           listen       8080;
           server_name  _;
 
-          client_max_body_size {{ .Values.apiGatewayNginx.clientMaxBodySize | default "1m" }};
+          {{- if .Values.apiGatewayNginx.clientMaxBodySize }}
+            client_max_body_size {{ .Values.apiGatewayNginx.clientMaxBodySize }};
+          {{- end }}
 
           include /etc/nginx/keptn-endpoints-pre-0-7.conf;
           include /etc/nginx/keptn-endpoints.conf;

--- a/installer/manifests/keptn/charts/control-plane/templates/api-gateway-nginx.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/api-gateway-nginx.yaml
@@ -55,6 +55,8 @@ data:
           listen       8080;
           server_name  _;
 
+          client_max_body_size {{ .Values.apiGatewayNginx.clientMaxBodySize | default "1m" }};
+
           include /etc/nginx/keptn-endpoints-pre-0-7.conf;
           include /etc/nginx/keptn-endpoints.conf;
       }

--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -75,6 +75,7 @@ apiGatewayNginx:
   nodeSelector: {}
   gracePeriod: 60
   preStopHookTime: 5
+  clientMaxBodySize: "1m"
 
 remediationService:
   image:

--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -75,7 +75,7 @@ apiGatewayNginx:
   nodeSelector: {}
   gracePeriod: 60
   preStopHookTime: 5
-  clientMaxBodySize: "1m"
+  clientMaxBodySize: ""
 
 remediationService:
   image:

--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -75,7 +75,7 @@ apiGatewayNginx:
   nodeSelector: {}
   gracePeriod: 60
   preStopHookTime: 5
-  clientMaxBodySize: ""
+  clientMaxBodySize: "5m"
 
 remediationService:
   image:


### PR DESCRIPTION
## This PR
- adds the ability to adjust the `client_max_body_size` parameter of nginx at install time (via helm values) to allow upload of larger resources if desired

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #7567 

### Notes
I'm not sure if we should already increase the default value to 5 MB or if 1 MB is sufficient for most workloads.

