### PR TITLE
ci: Added cypress tests to Zero Downtime pipeline

### DIFF
--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -354,7 +354,7 @@ jobs:
           set -euo pipefail 
           
           cd ../test/zero-downtime && go test -json -v -run Test_ZeroDowntime -v -timeout 90m 2>&1 | tee /tmp/gotest.log &
-          if [[ "${{ github.event.inputs.testUI }}" == true ]]; then
+          if [[ "${{ github.event.inputs.testUI }}" == 'true' ]]; then
             while [[ $(jobs -pr) ]]; do
               npm run test:ui >> /tmp/uitest.log 2>&1 
             done

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -334,8 +334,7 @@ jobs:
           # Optional: pass GITHUB_TOKEN to avoid rate limiting.
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install npm
-        id: install_npm
+      - name: Install Node Dependencies
         working-directory: bridge
         run: yarn install --frozen-lockfile
 
@@ -454,7 +453,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: test-log
+          name: go-test-log
           path: /tmp/gotest.log
           if-no-files-found: error
 

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -368,7 +368,7 @@ jobs:
           cat /tmp/gotest.log | gotestfmt
 
       - name: Format cypress log output
-        if: "${{ github.event.inputs.testUI }}" == 'true'
+        if: event.inputs.testUI == 'true'
         working-directory: bridge
         run: cat uitest.log
 

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -354,9 +354,9 @@ jobs:
           set -euo pipefail 
           
           cd ../test/zero-downtime && go test -json -v -run Test_ZeroDowntime -v -timeout 90m 2>&1 | tee /tmp/gotest.log &
-          if [[ "${{ github.event.inputs.testUI }}" == 'true' ]]; then
-            echo "New Run: "  >> /tmp/uitest.log 
+          if [[ "${{ github.event.inputs.testUI }}" == 'true' ]]; then   
             while [[ $(jobs -pr) ]]; do
+              echo "New Run: "  >> /tmp/uitest.log 
               npm run test:ui >> /tmp/uitest.log 2>&1 
             done
           fi

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -115,7 +115,7 @@ jobs:
               -H "Authorization: token $GITHUB_TOKEN" \
               "api.github.com/repos/$REPO_SLUG/actions/workflows/CI.yml/runs?branch=$BRANCH" | \
             jq '[.workflow_runs[] | select(
-              (.head_commit != null) and (.head_commit.author.name | endswith("[bot]") | not ) and ( .conclusion == "success" ) 
+              (.head_commit != null) and (.head_commit.author.name | endswith("[bot]") | not ) and ( .conclusion == "success" )
             )][0] | .id')
           echo "Run ID that will be used to download artifacts from: $RUN_ID"
           echo "::set-output name=RUN_ID::$RUN_ID"
@@ -177,18 +177,18 @@ jobs:
           HELM_CHART_NAME: ${{ steps.extract_helm_chart_name.outputs.HELM_CHART_NAME }}
         run: |
           CHART_REPO="https://charts.keptn.sh"
-          if [[ ${{ github.event.inputs.upgradeTo }} == *"-dev"* ]]; then 
-            CHART_REPO="https://charts-dev.keptn.sh" 
+          if [[ ${{ github.event.inputs.upgradeTo }} == *"-dev"* ]]; then
+            CHART_REPO="https://charts-dev.keptn.sh"
           fi
           helm repo add keptndev $CHART_REPO
           helm repo update
           helm pull keptndev/keptn --version ${{ github.event.inputs.upgradeTo }} --destination test/zero-downtime
-          echo "copying helm chart in zero downtime folder" 
+          echo "copying helm chart in zero downtime folder"
           cp ${HELM_CHART_NAME} test/zero-downtime/keptn-installed.tgz
           cd test/zero-downtime
           echo "Downloaded files:"
           ls -la ./keptn*.tgz
