### PR TITLE
fix(cli): Remove unnecessary `--sequence` flag from `keptn trigger sequence`

### DIFF
--- a/cli/cmd/trigger_sequence.go
+++ b/cli/cmd/trigger_sequence.go
@@ -63,6 +63,9 @@ The name of the sequence has to be provided as an argument to the command. The s
 	Example:      `keptn trigger sequence <sequence-name> --project=<project> --service=<service> --stage=<stage>`,
 	SilenceUsage: true,
 	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return errors.New("required argument sequence-name not set")
+		}
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/cmd/trigger_sequence.go
+++ b/cli/cmd/trigger_sequence.go
@@ -22,7 +22,6 @@ type sequenceStruct struct {
 	Project  *string `json:"project"`
 	Service  *string `json:"service"`
 	Stage    *string `json:"stage"`
-	Sequence *string `json:"sequence"`
 }
 
 var sequence = sequenceStruct{}
@@ -67,11 +66,11 @@ The name of the sequence has to be provided as an argument to the command. The s
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return doTriggerSequence(sequence)
+		return doTriggerSequence(sequence, args[0])
 	},
 }
 
-func doTriggerSequence(sequenceInputData sequenceStruct) error {
+func doTriggerSequence(sequenceInputData sequenceStruct, sequenceName string) error {
 	var endPoint url.URL
 	var apiToken string
 	var err error
@@ -86,7 +85,7 @@ func doTriggerSequence(sequenceInputData sequenceStruct) error {
 		return errors.New(authErrorMsg)
 	}
 
-	logging.PrintLog("Triggering sequence "+*sequenceInputData.Sequence+" in project "+*sequenceInputData.Project+" in stage "+*sequenceInputData.Stage+" service "+*sequenceInputData.Service, logging.InfoLevel)
+	logging.PrintLog("Triggering sequence "+sequenceName+" in project "+*sequenceInputData.Project+" in stage "+*sequenceInputData.Stage+" service "+*sequenceInputData.Service, logging.InfoLevel)
 
 	api, err := internal.APIProvider(endPoint.String(), apiToken)
 	if err != nil {
@@ -112,7 +111,7 @@ func doTriggerSequence(sequenceInputData sequenceStruct) error {
 
 	sdkEvent := cloudevents.NewEvent()
 	sdkEvent.SetID(uuid.New().String())
-	sdkEvent.SetType(keptnv2.GetTriggeredEventType(*sequenceInputData.Stage + "." + *sequenceInputData.Sequence))
+	sdkEvent.SetType(keptnv2.GetTriggeredEventType(*sequenceInputData.Stage + "." + sequenceName))
 	sdkEvent.SetSource("https://github.com/keptn/keptn/cli#configuration-change")
 	sdkEvent.SetDataContentType(cloudevents.ApplicationJSON)
 	sdkEvent.SetData(cloudevents.ApplicationJSON, triggeredEvent)
@@ -153,10 +152,6 @@ func doTriggerSequencePreRunCheck(sequenceInputData sequenceStruct) error {
 		return fmt.Errorf("Stage has to be provided")
 	}
 
-	if sequenceInputData.Sequence == nil {
-		return fmt.Errorf("Sequence has to be provided")
-	}
-
 	return nil
 }
 
@@ -173,9 +168,5 @@ func init() {
 	sequence.Stage = triggerSequenceCmd.Flags().StringP("stage", "", "",
 		"The stage in which the new artifact will be triggered")
 	triggerSequenceCmd.MarkFlagRequired("stage")
-
-	sequence.Sequence = triggerSequenceCmd.Flags().StringP("sequence", "", "",
-		"The sequence for which the new artifact will be triggered")
-	triggerSequenceCmd.MarkFlagRequired("sequence")
 
 }

--- a/cli/cmd/trigger_sequence_test.go
+++ b/cli/cmd/trigger_sequence_test.go
@@ -231,3 +231,7 @@ func TestTriggerSequenceNonExistingService(t *testing.T) {
 func TestTriggerSequenceFlag(t *testing.T) {
 	testInvalidInputHelper("trigger sequence seq2 --sequence=seq --project=proj --service=serv --stage=dev --mock", "unknown flag: --sequence", t)
 }
+
+func TestTriggerSequenceMissing(t *testing.T) {
+	testInvalidInputHelper("trigger sequence --project=proj --service=serv --stage=dev --mock", "required argument sequence-name not set", t)
+}

--- a/cli/cmd/trigger_sequence_test.go
+++ b/cli/cmd/trigger_sequence_test.go
@@ -105,7 +105,7 @@ func TestTriggerSequence(t *testing.T) {
 
 	os.Setenv("MOCK_SERVER", ts.URL)
 
-	cmd := fmt.Sprintf("trigger sequence --sequence=%s --project=%s --service=%s --stage=%s --mock", "hello", "hello-world", "demo", "dev")
+	cmd := fmt.Sprintf("trigger sequence %s --project=%s --service=%s --stage=%s --mock", "hello", "hello-world", "demo", "dev")
 	_, err := executeActionCommandC(cmd)
 
 	if err != nil {
@@ -151,7 +151,7 @@ func TestTriggerSequenceNonExistingProject(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {
-			cmd := fmt.Sprintf("trigger sequence --sequence=%s --project=%s --service=mysvc --stage=%s --mock",
+			cmd := fmt.Sprintf("trigger sequence %s --project=%s --service=mysvc --stage=%s --mock",
 				tt.project,
 				"hello",
 				"dev")
@@ -213,10 +213,11 @@ func TestTriggerSequenceNonExistingService(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {
-			cmd := fmt.Sprintf("trigger sequence --sequence=%s --project=%s --service=%s --mock",
+			cmd := fmt.Sprintf("trigger sequence %s --project=%s --service=%s --stage=%s --mock",
 				sequenceName,
 				projectName,
 				tt.service,
+				"dev",
 			)
 			_, err := executeActionCommandC(cmd)
 
@@ -225,4 +226,8 @@ func TestTriggerSequenceNonExistingService(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTriggerSequenceFlag(t *testing.T) {
+	testInvalidInputHelper("trigger sequence seq2 --sequence=seq --project=proj --service=serv --stage=dev --mock", "unknown flag: --sequence", t)
 }


### PR DESCRIPTION
Signed-off-by: odubajDT <ondrej.dubaj@dynatrace.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- removed --sequence flag from command

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #7884 

#### Before
```Usage:
  keptn trigger sequence [flags]

Aliases:
  sequence, sequence

Examples:
keptn trigger sequence <sequence-name> --project=<project> --service=<service> --stage=<stage>

Flags:
      --project string    The project containing the service for which the new artifact will be triggered
      --sequence string   The sequence for which the new artifact will be triggered
      --service string    The service for which the new artifact will be triggered
      --stage string      The stage in which the new artifact will be triggered
```

#### After
```Usage:
  keptn trigger sequence [flags]

Aliases:
  sequence, sequence

Examples:
keptn trigger sequence <sequence-name> --project=<project> --service=<service> --stage=<stage>

Flags:
      --project string   The project containing the service for which the new artifact will be triggered
      --service string   The service for which the new artifact will be triggered
      --stage string     The stage in which the new artifact will be triggered
```

