### PR TITLE
fix(cp-connector): fix passing deduplicated subjects to nats subscriber

### DIFF
--- a/cp-connector/pkg/controlplane/eventsource.go
+++ b/cp-connector/pkg/controlplane/eventsource.go
@@ -109,7 +109,7 @@ func (n *NATSEventSource) OnSubscriptionUpdate(subjects []string) {
 			n.logger.Errorf("Could not handle subscription update: %v", err)
 			return
 		}
-		if err := n.connector.QueueSubscribeMultiple(subjects, n.queueGroup, n.eventProcessFn); err != nil {
+		if err := n.connector.QueueSubscribeMultiple(s, n.queueGroup, n.eventProcessFn); err != nil {
 			n.logger.Errorf("Could not handle subscription update: %v", err)
 			return
 		}


### PR DESCRIPTION
This PR fixes the default event source used in `cp-connector` which did not pass the "deduplicated" slice of subjects to the nats component.