-          echo "UPGRADE_HELM_CHART=$(ls './keptn-${{ github.event.inputs.upgradeTo }}.tgz')" >> $GITHUB_ENV      
+          echo "UPGRADE_HELM_CHART=$(ls './keptn-${{ github.event.inputs.upgradeTo }}.tgz')" >> $GITHUB_ENV
           echo "INSTALL_HELM_CHART=$(ls ./keptn-installed.tgz)" >> $GITHUB_ENV
 
       - name: Install and start GKE cluster
@@ -206,30 +206,30 @@ jobs:
           export CLUSTER_NAME_NIGHTLY=${{ matrix.CLUSTER_NAME }}
           echo "Setting up GCloud CLI"
           export OS_TYPE="linux"
-          
+
           echo ${GCLOUD_SERVICE_KEY} | base64 --decode > ~/gcloud-service-key.json
           export GOOGLE_APPLICATION_CREDENTIALS=~/gcloud-service-key.json
           export CLOUDSDK_CORE_DISABLE_PROMPTS=1;
-          
+
           gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
           gcloud --quiet config set project "$GCLOUD_PROJECT_NAME"
           gcloud --quiet config set container/cluster "$CLUSTER_NAME_NIGHTLY"
           gcloud --quiet config set compute/zone "${CLOUDSDK_COMPUTE_ZONE}"
-          
+
           echo "GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS}" >> $GITHUB_ENV
-          
+
           echo "Setting up kubectl"
           echo "Setting KUBECONFIG to $PWD/.kubeconfig"
-          
+
           echo "$GKE_KUBECONFIG" >> "$PWD/.kubeconfig"
           chmod 600 "$PWD/.kubeconfig"
           export KUBECONFIG="$PWD/.kubeconfig"
-          
+
           echo "KUBECONFIG=${KUBECONFIG}" >> $GITHUB_ENV
-          
+
           echo "Setting kube context..."
           kubectl config use-context "$CLUSTER_NAME_NIGHTLY"
-          
+
           echo "##[set-output name=CLUSTER_NAME_NIGHTLY;]$(echo ${CLUSTER_NAME_NIGHTLY})"
 
       - name: Install Keptn
@@ -240,14 +240,14 @@ jobs:
         run: |
           echo "Installing Keptn on cluster"
           echo "{}" > creds.json # empty credentials file
-          
+
           echo "::group::Keptn Installation Log"
-          
+
           # Use Keptn helm chart to be able to customize the values
           helm install -n ${KEPTN_NAMESPACE} keptn ${HELM_CHART_NAME} \
             --create-namespace \
-            --values=./test/zero-downtime/assets/test-values.yml 
-          
+            --values=./test/zero-downtime/assets/test-values.yml
+
           echo "::endgroup::"
 
       - name: Install Gitea
@@ -297,9 +297,9 @@ jobs:
           source test/utils.sh
 
           # authenticate at Keptn API
-          
+
           KEPTN_ENDPOINT=http://$(kubectl -n ${KEPTN_NAMESPACE} get service api-gateway-nginx -o jsonpath='{.status.loadBalancer.ingress[0].ip}')/api
- 
+
           KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n ${KEPTN_NAMESPACE} -ojsonpath={.data.keptn-api-token} | base64 --decode)
           echo "KEPTN_ENDPOINT=${KEPTN_ENDPOINT}"
           echo "##[set-output name=KEPTN_ENDPOINT;]$(echo ${KEPTN_ENDPOINT})"
@@ -311,11 +311,11 @@ jobs:
           HELM_SERVICE_HELM_CHART_NAME: ${{ steps.extract_helm_chart_name.outputs.HELM_SERVICE_HELM_CHART_NAME }}
           JMETER_SERVICE_HELM_CHART_NAME: ${{ steps.extract_helm_chart_name.outputs.JMETER_SERVICE_HELM_CHART_NAME }}
         run: |
-          
+
           # In-cluster execution plane
           helm install helm-service "${HELM_SERVICE_HELM_CHART_NAME}" -n ${{ env.KEPTN_NAMESPACE }}
           helm install jmeter-service "${JMETER_SERVICE_HELM_CHART_NAME}" -n ${{ env.KEPTN_NAMESPACE }}
