### PR TITLE
feat(bridge): Remove polling for services in settings screen

### DIFF
--- a/bridge/client/app/_components/ktb-service-settings-list/ktb-service-settings-list.component.spec.ts
+++ b/bridge/client/app/_components/ktb-service-settings-list/ktb-service-settings-list.component.spec.ts
@@ -4,7 +4,6 @@ import { AppModule } from '../../app.module';
 import { ActivatedRoute, convertToParamMap } from '@angular/router';
 import { of } from 'rxjs';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { POLLING_INTERVAL_MILLIS } from '../../_utils/app.utils';
 import { ApiService } from '../../_services/api.service';
 import { ApiServiceMock } from '../../_services/api.service.mock';
 
@@ -17,7 +16,6 @@ describe('KtbServiceSettingsListComponent', () => {
       imports: [AppModule, HttpClientTestingModule],
       providers: [
         { provide: ApiService, useClass: ApiServiceMock },
-        { provide: POLLING_INTERVAL_MILLIS, useValue: 0 },
         {
           provide: ActivatedRoute,
           useValue: {

--- a/bridge/client/app/_components/ktb-service-settings-list/ktb-service-settings-list.component.ts
+++ b/bridge/client/app/_components/ktb-service-settings-list/ktb-service-settings-list.component.ts
@@ -1,26 +1,19 @@
-import { Component, Inject, OnDestroy } from '@angular/core';
+import { Component } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { Subscription } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 import { DataService } from '../../_services/data.service';
 import { DtTableDataSource } from '@dynatrace/barista-components/table';
-import { AppUtils, POLLING_INTERVAL_MILLIS } from '../../_utils/app.utils';
 
 @Component({
   selector: 'ktb-service-settings-list',
   templateUrl: './ktb-service-settings-list.component.html',
 })
-export class KtbServiceSettingsListComponent implements OnDestroy {
+export class KtbServiceSettingsListComponent {
   public projectName?: string;
   public isLoading = false;
   public dataSource: DtTableDataSource<string> = new DtTableDataSource<string>();
-  private _timer: Subscription = Subscription.EMPTY;
 
-  constructor(
-    private router: ActivatedRoute,
-    private dataService: DataService,
-    @Inject(POLLING_INTERVAL_MILLIS) private initialDelayMillis: number
-  ) {
+  constructor(private router: ActivatedRoute, private dataService: DataService) {
     this.router.paramMap
       .pipe(
         map((params) => params.get('projectName')),
@@ -30,20 +23,12 @@ export class KtbServiceSettingsListComponent implements OnDestroy {
         this.projectName = projectName;
         this.isLoading = true;
 
-        this._timer.unsubscribe();
-
-        this._timer = AppUtils.createTimer(0, initialDelayMillis).subscribe(() => {
-          if (this.projectName) {
-            this.dataService.getServiceNames(this.projectName).subscribe((services) => {
-              this.dataSource = new DtTableDataSource<string>(services);
-              this.isLoading = false;
-            });
-          }
-        });
+        if (this.projectName) {
+          this.dataService.getServiceNames(this.projectName).subscribe((services) => {
+            this.dataSource = new DtTableDataSource<string>(services);
+            this.isLoading = false;
+          });
+        }
       });
-  }
-
-  public ngOnDestroy(): void {
-    this._timer.unsubscribe();
   }
 }


### PR DESCRIPTION
## This PR
- Removes polling from component
- Removes dependency on POLLING_INTERVAL_MILLIS
- Adapts spec

### Related Issues

Resolves #7799 

### How to test

1. Go to `Settings` and click on `Services`
2. Watch DevTools/Network panel for additional requests to `/api/project/sockshop/services` (should be only a single request over time)

Signed-off-by: ermin.muratovic <ermin.muratovic@gmail.com>