### PR TITLE
fix: Correctly match nginx location for Bridge

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/templates/api-gateway-nginx.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/api-gateway-nginx.yaml
@@ -77,7 +77,7 @@ data:
       proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    location ~* {{ .Values.prefixPath }}/bridge {
+    location {{ .Values.prefixPath }}/bridge {
       rewrite {{ .Values.prefixPath }}/bridge(/.*) $1 break;
       proxy_pass http://bridge:8080;
       proxy_http_version 1.1;


### PR DESCRIPTION
Signed-off-by: Giovanni Liva <giovanni.liva@dynatrace.com>
