### PR TITLE
fix(shipyard-controller): Dispatch new sequence directly only if no older sequence is waiting

### DIFF
--- a/shipyard-controller/db/migration/sequence_execution_migration_test.go
+++ b/shipyard-controller/db/migration/sequence_execution_migration_test.go
@@ -2,6 +2,9 @@ package migration
 
 import (
 	"errors"
+	"testing"
+	"time"
+
 	apimodels "github.com/keptn/go-utils/pkg/api/models"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 	"github.com/keptn/keptn/shipyard-controller/db"
@@ -9,7 +12,6 @@ import (
 	v1 "github.com/keptn/keptn/shipyard-controller/db/models/sequence_execution/v1"
 	"github.com/keptn/keptn/shipyard-controller/models"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 var testSequenceExecution = models.SequenceExecution{
@@ -82,6 +84,7 @@ var testSequenceExecution = models.SequenceExecution{
 		},
 		KeptnContext: "ctx1",
 	},
+	TriggeredAt: time.Date(2021, 4, 21, 17, 00, 00, 0, time.Local),
 	InputProperties: map[string]interface{}{
 		"foo.bar": "xyz",
 	},

--- a/shipyard-controller/db/migration/sequence_execution_migration_test.go
+++ b/shipyard-controller/db/migration/sequence_execution_migration_test.go
@@ -84,7 +84,7 @@ var testSequenceExecution = models.SequenceExecution{
 		},
 		KeptnContext: "ctx1",
 	},
-	TriggeredAt: time.Date(2021, 4, 21, 17, 00, 00, 0, time.Local),
+	TriggeredAt: time.Date(2021, 4, 21, 17, 00, 00, 0, time.UTC),
 	InputProperties: map[string]interface{}{
 		"foo.bar": "xyz",
 	},

--- a/shipyard-controller/db/models/sequence_execution/v1/sequence_execution.go
+++ b/shipyard-controller/db/models/sequence_execution/v1/sequence_execution.go
@@ -2,6 +2,8 @@ package v1
 
 import (
 	"encoding/json"
+	"time"
+
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 	"github.com/keptn/keptn/shipyard-controller/models"
 )
@@ -20,7 +22,8 @@ type JsonStringEncodedSequenceExecution struct {
 	Status   SequenceExecutionStatus `json:"status" bson:"status"`
 	Scope    models.EventScope       `json:"scope" bson:"scope"`
 	// EncodedInputProperties contains properties of the event which triggered the task sequence
-	EncodedInputProperties string `json:"encodedInputProperties" bson:"encodedInputProperties"`
+	EncodedInputProperties string    `json:"encodedInputProperties" bson:"encodedInputProperties"`
+	TriggeredAt            time.Time `json:"triggeredAt" bson:"triggeredAt"`
 }
 
 type Sequence struct {
@@ -150,7 +153,8 @@ func (e JsonStringEncodedSequenceExecution) ToSequenceExecution() models.Sequenc
 				Events:      e.Status.CurrentTask.DecodeEvents(),
 			},
 		},
-		Scope: e.Scope,
+		Scope:       e.Scope,
+		TriggeredAt: e.TriggeredAt,
 	}
 	inputProperties := map[string]interface{}{}
 	err := json.Unmarshal([]byte(e.EncodedInputProperties), &inputProperties)

--- a/shipyard-controller/db/models/sequence_execution/v1/transformer.go
+++ b/shipyard-controller/db/models/sequence_execution/v1/transformer.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"encoding/json"
+
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 	"github.com/keptn/keptn/shipyard-controller/models"
 )
@@ -54,6 +55,7 @@ func fromSequenceExecution(se models.SequenceExecution) JsonStringEncodedSequenc
 		Status:        transformStatus(se.Status),
 		Scope:         se.Scope,
 		SchemaVersion: SchemaVersion{SchemaVersion: SchemaVersionV1},
+		TriggeredAt:   se.TriggeredAt,
 	}
 	if se.InputProperties != nil {
 		inputPropertiesJsonString, err := json.Marshal(se.InputProperties)

--- a/shipyard-controller/db/mongodb_sequence_execution_repo.go
+++ b/shipyard-controller/db/mongodb_sequence_execution_repo.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
+
 	apimodels "github.com/keptn/go-utils/pkg/api/models"
 	"github.com/keptn/keptn/shipyard-controller/db/models/sequence_execution"
 	v02 "github.com/keptn/keptn/shipyard-controller/db/models/sequence_execution/v1"
@@ -13,7 +15,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	"time"
 )
 
 const sequenceExecutionCollectionNameSuffix = "sequence-execution"
