### PR TITLE
fix(webhook-service): Added missing webhook-config version check

### DIFF
--- a/test/go-tests/test_customendpoints.go
+++ b/test/go-tests/test_customendpoints.go
@@ -3,17 +3,18 @@ package go_tests
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/imroc/req"
 	"github.com/keptn/go-utils/pkg/api/models"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 	keptnkubeutils "github.com/keptn/kubernetes-utils/pkg"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"net/http"
-	"os"
-	"strings"
-	"testing"
-	"time"
 )
 
 const customEndpointShipyard = `apiVersion: "spec.keptn.sh/0.2.0"
@@ -104,7 +105,7 @@ func Test_CustomUserManagedEndpointsTest(t *testing.T) {
 			return false
 		}
 		return true
-	}, 60*time.Second, 5*time.Second)
+	}, 120*time.Second, 5*time.Second)
 	t.Log("Deployment has been completed")
 
 	deploymentFinishedEventData := &keptnv2.DeploymentFinishedEventData{}
@@ -149,7 +150,7 @@ func Test_CustomUserManagedEndpointsTest(t *testing.T) {
 			return false
 		}
 		return true
-	}, 60*time.Second, 5*time.Second)
+	}, 120*time.Second, 5*time.Second)
 	t.Log("Deployment has been completed")
 
 	err = keptnv2.EventDataAs(*deploymentFinishedEvent, deploymentFinishedEventData)

--- a/test/go-tests/test_webhook.go
+++ b/test/go-tests/test_webhook.go
@@ -390,7 +390,7 @@ spec:
       requests:
         - "curl http://shipyard-controller:8080/v1/project/{{.data.project}}/stage/{{.data.stage}}"`
 
-const webhookSimpleYamlBeta = `apiVersion: webhookconfig.keptn.sh/v1beta11
+const webhookSimpleYamlBeta = `apiVersion: webhookconfig.keptn.sh/v1beta1
 kind: WebhookConfig
 metadata:
   name: webhook-configuration

--- a/webhook-service/lib/webhook_config.go
+++ b/webhook-service/lib/webhook_config.go
@@ -58,6 +58,7 @@ type WebHookSecretRef struct {
 
 const webhookConfInvalid = "Webhook configuration invalid: "
 const betaApiVersion = "webhookconfig.keptn.sh/v1beta1"
+const alphaApiVersion = "webhookconfig.keptn.sh/v1alpha1"
 
 var supportedCurlMethods = [4]string{"POST", "PUT", "GET", "HEAD"}
 
@@ -68,6 +69,10 @@ func DecodeWebHookConfigYAML(webhookConfigYaml []byte) (*WebHookConfig, error) {
 
 	if err := yaml.Unmarshal(webhookConfigYaml, webHookConfig); err != nil {
 		return nil, err
+	}
+
+	if webHookConfig.ApiVersion != alphaApiVersion && webHookConfig.ApiVersion != betaApiVersion {
+		return nil, errors.New(fmt.Sprintf(webhookConfInvalid+"unsupported webhook configuration version '%s'", webHookConfig.ApiVersion))
 	}
 
 	if len(webHookConfig.Spec.Webhooks) == 0 {

--- a/webhook-service/lib/webhook_config_test.go
+++ b/webhook-service/lib/webhook_config_test.go
@@ -376,6 +376,47 @@ spec:
 			want:    nil,
 			wantErr: true,
 		},
+		{
+			name: "unsupported alpha version",
+			args: args{
+				webhookConfigYaml: []byte(`apiVersion: webhookconfig.keptn.sh/v1alpha11
+kind: WebhookConfig
+metadata:
+  name: webhook-configuration
+spec:
+  webhooks:
+    - type: "sh.keptn.event.webhook.triggered"
+      subscriptionID: "my-subscription-id"
+      envFrom:
+        - secretRef:
+          name: mysecret
+      requests:
+        - "curl http://localhost:8080 {{.data.project}} {{.env.mysecret}}"`),
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "unsupported beta version",
+			args: args{
+				webhookConfigYaml: []byte(`apiVersion: webhookconfig.keptn.sh/v1beta11
+kind: WebhookConfig
+metadata:
+  name: webhook-configuration
+spec:
+  webhooks:
+    - type: "sh.keptn.event.webhook.triggered"
+      subscriptionID: "my-subscription-id"
+      envFrom:
+        - secretRef:
+          name: mysecret
+      requests:
+        - url: http://localhost:8080
+          method: POST`),
+			},
+			want:    nil,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: odubajDT <ondrej.dubaj@dynatrace.com>

### Notes
When retrieving resources from git repository, the first step is decoding the content of webhook.yaml to a struct. Here we have two versions (alpha and beta) which are mostly normalized the same way except beta has a few additional checks. These checks were executed only if the version of the webhook-config was v1beta1, if it was different, additional checks were not executed. So actually the in the integration test, we had a valid webhook-config, so if the extra pre-check is or is not executed, it does not matter, the webhook is executed normally (and it's working), just the extra pre-checks were not executed. 

### Integration tests
https://github.com/keptn/keptn/actions/runs/2372897926


