### PR TITLE
fix(go-sdk): Use the correct env var for setting the integration version

### DIFF
--- a/go-sdk/pkg/sdk/config.go
+++ b/go-sdk/pkg/sdk/config.go
@@ -1,8 +1,9 @@
 package sdk
 
 import (
-	"github.com/kelseyhightower/envconfig"
 	"log"
+
+	"github.com/kelseyhightower/envconfig"
 )
 
 type envConfig struct {
@@ -12,7 +13,7 @@ type envConfig struct {
 	HealthEndpointPort      string `envconfig:"HEALTH_ENDPOINT_PORT" default:"8080"`
 	HealthEndpointEnabled   bool   `envconfig:"HEALTH_ENDPOINT_ENABLED" default:"true"`
 	Location                string `envconfig:"LOCATION" default:"control-plane"`
-	Version                 string `envconfig:"VERSION" default:""`
+	K8sDeploymentVersion    string `envconfig:"K8S_DEPLOYMENT_VERSION" default:""`
 	K8sDeploymentName       string `envconfig:"K8S_DEPLOYMENT_NAME" default:""`
 	K8sNamespace            string `envconfig:"K8S_NAMESPACE" default:""`
 	K8sPodName              string `envconfig:"K8S_POD_NAME" default:""`

--- a/go-sdk/pkg/sdk/keptn.go
+++ b/go-sdk/pkg/sdk/keptn.go
@@ -2,6 +2,13 @@ package sdk
 
 import (
 	"context"
+	"log"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+
 	"github.com/kelseyhightower/envconfig"
 	"github.com/keptn/go-utils/pkg/api/models"
 	api "github.com/keptn/go-utils/pkg/api/utils"
@@ -9,12 +16,6 @@ import (
 	api2 "github.com/keptn/keptn/cp-common/api"
 	"github.com/keptn/keptn/cp-connector/pkg/controlplane"
 	"github.com/keptn/keptn/cp-connector/pkg/nats"
-	"log"
-	"os"
-	"os/signal"
-	"strings"
-	"sync"
-	"syscall"
 )
 
 const (
@@ -276,7 +277,7 @@ func (k *Keptn) RegistrationData() controlplane.RegistrationData {
 		Name: k.source,
 		MetaData: models.MetaData{
 			Hostname:           k.env.K8sNodeName,
-			IntegrationVersion: k.env.Version,
+			IntegrationVersion: k.env.K8sDeploymentVersion,
 			Location:           k.env.Location,
 			DistributorVersion: "0.15.0", // note: to be deleted when bridge stops requiring this info
 			KubernetesMetaData: models.KubernetesMetaData{

--- a/go-sdk/pkg/sdk/keptn_test.go
+++ b/go-sdk/pkg/sdk/keptn_test.go
@@ -3,12 +3,13 @@ package sdk
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/google/uuid"
 	"github.com/keptn/go-utils/pkg/api/models"
 	"github.com/keptn/go-utils/pkg/common/strutils"
 	"github.com/keptn/go-utils/pkg/lib/v0_2_0"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func Test_ReceivingEventWithMissingType(t *testing.T) {
@@ -133,13 +134,13 @@ func Test_NoFinishedEventDataProvided(t *testing.T) {
 
 func Test_InitialRegistrationData(t *testing.T) {
 	keptn := Keptn{env: envConfig{
-		PubSubTopic:       "sh.keptn.event.task1.triggered,sh.keptn.event.task2.triggered",
-		Location:          "localhost",
-		Version:           "v1",
-		K8sDeploymentName: "k8s-deployment",
-		K8sNamespace:      "k8s-namespace",
-		K8sPodName:        "k8s-podname",
-		K8sNodeName:       "k8s-nodename",
+		PubSubTopic:          "sh.keptn.event.task1.triggered,sh.keptn.event.task2.triggered",
+		Location:             "localhost",
+		K8sDeploymentVersion: "v1",
+		K8sDeploymentName:    "k8s-deployment",
+		K8sNamespace:         "k8s-namespace",
+		K8sPodName:           "k8s-podname",
+		K8sNodeName:          "k8s-nodename",
 	}}
 
 	regData := keptn.RegistrationData()


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->
fixes the error where the SDK is looking for `VERSION` instead of `K8S_DEPLOYMENT_VERSION` env var to set the integration version via the Uniform API
