### PR TITLE
chore(installer): Adapted default values for preStop hook times and resource-service resource limits

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/templates/configuration-service.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/configuration-service.yaml
@@ -97,7 +97,7 @@ spec:
               memory: "32Mi"
               cpu: "25m"
             limits:
-              memory: "64Mi"
+              memory: "256Mi"
               cpu: "100m"
           volumeMounts:
             - mountPath: /data/config

--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -74,7 +74,7 @@ apiGatewayNginx:
     tag: 1.21.6-alpine
   nodeSelector: {}
   gracePeriod: 60
-  preStopHookTime: 5
+  preStopHookTime: 20
   clientMaxBodySize: "5m"
 
 remediationService:

--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -187,7 +187,7 @@ secretService:
     tag: ""
   nodeSelector: {}
   gracePeriod: 60
-  preStopHookTime: 5
+  preStopHookTime: 20
 
 configurationService:
   image:
@@ -203,7 +203,7 @@ configurationService:
     GIT_KEPTN_EMAIL: "keptn@keptn.sh"
   nodeSelector: {}
   gracePeriod: 60
-  preStopHookTime: 5
+  preStopHookTime: 20
 
 resourceService:
   enabled: true
@@ -217,7 +217,7 @@ resourceService:
     DIRECTORY_STAGE_STRUCTURE: "false"
   nodeSelector: {}
   gracePeriod: 60
-  preStopHookTime: 5
+  preStopHookTime: 20
 
 mongodbDatastore:
   image:
@@ -225,7 +225,7 @@ mongodbDatastore:
     tag: ""
   nodeSelector: {}
   gracePeriod: 60
-  preStopHookTime: 5
+  preStopHookTime: 20
 
 lighthouseService:
   image:


### PR DESCRIPTION
This PR adapts the default values for the preStop hook times of the following services:

resource-service
mongodb-datastore
secret-service

Additionally, the memory limit for the resource-service has been increased to 256Mi