-          
+
           helm test jmeter-service -n ${{ env.KEPTN_NAMESPACE }}
           helm test helm-service -n ${{ env.KEPTN_NAMESPACE }}
 
@@ -325,11 +325,17 @@ jobs:
           # Optional: pass GITHUB_TOKEN to avoid rate limiting.
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install npm
+        id: install_npm
+        working-directory: bridge
+        run: |
+          cp package.json yarn.lock
+          yarn install --frozen-lockfile
+
       - name: Prepare test run
         id: prepare_test_run
         working-directory: test/zero-downtime
-        run: |
-          go get ./...
+        run: go get ./...
 
       #######################################################################
       # TESTS
@@ -343,9 +349,8 @@ jobs:
           GOMAXPROCS: 10
           KEPTN_ENDPOINT: ${{ steps.determine_keptn_endpoint.outputs.KEPTN_ENDPOINT }}
         run: |
-          set -euo pipefail
-          npm ci   
-          npm test:ui &
+          set -euo pipefail 
+          npm run test:ui &
           cd ../test/zero-downtime && go test -json -v -run Test_ZeroDowntime -v -timeout 90m 2>&1 | tee /tmp/gotest.log 
 
       - name: Format log output

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -371,7 +371,7 @@ jobs:
           cat /tmp/gotest.log | gotestfmt
 
       - name: Format cypress log output
-        if: github.event.inputs.testUI == true
+        if: always() && github.event.inputs.testUI == 'true'
         working-directory: bridge
         run: cat uitest.log
 
@@ -460,7 +460,7 @@ jobs:
       # Upload the original cypress test log as an artifact for later review.
       - name: Upload cypress test log
         uses: actions/upload-artifact@v2
-        if: github.event.inputs.testUI == true
+        if: always() && github.event.inputs.testUI == 'true'
         with:
           name: ui-test-log
           path:  /tmp/uitest.log

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -351,7 +351,7 @@ jobs:
           
           cd ../test/zero-downtime && go test -json -v -run Test_ZeroDowntime -v -timeout 90m 2>&1 | tee /tmp/gotest.log &
           while [[ $(jobs -pr) ]]; do
-            npm run test:ui >> uitest.log 2>&1 
+            npm run test:ui >> /tmp/uitest.log 2>&1 
           done
 
       - name: Format go test log output
@@ -453,7 +453,7 @@ jobs:
         if: always()
         with:
           name: ui-test-log
-          path:  ../bridge/uitest.log
+          path:  /tmp/uitest.log
           if-no-files-found: error
 
   calculate-total-runtime:

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -348,8 +348,11 @@ jobs:
           KEPTN_ENDPOINT: ${{ steps.determine_keptn_endpoint.outputs.KEPTN_ENDPOINT }}
         run: |
           set -euo pipefail 
-          npm run test:ui > uitest.log 2>&1 &
-          cd ../test/zero-downtime && go test -json -v -run Test_ZeroDowntime -v -timeout 90m 2>&1 | tee /tmp/gotest.log 
+          
+          cd ../test/zero-downtime && go test -json -v -run Test_ZeroDowntime -v -timeout 90m 2>&1 | tee /tmp/gotest.log &
+          while [[ $(jobs -pr) ]]; do
+            npm run test:ui >> uitest.log 2>&1 
+          done
 
       - name: Format go test log output
         if: always()

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -338,13 +338,15 @@ jobs:
       - name: Zero Downtime Tests
         id: test_zero_downtime
         timeout-minutes: 90
-        working-directory: test/zero-downtime
+        working-directory: bridge
         env:
           GOMAXPROCS: 10
           KEPTN_ENDPOINT: ${{ steps.determine_keptn_endpoint.outputs.KEPTN_ENDPOINT }}
         run: |
           set -euo pipefail
