### PR TITLE
fix(installer): Redirect output of preStop hook command to /dev/null

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/templates/shipyard-controller.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/shipyard-controller.yaml
@@ -44,7 +44,7 @@ spec:
                 command:
                   - /bin/sh
                   - -c
-                  - wget http://localhost:8081/operations/v1/pre-stop
+                  - wget -qO- http://localhost:8081/operations/v1/pre-stop &> /dev/null
           livenessProbe:
             httpGet:
               path: /health

--- a/installer/manifests/keptn/charts/control-plane/templates/shipyard-controller.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/shipyard-controller.yaml
@@ -44,7 +44,7 @@ spec:
                 command:
                   - /bin/sh
                   - -c
-                  - wget -qO- http://localhost:8081/operations/v1/pre-stop &> /dev/null
+                  - wget -O- http://localhost:8081/operations/v1/pre-stop
           livenessProbe:
             httpGet:
               path: /health


### PR DESCRIPTION
On GKE 1.22 the preStop hook was failing with the error message `wget: can't open pre-stop: Read only file system`.
Redirecting the output to /dev/null should solve this