### PR TITLE
fix(shipyard-controller): Set the sequence execution state back to `started` when approval task has been finished 

### DIFF
--- a/shipyard-controller/handler/shipyardcontroller.go
+++ b/shipyard-controller/handler/shipyardcontroller.go
@@ -794,16 +794,7 @@ func (sc *shipyardController) triggerTask(eventScope models.EventScope, sequence
 
 	sc.onSequenceTaskTriggered(*storeEvent)
 
-	sequenceExecution.Status.CurrentTask = models.TaskExecutionState{
-		Name:        task.Name,
-		TriggeredID: storeEvent.ID,
-		Events:      []models.TaskEvent{},
-	}
-
-	// special handling for approval events
-	if task.Name == "approval" {
-		sequenceExecution.Status.State = apimodels.SequenceWaitingForApprovalState
-	}
+	sequenceExecution.SetNextCurrentTask(task.Name, storeEvent.ID)
 
 	if err := sc.sequenceExecutionRepo.Upsert(sequenceExecution, nil); err != nil {
 		return err

--- a/shipyard-controller/models/sequence_execution.go
+++ b/shipyard-controller/models/sequence_execution.go
@@ -190,6 +190,27 @@ func (e *SequenceExecution) Resume() bool {
 	return true
 }
 
+// SetNextCurrentTask updates the Current task of the sequence and sets the current state appropriately, considering the special logic that should be applied for approval tasks
+func (e *SequenceExecution) SetNextCurrentTask(taskName, triggeredEventID string) {
+	e.Status.CurrentTask = TaskExecutionState{
+		Name:        taskName,
+		TriggeredID: triggeredEventID,
+		Events:      []TaskEvent{},
+	}
+
+	// special handling for approval events
+	nextState := models.SequenceStartedState
+	if taskName == keptnv2.ApprovalTaskName {
+		nextState = models.SequenceWaitingForApprovalState
+	}
+
+	if e.IsPaused() {
+		e.Status.StateBeforePause = nextState
+	} else {
+		e.Status.State = nextState
+	}
+}
+
 // IsFinished indicates if a task is finished, i.e. the number of task.started and task.finished events line up
 func (e *TaskExecutionState) IsFinished() bool {
 	if len(e.Events) == 0 {


### PR DESCRIPTION
Backport of #7838