### PR TITLE
fix(shipyard-controller): Make sure result and status are set if sequence is timed out

### DIFF
--- a/shipyard-controller/handler/shipyardcontroller.go
+++ b/shipyard-controller/handler/shipyardcontroller.go
@@ -542,7 +542,7 @@ func (sc *shipyardController) timeoutSequence(timeout apimodels.SequenceTimeout)
 	sequenceExecution := sequenceExecutions[0]
 	sc.onSequenceTimeout(timeout.LastEvent)
 
-	if err := sc.completeTaskSequence(sequenceExecution.Scope, sequenceExecution, apimodels.TimedOut); err != nil {
+	if err := sc.completeTaskSequence(*eventScope, sequenceExecution, apimodels.TimedOut); err != nil {
 		return err
 	}
 	return nil

--- a/shipyard-controller/handler/shipyardcontroller_component_test.go
+++ b/shipyard-controller/handler/shipyardcontroller_component_test.go
@@ -930,6 +930,19 @@ func Test_shipyardController_TimeoutSequence(t *testing.T) {
 
 	require.Nil(t, err)
 	require.Len(t, fakeTimeoutHook.OnSequenceTimeoutCalls(), 1)
+
+	eventDispatcherMock := sc.eventDispatcher.(*fake.IEventDispatcherMock)
+
+	require.Len(t, eventDispatcherMock.AddCalls(), 1)
+
+	sentEvent := eventDispatcherMock.AddCalls()[0]
+
+	eventData := &keptnv2.EventData{}
+	err = sentEvent.Event.Event.DataAs(eventData)
+
+	require.Nil(t, err)
+	require.Equal(t, keptnv2.ResultFailed, eventData.Result)
+	require.Equal(t, keptnv2.StatusErrored, eventData.Status)
 }
 
 func Test_shipyardController_CancelSequence(t *testing.T) {

--- a/shipyard-controller/nats/connection_test.go
+++ b/shipyard-controller/nats/connection_test.go
@@ -66,7 +66,7 @@ func TestNatsConnectionHandler(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return len(mockNatsEventHandler.ProcessCalls()) == 2
-	}, 15*time.Second, 5*time.Second)
+	}, 15*time.Second, 1*time.Second)
 
 	// call cancel() and wait for the consumer to shut down
 	// this is to ensure that the pull subscription created during this test does not interfere with the other tests
@@ -74,7 +74,7 @@ func TestNatsConnectionHandler(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return nh.subscriptions[0].isActive == false
-	}, 15*time.Second, 5*time.Second)
+	}, 15*time.Second, 1*time.Second)
 }
 
 func TestNatsConnectionHandler_ShutdownSubscriber(t *testing.T) {
@@ -111,7 +111,7 @@ func TestNatsConnectionHandler_ShutdownSubscriber(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return len(mockNatsEventHandler.ProcessCalls()) == 2
-	}, 15*time.Second, 5*time.Second)
+	}, 15*time.Second, 1*time.Second)
 
 	// call cancel() and wait for the consumer to shut down
 	// this is to ensure that the pull subscription created during this test does not interfere with the other tests
@@ -168,7 +168,7 @@ func TestNatsConnectionHandler_SendBeforeSubscribing(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return len(mockNatsEventHandler.ProcessCalls()) > 0
-	}, 15*time.Second, 5*time.Second)
+	}, 15*time.Second, 1*time.Second)
 
 	// call cancel() and wait for the consumer to shut down
 	// this is to ensure that the pull subscription created during this test does not interfere with the other tests
@@ -176,7 +176,7 @@ func TestNatsConnectionHandler_SendBeforeSubscribing(t *testing.T) {
 	// wait for the consumer to shut down
 	require.Eventually(t, func() bool {
 		return nh.subscriptions[0].isActive == false
-	}, 15*time.Second, 5*time.Second)
+	}, 15*time.Second, 1*time.Second)
 }
 
 func TestNatsConnectionHandler_MisconfiguredStreamIsUpdated(t *testing.T) {
@@ -222,7 +222,7 @@ func TestNatsConnectionHandler_MisconfiguredStreamIsUpdated(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return len(mockNatsEventHandler.ProcessCalls()) > 0
-	}, 15*time.Second, 5*time.Second)
+	}, 15*time.Second, 1*time.Second)
 
 	// call cancel() and wait for the consumer to shut down
 	// this is to ensure that the pull subscription created during this test does not interfere with the other tests
@@ -230,7 +230,7 @@ func TestNatsConnectionHandler_MisconfiguredStreamIsUpdated(t *testing.T) {
 	// wait for the consumer to shut down
 	require.Eventually(t, func() bool {
 		return nh.subscriptions[0].isActive == false
-	}, 15*time.Second, 5*time.Second)
+	}, 15*time.Second, 1*time.Second)
 }
 
 func TestNatsConnectionHandler_MultipleSubscribers(t *testing.T) {
@@ -263,7 +263,7 @@ func TestNatsConnectionHandler_MultipleSubscribers(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return len(mockNatsEventHandler.ProcessCalls()) > 0
-	}, 15*time.Second, 5*time.Second)
+	}, 15*time.Second, 1*time.Second)
 
 	require.Len(t, mockNatsEventHandler.ProcessCalls(), 1)
 
@@ -273,7 +273,7 @@ func TestNatsConnectionHandler_MultipleSubscribers(t *testing.T) {
 	// wait for the consumers to shut down
 	require.Eventually(t, func() bool {
 		return nh1.subscriptions[0].isActive == false && nh2.subscriptions[0].isActive == false
-	}, 15*time.Second, 5*time.Second)
+	}, 15*time.Second, 1*time.Second)
 }
 
 func TestNatsConnectionHandler_ErrorWhenHandlingEvent(t *testing.T) {
@@ -310,7 +310,7 @@ func TestNatsConnectionHandler_ErrorWhenHandlingEvent(t *testing.T) {
 	// verify that the event after the bad one was still handled
 	require.Eventually(t, func() bool {
 		return len(mockNatsEventHandler.ProcessCalls()) == 1
-	}, 15*time.Second, 5*time.Second)
+	}, 15*time.Second, 1*time.Second)
 
 	// call cancel() and wait for the consumer to shut down
 	// this is to ensure that the pull subscription created during this test does not interfere with the other tests
@@ -318,7 +318,7 @@ func TestNatsConnectionHandler_ErrorWhenHandlingEvent(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return nh.subscriptions[0].isActive == false
-	}, 15*time.Second, 5*time.Second)
+	}, 15*time.Second, 1*time.Second)
 }
 
 func TestNatsConnectionHandler_NatsServerDown(t *testing.T) {


### PR DESCRIPTION
Closes #7898 

This PR also adjusts some of the intervals at which assertions are checked in the Nats connection unit tests since these tests had a few flaky runs recently