### PR TITLE
test(bridge): Fix flaky UI test on first day of a month

### DIFF
--- a/bridge/cypress/integration/trigger-sequence.spec.ts
+++ b/bridge/cypress/integration/trigger-sequence.spec.ts
@@ -266,9 +266,9 @@ describe('Trigger an evaluation sequence', () => {
   it('should have disabled trigger button if end date is before start date', () => {
     triggerSequencePage
       .selectEvaluationEndDate()
-      .setStartDate(1, '1', '15', '0')
+      .setStartDate(0, '1', '15', '0')
       .assertTriggerSequenceEnabled(false)
-      .setEndDate(0, '1', '15', '0')
+      .setEndDate(0, '1', '15', '0', 1)
       .assertEvaluationDateErrorExists(true)
       .assertTriggerSequenceEnabled(false);
   });
@@ -319,8 +319,8 @@ describe('Trigger an evaluation sequence', () => {
     triggerSequencePage
       .assertTriggerSequenceEnabled(true)
       .selectEvaluationEndDate()
-      .setStartDate(1, '1', '1', '1')
-      .setEndDate(0, '1', '1', '1')
+      .setStartDate(0, '1', '1', '1')
+      .setEndDate(0, '1', '1', '1', 1)
       .assertEvaluationDateErrorExists(true)
       .assertTriggerSequenceEnabled(false)
 
@@ -340,8 +340,8 @@ describe('Trigger an evaluation sequence', () => {
       .assertEvaluationTimeframeErrorExists(true)
 
       .selectEvaluationEndDate()
-      .setStartDate(0, '1', '1', '1')
-      .setEndDate(1, '1', '1', '1')
+      .setStartDate(0, '1', '1', '1', 1)
+      .setEndDate(0, '1', '1', '1')
       .assertEvaluationDateErrorExists(false)
       .assertTriggerSequenceEnabled(true)
       .assertEvaluationTimeframeErrorExists(false)

--- a/bridge/cypress/support/pageobjects/TriggerSequenceSubPage.ts
+++ b/bridge/cypress/support/pageobjects/TriggerSequenceSubPage.ts
@@ -67,12 +67,12 @@ export class TriggerSequenceSubPage {
     return this;
   }
 
-  public setStartDate(calElement: number, hours: string, minutes: string, seconds: string): this {
-    return this.clickStartTime().selectDateTime(calElement, hours, minutes, seconds);
+  public setStartDate(calElement: number, hours: string, minutes: string, seconds: string, goBackMonths = 0): this {
+    return this.clickStartTime().selectDateTime(calElement, hours, minutes, seconds, goBackMonths);
   }
 
-  public setEndDate(calElement: number, hours: string, minutes: string, seconds: string): this {
-    return this.clickEndTime().selectDateTime(calElement, hours, minutes, seconds);
+  public setEndDate(calElement: number, hours: string, minutes: string, seconds: string, goBackMonths = 0): this {
+    return this.clickEndTime().selectDateTime(calElement, hours, minutes, seconds, goBackMonths);
   }
 
   public assertStartDateDisplayValue(value: string): this {
@@ -85,7 +85,16 @@ export class TriggerSequenceSubPage {
     return this;
   }
 
-  public selectDateTime(calElement: number, hours: string, minutes: string, seconds: string): this {
+  public selectDateTime(
+    calElement: number,
+    hours: string,
+    minutes: string,
+    seconds: string,
+    goBackMonths: number
+  ): this {
+    for (let i = 0; i < goBackMonths; ++i) {
+      cy.get('.dt-calendar-header-button-prev-month').click();
+    }
     cy.get('.dt-calendar-table-cell').eq(calElement).click();
     cy.byTestId('keptn-datetime-picker-submit').should('be.enabled');
     cy.byTestId('keptn-datetime-picker-time').byTestId('keptn-time-input-hours').type(hours);


### PR DESCRIPTION
On the first day of the month, some UI tests were not successful because it was not able to select two different days

Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>