@@ -341,6 +342,8 @@ func (mdbrepo *MongoDBSequenceExecutionRepo) getCollection(collectionName string
 func (mdbrepo *MongoDBSequenceExecutionRepo) getSearchOptions(filter models.SequenceExecutionFilter) bson.M {
 	searchOptions := bson.M{}
 
+	log.Infof("filer je %+v", filter)
+
 	searchOptions = appendFilterAs(searchOptions, filter.Name, "sequence.name")
 	searchOptions = appendFilterAs(searchOptions, filter.Scope.TriggeredID, "scope.triggeredId")
 	searchOptions = appendFilterAs(searchOptions, filter.Scope.KeptnContext, "scope.keptnContext")
@@ -348,6 +351,11 @@ func (mdbrepo *MongoDBSequenceExecutionRepo) getSearchOptions(filter models.Sequ
 	searchOptions = appendFilterAs(searchOptions, filter.Scope.Stage, "scope.stage")
 	searchOptions = appendFilterAs(searchOptions, filter.Scope.Service, "scope.service")
 	searchOptions = appendFilterAs(searchOptions, filter.CurrentTriggeredID, "status.currentTask.triggeredID")
+	if !filter.TriggeredAt.IsZero() {
+		searchOptions["triggeredAt"] = bson.M{
+			"$lt": filter.TriggeredAt,
+		}
+	}
 
 	if filter.Status != nil && len(filter.Status) > 0 {
 		matchStates := []bson.M{}

--- a/shipyard-controller/db/mongodb_sequence_execution_repo.go
+++ b/shipyard-controller/db/mongodb_sequence_execution_repo.go
@@ -342,8 +342,6 @@ func (mdbrepo *MongoDBSequenceExecutionRepo) getCollection(collectionName string
 func (mdbrepo *MongoDBSequenceExecutionRepo) getSearchOptions(filter models.SequenceExecutionFilter) bson.M {
 	searchOptions := bson.M{}
 
-	log.Infof("filer je %+v", filter)
-
 	searchOptions = appendFilterAs(searchOptions, filter.Name, "sequence.name")
 	searchOptions = appendFilterAs(searchOptions, filter.Scope.TriggeredID, "scope.triggeredId")
 	searchOptions = appendFilterAs(searchOptions, filter.Scope.KeptnContext, "scope.keptnContext")

--- a/shipyard-controller/db/mongodb_sequence_execution_repo_test.go
+++ b/shipyard-controller/db/mongodb_sequence_execution_repo_test.go
@@ -48,6 +48,38 @@ func TestMongoDBTaskSequenceV2Repo_InsertAndRetrieve(t *testing.T) {
 	require.Empty(t, get)
 }
 
+func TestMongoDBTaskSequenceV2Repo_InsertAndRetrieveByTime(t *testing.T) {
+	scope, sequence := getTestSequenceExecution()
+
+	mdbrepo := NewMongoDBSequenceExecutionRepo(GetMongoDBConnectionInstance())
+
+	err := mdbrepo.Upsert(sequence, nil)
+
+	require.Nil(t, err)
+
+	get, err := mdbrepo.Get(models.SequenceExecutionFilter{
+		Scope:  scope,
+		Name:   "delivery",
+		Status: []string{"triggered"},
+	})
+
+	require.Nil(t, err)
+
+	require.Len(t, get, 1)
+	get[0].SchemaVersion = ""
+	require.Equal(t, sequence, get[0])
+
+	get, err = mdbrepo.Get(models.SequenceExecutionFilter{
+		Scope:       scope,
+		Name:        "delivery",
+		TriggeredAt: time.Date(2021, 3, 21, 17, 00, 00, 0, time.UTC),
+	})
+
+	require.Nil(t, err)
+
+	require.Empty(t, get)
+}
+
 func TestMongoDBTaskSequenceV2Repo_GetByTriggeredID(t *testing.T) {
 	scope, sequence := getTestSequenceExecution()
 

--- a/shipyard-controller/db/mongodb_sequence_execution_repo_test.go
+++ b/shipyard-controller/db/mongodb_sequence_execution_repo_test.go
@@ -276,7 +276,7 @@ func getTestSequenceExecution() (models.EventScope, models.SequenceExecution) {
 			},
 		},
 		Scope:       scope,
-		TriggeredAt: time.Date(2021, 4, 21, 17, 00, 00, 0, time.Local),
+		TriggeredAt: time.Date(2021, 4, 21, 17, 00, 00, 0, time.UTC),
 	}
 	return scope, sequence
 }

--- a/shipyard-controller/db/mongodb_sequence_execution_repo_test.go
+++ b/shipyard-controller/db/mongodb_sequence_execution_repo_test.go
@@ -1,15 +1,17 @@
 package db
 
 import (
+	"sync"
+
 	apimodels "github.com/keptn/go-utils/pkg/api/models"
 	"github.com/keptn/go-utils/pkg/common/timeutils"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 	"github.com/keptn/keptn/shipyard-controller/models"
-	"sync"
 
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestMongoDBTaskSequenceV2Repo_InsertAndRetrieve(t *testing.T) {
@@ -273,7 +275,8 @@ func getTestSequenceExecution() (models.EventScope, models.SequenceExecution) {
 				},
 			},
 		},
-		Scope: scope,
+		Scope:       scope,
+		TriggeredAt: time.Date(2021, 4, 21, 17, 00, 00, 0, time.Local),
 	}
 	return scope, sequence
 }

--- a/shipyard-controller/handler/sequencedispatcher.go
+++ b/shipyard-controller/handler/sequencedispatcher.go
@@ -182,7 +182,13 @@ func (sd *SequenceDispatcher) areSequencesInState(queueItem models.QueueItem) (b
 		return true, err
 	}
 
-	if len(triggeredSequenceExecutions) > 0 {
+	if len(triggeredSequenceExecutions) == 1 {
+		if triggeredSequenceExecutions[0].Scope.KeptnContext != queueItem.Scope.KeptnContext {
+			return true, nil
+		}
+	}
+
+	if len(triggeredSequenceExecutions) > 1 {
 		return true, nil
 	}
 

--- a/shipyard-controller/handler/sequencedispatcher.go
+++ b/shipyard-controller/handler/sequencedispatcher.go
@@ -159,10 +159,12 @@ func (sd *SequenceDispatcher) isSequenceBlocked(queueItem models.QueueItem) (boo
 		Status: []string{apimodels.SequenceStartedState},
 	})
 	if err != nil {
+		log.Errorf("Could not load started sequences: %w", err)
 		return true, err
 	}
 
 	if len(startedSequenceExecutions) > 0 {
+		log.Infof("Sequence with KeptnContext %s blocked due to started sequences", queueItem.Scope.KeptnContext)
 		return true, nil
 	}
 
@@ -179,19 +181,23 @@ func (sd *SequenceDispatcher) isSequenceBlocked(queueItem models.QueueItem) (boo
 		TriggeredAt: queueItem.Timestamp,
 	})
 	if err != nil {
+		log.Errorf("Could not load triggered sequences: %w", err)
 		return true, err
 	}
 
 	if len(triggeredSequenceExecutions) == 1 {
 		if triggeredSequenceExecutions[0].Scope.KeptnContext != queueItem.Scope.KeptnContext {
+			log.Infof("Sequence with KeptnContext %s blocked due to triggered sequence", queueItem.Scope.KeptnContext)
 			return true, nil
 		}
 	}
 
 	if len(triggeredSequenceExecutions) > 1 {
+		log.Infof("Sequence with KeptnContext %s blocked due to triggered sequences", queueItem.Scope.KeptnContext)
 		return true, nil
 	}
 
+	log.Infof("Sequence with KeptnContext %s not blocked by any other sequence", queueItem.Scope.KeptnContext)
 	return false, nil
 }
 

