### PR TITLE
fix(installer): Fix wrong regex for log location

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/templates/api-gateway-nginx.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/api-gateway-nginx.yaml
@@ -137,7 +137,7 @@ data:
       deny all;
     }
 
-    location  {{ .Values.prefixPath }}/api/mongodb-datastore {
+    location {{ .Values.prefixPath }}/api/mongodb-datastore {
       # auth via backend (if the subrequest returns a 2xx response code, the access is allowed. If it returns 401 or 403,
       # the access is denied) before we store the file
       # see http://nginx.org/en/docs/http/ngx_http_auth_request_module.html
@@ -169,7 +169,7 @@ data:
     }
 
     # block DELETE calls to /api/controlplane/v1/log
-    location ~* {{ .Values.prefixPath }}/api/controlPlane/v1/log {
+    location {{ .Values.prefixPath }}/api/controlPlane/v1/log {
       limit_except GET POST PUT PATCH OPTIONS HEAD {
         deny all;
       }


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- Fixes the regex for `/api/controlplane/v1/log` which was overlapping with `/bridge/api/controlPlane/v1/log`

### How to test
<!-- if applicable, add testing instructions under this section -->

Open in your browser `http://<keptnURL>/bridge/api/controlPlane/v1/log?integrationId=e76cf51290248fe01f797e0bd533993b980f79b1&pageSize=100`

Before you were getting a 401, now you should get the log list
