### PR TITLE
fix(installer): Use exec preStop hook for shipyard controller

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/templates/shipyard-controller.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/shipyard-controller.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -39,10 +40,11 @@ spec:
           image: {{ .Values.shipyardController.image.repository }}:{{ .Values.shipyardController.image.tag | default .Chart.AppVersion }}
           lifecycle:
             preStop:
-              httpGet:
-                port: 8081
-                path: /operations/v1/pre-stop
-                host: localhost
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - wget http://localhost:8081/operations/v1/pre-stop
           livenessProbe:
             httpGet:
               path: /health


### PR DESCRIPTION
This PR changes the preStop hook type of the shipyard-controller to `exec` instead of `http`.
During testing I noticed that the http preStop hook was not executed correctly, as indicated in the following `FailedPreStopHook` event:

```
6m8s        Warning   FailedPreStopHook   pod/shipyard-controller-5fd89499c8-5xqt7    HTTP lifecycle hook (operations/v1/pre-stop) for Container "shipyard-controller" in Pod "shipyard-controller-5fd89499c8-5xqt7_keptn(77ea19e9-2c59-4009-bc5d-2ad506af04f9)" failed - error: Get "http://localhost:8081/operations/v1/pre-stop": dial tcp 127.0.0.1:8081: connect: connection refused, message: ""
```

This lead to the pod being terminated immediately.

Changing the preStop hook to an `exec` type solved this issue