### PR TITLE
fix: Make sure that all events are being processed before shutting down lighthouse/approval service

### DIFF
--- a/approval-service/main.go
+++ b/approval-service/main.go
@@ -79,11 +79,11 @@ func main() {
 	}
 
 	// this segment will be reached once the context has been cancelled - i.e. due to receiving the SIGTERM signal
-	logger.Info("Waiting for event handlers to finish")
+	logger.Info("Waiting for approval event handlers to finish")
 	// add additional waiting time to ensure the waitGroup has been increased for all events that have been received between receiving SIGTERM and this point
 	<-time.After(5 * time.Second)
 	wg.Wait()
-	logger.Info("All handlers finished - exiting")
+	logger.Info("All approval handlers finished - exiting")
 }
 
 type ApprovalService struct {

--- a/lighthouse-service/main.go
+++ b/lighthouse-service/main.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
+	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	logger "github.com/sirupsen/logrus"
@@ -68,11 +69,18 @@ func main() {
 		}))
 	}()
 
-	ctx := getGracefulContext()
+	ctx, wg := getGracefulContext()
 	err = controlPlane.Register(ctx, LighthouseService{env})
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// this segment will be reached once the context has been cancelled - i.e. due to receiving the SIGTERM signal
+	logger.Info("Waiting for event handlers to finish")
+	// add additional waiting time to ensure the waitGroup has been increased for all events that have been received between receiving SIGTERM and this point
+	<-time.After(5 * time.Second)
+	wg.Wait()
+	logger.Info("All handlers finished - exiting")
 }
 
 type LighthouseService struct {
@@ -124,7 +132,7 @@ func (l LighthouseService) RegistrationData() controlplane.RegistrationData {
 	}
 }
 
-func getGracefulContext() context.Context {
+func getGracefulContext() (context.Context, *sync.WaitGroup) {
 
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
@@ -135,10 +143,7 @@ func getGracefulContext() context.Context {
 		<-ch
 		logger.Info("Container termination triggered, starting graceful shutdown and cancelling context")
 		cancel()
-		logger.Info("Waiting for event handlers to finish")
-		wg.Wait()
-		logger.Info("All handlers finished - ready to shut down")
 	}()
 
-	return ctx
+	return ctx, wg
 }

--- a/lighthouse-service/main.go
+++ b/lighthouse-service/main.go
@@ -76,11 +76,11 @@ func main() {
 	}
 
 	// this segment will be reached once the context has been cancelled - i.e. due to receiving the SIGTERM signal
-	logger.Info("Waiting for event handlers to finish")
+	logger.Info("Waiting for evaluation event handlers to finish")
 	// add additional waiting time to ensure the waitGroup has been increased for all events that have been received between receiving SIGTERM and this point
 	<-time.After(5 * time.Second)
 	wg.Wait()
-	logger.Info("All handlers finished - exiting")
+	logger.Info("All evaluation handlers finished - exiting")
 }
 
 type LighthouseService struct {


### PR DESCRIPTION
In the previous implementation of the `getGracefulContext()` function, we started a goroutine that waits for the waitGroup to be finished, but we did not wait for that goroutine - which lead to the pod being shut down prematurely even though there might still be some events being processed.

Also, during testing it seemed like addiing a small delay between cancelling the context (i.e. unsubscribing from nats) and calling `wg.Wait()` seemed to solve the problem where it was still the case that events were not fully processed before shutting down. My theory for that is that if `wg.Wait()` being called before an event handler has the chance to increase the wait group might lead to this behavior.