### PR TITLE
fix(bridge): Allow Webhook configuration URL to be a secret

### DIFF
--- a/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.html
+++ b/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.html
@@ -28,7 +28,7 @@
         class="resize-vertical url-input"
       ></textarea>
       <dt-error *ngIf="getFormControl('url').errors?.required">URL must not be empty</dt-error>
-      <dt-error *ngIf="getFormControl('url').errors?.url"> URL must start with http(s):// </dt-error>
+      <dt-error *ngIf="getFormControl('url').errors?.urlOrSecret"> URL must start with http(s):// or be a secret </dt-error>
       <dt-error *ngIf="getFormControl('url').errors?.space"> URL must not contain spaces </dt-error>
       <div dtSuffix uitestid="event-url">
         <ng-container

--- a/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.html
+++ b/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.html
@@ -30,7 +30,7 @@
       <dt-error *ngIf="getFormControl('url').errors?.required">URL must not be empty</dt-error>
       <dt-error *ngIf="getFormControl('url').errors?.urlOrSecret">
         Must either be a URL starting with http(s):// or a reference to a secret. A combination of both is possible too:
-        https://{{.secret.a.b}}
+        https://{{ '{{.secret.a.b}}' }}
       </dt-error>
       <dt-error *ngIf="getFormControl('url').errors?.space"> URL must not contain spaces </dt-error>
       <div dtSuffix uitestid="event-url">

--- a/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.html
+++ b/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.html
@@ -29,7 +29,8 @@
       ></textarea>
       <dt-error *ngIf="getFormControl('url').errors?.required">URL must not be empty</dt-error>
       <dt-error *ngIf="getFormControl('url').errors?.urlOrSecret">
-        URL must start with http(s):// or be a secret
+        Must either be a URL starting with http(s):// or a reference to a secret. A combination of both is possible too:
+        https://{{.secret.a.b}}
       </dt-error>
       <dt-error *ngIf="getFormControl('url').errors?.space"> URL must not contain spaces </dt-error>
       <div dtSuffix uitestid="event-url">

--- a/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.html
+++ b/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.html
@@ -28,7 +28,9 @@
         class="resize-vertical url-input"
       ></textarea>
       <dt-error *ngIf="getFormControl('url').errors?.required">URL must not be empty</dt-error>
-      <dt-error *ngIf="getFormControl('url').errors?.urlOrSecret"> URL must start with http(s):// or be a secret </dt-error>
+      <dt-error *ngIf="getFormControl('url').errors?.urlOrSecret">
+        URL must start with http(s):// or be a secret
+      </dt-error>
       <dt-error *ngIf="getFormControl('url').errors?.space"> URL must not contain spaces </dt-error>
       <div dtSuffix uitestid="event-url">
         <ng-container

--- a/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.spec.ts
+++ b/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.spec.ts
@@ -111,9 +111,19 @@ describe('KtbWebhookSettingsComponent', () => {
     }
   });
 
+  it('should be invalid URL if the secret syntax is invalid', () => {
+    const urlControl: AbstractControl = component.webhookConfigForm.get('url') as AbstractControl;
+    const urls = ['{{secret.keptn.url}}', '{.secret.keptn.url}'];
+
+    for (const url of urls) {
+      urlControl.setValue(url);
+      expect(urlControl.valid).toEqual(false);
+    }
+  });
+
   it('should be valid URL when it starts with a secret', () => {
     const urlControl: AbstractControl = component.webhookConfigForm.get('url') as AbstractControl;
-    const urls = ['{{.secret.gremlin.url}}'];
+    const urls = ['{{.secret.keptn.url}}'];
 
     for (const url of urls) {
       urlControl.setValue(url);

--- a/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.spec.ts
+++ b/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.spec.ts
@@ -111,6 +111,18 @@ describe('KtbWebhookSettingsComponent', () => {
     }
   });
 
+  it('should be valid URL when it starts with a secret', () => {
+    const urlControl: AbstractControl = component.webhookConfigForm.get('url') as AbstractControl;
+    const urls = [
+      '{{.secret.gremlin.url}}',
+    ];
+
+    for (const url of urls) {
+      urlControl.setValue(url);
+      expect(urlControl.valid).toEqual(true);
+    }
+  });
+
   it('should add headers', () => {
     // given
     const addHeaderButton = getAddHeaderButton();

--- a/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.spec.ts
+++ b/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.spec.ts
@@ -113,9 +113,7 @@ describe('KtbWebhookSettingsComponent', () => {
 
   it('should be valid URL when it starts with a secret', () => {
     const urlControl: AbstractControl = component.webhookConfigForm.get('url') as AbstractControl;
-    const urls = [
-      '{{.secret.gremlin.url}}',
-    ];
+    const urls = ['{{.secret.gremlin.url}}'];
 
     for (const url of urls) {
       urlControl.setValue(url);

--- a/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.ts
+++ b/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.ts
@@ -18,7 +18,7 @@ export class KtbWebhookSettingsComponent implements OnInit {
   private _webhook: WebhookConfig = new WebhookConfig();
   public webhookConfigForm = new FormGroup({
     method: new FormControl('', [Validators.required]),
-    url: new FormControl('', [Validators.required, FormUtils.isUrlValidator]),
+    url: new FormControl('', [Validators.required, FormUtils.isUrlOrSecretValidator]),
     payload: new FormControl('', [FormUtils.payloadSpecialCharValidator]),
     header: new FormArray([]),
     proxy: new FormControl('', [FormUtils.isUrlValidator]),

--- a/bridge/client/app/_utils/form.utils.ts
+++ b/bridge/client/app/_utils/form.utils.ts
@@ -25,7 +25,7 @@ export class FormUtils {
     control: AbstractControl
   ): { urlOrSecret: { value: boolean } } | { space: { value: boolean } } | null {
     if (control.value) {
-      if ((control.value.search(/^http(s?):\/\//) === -1) && (control.value.search(/^{{(.+)}}/) === -1)) {
+      if (control.value.search(/^http(s?):\/\//) === -1 && control.value.search(/^{{(\..+)}}/) === -1) {
         return { urlOrSecret: { value: true } };
       } else if (control.value.includes(' ')) {
         return { space: { value: true } };

--- a/bridge/client/app/_utils/form.utils.ts
+++ b/bridge/client/app/_utils/form.utils.ts
@@ -21,6 +21,19 @@ export class FormUtils {
     return null;
   }
 
+  public static isUrlOrSecretValidator(
+    control: AbstractControl
+  ): { urlOrSecret: { value: boolean } } | { space: { value: boolean } } | null {
+    if (control.value) {
+      if ((control.value.search(/^http(s?):\/\//) === -1) && (control.value.search(/^{{(.+)}}/) === -1)) {
+        return { urlOrSecret: { value: true } };
+      } else if (control.value.includes(' ')) {
+        return { space: { value: true } };
+      }
+    }
+    return null;
+  }
+
   public static isSshValidator(control: AbstractControl): ValidationErrors | null {
     if (control.value && !control.value.startsWith('ssh://')) {
       return { ssh: true };


### PR DESCRIPTION
## This PR

- Allows the user to use a secret for defining the URL for a Webhook.

### Related Issues

Fixes #6727

