### PR TITLE
feat(bridge): Show automatic provisioning message

### DIFF
--- a/bridge/client/app/_components/ktb-project-settings/ktb-project-settings.component.html
+++ b/bridge/client/app/_components/ktb-project-settings/ktb-project-settings.component.html
@@ -33,15 +33,20 @@
       </ng-template>
       <div class="mb-3 settings-section" *ngIf="resourceServiceEnabled !== undefined; else loading">
         <ng-container *ngIf="resourceServiceEnabled; else defaultGit">
-          <p class="mt-0 mb-3" *ngIf="state.gitUpstreamRequired">
+          <p class="mt-0 mb-3" uitestid="ktb-settings-git-upstream-message" *ngIf="state.gitUpstreamRequired">
             A Git upstream repository has to be set. You can connect your Git repository with HTTPS or SSH.
             Instructions, on how to set up your Git provider can be found in the
             <a [href]="'/manage/git_upstream/' | keptnUrl" target="_blank">Git-based upstream documentation</a>.
           </p>
-          <p class="mt-0 mb-3" *ngIf="!state.gitUpstreamRequired">
-            It is recommended to set a Git upstream repository. You can connect your Git repository with HTTPS or SSH.
-            Instructions, on how to set up your Git provider can be found in the
-            <a [href]="'/manage/git_upstream/' | keptnUrl" target="_blank">Git-based upstream documentation</a>.
+          <p class="mt-0 mb-3" uitestid="ktb-settings-git-upstream-message" *ngIf="!state.gitUpstreamRequired">
+            <ng-container *ngIf="state.automaticProvisioningMessage; else defaultGitRequiredMessage">
+              {{ state.automaticProvisioningMessage }}
+            </ng-container>
+            <ng-template #defaultGitRequiredMessage>
+              It is recommended to set a Git upstream repository. You can connect your Git repository with HTTPS or SSH.
+              Instructions, on how to set up your Git provider can be found in the
+              <a [href]="'/manage/git_upstream/' | keptnUrl" target="_blank">Git-based upstream documentation</a>.
+            </ng-template>
           </p>
 
           <ktb-project-settings-git-extended

--- a/bridge/client/app/_components/ktb-project-settings/ktb-project-settings.component.ts
+++ b/bridge/client/app/_components/ktb-project-settings/ktb-project-settings.component.ts
@@ -69,7 +69,7 @@ export class KtbProjectSettingsComponent implements OnInit, OnDestroy, PendingCh
     filter((keptnInfo: KeptnInfo | undefined): keptnInfo is KeptnInfo => !!keptnInfo),
     map((keptnInfo: KeptnInfo) => ({
       gitUpstreamRequired: !keptnInfo.metadata.automaticprovisioning,
-      automaticProvisioningMessage: keptnInfo.bridgeInfo.automaticProvisioningMsg?.trim(),
+      automaticProvisioningMessage: keptnInfo.bridgeInfo.automaticProvisioningMsg,
     })),
     startWith({ gitUpstreamRequired: undefined, automaticProvisioningMessage: undefined })
   );