--- a/shipyard-controller/handler/sequencedispatcher.go
+++ b/shipyard-controller/handler/sequencedispatcher.go
@@ -197,7 +197,6 @@ func (sd *SequenceDispatcher) isSequenceBlocked(queueItem models.QueueItem) (boo
 		return true, nil
 	}
 
-	log.Infof("Sequence with KeptnContext %s is not blocked by any other sequence in stage %s", queueItem.Scope.KeptnContext, queueItem.Scope.Stage)
 	return false, nil
 }
 

--- a/shipyard-controller/handler/sequencedispatcher.go
+++ b/shipyard-controller/handler/sequencedispatcher.go
@@ -159,7 +159,7 @@ func (sd *SequenceDispatcher) isSequenceBlocked(queueItem models.QueueItem) (boo
 		Status: []string{apimodels.SequenceStartedState},
 	})
 	if err != nil {
-		log.Errorf("Could not load started sequences: %w", err)
+		log.Errorf("Could not load started sequences: %v", err)
 		return true, err
 	}
 
@@ -181,7 +181,7 @@ func (sd *SequenceDispatcher) isSequenceBlocked(queueItem models.QueueItem) (boo
 		TriggeredAt: queueItem.Timestamp,
 	})
 	if err != nil {
-		log.Errorf("Could not load triggered sequences: %w", err)
+		log.Errorf("Could not load triggered sequences: %v", err)
 		return true, err
 	}
 

--- a/shipyard-controller/handler/sequencedispatcher_test.go
+++ b/shipyard-controller/handler/sequencedispatcher_test.go
@@ -107,7 +107,7 @@ func TestSequenceDispatcher(t *testing.T) {
 	}
 	err := sequenceDispatcher.Add(queueItem)
 	require.Nil(t, err)
-	require.Len(t, mockSequenceExecutionRepo.GetCalls(), 1)
+	require.Len(t, mockSequenceExecutionRepo.GetCalls(), 2)
 	require.Equal(t, mockSequenceExecutionRepo.GetCalls()[0].Filter.Scope.Project, queueItem.Scope.Project)
 	require.Equal(t, mockSequenceExecutionRepo.GetCalls()[0].Filter.Scope.Stage, queueItem.Scope.Stage)
 
@@ -147,7 +147,7 @@ func TestSequenceDispatcher(t *testing.T) {
 	}
 	err = sequenceDispatcher.Add(queueItemPar)
 
-	require.Len(t, mockSequenceExecutionRepo.GetCalls(), 2)
+	require.Len(t, mockSequenceExecutionRepo.GetCalls(), 4)
 
 	// GetEvents and DeleteQueuedSequences should have been called again at this point
 	require.Len(t, mockEventRepo.GetEventsCalls(), 2)
@@ -193,7 +193,7 @@ func TestSequenceDispatcher(t *testing.T) {
 	}
 	err = sequenceDispatcher.Add(queueItem2)
 
-	require.Len(t, mockSequenceExecutionRepo.GetCalls(), 3)
+	require.Len(t, mockSequenceExecutionRepo.GetCalls(), 5)
 
 	// GetEvents and DeleteQueuedSequences should not have been called again at this point
 	require.Len(t, mockEventRepo.GetEventsCalls(), 2)
@@ -223,7 +223,7 @@ func TestSequenceDispatcher(t *testing.T) {
 	}
 	err = sequenceDispatcher.Add(queueItem3)
 	// no new call to check sequences because Read disabled
-	require.Len(t, mockSequenceExecutionRepo.GetCalls(), 3)
+	require.Len(t, mockSequenceExecutionRepo.GetCalls(), 5)
 	//new item should have been added to queue
 	require.Len(t, mockSequenceQueueRepo.QueueSequenceCalls(), 2)
 
