### PR TITLE
fix(mongodb-datastore): Change name of integration to name of service instead of pod name

### DIFF
--- a/mongodb-datastore/handlers/events.go
+++ b/mongodb-datastore/handlers/events.go
@@ -26,7 +26,7 @@ func (erh EventRequestHandler) OnEvent(ctx context.Context, event keptnapi.Keptn
 
 func (erh EventRequestHandler) RegistrationData() controlplane.RegistrationData {
 	return controlplane.RegistrationData{
-		Name: erh.Env.K8SPodName,
+		Name: erh.Env.K8SDeploymentName,
 		MetaData: keptnapi.MetaData{
 			Hostname:           erh.Env.K8SNodeName,
 			IntegrationVersion: erh.Env.K8SDeploymentVersion,


### PR DESCRIPTION
This ensures that multiple instances of the mongodb-datastore are registered with the same name, and therefore are part of the same nats queue group