### PR TITLE
fix: Ensure that all mongodb cursors are being closed after use

### DIFF
--- a/mongodb-datastore/db/mongodb_event_repo.go
+++ b/mongodb-datastore/db/mongodb_event_repo.go
@@ -475,17 +475,20 @@ func (mr *MongoDBEventRepo) aggregateFromDB(collectionName string, pipeline mong
 	defer cancel()
 
 	cur, err := collection.Aggregate(ctx, pipeline)
-
-	if err != nil {
-		logger.WithError(err).Error("Could not retrieve events from collectiong elements in events collection")
-		return nil, err
-	}
 	// close the cursor after the function has completed to avoid memory leaks
 	defer func() {
+		if cur == nil {
+			return
+		}
 		if err := cur.Close(ctx); err != nil {
 			logger.WithError(err).Error("Could not close cursor")
 		}
 	}()
+	if err != nil {
+		logger.WithError(err).Error("Could not retrieve events from collectiong elements in events collection")
+		return nil, err
+	}
+
 	result.Events = formatEventResults(ctx, cur)
 
 	return result, nil
@@ -531,17 +534,20 @@ func (mr *MongoDBEventRepo) findInDB(collectionName string, pageSize int64, next
 	}
 
 	cur, err := collection.Find(ctx, searchOptions, sortOptions)
-
-	if err != nil {
-		logger.WithError(err).Error("Could not retrieve elements from events collection")
-		return nil, err
-	}
 	// close the cursor after the function has completed to avoid memory leaks
 	defer func() {
+		if cur == nil {
+			return
+		}
 		if err := cur.Close(ctx); err != nil {
 			logger.WithError(err).Error("Could not close cursor.")
 		}
 	}()
+	if err != nil {
+		logger.WithError(err).Error("Could not retrieve elements from events collection")
+		return nil, err
+	}
+
 	result.Events = formatEventResults(ctx, cur)
 
 	result.PageSize = pageSize

--- a/shipyard-controller/db/common.go
+++ b/shipyard-controller/db/common.go
@@ -1,0 +1,16 @@
+package db
+
+import (
+	"context"
+	log "github.com/sirupsen/logrus"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func closeCursor(ctx context.Context, cur *mongo.Cursor) {
+	if cur == nil {
+		return
+	}
+	if err := cur.Close(ctx); err != nil {
+		log.Errorf("Could not close cursor: %v", err)
+	}
+}

--- a/shipyard-controller/db/mongodb.go
+++ b/shipyard-controller/db/mongodb.go
@@ -13,12 +13,8 @@ func SetupTTLIndex(ctx context.Context, propertyName string, duration time.Durat
 	ttlInSeconds := int32(duration.Seconds())
 	indexName := propertyName + "_1"
 	cur, err := collection.Indexes().List(ctx)
-	defer func() {
-		if cur == nil {
-			return
-		}
-		cur.Close(ctx)
-	}()
+	defer closeCursor(ctx, cur)
+
 	if err != nil {
 		return fmt.Errorf("could not load list of indexes of collection %s: %w", collection.Name(), err)
 	}

--- a/shipyard-controller/db/mongodb.go
+++ b/shipyard-controller/db/mongodb.go
@@ -13,6 +13,12 @@ func SetupTTLIndex(ctx context.Context, propertyName string, duration time.Durat
 	ttlInSeconds := int32(duration.Seconds())
 	indexName := propertyName + "_1"
 	cur, err := collection.Indexes().List(ctx)
+	defer func() {
+		if cur == nil {
+			return
+		}
+		cur.Close(ctx)
+	}()
 	if err != nil {
 		return fmt.Errorf("could not load list of indexes of collection %s: %w", collection.Name(), err)
 	}

--- a/shipyard-controller/db/mongodb_event_repo.go
+++ b/shipyard-controller/db/mongodb_event_repo.go
@@ -51,12 +51,8 @@ func (mdbrepo *MongoDBEventsRepo) GetEvents(project string, filter common.EventF
 	sortOptions := options.Find().SetSort(bson.D{{Key: "time", Value: -1}})
 
 	cur, err := collection.Find(ctx, searchOptions, sortOptions)
-	defer func() {
-		if cur == nil {
-			return
-		}
-		cur.Close(ctx)
-	}()
+	defer closeCursor(ctx, cur)
+
 	if err != nil && errors.Is(err, mongo.ErrNoDocuments) {
 		return nil, ErrNoEventFound
 	} else if err != nil {
@@ -119,12 +115,8 @@ func (mdbrepo *MongoDBEventsRepo) GetRootEvents(getRootParams models.GetRootEven
 	}
 
 	cur, err := collection.Find(ctx, searchOptions, sortOptions)
-	defer func() {
-		if cur == nil {
-			return
-		}
-		cur.Close(ctx)
-	}()
+	defer closeCursor(ctx, cur)
+
 	if err != nil && err != mongo.ErrNoDocuments {
 		return nil, err
 	}

--- a/shipyard-controller/db/mongodb_event_repo.go
+++ b/shipyard-controller/db/mongodb_event_repo.go
@@ -51,6 +51,12 @@ func (mdbrepo *MongoDBEventsRepo) GetEvents(project string, filter common.EventF
 	sortOptions := options.Find().SetSort(bson.D{{Key: "time", Value: -1}})
 
 	cur, err := collection.Find(ctx, searchOptions, sortOptions)
+	defer func() {
+		if cur == nil {
+			return
+		}
+		cur.Close(ctx)
+	}()
 	if err != nil && errors.Is(err, mongo.ErrNoDocuments) {
 		return nil, ErrNoEventFound
 	} else if err != nil {
@@ -61,7 +67,6 @@ func (mdbrepo *MongoDBEventsRepo) GetEvents(project string, filter common.EventF
 
 	events := []apimodels.KeptnContextExtendedCE{}
 
-	defer cur.Close(ctx)
 	for cur.Next(ctx) {
 		event, err := decodeKeptnEvent(cur)
 		if err != nil {
@@ -114,6 +119,12 @@ func (mdbrepo *MongoDBEventsRepo) GetRootEvents(getRootParams models.GetRootEven
 	}
 
 	cur, err := collection.Find(ctx, searchOptions, sortOptions)
+	defer func() {
+		if cur == nil {
+			return
+		}
+		cur.Close(ctx)
+	}()
 	if err != nil && err != mongo.ErrNoDocuments {
 		return nil, err
 	}

--- a/shipyard-controller/db/mongodb_eventqueue_repo.go
+++ b/shipyard-controller/db/mongodb_eventqueue_repo.go
@@ -182,12 +182,8 @@ func (m *MongoDBEventQueueRepo) GetEventQueueSequenceStates(filter models.EventQ
 		searchOptions[stageScope] = filter.Scope.Stage
 	}
 	cur, err := collection.Find(ctx, searchOptions)
-	defer func() {
-		if cur == nil {
-			return
-		}
-		cur.Close(ctx)
-	}()
+	defer closeCursor(ctx, cur)
+
 	if err != nil && errors.Is(err, mongo.ErrNoDocuments) {
 		return nil, ErrNoEventFound
 	} else if err != nil {
@@ -252,12 +248,8 @@ func insertQueueItemIntoCollection(ctx context.Context, collection *mongo.Collec
 
 func getQueueItemsFromCollection(collection *mongo.Collection, ctx context.Context, searchOptions bson.M, opts ...*options.FindOptions) ([]models.QueueItem, error) {
 	cur, err := collection.Find(ctx, searchOptions, opts...)
-	defer func() {
-		if cur == nil {
-			return
-		}
-		cur.Close(ctx)
-	}()
+	defer closeCursor(ctx, cur)
+
 	if err != nil && errors.Is(err, mongo.ErrNoDocuments) {
 		return nil, ErrNoEventFound
 	} else if err != nil {

--- a/shipyard-controller/db/mongodb_eventqueue_repo.go
+++ b/shipyard-controller/db/mongodb_eventqueue_repo.go
@@ -182,6 +182,12 @@ func (m *MongoDBEventQueueRepo) GetEventQueueSequenceStates(filter models.EventQ
 		searchOptions[stageScope] = filter.Scope.Stage
 	}
 	cur, err := collection.Find(ctx, searchOptions)
+	defer func() {
+		if cur == nil {
+			return
+		}
+		cur.Close(ctx)
+	}()
 	if err != nil && errors.Is(err, mongo.ErrNoDocuments) {
 		return nil, ErrNoEventFound
 	} else if err != nil {
@@ -192,7 +198,6 @@ func (m *MongoDBEventQueueRepo) GetEventQueueSequenceStates(filter models.EventQ
 
 	stateItems := []models.EventQueueSequenceState{}
 
-	defer cur.Close(ctx)
 	for cur.Next(ctx) {
 		stateItem := models.EventQueueSequenceState{}
 		err := cur.Decode(&stateItem)
@@ -247,6 +252,12 @@ func insertQueueItemIntoCollection(ctx context.Context, collection *mongo.Collec
 
 func getQueueItemsFromCollection(collection *mongo.Collection, ctx context.Context, searchOptions bson.M, opts ...*options.FindOptions) ([]models.QueueItem, error) {
 	cur, err := collection.Find(ctx, searchOptions, opts...)
+	defer func() {
+		if cur == nil {
+			return
+		}
+		cur.Close(ctx)
+	}()
 	if err != nil && errors.Is(err, mongo.ErrNoDocuments) {
 		return nil, ErrNoEventFound
 	} else if err != nil {
@@ -257,7 +268,6 @@ func getQueueItemsFromCollection(collection *mongo.Collection, ctx context.Conte
 
 	queuedItems := []models.QueueItem{}
 
-	defer cur.Close(ctx)
 	for cur.Next(ctx) {
 		queueItem := models.QueueItem{}
 		err := cur.Decode(&queueItem)

--- a/shipyard-controller/db/mongodb_log_repo.go
+++ b/shipyard-controller/db/mongodb_log_repo.go
@@ -81,12 +81,8 @@ func (mdbrepo *MongoDBLogRepo) GetLogEntries(params models.GetLogParams) (*model
 	}
 
 	cur, err := collection.Find(ctx, searchOptions, sortOptions)
-	defer func() {
-		if cur == nil {
-			return
-		}
-		cur.Close(ctx)
-	}()
+	defer closeCursor(ctx, cur)
+
 	if err != nil && err != mongo.ErrNoDocuments {
 		return nil, err
 	}

--- a/shipyard-controller/db/mongodb_log_repo.go
+++ b/shipyard-controller/db/mongodb_log_repo.go
@@ -81,6 +81,12 @@ func (mdbrepo *MongoDBLogRepo) GetLogEntries(params models.GetLogParams) (*model
 	}
 
 	cur, err := collection.Find(ctx, searchOptions, sortOptions)
+	defer func() {
+		if cur == nil {
+			return
+		}
+		cur.Close(ctx)
+	}()
 	if err != nil && err != mongo.ErrNoDocuments {
 		return nil, err
 	}

--- a/shipyard-controller/db/mongodb_sequence_execution_repo.go
+++ b/shipyard-controller/db/mongodb_sequence_execution_repo.go
@@ -64,12 +64,8 @@ func (mdbrepo *MongoDBSequenceExecutionRepo) Get(filter models.SequenceExecution
 	searchOptions := mdbrepo.getSearchOptions(filter)
 
 	cur, err := collection.Find(ctx, searchOptions)
-	defer func() {
-		if cur == nil {
-			return
-		}
-		cur.Close(ctx)
-	}()
+	defer closeCursor(ctx, cur)
+
 	if err != nil && err != mongo.ErrNoDocuments {
 		return nil, err
 	}
@@ -291,15 +287,8 @@ func (mdbrepo *MongoDBSequenceExecutionRepo) IsContextPaused(eventScope models.E
 		searchOptions[keptnContextScope] = eventScope.KeptnContext
 	}
 	cur, err := collection.Find(ctx, searchOptions)
-	defer func() {
-		if cur == nil {
-			return
-		}
-		err := cur.Close(ctx)
-		if err != nil {
-			log.Errorf("could not close cursor: %v", err)
-		}
-	}()
+	defer closeCursor(ctx, cur)
+
 	if err != nil {
 		log.Errorf("Could not retrieve sequence context: %v", err)
 		return false

--- a/shipyard-controller/db/mongodb_state_repo.go
+++ b/shipyard-controller/db/mongodb_state_repo.go
@@ -83,6 +83,14 @@ func (mdbrepo *MongoDBStateRepo) FindSequenceStates(filter models.StateFilter) (
 	}
 
 	cur, err := collection.Find(ctx, searchOptions, sortOptions)
+	defer func() {
+		if cur == nil {
+			return
+		}
+		if err := cur.Close(ctx); err != nil {
+			log.Errorf("could not close cursor: %v", err)
+		}
+	}()
 	if err != nil && err != mongo.ErrNoDocuments {
 		return nil, err
 	}

--- a/shipyard-controller/db/mongodb_state_repo.go
+++ b/shipyard-controller/db/mongodb_state_repo.go
@@ -83,14 +83,8 @@ func (mdbrepo *MongoDBStateRepo) FindSequenceStates(filter models.StateFilter) (
 	}
 
 	cur, err := collection.Find(ctx, searchOptions, sortOptions)
-	defer func() {
-		if cur == nil {
-			return
-		}
-		if err := cur.Close(ctx); err != nil {
-			log.Errorf("could not close cursor: %v", err)
-		}
-	}()
+	defer closeCursor(ctx, cur)
+
 	if err != nil && err != mongo.ErrNoDocuments {
 		return nil, err
 	}

--- a/shipyard-controller/db/mongodb_uniform_repo.go
+++ b/shipyard-controller/db/mongodb_uniform_repo.go
@@ -328,14 +328,8 @@ func (mdbrepo *MongoDBUniformRepo) getCollectionAndContext() (*mongo.Collection,
 func (mdbrepo *MongoDBUniformRepo) findIntegrations(searchParams models.GetUniformIntegrationsParams, collection *mongo.Collection, ctx context.Context) ([]apimodels.Integration, error) {
 	searchOptions := mdbrepo.getSearchOptions(searchParams)
 	cur, err := collection.Find(ctx, searchOptions)
-	defer func() {
-		if cur == nil {
-			return
-		}
-		if err := cur.Close(ctx); err != nil {
-			logger.Errorf("could not close cursor: %v", err)
-		}
-	}()
+	defer closeCursor(ctx, cur)
+
 	if err != nil && err != mongo.ErrNoDocuments {
 		return nil, err
 	}
@@ -369,14 +363,8 @@ func (mdbrepo *MongoDBUniformRepo) DeleteServiceFromSubscriptions(subscriptionNa
 	}
 
 	cur, err := collection.Find(ctx, filter)
-	defer func() {
-		if cur == nil {
-			return
-		}
-		if err := cur.Close(ctx); err != nil {
-			logger.Errorf("could not close cursor: %v", err)
-		}
-	}()
+	defer closeCursor(ctx, cur)
+
 	if err != nil && err != mongo.ErrNoDocuments {
 		return err
 	}

--- a/shipyard-controller/db/mongodb_uniform_repo.go
+++ b/shipyard-controller/db/mongodb_uniform_repo.go
@@ -328,6 +328,14 @@ func (mdbrepo *MongoDBUniformRepo) getCollectionAndContext() (*mongo.Collection,
 func (mdbrepo *MongoDBUniformRepo) findIntegrations(searchParams models.GetUniformIntegrationsParams, collection *mongo.Collection, ctx context.Context) ([]apimodels.Integration, error) {
 	searchOptions := mdbrepo.getSearchOptions(searchParams)
 	cur, err := collection.Find(ctx, searchOptions)
+	defer func() {
+		if cur == nil {
+			return
+		}
+		if err := cur.Close(ctx); err != nil {
+			logger.Errorf("could not close cursor: %v", err)
+		}
+	}()
 	if err != nil && err != mongo.ErrNoDocuments {
 		return nil, err
 	}
@@ -361,7 +369,14 @@ func (mdbrepo *MongoDBUniformRepo) DeleteServiceFromSubscriptions(subscriptionNa
 	}
 
 	cur, err := collection.Find(ctx, filter)
-
+	defer func() {
+		if cur == nil {
+			return
+		}
+		if err := cur.Close(ctx); err != nil {
+			logger.Errorf("could not close cursor: %v", err)
+		}
+	}()
 	if err != nil && err != mongo.ErrNoDocuments {
 		return err
 	}

--- a/statistics-service/db/migrator.go
+++ b/statistics-service/db/migrator.go
@@ -63,10 +63,17 @@ func (m *Migrator) migrateBatch(ctx context.Context) (bool, error) {
 		Limit: crateInt64P(m.batchSize),
 		Skip:  crateInt64P(skips),
 	})
+	defer func() {
+		if cur == nil {
+			return
+		}
+		if err := cur.Close(ctx); err != nil {
+			log.Errorf("could not close cursor: %v", err)
+		}
+	}()
 	if err != nil {
 		return false, err
 	}
-	defer cur.Close(ctx)
 
 	currBatchSize := 0
 	for cur.Next(ctx) {

--- a/statistics-service/db/statistics_mongodb_repo.go
+++ b/statistics-service/db/statistics_mongodb_repo.go
@@ -42,12 +42,17 @@ func (s *StatisticsMongoDBRepo) GetStatistics(from, to time.Time) ([]operations.
 	}
 
 	cur, err := s.statsCollection.Find(ctx, searchOptions)
+	defer func() {
+		if cur == nil {
+			return
+		}
+		cur.Close(ctx)
+	}()
 	if err != nil {
 		return nil, err
 	}
 
 	result := []operations.Statistics{}
-	defer cur.Close(ctx)
 	if cur.RemainingBatchLength() == 0 {
 		return nil, ErrNoStatisticsFound
 	}


### PR DESCRIPTION
This PR adds a defer function in which `cur.Close()` after every initialitation of a mongodb cursor