-          go test -json -v -run Test_ZeroDowntime -v -timeout 90m 2>&1 | tee /tmp/gotest.log
+          npm ci   
+          npm test:ui &
+          cd ../test/zero-downtime && go test -json -v -run Test_ZeroDowntime -v -timeout 90m 2>&1 | tee /tmp/gotest.log 
 
       - name: Format log output
         if: always()

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -355,7 +355,7 @@ jobs:
           set -euo pipefail 
           
           cd ../test/zero-downtime && go test -json -v -run Test_ZeroDowntime -v -timeout 90m 2>&1 | tee /tmp/gotest.log &
-          if "${{ github.event.inputs.testUI }}" == 'true'
+          if [[ "${{ github.event.inputs.testUI }}" == 'true' ]]; then
             while [[ $(jobs -pr) ]]; do
               npm run test:ui >> /tmp/uitest.log 2>&1 
             done

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -349,7 +349,7 @@ jobs:
           KEPTN_ENDPOINT: ${{ steps.determine_keptn_endpoint.outputs.KEPTN_ENDPOINT }}
         run: |
           set -euo pipefail 
-          npm run test:ui 2>&1 > uitest.txt &
+          npm run test:ui > uitest.txt 2>&1 &
           cd ../test/zero-downtime && go test -json -v -run Test_ZeroDowntime -v -timeout 90m 2>&1 | tee /tmp/gotest.log 
 
       - name: Format go test log output

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -368,7 +368,7 @@ jobs:
           cat /tmp/gotest.log | gotestfmt
 
       - name: Format cypress log output
-        if: ${{ github.event_name }} == 'workflow_dispatch' && ${{ event.inputs.testUI == 'true' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && event.inputs.testUI == 'true' }}
         working-directory: bridge
         run: cat uitest.log
 

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -1,5 +1,9 @@
 name: ZeroDowntime Tests
 on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: '0 1 * * 1' # run zd tests at 1 AM (UTC), monday(1)
+
   workflow_dispatch: # run zero downtime tests selecting the installation branch and the upgrade chart
     inputs:
       branch:
@@ -368,7 +372,7 @@ jobs:
           cat /tmp/gotest.log | gotestfmt
 
       - name: Format cypress log output
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.testUI == 'true' }}
+        if: github.event.inputs.testUI == 'true'
         working-directory: bridge
         run: cat uitest.log
 
@@ -457,7 +461,7 @@ jobs:
       # Upload the original cypress test log as an artifact for later review.
       - name: Upload cypress test log
         uses: actions/upload-artifact@v2
-        if: ${{ github.event.inputs.testUI == 'true' }}
+        if: github.event.inputs.testUI == 'true'
         with:
           name: ui-test-log
           path:  /tmp/uitest.log

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -368,7 +368,7 @@ jobs:
           cat /tmp/gotest.log | gotestfmt
 
       - name: Format cypress log output
-        if: ${{ github.event_name == 'workflow_dispatch' && event.inputs.testUI == 'true' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.testUI == 'true' }}
         working-directory: bridge
         run: cat uitest.log
 

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -1,9 +1,5 @@
 name: ZeroDowntime Tests
 on:
-  schedule:
-    # * is a special character in YAML so you have to quote this string
-    - cron: '0 1 * * 1' # run zd tests at 1 AM (UTC), monday(1)
-
   workflow_dispatch: # run zero downtime tests selecting the installation branch and the upgrade chart
     inputs:
       branch:
@@ -373,7 +369,7 @@ jobs:
       - name: Format cypress log output
         if: always() && github.event.inputs.testUI == 'true'
         working-directory: bridge
-        run: cat uitest.log
+        run: cat /tmp/uitest.log
 
       #######################################################################
       # TEARDOWN

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -358,7 +358,7 @@ jobs:
           set -euo pipefail 
           
           cd ../test/zero-downtime && go test -json -v -run Test_ZeroDowntime -v -timeout 90m 2>&1 | tee /tmp/gotest.log &
