### PR TITLE
feat: Enable Resource-Service by default

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -206,7 +206,7 @@ configurationService:
   preStopHookTime: 5
 
 resourceService:
-  enabled: false
+  enabled: true
   replicas: 1
   image:
     repository: docker.io/keptn/resource-service


### PR DESCRIPTION
Signed-off-by: Giovanni Liva <giovanni.liva@dynatrace.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR

makes the `resource-service` enabled by default.

As a follow-up, we should work on some clean-up tasks for the K8s service name and pipeline: #7827

