### PR TITLE
fix(bridge): Fix D3 heatmap selection

### DIFF
--- a/bridge/client/app/_components/ktb-heatmap/ktb-heatmap.component.spec.ts
+++ b/bridge/client/app/_components/ktb-heatmap/ktb-heatmap.component.spec.ts
@@ -109,35 +109,51 @@ describe('KtbHeatmapComponent', () => {
 
   it('should not select dataPoint if it is not in the dataSource', () => {
     component.dataPoints = [];
-    component.selectDataPoint = 'myIdentifier';
-    expect(component.selectedDataPoint).toBeUndefined();
+    component.selectedIdentifier = 'myIdentifier';
+    expect(component.selectedIdentifier).toBe('myIdentifier');
+    expect(component['_selectedDataPoint']).toBeUndefined();
   });
 
   it('should select dataPoint and not emit it if it is preselected', () => {
     // given
     const dataPoints = mockDataPoints(1, 0);
-    const emitSpy = jest.spyOn(component.selectedDataPointChange, 'emit');
+    const emitSpy = jest.spyOn(component.selectedIdentifierChange, 'emit');
     component.dataPoints = dataPoints;
 
     // when
-    component.selectDataPoint = dataPoints[0].identifier;
+    component.selectedIdentifier = dataPoints[0].identifier;
 
     // then
-    expect(component.selectedDataPoint).toEqual(dataPoints[0]);
+    expect(component.selectedIdentifier).toEqual(dataPoints[0].identifier);
+    expect(emitSpy).not.toHaveBeenCalled();
+  });
+
+  it('should select dataPoint with previously set identifier that was not found', () => {
+    // given
+    const emitSpy = jest.spyOn(component.selectedIdentifierChange, 'emit');
+
+    // when
+    component.selectedIdentifier = 'myEvaluation0';
+    const dataPoints = mockDataPoints(1, 0);
+    component.dataPoints = dataPoints;
+
+    // then
+    expect(component.selectedIdentifier).toEqual(dataPoints[0].identifier);
+    expect(component['_selectedDataPoint']).toEqual(dataPoints[0]);
     expect(emitSpy).not.toHaveBeenCalled();
   });
 
   it('should select dataPoint and emit it if it is preselected', () => {
     // given
     const dataPoints = mockDataPoints(1, 0);
-    const emitSpy = jest.spyOn(component.selectedDataPointChange, 'emit');
+    const emitSpy = jest.spyOn(component.selectedIdentifierChange, 'emit');
     component.dataPoints = dataPoints;
 
     // when
     component['click'](dataPoints[0], false);
 
     // then
-    expect(component.selectedDataPoint).toEqual(dataPoints[0]);
+    expect(component.selectedIdentifier).toEqual(dataPoints[0].identifier);
     expect(emitSpy).toHaveBeenCalled();
   });
 

--- a/bridge/client/app/_components/ktb-heatmap/testing/ktb-test-heatmap.component.html
+++ b/bridge/client/app/_components/ktb-heatmap/testing/ktb-test-heatmap.component.html
@@ -1,4 +1,4 @@
 <div class="heatmap-container">
-  <ktb-heatmap [dataPoints]="dataPoints"> </ktb-heatmap>
+  <ktb-heatmap [dataPoints]="dataPoints" [selectedIdentifier]="selectedIdentifier"> </ktb-heatmap>
   <ktb-heatmap [dataPoints]="dataPoints" class="mt-3"> </ktb-heatmap>
 </div>

--- a/bridge/client/app/_components/ktb-heatmap/testing/ktb-test-heatmap.component.ts
+++ b/bridge/client/app/_components/ktb-heatmap/testing/ktb-test-heatmap.component.ts
@@ -15,6 +15,7 @@ import { ResultTypes } from '../../../../../shared/models/result-types';
 })
 export class KtbTestHeatmapComponent implements OnInit {
   public dataPoints: IDataPoint[] = [];
+  public selectedIdentifier?: string;
   private sliCount = 12;
   private evaluationCount = 50;
 
@@ -23,6 +24,7 @@ export class KtbTestHeatmapComponent implements OnInit {
   }
 
   public setDataPoints(): void {
+    this.selectedIdentifier = 'keptnContext_2';
     this.dataPoints = this.generateTestData(this.sliCount, this.evaluationCount);
   }
 


### PR DESCRIPTION
Fixes #7841

Additional changes:
The heatmap now only emits the selected identifier instead of the whole dataPoint.

Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>