### PR TITLE
fix(cp-connector): Unsubscribe instead of disconnect from nats on cancel

### DIFF
--- a/cp-connector/pkg/controlplane/eventsource.go
+++ b/cp-connector/pkg/controlplane/eventsource.go
@@ -93,8 +93,8 @@ func (n *NATSEventSource) Start(ctx context.Context, registrationData Registrati
 	}
 	go func() {
 		<-ctx.Done()
-		if err := n.connector.Disconnect(); err != nil {
-			n.logger.Errorf("Unable to disconnect from NATS: %v", err)
+		if err := n.connector.UnsubscribeAll(); err != nil {
+			n.logger.Errorf("Unable to unsubscribe from NATS: %v", err)
 			return
 		}
 	}()

--- a/cp-connector/pkg/controlplane/eventsource_test.go
+++ b/cp-connector/pkg/controlplane/eventsource_test.go
@@ -140,23 +140,23 @@ func TestEventSourceForwardsEventToChannel(t *testing.T) {
 func TestEventSourceCancelDisconnectsFromBroker(t *testing.T) {
 	natsConnectorMock := &NATSConnectorMock{
 		QueueSubscribeMultipleFn: func(subjects []string, queueGroup string, fn nats2.ProcessEventFn) error { return nil },
-		DisconnectFn:             func() error { return nil },
+		UnsubscribeAllFn:         func() error { return nil },
 	}
 	ctx, cancel := context.WithCancel(context.TODO())
 	NewNATSEventSource(natsConnectorMock).Start(ctx, RegistrationData{}, make(chan EventUpdate))
 	cancel()
-	require.Eventually(t, func() bool { return natsConnectorMock.DisconnectCalls == 1 }, 2*time.Second, 100*time.Millisecond)
+	require.Eventually(t, func() bool { return natsConnectorMock.UnsubscribeAllCalls == 1 }, 2*time.Second, 100*time.Millisecond)
 }
 
 func TestEventSourceCancelDisconnectFromBrokerFails(t *testing.T) {
 	natsConnectorMock := &NATSConnectorMock{
 		QueueSubscribeMultipleFn: func(subjects []string, queueGroup string, fn nats2.ProcessEventFn) error { return nil },
-		DisconnectFn:             func() error { return fmt.Errorf("error occured") },
+		UnsubscribeAllFn:         func() error { return fmt.Errorf("error occured") },
 	}
 	ctx, cancel := context.WithCancel(context.TODO())
 	NewNATSEventSource(natsConnectorMock).Start(ctx, RegistrationData{}, make(chan EventUpdate))
 	cancel()
-	require.Eventually(t, func() bool { return natsConnectorMock.DisconnectCalls == 1 }, 2*time.Second, 100*time.Millisecond)
+	require.Eventually(t, func() bool { return natsConnectorMock.UnsubscribeAllCalls == 1 }, 2*time.Second, 100*time.Millisecond)
 }
 
 func TestEventSourceQueueSubscribeFails(t *testing.T) {


### PR DESCRIPTION
This PR changes the `NatsEventSource` of the `cp-connector` to unsubscribe from its subscribed topics when the context is cancelled. Previously it was disconnecting from nats altogether, which means that the service using this lib was not able to send out events (e.g. finished events). when it was still processing an event at the time of cancellation