### PR TITLE
fix: Removed wrong beta11 from webhook integration test

### DIFF
--- a/test/go-tests/test_webhook.go
+++ b/test/go-tests/test_webhook.go
@@ -377,7 +377,7 @@ spec:
         - url: http://shipyard-controller:8080/v1/project/{{.data.project}}/stage/{{.data.stage}}
           method: GET`
 
-const failwebhookSimpleYamlBeta = `apiVersion: webhookconfig.keptn.sh/v1beta11
+const failwebhookSimpleYamlBeta = `apiVersion: webhookconfig.keptn.sh/v1beta1
 kind: WebhookConfig
 metadata:
   name: webhook-configuration
@@ -418,7 +418,7 @@ spec:
         - url: http://keptn.sh
           method: GET`
 
-const webhookSimpleYamlBetaAPI = `apiVersion: webhookconfig.keptn.sh/v1beta11
+const webhookSimpleYamlBetaAPI = `apiVersion: webhookconfig.keptn.sh/v1beta1
 kind: WebhookConfig
 metadata:
   name: webhook-configuration


### PR DESCRIPTION

Fixes #7857 

### How to test
<!-- if applicable, add testing instructions under this section -->

https://github.com/keptn/keptn/actions/runs/2382865619