### PR TITLE
test(bridge): Fix flaky invalid host error

### DIFF
--- a/bridge/angular.json
+++ b/bridge/angular.json
@@ -118,7 +118,8 @@
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
             "browserTarget": "bridge:build:test",
-            "port": 5000
+            "port": 5000,
+            "liveReload": false
           }
         },
         "extract-i18n": {


### PR DESCRIPTION
Fixes flaky errors and warnings
```
warning: WebSocket connection to 'ws://localhost:5000/sockjs-node/...' failed: WebSocket is closed before the connection is established.

error: Invalid Host/Origin header
error: [WDS] Disconnected!
```
Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>