### PR TITLE
feat(cp-connector): Make sure event timestamp is always set 

### DIFF
--- a/cp-connector/pkg/nats/nats.go
+++ b/cp-connector/pkg/nats/nats.go
@@ -4,12 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
-	"time"
-
 	"github.com/keptn/go-utils/pkg/api/models"
 	"github.com/keptn/keptn/cp-connector/pkg/logger"
 	"github.com/nats-io/nats.go"
+	"os"
+	"time"
 )
 
 var _ NATS = (*NatsConnector)(nil)
@@ -127,6 +126,7 @@ func (nc *NatsConnector) Publish(event models.KeptnContextExtendedCE) error {
 	if event.Type == nil || *event.Type == "" {
 		return ErrPubEventTypeMissing
 	}
+	// make sure the time stamp of the event is set to the current time
 	event.Time = time.Now().UTC()
 	serializedEvent, err := json.Marshal(event)
 	if err != nil {

--- a/cp-connector/pkg/nats/nats.go
+++ b/cp-connector/pkg/nats/nats.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/keptn/go-utils/pkg/api/models"
 	"github.com/keptn/keptn/cp-connector/pkg/logger"
@@ -126,6 +127,7 @@ func (nc *NatsConnector) Publish(event models.KeptnContextExtendedCE) error {
 	if event.Type == nil || *event.Type == "" {
 		return ErrPubEventTypeMissing
 	}
+	event.Time = time.Now().UTC()
 	serializedEvent, err := json.Marshal(event)
 	if err != nil {
 		return fmt.Errorf("could not publish event: %w", err)

--- a/cp-connector/pkg/nats/nats_test.go
+++ b/cp-connector/pkg/nats/nats_test.go
@@ -1,6 +1,7 @@
 package nats_test
 
 import (
+	"encoding/json"
 	"github.com/keptn/go-utils/pkg/api/models"
 	"github.com/keptn/go-utils/pkg/common/strutils"
 	"github.com/keptn/go-utils/pkg/lib/v0_2_0"
@@ -191,6 +192,10 @@ func TestPublish(t *testing.T) {
 
 	err := nc.Subscribe("subj", func(e *nats.Msg) error {
 		received = true
+		ev := &models.KeptnContextExtendedCE{}
+		err := json.Unmarshal(e.Data, ev)
+		require.Nil(t, err)
+		require.NotEmpty(t, ev.Time)
 		return nil
 	})
 	require.Nil(t, err)


### PR DESCRIPTION
This PR extends the `Publish()` method of the cp-connector to make sure the timestamp of an event is always set to the current time