### PR TITLE
ci: Increase concurrent dependency PR limit

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,7 @@
   ],
   "addLabels": ["dependencies"],
   "cloneSubmodules": true,
+  "prConcurrentLimit": 15,
   "stabilityDays": 3,
   "timezone": "Europe/Vienna",
   "ignoreDeps": [


### PR DESCRIPTION
### This PR
- increases the limit of concurrent renovate PRs
- this is done because the new keptn libraries will always have open PRs since they are commit hash based and those change all the time