--- a/bridge/client/app/_components/ktb-project-settings/ktb-project-settings.component.ts
+++ b/bridge/client/app/_components/ktb-project-settings/ktb-project-settings.component.ts
@@ -25,6 +25,7 @@ type DialogState = null | 'unsaved';
 
 interface ProjectSettingsState {
   gitUpstreamRequired: boolean | undefined;
+  automaticProvisioningMessage: string | undefined;
 }
 
 @Component({
@@ -66,8 +67,11 @@ export class KtbProjectSettingsComponent implements OnInit, OnDestroy, PendingCh
 
   readonly state$: Observable<ProjectSettingsState> = this.dataService.keptnInfo.pipe(
     filter((keptnInfo: KeptnInfo | undefined): keptnInfo is KeptnInfo => !!keptnInfo),
-    map((keptnInfo: KeptnInfo) => ({ gitUpstreamRequired: !keptnInfo.metadata.automaticprovisioning })),
-    startWith({ gitUpstreamRequired: undefined })
+    map((keptnInfo: KeptnInfo) => ({
+      gitUpstreamRequired: !keptnInfo.metadata.automaticprovisioning,
+      automaticProvisioningMessage: keptnInfo.bridgeInfo.automaticProvisioningMsg?.trim(),
+    })),
+    startWith({ gitUpstreamRequired: undefined, automaticProvisioningMessage: undefined })
   );
 
   constructor(

--- a/bridge/cypress/integration/project-create-extended.spec.ts
+++ b/bridge/cypress/integration/project-create-extended.spec.ts
@@ -367,7 +367,7 @@ describe('Automatic provisioning message', () => {
 
   it('should show the default git message if automatic provisioning message consists of empty chars', () => {
     const info = { ...bridgeInfo };
-    info.automaticProvisioningMsg = '      ';
+    info.automaticProvisioningMsg = '';
     cy.intercept('/api/v1/metadata', { fixture: 'metadata.ap-enabled.mock' }).as('metadata');
     cy.intercept('/api/bridgeInfo', info);
     createProjectPage.visit();

--- a/bridge/cypress/support/pageobjects/NewProjectCreatePage.ts
+++ b/bridge/cypress/support/pageobjects/NewProjectCreatePage.ts
@@ -424,6 +424,11 @@ class NewProjectCreatePage {
     cy.byTestId('ktb-project-update-button').should(status ? 'be.enabled' : 'be.disabled');
     return this;
   }
+
+  public assertGitUpstreamMessageContains(message: string): this {
+    cy.byTestId('ktb-settings-git-upstream-message').should('contain', message);
+    return this;
+  }
 }
 
 export default NewProjectCreatePage;

--- a/bridge/server/api/index.ts
+++ b/bridge/server/api/index.ts
@@ -35,6 +35,7 @@ const apiRouter = (params: {
   const projectsPageSize = EnvironmentUtils.getNumber(process.env.PROJECTS_PAGE_SIZE);
   const servicesPageSize = EnvironmentUtils.getNumber(process.env.SERVICES_PAGE_SIZE);
   const keptnInstallationType = process.env.KEPTN_INSTALLATION_TYPE;
+  const automaticProvisioningMsg = process.env.AUTOMATIC_PROVISIONING_MSG;
   const dataService = new DataService(apiUrl, apiToken);
 
   // bridgeInfo endpoint: Provide certain metadata for Bridge
@@ -53,6 +54,7 @@ const apiRouter = (params: {
       servicesPageSize,
       authType,
       ...(user && { user }),
+      automaticProvisioningMsg,
     };
 
     try {

--- a/bridge/server/api/index.ts
+++ b/bridge/server/api/index.ts
@@ -35,7 +35,7 @@ const apiRouter = (params: {
   const projectsPageSize = EnvironmentUtils.getNumber(process.env.PROJECTS_PAGE_SIZE);
   const servicesPageSize = EnvironmentUtils.getNumber(process.env.SERVICES_PAGE_SIZE);
   const keptnInstallationType = process.env.KEPTN_INSTALLATION_TYPE;
-  const automaticProvisioningMsg = process.env.AUTOMATIC_PROVISIONING_MSG;
+  const automaticProvisioningMsg = process.env.AUTOMATIC_PROVISIONING_MSG?.trim();
   const dataService = new DataService(apiUrl, apiToken);
 
   // bridgeInfo endpoint: Provide certain metadata for Bridge

--- a/bridge/server/test/bridge-info.spec.ts
+++ b/bridge/server/test/bridge-info.spec.ts
@@ -4,9 +4,18 @@ import { Express } from 'express';
 
 describe('Test /bridgeInfo', () => {
   let app: Express;
+  const originalEnv = process.env;
 
   beforeAll(async () => {
+    process.env = {
+      ...originalEnv,
+      AUTOMATIC_PROVISIONING_MSG: '  message   ',
+    };
     app = await setupServer();
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
   });
 
   it('should return bridgeInfo', async () => {
@@ -22,6 +31,7 @@ describe('Test /bridgeInfo', () => {
         RESOURCE_SERVICE_ENABLED: false,
       },
       authType: 'NONE',
+      automaticProvisioningMsg: 'message',
     });
     expect(response.statusCode).toBe(200);
   });

--- a/bridge/shared/interfaces/keptn-info-result.ts
+++ b/bridge/shared/interfaces/keptn-info-result.ts
@@ -13,4 +13,5 @@ export interface KeptnInfoResult {
   servicesPageSize?: number;
   authType: string;
   user?: string;
+  automaticProvisioningMsg?: string;
 }

--- a/installer/manifests/keptn/charts/control-plane/templates/core.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/core.yaml
@@ -202,7 +202,7 @@ spec:
             - name: CONFIG_DIR
               value: "/config"
             - name: AUTOMATIC_PROVISIONING_MSG
-              value: {{.Values.bridge.automaticProvisioningMsg}}
+              value: {{ .Values.bridge.automaticProvisioningMsg }}
             - name: RESOURCE_SERVICE_ENABLED
               value: {{.Values.resourceService.enabled | quote}}
             {{- range $key, $value := .Values.bridge.env }}

--- a/installer/manifests/keptn/charts/control-plane/templates/core.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/core.yaml
@@ -201,6 +201,8 @@ spec:
               value: {{ .Values.mongo.auth.bridgeAuthDatabase | default "openid" }}
             - name: CONFIG_DIR
               value: "/config"
+            - name: AUTOMATIC_PROVISIONING_MSG
+              value: {{.Values.bridge.automaticProvisioningMsg}}
             - name: RESOURCE_SERVICE_ENABLED
               value: {{.Values.resourceService.enabled | quote}}
             {{- range $key, $value := .Values.bridge.env }}

--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -130,6 +130,7 @@ bridge:
     userIdentifier: ""
     mongoConnectionString: ""
   nodeSelector: {}
+  automaticProvisioningMsg: ""
 
 distributor:
   metadata:


### PR DESCRIPTION
If automatic provisioning is enabled (git upstream is not required) and the message is set via helm value it is shown in the form.