@@ -341,7 +341,7 @@ func TestSequenceDispatcher_AddError(t *testing.T) {
 	theClock.Add(11 * time.Second)
 
 	// queue repo should have been queried
-	require.Len(t, mockSequenceQueueRepo.GetQueuedSequencesCalls(), 2)
+	require.Len(t, mockSequenceQueueRepo.GetQueuedSequencesCalls(), 1)
 	require.Len(t, mockSequenceExecutionRepo.GetCalls(), 1)
 	require.Empty(t, mockSequenceQueueRepo.DeleteQueuedSequencesCalls())
 
@@ -352,123 +352,123 @@ func TestSequenceDispatcher_AddError(t *testing.T) {
 	require.Error(t, err2, "could not append item!")
 	theClock.Add(11 * time.Second)
 	// queue repo should have been queried
-	require.Len(t, mockSequenceQueueRepo.GetQueuedSequencesCalls(), 4)
-	require.Len(t, mockSequenceExecutionRepo.GetCalls(), 1)
+	require.Len(t, mockSequenceQueueRepo.GetQueuedSequencesCalls(), 2)
+	require.Len(t, mockSequenceExecutionRepo.GetCalls(), 2)
 	require.Empty(t, mockSequenceQueueRepo.DeleteQueuedSequencesCalls())
 
 }
 
-func TestSequenceDispatcher_QueueIsNotEmpty(t *testing.T) {
-	theClock := clock.NewMock()
+// func TestSequenceDispatcher_QueueIsNotEmpty(t *testing.T) {
+// 	theClock := clock.NewMock()
 
-	startSequenceCalls := []apimodels.KeptnContextExtendedCE{}
-	triggeredEvents := []apimodels.KeptnContextExtendedCE{
-		{
-			Data: keptnv2.EventData{
-				Project: "my-project",
-				Stage:   "my-stage",
-				Service: "my-service",
-			},
-			ID:             "my-event-id",
-			Shkeptncontext: "my-context-id",
-			Type:           common.Stringp(keptnv2.GetTriggeredEventType("dev.delivery")),
-		},
-	}
+// 	startSequenceCalls := []apimodels.KeptnContextExtendedCE{}
+// 	triggeredEvents := []apimodels.KeptnContextExtendedCE{
+// 		{
+// 			Data: keptnv2.EventData{
+// 				Project: "my-project",
+// 				Stage:   "my-stage",
+// 				Service: "my-service",
+// 			},
+// 			ID:             "my-event-id",
+// 			Shkeptncontext: "my-context-id",
+// 			Type:           common.Stringp(keptnv2.GetTriggeredEventType("dev.delivery")),
+// 		},
+// 	}
 
-	mockQueue := []models.QueueItem{}
+// 	mockQueue := []models.QueueItem{}
 
-	mockEventRepo := &dbmock.EventRepoMock{
-		GetEventsFunc: func(project string, filter common.EventFilter, status ...common.EventStatus) ([]apimodels.KeptnContextExtendedCE, error) {
-			return triggeredEvents, nil
-		},
-	}
+// 	mockEventRepo := &dbmock.EventRepoMock{
+// 		GetEventsFunc: func(project string, filter common.EventFilter, status ...common.EventStatus) ([]apimodels.KeptnContextExtendedCE, error) {
+// 			return triggeredEvents, nil
+// 		},
+// 	}
 
-	currentSequenceExecutions := []models.SequenceExecution{}
+// 	currentSequenceExecutions := []models.SequenceExecution{}
 
-	mockSequenceQueueRepo := &dbmock.SequenceQueueRepoMock{
-		QueueSequenceFunc: func(item models.QueueItem) error {
-			mockQueue = append(mockQueue, item)
-			return nil
-		},
-		GetQueuedSequencesFunc: func() ([]models.QueueItem, error) {
-			return mockQueue, nil
-		},
-		DeleteQueuedSequencesFunc: func(itemFilter models.QueueItem) error {
-			for index := range mockQueue {
-				if mockQueue[index].EventID == itemFilter.EventID {
-					mockQueue = append(mockQueue[:index], mockQueue[index+1:]...)
-				}
-			}
-			return nil
-		},
-	}
+// 	mockSequenceQueueRepo := &dbmock.SequenceQueueRepoMock{
+// 		QueueSequenceFunc: func(item models.QueueItem) error {
+// 			mockQueue = append(mockQueue, item)
+// 			return nil
+// 		},
+// 		GetQueuedSequencesFunc: func() ([]models.QueueItem, error) {
+// 			return mockQueue, nil
+// 		},
+// 		DeleteQueuedSequencesFunc: func(itemFilter models.QueueItem) error {
+// 			for index := range mockQueue {
+// 				if mockQueue[index].EventID == itemFilter.EventID {
+// 					mockQueue = append(mockQueue[:index], mockQueue[index+1:]...)
+// 				}
+// 			}
+// 			return nil
+// 		},
+// 	}
 
-	mockSequenceExecutionRepo := &dbmock.SequenceExecutionRepoMock{
-		GetFunc: func(filter models.SequenceExecutionFilter) ([]models.SequenceExecution, error) {
-			return currentSequenceExecutions, nil
-		},
-		GetByTriggeredIDFunc: func(project string, triggeredID string) (*models.SequenceExecution, error) {
-			return &models.SequenceExecution{
-				ID: "my-id",
-				Status: models.SequenceExecutionStatus{
-					State: apimodels.SequenceTriggeredState,
-				},
-			}, nil
-		},
-		IsContextPausedFunc: func(eventScope models.EventScope) bool {
-			return false
-		},
-	}
+// 	mockSequenceExecutionRepo := &dbmock.SequenceExecutionRepoMock{
+// 		GetFunc: func(filter models.SequenceExecutionFilter) ([]models.SequenceExecution, error) {
+// 			return currentSequenceExecutions, nil
+// 		},
+// 		GetByTriggeredIDFunc: func(project string, triggeredID string) (*models.SequenceExecution, error) {
+// 			return &models.SequenceExecution{
+// 				ID: "my-id",
+// 				Status: models.SequenceExecutionStatus{
+// 					State: apimodels.SequenceTriggeredState,
+// 				},
+// 			}, nil
+// 		},
+// 		IsContextPausedFunc: func(eventScope models.EventScope) bool {
+// 			return false
+// 		},
+// 	}
 
-	sequenceDispatcher := handler.NewSequenceDispatcher(mockEventRepo, mockSequenceQueueRepo, mockSequenceExecutionRepo, 10*time.Second, theClock, common.SDModeRW)
+// 	sequenceDispatcher := handler.NewSequenceDispatcher(mockEventRepo, mockSequenceQueueRepo, mockSequenceExecutionRepo, 10*time.Second, theClock, common.SDModeRW)
 
-	sequenceDispatcher.Run(context.Background(), common.SDModeRW, func(event apimodels.KeptnContextExtendedCE) error {
-		startSequenceCalls = append(startSequenceCalls, event)
-		return nil
-	})
+// 	sequenceDispatcher.Run(context.Background(), common.SDModeRW, func(event apimodels.KeptnContextExtendedCE) error {
+// 		startSequenceCalls = append(startSequenceCalls, event)
+// 		return nil
+// 	})
 
-	// check if repos are queried
-	theClock.Add(11 * time.Second)
-	// queue repo should have been queried
-	require.Len(t, mockSequenceQueueRepo.GetQueuedSequencesCalls(), 1)
-	// since no elements have been added to the queue yet, the other repos should not have been queried at this point// since one element has been added to the queue, the other sequence previously in the queue was dispatched
-	require.Len(t, mockSequenceQueueRepo.DeleteQueuedSequencesCalls(), 0)
+// 	// check if repos are queried
+// 	theClock.Add(11 * time.Second)
+// 	// queue repo should have been queried
+// 	require.Len(t, mockSequenceQueueRepo.GetQueuedSequencesCalls(), 1)
+// 	// since no elements have been added to the queue yet, the other repos should not have been queried at this point// since one element has been added to the queue, the other sequence previously in the queue was dispatched
+// 	require.Len(t, mockSequenceQueueRepo.DeleteQueuedSequencesCalls(), 0)
 
-	mockQueue = append(mockQueue, models.QueueItem{
-		Scope: models.EventScope{
-			EventData: keptnv2.EventData{
-				Project: "my-project",
-				Stage:   "my-stage",
-				Service: "my-service",
-			},
-			KeptnContext: "my-context-id2",
-			EventType:    keptnv2.GetTriggeredEventType("dev.delivery"),
-		},
-		EventID: "my-event-id2",
-	})
+// 	mockQueue = append(mockQueue, models.QueueItem{
+// 		Scope: models.EventScope{
+// 			EventData: keptnv2.EventData{
+// 				Project: "my-project",
+// 				Stage:   "my-stage",
+// 				Service: "my-service",
+// 			},
+// 			KeptnContext: "my-context-id2",
+// 			EventType:    keptnv2.GetTriggeredEventType("dev.delivery"),
+// 		},
+// 		EventID: "my-event-id2",
+// 	})
 
-	// now, let's add a sequence to the queue - should not be started immediately since there is another queued sequence
-	queueItem := models.QueueItem{
-		Scope: models.EventScope{
-			EventData: keptnv2.EventData{
-				Project: "my-project",
-				Stage:   "my-stage",
-				Service: "my-service",
-			},
-			KeptnContext: "my-context-id2",
-			EventType:    keptnv2.GetTriggeredEventType("dev.delivery"),
-		},
-		EventID: "my-event-id2",
-	}
-	err := sequenceDispatcher.Add(queueItem)
-	require.Equal(t, err.Error(), "sequence is currently blocked by waiting for another sequence to end")
-	require.Len(t, mockSequenceExecutionRepo.GetCalls(), 0)
+// 	// now, let's add a sequence to the queue - should not be started immediately since there is another queued sequence
+// 	queueItem := models.QueueItem{
+// 		Scope: models.EventScope{
+// 			EventData: keptnv2.EventData{
+// 				Project: "my-project",
+// 				Stage:   "my-stage",
+// 				Service: "my-service",
+// 			},
+// 			KeptnContext: "my-context-id2",
+// 			EventType:    keptnv2.GetTriggeredEventType("dev.delivery"),
+// 		},
+// 		EventID: "my-event-id2",
+// 	}
+// 	err := sequenceDispatcher.Add(queueItem)
+// 	require.Equal(t, err.Error(), "sequence is currently blocked by waiting for another sequence to end")
+// 	require.Len(t, mockSequenceExecutionRepo.GetCalls(), 0)
 
-	require.Len(t, mockEventRepo.GetEventsCalls(), 0)
+// 	require.Len(t, mockEventRepo.GetEventsCalls(), 0)
 
-	// the sequence should be inserted into the queue
-	require.Len(t, mockSequenceQueueRepo.QueueSequenceCalls(), 1)
-}
+// 	// the sequence should be inserted into the queue
+// 	require.Len(t, mockSequenceQueueRepo.QueueSequenceCalls(), 1)
+// }
 
 func getQueueItem(id string) models.QueueItem {
 	return models.QueueItem{

--- a/shipyard-controller/handler/sequencedispatcher_test.go
+++ b/shipyard-controller/handler/sequencedispatcher_test.go
@@ -3,6 +3,9 @@ package handler_test
 import (
 	"context"
 	"errors"
+	"testing"
+	"time"
+
 	"github.com/benbjohnson/clock"
 	apimodels "github.com/keptn/go-utils/pkg/api/models"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
@@ -11,8 +14,6 @@ import (
 	"github.com/keptn/keptn/shipyard-controller/handler"
 	"github.com/keptn/keptn/shipyard-controller/models"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
 )
 
 func TestSequenceDispatcher(t *testing.T) {
@@ -340,7 +341,7 @@ func TestSequenceDispatcher_AddError(t *testing.T) {
 	theClock.Add(11 * time.Second)
 
 	// queue repo should have been queried
-	require.Len(t, mockSequenceQueueRepo.GetQueuedSequencesCalls(), 1)
+	require.Len(t, mockSequenceQueueRepo.GetQueuedSequencesCalls(), 2)
 	require.Len(t, mockSequenceExecutionRepo.GetCalls(), 1)
 	require.Empty(t, mockSequenceQueueRepo.DeleteQueuedSequencesCalls())
 
@@ -351,7 +352,7 @@ func TestSequenceDispatcher_AddError(t *testing.T) {
 	require.Error(t, err2, "could not append item!")
 	theClock.Add(11 * time.Second)
 	// queue repo should have been queried
-	require.Len(t, mockSequenceQueueRepo.GetQueuedSequencesCalls(), 2)
+	require.Len(t, mockSequenceQueueRepo.GetQueuedSequencesCalls(), 4)
 	require.Len(t, mockSequenceExecutionRepo.GetCalls(), 1)
 	require.Empty(t, mockSequenceQueueRepo.DeleteQueuedSequencesCalls())
 

--- a/shipyard-controller/handler/sequencedispatcher_test.go
+++ b/shipyard-controller/handler/sequencedispatcher_test.go
@@ -358,117 +358,144 @@ func TestSequenceDispatcher_AddError(t *testing.T) {
 
 }
 
-// func TestSequenceDispatcher_QueueIsNotEmpty(t *testing.T) {
-// 	theClock := clock.NewMock()
+func TestSequenceDispatcher_QueueIsNotEmpty(t *testing.T) {
+	theClock := clock.NewMock()
 
-// 	startSequenceCalls := []apimodels.KeptnContextExtendedCE{}
-// 	triggeredEvents := []apimodels.KeptnContextExtendedCE{
-// 		{
-// 			Data: keptnv2.EventData{
-// 				Project: "my-project",
-// 				Stage:   "my-stage",
-// 				Service: "my-service",
-// 			},
-// 			ID:             "my-event-id",
-// 			Shkeptncontext: "my-context-id",
-// 			Type:           common.Stringp(keptnv2.GetTriggeredEventType("dev.delivery")),
-// 		},
-// 	}
+	startSequenceCalls := []apimodels.KeptnContextExtendedCE{}
+	triggeredEvents := []apimodels.KeptnContextExtendedCE{
+		{
+			Data: keptnv2.EventData{
+				Project: "my-project",
+				Stage:   "my-stage",
+				Service: "my-service",
+			},
+			ID:             "my-event-id",
+			Shkeptncontext: "my-context-id",
+			Type:           common.Stringp(keptnv2.GetTriggeredEventType("dev.delivery")),
+		},
+	}
 
-// 	mockQueue := []models.QueueItem{}
+	mockQueue := []models.QueueItem{}
 
-// 	mockEventRepo := &dbmock.EventRepoMock{
-// 		GetEventsFunc: func(project string, filter common.EventFilter, status ...common.EventStatus) ([]apimodels.KeptnContextExtendedCE, error) {
-// 			return triggeredEvents, nil
-// 		},
-// 	}
+	mockEventRepo := &dbmock.EventRepoMock{
+		GetEventsFunc: func(project string, filter common.EventFilter, status ...common.EventStatus) ([]apimodels.KeptnContextExtendedCE, error) {
+			return triggeredEvents, nil
+		},
+	}
 
-// 	currentSequenceExecutions := []models.SequenceExecution{}
+	currentSequenceExecutions := []models.SequenceExecution{}
 
-// 	mockSequenceQueueRepo := &dbmock.SequenceQueueRepoMock{
-// 		QueueSequenceFunc: func(item models.QueueItem) error {
-// 			mockQueue = append(mockQueue, item)
-// 			return nil
-// 		},
-// 		GetQueuedSequencesFunc: func() ([]models.QueueItem, error) {
-// 			return mockQueue, nil
-// 		},
-// 		DeleteQueuedSequencesFunc: func(itemFilter models.QueueItem) error {
-// 			for index := range mockQueue {
-// 				if mockQueue[index].EventID == itemFilter.EventID {
-// 					mockQueue = append(mockQueue[:index], mockQueue[index+1:]...)
-// 				}
-// 			}
-// 			return nil
-// 		},
-// 	}
+	mockSequenceQueueRepo := &dbmock.SequenceQueueRepoMock{
+		QueueSequenceFunc: func(item models.QueueItem) error {
+			mockQueue = append(mockQueue, item)
+			return nil
+		},
+		GetQueuedSequencesFunc: func() ([]models.QueueItem, error) {
+			return mockQueue, nil
+		},
+		DeleteQueuedSequencesFunc: func(itemFilter models.QueueItem) error {
+			for index := range mockQueue {
+				if mockQueue[index].EventID == itemFilter.EventID {
+					mockQueue = append(mockQueue[:index], mockQueue[index+1:]...)
+				}
+			}
+			return nil
+		},
+	}
 
-// 	mockSequenceExecutionRepo := &dbmock.SequenceExecutionRepoMock{
-// 		GetFunc: func(filter models.SequenceExecutionFilter) ([]models.SequenceExecution, error) {
-// 			return currentSequenceExecutions, nil
-// 		},
-// 		GetByTriggeredIDFunc: func(project string, triggeredID string) (*models.SequenceExecution, error) {
-// 			return &models.SequenceExecution{
-// 				ID: "my-id",
-// 				Status: models.SequenceExecutionStatus{
-// 					State: apimodels.SequenceTriggeredState,
-// 				},
-// 			}, nil
-// 		},
-// 		IsContextPausedFunc: func(eventScope models.EventScope) bool {
-// 			return false
-// 		},
-// 	}
+	mockSequenceExecutionRepo := &dbmock.SequenceExecutionRepoMock{
+		GetFunc: func(filter models.SequenceExecutionFilter) ([]models.SequenceExecution, error) {
+			return currentSequenceExecutions, nil
+		},
+		GetByTriggeredIDFunc: func(project string, triggeredID string) (*models.SequenceExecution, error) {
+			return &models.SequenceExecution{
+				ID: "my-id",
+				Status: models.SequenceExecutionStatus{
+					State: apimodels.SequenceTriggeredState,
+				},
+			}, nil
+		},
+		IsContextPausedFunc: func(eventScope models.EventScope) bool {
+			return false
+		},
+	}
 
-// 	sequenceDispatcher := handler.NewSequenceDispatcher(mockEventRepo, mockSequenceQueueRepo, mockSequenceExecutionRepo, 10*time.Second, theClock, common.SDModeRW)
+	sequenceDispatcher := handler.NewSequenceDispatcher(mockEventRepo, mockSequenceQueueRepo, mockSequenceExecutionRepo, 10*time.Second, theClock, common.SDModeRW)
 
-// 	sequenceDispatcher.Run(context.Background(), common.SDModeRW, func(event apimodels.KeptnContextExtendedCE) error {
-// 		startSequenceCalls = append(startSequenceCalls, event)
-// 		return nil
-// 	})
+	sequenceDispatcher.Run(context.Background(), common.SDModeRW, func(event apimodels.KeptnContextExtendedCE) error {
+		startSequenceCalls = append(startSequenceCalls, event)
+		return nil
+	})
 
-// 	// check if repos are queried
-// 	theClock.Add(11 * time.Second)
-// 	// queue repo should have been queried
-// 	require.Len(t, mockSequenceQueueRepo.GetQueuedSequencesCalls(), 1)
-// 	// since no elements have been added to the queue yet, the other repos should not have been queried at this point// since one element has been added to the queue, the other sequence previously in the queue was dispatched
-// 	require.Len(t, mockSequenceQueueRepo.DeleteQueuedSequencesCalls(), 0)
+	// check if repos are queried
+	theClock.Add(11 * time.Second)
+	// queue repo should have been queried
+	require.Len(t, mockSequenceQueueRepo.GetQueuedSequencesCalls(), 1)
+	// since no elements have been added to the queue yet, the other repos should not have been queried at this point// since one element has been added to the queue, the other sequence previously in the queue was dispatched
+	require.Len(t, mockSequenceQueueRepo.DeleteQueuedSequencesCalls(), 0)
 
-// 	mockQueue = append(mockQueue, models.QueueItem{
-// 		Scope: models.EventScope{
-// 			EventData: keptnv2.EventData{
-// 				Project: "my-project",
-// 				Stage:   "my-stage",
-// 				Service: "my-service",
-// 			},
-// 			KeptnContext: "my-context-id2",
-// 			EventType:    keptnv2.GetTriggeredEventType("dev.delivery"),
-// 		},
-// 		EventID: "my-event-id2",
-// 	})
+	// now, let's add a sequence - should be started immediately since there is another sequence in execution with different stage
+	queueItem := models.QueueItem{
+		Scope: models.EventScope{
+			EventData: keptnv2.EventData{
+				Project: "my-project2",
+				Stage:   "my-stage2",
+				Service: "my-service2",
+			},
+			KeptnContext: "my-context-id2",
+			EventType:    keptnv2.GetTriggeredEventType("dev.delivery"),
+		},
+		EventID: "my-event-id2",
+	}
+	err := sequenceDispatcher.Add(queueItem)
+	require.Nil(t, err)
+	require.Len(t, mockSequenceExecutionRepo.GetCalls(), 2)
 
-// 	// now, let's add a sequence to the queue - should not be started immediately since there is another queued sequence
-// 	queueItem := models.QueueItem{
-// 		Scope: models.EventScope{
-// 			EventData: keptnv2.EventData{
-// 				Project: "my-project",
-// 				Stage:   "my-stage",
-// 				Service: "my-service",
-// 			},
-// 			KeptnContext: "my-context-id2",
-// 			EventType:    keptnv2.GetTriggeredEventType("dev.delivery"),
-// 		},
-// 		EventID: "my-event-id2",
-// 	}
-// 	err := sequenceDispatcher.Add(queueItem)
-// 	require.Equal(t, err.Error(), "sequence is currently blocked by waiting for another sequence to end")
-// 	require.Len(t, mockSequenceExecutionRepo.GetCalls(), 0)
+	require.Len(t, mockEventRepo.GetEventsCalls(), 1)
 
-// 	require.Len(t, mockEventRepo.GetEventsCalls(), 0)
+	// the sequence should be inserted into the queue
+	require.Len(t, mockSequenceQueueRepo.QueueSequenceCalls(), 0)
 
-// 	// the sequence should be inserted into the queue
-// 	require.Len(t, mockSequenceQueueRepo.QueueSequenceCalls(), 1)
-// }
+	currentSequenceExecutions = []models.SequenceExecution{{
+		ID: "my-id",
+		Sequence: keptnv2.Sequence{
+			Name: "delivery",
+		},
+		Status: models.SequenceExecutionStatus{
+			State: apimodels.SequenceStartedState,
+		},
+		Scope: models.EventScope{
+			EventData: keptnv2.EventData{
+				Project: "my-project",
+				Stage:   "my-stage",
+				Service: "my-service",
+			},
+			KeptnContext: "my-context-id",
+		},
+	}}
+
+	// now, let's add a sequence - should not be started immediately since there is another sequence in execution in the same stage
+	queueItem = models.QueueItem{
+		Scope: models.EventScope{
+			EventData: keptnv2.EventData{
+				Project: "my-project",
+				Stage:   "my-stage",
+				Service: "my-service",
+			},
+			KeptnContext: "my-context-id3",
+			EventType:    keptnv2.GetTriggeredEventType("dev.delivery"),
+		},
+		EventID: "my-event-id2",
+	}
+	err = sequenceDispatcher.Add(queueItem)
+	require.Equal(t, err.Error(), "sequence is currently blocked by waiting for another sequence to end")
+	require.Len(t, mockSequenceExecutionRepo.GetCalls(), 3)
+
+	require.Len(t, mockEventRepo.GetEventsCalls(), 1)
+
+	// the sequence should be inserted into the queue
+	require.Len(t, mockSequenceQueueRepo.QueueSequenceCalls(), 1)
+}
 
 func getQueueItem(id string) models.QueueItem {
 	return models.QueueItem{

--- a/shipyard-controller/handler/sequencedispatcher_test.go
+++ b/shipyard-controller/handler/sequencedispatcher_test.go
@@ -353,7 +353,7 @@ func TestSequenceDispatcher_AddError(t *testing.T) {
 	theClock.Add(11 * time.Second)
 	// queue repo should have been queried
 	require.Len(t, mockSequenceQueueRepo.GetQueuedSequencesCalls(), 2)
-	require.Len(t, mockSequenceExecutionRepo.GetCalls(), 2)
+	require.Len(t, mockSequenceExecutionRepo.GetCalls(), 1)
 	require.Empty(t, mockSequenceQueueRepo.DeleteQueuedSequencesCalls())
 
 }
@@ -453,9 +453,10 @@ func TestSequenceDispatcher_QueueIsNotEmpty(t *testing.T) {
 
 	require.Len(t, mockEventRepo.GetEventsCalls(), 1)
 
-	// the sequence should be inserted into the queue
+	// the sequence should not be inserted into the queue
 	require.Len(t, mockSequenceQueueRepo.QueueSequenceCalls(), 0)
 
+	// let's add some running sequences
 	currentSequenceExecutions = []models.SequenceExecution{{
 		ID: "my-id",
 		Sequence: keptnv2.Sequence{

--- a/shipyard-controller/handler/shipyardcontroller.go
+++ b/shipyard-controller/handler/shipyardcontroller.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
+
 	"github.com/google/uuid"
 	apimodels "github.com/keptn/go-utils/pkg/api/models"
 	"github.com/keptn/go-utils/pkg/common/timeutils"
@@ -14,7 +16,6 @@ import (
 	"github.com/keptn/keptn/shipyard-controller/handler/sequencehooks"
 	"github.com/keptn/keptn/shipyard-controller/models"
 	log "github.com/sirupsen/logrus"
-	"time"
 )
 
 const maxRepoReadRetries = 5
@@ -249,6 +250,7 @@ func (sc *shipyardController) handleSequenceTriggered(event apimodels.KeptnConte
 		},
 		InputProperties: inputProperties,
 		Scope:           *eventScope,
+		TriggeredAt:     time.Now().UTC(),
 	}
 	sequenceExecution.Scope.TriggeredID = event.ID
 	sequenceExecution.Scope.GitCommitID = eventScope.WrappedEvent.GitCommitID

--- a/shipyard-controller/models/sequence_execution.go
+++ b/shipyard-controller/models/sequence_execution.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"time"
+
 	"github.com/keptn/go-utils/pkg/api/models"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 	"github.com/keptn/keptn/shipyard-controller/common"
@@ -20,6 +22,7 @@ type SequenceExecution struct {
 	Scope    EventScope              `json:"scope" bson:"scope"`
 	// InputProperties contains properties of the event which triggered the task sequence
 	InputProperties map[string]interface{} `json:"inputProperties" bson:"inputProperties"`
+	TriggeredAt     time.Time              `json:"triggeredAt" bson:"triggeredAt"`
 }
 
 type SequenceExecutionStatus struct {
@@ -266,6 +269,7 @@ type SequenceExecutionFilter struct {
 	Status             []string
 	Name               string
 	CurrentTriggeredID string
+	TriggeredAt        time.Time
 }
 
 type SequenceExecutionUpsertOptions struct {


### PR DESCRIPTION
Signed-off-by: odubajDT <ondrej.dubaj@dynatrace.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- dispaches new sequences directly only if no older sequence is executed (in state triggered or started) in the same stage, service and project
- refactoring the Add() method
- adding unit tests

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #7767

### Integration tests
https://github.com/keptn/keptn/actions/runs/2369401694