-          if [[ "${{ github.event.inputs.testUI }}" == 'true' ]]; then
+          if [[ "${{ github.event.inputs.testUI }}" == true ]]; then
             while [[ $(jobs -pr) ]]; do
               npm run test:ui >> /tmp/uitest.log 2>&1 
             done
@@ -371,7 +371,7 @@ jobs:
           cat /tmp/gotest.log | gotestfmt
 
       - name: Format cypress log output
-        if: github.event.inputs.testUI == 'true'
+        if: github.event.inputs.testUI == true
         working-directory: bridge
         run: cat uitest.log
 
@@ -460,7 +460,7 @@ jobs:
       # Upload the original cypress test log as an artifact for later review.
       - name: Upload cypress test log
         uses: actions/upload-artifact@v2
-        if: github.event.inputs.testUI == 'true'
+        if: github.event.inputs.testUI == true
         with:
           name: ui-test-log
           path:  /tmp/uitest.log

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -457,7 +457,7 @@ jobs:
       # Upload the original cypress test log as an artifact for later review.
       - name: Upload cypress test log
         uses: actions/upload-artifact@v2
-        if: always()
+        if: event.inputs.testUI == 'true'
         with:
           name: ui-test-log
           path:  /tmp/uitest.log

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -355,6 +355,7 @@ jobs:
           
           cd ../test/zero-downtime && go test -json -v -run Test_ZeroDowntime -v -timeout 90m 2>&1 | tee /tmp/gotest.log &
           if [[ "${{ github.event.inputs.testUI }}" == 'true' ]]; then
+            echo "New Run: "  >> /tmp/uitest.log 
             while [[ $(jobs -pr) ]]; do
               npm run test:ui >> /tmp/uitest.log 2>&1 
             done

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -329,7 +329,6 @@ jobs:
         id: install_npm
         working-directory: bridge
         run: |
-          cp package.json yarn.lock
           yarn install --frozen-lockfile
 
       - name: Prepare test run

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -368,7 +368,7 @@ jobs:
           cat /tmp/gotest.log | gotestfmt
 
       - name: Format cypress log output
-        if: event.inputs.testUI == 'true'
+        if: ${{ github.event_name }} == 'workflow_dispatch' && ${{ event.inputs.testUI == 'true' }}
         working-directory: bridge
         run: cat uitest.log
 
@@ -457,7 +457,7 @@ jobs:
       # Upload the original cypress test log as an artifact for later review.
       - name: Upload cypress test log
         uses: actions/upload-artifact@v2
-        if: event.inputs.testUI == 'true'
+        if: ${{ github.event.inputs.testUI == 'true' }}
         with:
           name: ui-test-log
           path:  /tmp/uitest.log

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -328,8 +328,7 @@ jobs:
       - name: Install npm
         id: install_npm
         working-directory: bridge
-        run: |
-          yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile
 
       - name: Prepare test run
         id: prepare_test_run
@@ -361,8 +360,7 @@ jobs:
       - name: Format cypress log output
         if: always()
         working-directory: bridge
-        run: |
-          cat uitest.log    
+        run: cat uitest.log
 
       #######################################################################
       # TEARDOWN
@@ -450,10 +448,9 @@ jobs:
       - name: Upload test log
         uses: actions/upload-artifact@v2
         if: always()
-        working-directory: bridge
         with:
           name: ui-test-log
-          path:  uitest.log
+          path:  ../bridge/uitest.log
           if-no-files-found: error
 
   calculate-total-runtime:

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -446,6 +446,16 @@ jobs:
           path: /tmp/gotest.log
           if-no-files-found: error
 
+      # Upload the original cypress test log as an artifact for later review.
+      - name: Upload test log
+        uses: actions/upload-artifact@v2
+        if: always()
+        working-directory: bridge
+        with:
+          name: ui-test-log
+          path:  uitest.log
+          if-no-files-found: error
+
   calculate-total-runtime:
     name: End-of-Pipeline Metrics
     if: always()

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -349,7 +349,7 @@ jobs:
           KEPTN_ENDPOINT: ${{ steps.determine_keptn_endpoint.outputs.KEPTN_ENDPOINT }}
         run: |
           set -euo pipefail 
