### PR TITLE
chore: Reduce execution time of shipyard-controller tests

### DIFF
--- a/shipyard-controller/db/migration/project_mv_migration_test.go
+++ b/shipyard-controller/db/migration/project_mv_migration_test.go
@@ -18,6 +18,11 @@ import (
 
 var mongoDbVersion = "4.4.9"
 
+func TestMain(m *testing.M) {
+	defer setupLocalMongoDB()()
+	m.Run()
+}
+
 func setupLocalMongoDB() func() {
 	mongoServer, err := memongo.Start(mongoDbVersion)
 	randomDbName := memongo.RandomDatabase()
@@ -41,8 +46,6 @@ func setupLocalMongoDB() func() {
 }
 
 func Test_MigratorRunsOnOldData(t *testing.T) {
-	defer setupLocalMongoDB()()
-
 	project := &apimodels.ExpandedProject{
 		ProjectName: "test-project",
 		Stages: []*apimodels.ExpandedStage{
@@ -95,8 +98,6 @@ func Test_MigratorRunsOnOldData(t *testing.T) {
 }
 
 func Test_MigratorRunsOnAlreadyMigratedData(t *testing.T) {
-	defer setupLocalMongoDB()()
-
 	project := &apimodels.ExpandedProject{
 		ProjectName: "test-project",
 		Stages: []*apimodels.ExpandedStage{
@@ -130,5 +131,4 @@ func Test_MigratorRunsOnAlreadyMigratedData(t *testing.T) {
 
 	assert.Contains(t, insertedProject.Stages[0].Services[0].LastEventTypes, "sh.keptn.event.get-sli.start")
 	assert.Contains(t, insertedProject.Stages[0].Services[0].LastEventTypes, `sh.keptn.event.get-sli~.started`)
-
 }

--- a/shipyard-controller/db/migration/sequence_execution_migration_test.go
+++ b/shipyard-controller/db/migration/sequence_execution_migration_test.go
@@ -91,7 +91,6 @@ var testSequenceExecution = models.SequenceExecution{
 }
 
 func TestSequenceExecutionMigrator_MigrateSequenceExecutions(t *testing.T) {
-	defer setupLocalMongoDB()()
 
 	dbConnection := db.GetMongoDBConnectionInstance()
 	projectRepo := db.NewMongoDBKeyEncodingProjectsRepo(dbConnection)
@@ -143,7 +142,6 @@ func TestSequenceExecutionMigrator_MigrateSequenceExecutions(t *testing.T) {
 }
 
 func TestSequenceExecutionMigrator_MigrateSequenceExecutions_MixedOldAndNew(t *testing.T) {
-	defer setupLocalMongoDB()()
 
 	dbConnection := db.GetMongoDBConnectionInstance()
 	projectRepo := db.NewMongoDBKeyEncodingProjectsRepo(dbConnection)
@@ -195,7 +193,6 @@ func TestSequenceExecutionMigrator_MigrateSequenceExecutions_MixedOldAndNew(t *t
 }
 
 func TestSequenceExecutionMigrator_MigrateMultipleTimes(t *testing.T) {
-	defer setupLocalMongoDB()()
 
 	dbConnection := db.GetMongoDBConnectionInstance()
 	projectRepo := db.NewMongoDBKeyEncodingProjectsRepo(dbConnection)

--- a/shipyard-controller/db/models/sequence_execution/v1/sequence_execution.go
+++ b/shipyard-controller/db/models/sequence_execution/v1/sequence_execution.go
@@ -154,7 +154,7 @@ func (e JsonStringEncodedSequenceExecution) ToSequenceExecution() models.Sequenc
 			},
 		},
 		Scope:       e.Scope,
-		TriggeredAt: e.TriggeredAt,
+		TriggeredAt: e.TriggeredAt.UTC(),
 	}
 	inputProperties := map[string]interface{}{}
 	err := json.Unmarshal([]byte(e.EncodedInputProperties), &inputProperties)

--- a/shipyard-controller/db/mongodb_sequence_execution_repo_test.go
+++ b/shipyard-controller/db/mongodb_sequence_execution_repo_test.go
@@ -252,6 +252,8 @@ func TestMongoDBTaskSequenceV2Repo_UpdateStatus(t *testing.T) {
 
 	require.Len(t, get, 1)
 	get[0].SchemaVersion = ""
+	t.Logf("%d", sequence.TriggeredAt.Unix())
+	t.Logf("%d", get[0].TriggeredAt.Unix())
 	require.Equal(t, sequence, get[0])
 	require.Nil(t, err)
 
@@ -308,7 +310,7 @@ func getTestSequenceExecution() (models.EventScope, models.SequenceExecution) {
 			},
 		},
 		Scope:       scope,
-		TriggeredAt: time.Date(2021, 4, 21, 17, 00, 00, 0, time.UTC),
+		TriggeredAt: time.Date(2021, 4, 21, 17, 00, 00, 0, time.UTC).UTC(),
 	}
 	return scope, sequence
 }


### PR DESCRIPTION
This PR should reduce the execution time of the shipyard controller tests by only setting up a memongo instance once per tested package, instead of setting it up in each test case. This reduces the execution time of the unit tests in our github actions to ~2m instead of previously 10m