### PR TITLE
chore(bridge): Only update sequence metadata when needed

### DIFF
--- a/bridge/client/app/_components/ktb-root-events-list/ktb-root-events-list.component.ts
+++ b/bridge/client/app/_components/ktb-root-events-list/ktb-root-events-list.component.ts
@@ -35,7 +35,6 @@ export class KtbRootEventsListComponent implements OnInit, OnDestroy {
   public loading = false;
 
   @Output() readonly selectedEventChange = new EventEmitter<{ sequence: Sequence; stage?: string }>();
-  @Output() readonly loadOldSequencesClicked = new EventEmitter<void>();
 
   @Input()
   get events(): Sequence[] {
@@ -81,7 +80,6 @@ export class KtbRootEventsListComponent implements OnInit, OnDestroy {
 
     this.dataService.sequencesUpdated.pipe(takeUntil(this.unsubscribe$)).subscribe(() => {
       this.loading = false;
-      this.loadOldSequencesClicked.emit();
       this._changeDetectorRef.markForCheck();
     });
   }

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.html
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.html
@@ -53,7 +53,6 @@
             [events]="getFilteredSequences(project.sequences)"
             [selectedEvent]="currentSequence"
             (selectedEventChange)="selectSequence($event)"
-            (loadOldSequencesClicked)="loadSequenceMetadata(project.projectName)"
             fxFlex
           ></ktb-root-events-list>
           <div class="mb-3"></div>


### PR DESCRIPTION
Every time there was an update in the sequence list, there was an API call for the metadata. This is not needed. Only the quick filter needs to be extended here (e.g. sequences with deleted services came in).

This should also fix a flaky UI test (element detached from DOM) because now the quick filter is not updated that often anymore.

Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>