### PR TITLE
fix(go-sdk): Return from event handler when wg for graceful shutdown cannot be retrieved from context

### DIFF
--- a/go-sdk/pkg/sdk/keptn.go
+++ b/go-sdk/pkg/sdk/keptn.go
@@ -184,6 +184,7 @@ func (k *Keptn) OnEvent(ctx context.Context, event models.KeptnContextExtendedCE
 	wg, ok := ctx.Value(gracefulShutdownKey).(wgInterface)
 	if !ok {
 		k.logger.Errorf("Unable to get graceful shutdown wait group. Skip processing of event %s", event.ID)
+		return nil
 	}
 	wg.Add(1)
 	k.runEventTaskAction(func() {

--- a/remediation-service/go.mod
+++ b/remediation-service/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/keptn/go-utils v0.15.1-0.20220517082831-2052e1404e4c
-	github.com/keptn/keptn/go-sdk v0.0.0-20220520062634-de4ebc5f2d55
+	github.com/keptn/keptn/go-sdk v0.0.0-20220520064235-546a544d9547
 	github.com/sirupsen/logrus v1.8.1
 )
 

--- a/remediation-service/go.sum
+++ b/remediation-service/go.sum
@@ -71,8 +71,8 @@ github.com/keptn/go-utils v0.15.1-0.20220517082831-2052e1404e4c h1:Y3z1aDzmYrSJb
 github.com/keptn/go-utils v0.15.1-0.20220517082831-2052e1404e4c/go.mod h1:oxLLKz2u9KId2HgLH63+T0pUbcgiDd2GDkRrRKwxGUU=
 github.com/keptn/keptn/cp-connector v0.0.0-20220519092125-885433905cc0 h1:pmbwyHQRO74dt3W24jCDyfUovDT89zsVXmC15UrAmn4=
 github.com/keptn/keptn/cp-connector v0.0.0-20220519092125-885433905cc0/go.mod h1:3fvunuLSccjS/4cIeNqYVr3eCZKznfgnpqDnE7WCqos=
-github.com/keptn/keptn/go-sdk v0.0.0-20220520062634-de4ebc5f2d55 h1:B/9jqduga99Ub644iHP8zoqPx9zAtLpXgpOWKNVpd7U=
-github.com/keptn/keptn/go-sdk v0.0.0-20220520062634-de4ebc5f2d55/go.mod h1:/qeqv6bPV/CqeruldCf/lzrXZZ2aDd2vO+d5Kw9tPPo=
+github.com/keptn/keptn/go-sdk v0.0.0-20220520064235-546a544d9547 h1:ebpJ5J5mewo5dO6ntQXuPDVXsjezVp124dyjcrbWbFk=
+github.com/keptn/keptn/go-sdk v0.0.0-20220520064235-546a544d9547/go.mod h1:/qeqv6bPV/CqeruldCf/lzrXZZ2aDd2vO+d5Kw9tPPo=
 github.com/klauspost/compress v1.14.4 h1:eijASRJcobkVtSt81Olfh7JX43osYLwy5krOJo6YEu4=
 github.com/klauspost/compress v1.14.4/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/webhook-service/go.mod
+++ b/webhook-service/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/keptn/go-utils v0.15.1-0.20220517082831-2052e1404e4c
-	github.com/keptn/keptn/go-sdk v0.0.0-20220520062634-de4ebc5f2d55
+	github.com/keptn/keptn/go-sdk v0.0.0-20220520064235-546a544d9547
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.1

--- a/webhook-service/go.sum
+++ b/webhook-service/go.sum
@@ -166,8 +166,8 @@ github.com/keptn/go-utils v0.15.1-0.20220517082831-2052e1404e4c h1:Y3z1aDzmYrSJb
 github.com/keptn/go-utils v0.15.1-0.20220517082831-2052e1404e4c/go.mod h1:oxLLKz2u9KId2HgLH63+T0pUbcgiDd2GDkRrRKwxGUU=
 github.com/keptn/keptn/cp-connector v0.0.0-20220519092125-885433905cc0 h1:pmbwyHQRO74dt3W24jCDyfUovDT89zsVXmC15UrAmn4=
 github.com/keptn/keptn/cp-connector v0.0.0-20220519092125-885433905cc0/go.mod h1:3fvunuLSccjS/4cIeNqYVr3eCZKznfgnpqDnE7WCqos=
-github.com/keptn/keptn/go-sdk v0.0.0-20220520062634-de4ebc5f2d55 h1:B/9jqduga99Ub644iHP8zoqPx9zAtLpXgpOWKNVpd7U=
-github.com/keptn/keptn/go-sdk v0.0.0-20220520062634-de4ebc5f2d55/go.mod h1:/qeqv6bPV/CqeruldCf/lzrXZZ2aDd2vO+d5Kw9tPPo=
+github.com/keptn/keptn/go-sdk v0.0.0-20220520064235-546a544d9547 h1:ebpJ5J5mewo5dO6ntQXuPDVXsjezVp124dyjcrbWbFk=
+github.com/keptn/keptn/go-sdk v0.0.0-20220520064235-546a544d9547/go.mod h1:/qeqv6bPV/CqeruldCf/lzrXZZ2aDd2vO+d5Kw9tPPo=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.14.4 h1:eijASRJcobkVtSt81Olfh7JX43osYLwy5krOJo6YEu4=


### PR DESCRIPTION
minor fix: onEvent handler of sdk shall return when waitgroup for graceful shutodwn cannot be retrieved from context