-          npm run test:ui > uitest.txt 2>&1 &
+          npm run test:ui > uitest.log 2>&1 &
           cd ../test/zero-downtime && go test -json -v -run Test_ZeroDowntime -v -timeout 90m 2>&1 | tee /tmp/gotest.log 
 
       - name: Format go test log output
@@ -360,8 +360,9 @@ jobs:
 
       - name: Format cypress log output
         if: always()
+        working-directory: bridge
         run: |
-          cat uitest.txt    
+          cat uitest.log    
 
       #######################################################################
       # TEARDOWN

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -349,14 +349,19 @@ jobs:
           KEPTN_ENDPOINT: ${{ steps.determine_keptn_endpoint.outputs.KEPTN_ENDPOINT }}
         run: |
           set -euo pipefail 
-          npm run test:ui &
+          npm run test:ui 2>&1 > uitest.txt &
           cd ../test/zero-downtime && go test -json -v -run Test_ZeroDowntime -v -timeout 90m 2>&1 | tee /tmp/gotest.log 
 
-      - name: Format log output
+      - name: Format go test log output
         if: always()
         run: |
           set -euo pipefail
           cat /tmp/gotest.log | gotestfmt
+
+      - name: Format cypress log output
+        if: always()
+        run: |
+          cat uitest.txt    
 
       #######################################################################
       # TEARDOWN

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -439,7 +439,7 @@ jobs:
           path: support-archive/*.zip
 
         # Upload the original go test log as an artifact for later review.
-      - name: Upload test log
+      - name: Upload go test log
         uses: actions/upload-artifact@v2
         if: always()
         with:
@@ -448,7 +448,7 @@ jobs:
           if-no-files-found: error
 
       # Upload the original cypress test log as an artifact for later review.
-      - name: Upload test log
+      - name: Upload cypress test log
         uses: actions/upload-artifact@v2
         if: always()
         with:

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -9,6 +9,11 @@ on:
       upgradeTo:
         description: 'The helm upgrade command will run with this version (e.g. 0.15.0-dev-PR-7504)'
         required: true
+      testUI:
+        type: boolean
+        description: 'Cypress tests for Bridge will be run in parallel to the zero downtime tests'
+        required: true
+        default: true
       deleteOnFinish:
         type: boolean
         required: false
@@ -350,9 +355,11 @@ jobs:
           set -euo pipefail 
           
           cd ../test/zero-downtime && go test -json -v -run Test_ZeroDowntime -v -timeout 90m 2>&1 | tee /tmp/gotest.log &
-          while [[ $(jobs -pr) ]]; do
-            npm run test:ui >> /tmp/uitest.log 2>&1 
-          done
+          if "${{ github.event.inputs.testUI }}" == 'true'
+            while [[ $(jobs -pr) ]]; do
+              npm run test:ui >> /tmp/uitest.log 2>&1 
+            done
+          fi
 
       - name: Format go test log output
         if: always()
@@ -361,7 +368,7 @@ jobs:
           cat /tmp/gotest.log | gotestfmt
 
       - name: Format cypress log output
-        if: always()
+        if: "${{ github.event.inputs.testUI }}" == 'true'
         working-directory: bridge
         run: cat uitest.log
 


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- adds cypress test to ZD pipeline
- example run : https://github.com/keptn/keptn/runs/6556725066?check_suite_focus=true
- tests can be enabled at pipeline selecting it as in here
![image](https://user-images.githubusercontent.com/89971034/169836745-fb1c9ca0-6e18-4cb1-aa8d-17ef4d21d993.png)

- test are run in parallel to zd and reported under **format cypress logs output** e.g.
  ![image](https://user-images.githubusercontent.com/89971034/169821283-0dc75ec4-3a34-4e3c-bcd5-d9a5f1cf2d80.png)

- artifact of logs is generated as well
- scheduled a run for every Monday 

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

#7662

