### PR TITLE
test(bridge): Fix failing auth.spec UI test

### DIFF
--- a/bridge/cypress/integration/auth.spec.ts
+++ b/bridge/cypress/integration/auth.spec.ts
@@ -79,9 +79,9 @@ describe('Test OAuth', () => {
     cy.intercept('/api/controlPlane/v1/project?disableUpstreamSync=true&pageSize=50', { statusCode: 403 }).as(
       'projects'
     );
-    cy.task('setExpectedErrorCount', 2);
+    cy.task('setExpectedErrorCount', 1);
 
-    cy.visit('/').wait('@projects').wait('@projects'); // triggered by app.component and dashboard
+    cy.visit('/').wait('@projects');
     basePage.notificationErrorVisible('You do not have the permissions to perform this action.');
   });
 });


### PR DESCRIPTION
https://github.com/keptn/keptn/pull/7812 removed the polling in the dashboard and https://github.com/keptn/keptn/pull/7794 added two checks here. Now without the polling, there is only one check for the response/error.

Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>