### PR TITLE
feat(bridge): Removes projects polling on dashboard #7796

### DIFF
--- a/bridge/client/app/dashboard/dashboard.component.spec.ts
+++ b/bridge/client/app/dashboard/dashboard.component.spec.ts
@@ -1,8 +1,7 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { DashboardComponent } from './dashboard.component';
-import { AppModule } from '../app.module';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { POLLING_INTERVAL_MILLIS } from '../_utils/app.utils';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AppModule } from '../app.module';
+import { DashboardComponent } from './dashboard.component';
 
 describe('DashboardComponent', () => {
   let component: DashboardComponent;
@@ -11,7 +10,6 @@ describe('DashboardComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AppModule, HttpClientTestingModule],
-      providers: [{ provide: POLLING_INTERVAL_MILLIS, useValue: 0 }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(DashboardComponent);

--- a/bridge/client/app/dashboard/dashboard.component.ts
+++ b/bridge/client/app/dashboard/dashboard.component.ts
@@ -1,11 +1,10 @@
-import { Component, Inject, NgZone, OnDestroy, OnInit } from '@angular/core';
+import { Component, NgZone, OnDestroy, OnInit } from '@angular/core';
+import { DtOverlay } from '@dynatrace/barista-components/overlay';
 import { Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
 import { Project } from '../_models/project';
 import { DataService } from '../_services/data.service';
-import { environment } from '../../environments/environment';
-import { takeUntil } from 'rxjs/operators';
-import { DtOverlay } from '@dynatrace/barista-components/overlay';
-import { AppUtils, POLLING_INTERVAL_MILLIS } from '../_utils/app.utils';
 
 @Component({
   selector: 'ktb-dashboard',
@@ -13,30 +12,19 @@ import { AppUtils, POLLING_INTERVAL_MILLIS } from '../_utils/app.utils';
   styleUrls: ['./dashboard.component.scss'],
 })
 export class DashboardComponent implements OnInit, OnDestroy {
-  public projects$: Observable<Project[] | undefined>;
+  public readonly projects$: Observable<Project[] | undefined> = this.dataService.projects;
   public logoInvertedUrl = environment?.config?.logoInvertedUrl;
   public isQualityGatesOnly = false;
   private readonly unsubscribe$: Subject<void> = new Subject<void>();
 
-  constructor(
-    private dataService: DataService,
-    private ngZone: NgZone,
-    private _dtOverlay: DtOverlay,
-    @Inject(POLLING_INTERVAL_MILLIS) private initialDelayMillis: number
-  ) {
-    this.projects$ = this.dataService.projects;
-  }
+  constructor(private dataService: DataService, private ngZone: NgZone, private _dtOverlay: DtOverlay) {}
 
   public ngOnInit(): void {
     this.dataService.isQualityGatesOnly.pipe(takeUntil(this.unsubscribe$)).subscribe((isQualityGatesOnly) => {
       this.isQualityGatesOnly = isQualityGatesOnly;
     });
 
-    AppUtils.createTimer(this.initialDelayMillis, this.initialDelayMillis)
-      .pipe(takeUntil(this.unsubscribe$))
-      .subscribe(() => {
-        this.loadProjects();
-      });
+    this.loadProjects();
   }
 
   public loadProjects(): void {

--- a/bridge/client/app/dashboard/dashboard.component.ts
+++ b/bridge/client/app/dashboard/dashboard.component.ts
@@ -23,8 +23,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.dataService.isQualityGatesOnly.pipe(takeUntil(this.unsubscribe$)).subscribe((isQualityGatesOnly) => {
       this.isQualityGatesOnly = isQualityGatesOnly;
     });
-
-    this.loadProjects();
   }
 
   public loadProjects(): void {


### PR DESCRIPTION
## This PR
- Removes polling for projects
- Removes dependency on POLLING_INTERVAL_MILLIS
- Adapts spec

### Related Issues
Resolves #7796 

### Notes
No useful screenshots available.

### How to test

1. Go to dashboard and open DevTools/Networking
2. No additional calls to `/api/controlPlane/v1/project?disableUpstreamSync=true&pageSize=50`