### PR TITLE
fix(shipyard-controller): Avoid lost writes to subscriptions due to concurrent writes

### DIFF
--- a/shipyard-controller/db/mongodb_state_repo_test.go
+++ b/shipyard-controller/db/mongodb_state_repo_test.go
@@ -52,6 +52,7 @@ func setupLocalMongoDB() (*memongo.Server, error) {
 		return nil, err
 	}
 
+	fmt.Println("Started mongodb server: ", mongoServer.URI())
 	return mongoServer, err
 }
 

--- a/shipyard-controller/db/mongodb_uniform_repo.go
+++ b/shipyard-controller/db/mongodb_uniform_repo.go
@@ -69,6 +69,10 @@ func (mdbrepo *MongoDBUniformRepo) CreateUniformIntegration(integration apimodel
 	}
 	defer cancel()
 
+	// ensure that we have an empty array of subscriptions if it was nil before, to be able to use $push later
+	if integration.Subscriptions == nil {
+		integration.Subscriptions = []apimodels.EventSubscription{}
+	}
 	_, err = collection.InsertOne(ctx, integration)
 	if mongo.IsDuplicateKeyError(err) {
 		return ErrUniformRegistrationAlreadyExists
@@ -82,6 +86,11 @@ func (mdbrepo *MongoDBUniformRepo) CreateOrUpdateUniformIntegration(integration 
 		return err
 	}
 	defer cancel()
+
+	// ensure that we have an empty array of subscriptions if it was nil before, to be able to use $push later
+	if integration.Subscriptions == nil {
+		integration.Subscriptions = []apimodels.EventSubscription{}
+	}
 
 	opts := options.Update().SetUpsert(true)
 	filter := bson.D{{"_id", integration.ID}}

--- a/shipyard-controller/db/mongodb_uniform_repo_test.go
+++ b/shipyard-controller/db/mongodb_uniform_repo_test.go
@@ -463,7 +463,7 @@ func TestMongoDBUniformRepo_ConcurrentlyUpdateSubscription(t *testing.T) {
 	nrRoutines := 100
 	testIntegration := generateIntegrations()[0]
 
-	testIntegration.Subscriptions = []apimodels.EventSubscription{}
+	testIntegration.Subscriptions = nil
 
 	mdbrepo := NewMongoDBUniformRepo(GetMongoDBConnectionInstance())
 

--- a/shipyard-controller/db/mongodb_uniform_repo_test.go
+++ b/shipyard-controller/db/mongodb_uniform_repo_test.go
@@ -456,7 +456,7 @@ func TestMongoDBUniformRepo_ConcurrentlyAddSubscriptions(t *testing.T) {
 	require.Nil(t, err)
 	require.Len(t, integrations, 1)
 	// verify that no subscription has been lost
-	require.Equal(t, integrations[0].Subscriptions, nrRoutines)
+	require.Len(t, integrations[0].Subscriptions, nrRoutines)
 }
 
 func TestMongoDBUniformRepo_ConcurrentlyUpdateSubscription(t *testing.T) {

--- a/shipyard-controller/db/mongodb_uniform_repo_test.go
+++ b/shipyard-controller/db/mongodb_uniform_repo_test.go
@@ -509,7 +509,7 @@ func TestMongoDBUniformRepo_ConcurrentlyUpdateSubscription(t *testing.T) {
 	integrations, err := mdbrepo.GetUniformIntegrations(models.GetUniformIntegrationsParams{ID: "i1"})
 	require.Nil(t, err)
 	require.Len(t, integrations, 1)
-	require.Equal(t, integrations[0].Subscriptions, 1)
+	require.Len(t, integrations[0].Subscriptions, 1)
 }
 
 func TestMongoDBUniformRepo_RemoveByServiceName(t *testing.T) {

--- a/shipyard-controller/db/mongodb_uniform_repo_test.go
+++ b/shipyard-controller/db/mongodb_uniform_repo_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/keptn/keptn/shipyard-controller/models"
 	"github.com/stretchr/testify/require"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -358,6 +359,157 @@ func TestMongoDBUniformRepo_InsertAndRetrieve(t *testing.T) {
 	require.Equal(t, integrationBeforeUpdate.MetaData.IntegrationVersion, fetchedIntegrationAfterUpdate.MetaData.IntegrationVersion)
 	require.Equal(t, integrationBeforeUpdate.MetaData.DistributorVersion, fetchedIntegrationAfterUpdate.MetaData.DistributorVersion)
 
+}
+
+func TestMongoDBUniformRepo_UpdateSubscription(t *testing.T) {
+	testIntegration := generateIntegrations()[0]
+
+	testIntegration.Subscriptions = []apimodels.EventSubscription{}
+
+	mdbrepo := NewMongoDBUniformRepo(GetMongoDBConnectionInstance())
+
+	err := mdbrepo.SetupTTLIndex(1 * time.Minute)
+	require.Nil(t, err)
+
+	// insert our integration entities
+	err = mdbrepo.CreateOrUpdateUniformIntegration(testIntegration)
+	require.Nil(t, err)
+
+	subscription := apimodels.EventSubscription{
+		ID:    "sub-id",
+		Event: "a-topic",
+		Filter: apimodels.EventSubscriptionFilter{
+			Projects: []string{"project"},
+			Stages:   []string{"a-stage"},
+			Services: []string{"a-service"},
+		},
+	}
+
+	err = mdbrepo.CreateOrUpdateSubscription("i1", subscription)
+	require.Nil(t, err)
+
+	integrations, err := mdbrepo.GetUniformIntegrations(models.GetUniformIntegrationsParams{ID: "i1"})
+	require.Nil(t, err)
+	require.Len(t, integrations, 1)
+	require.Len(t, integrations[0].Subscriptions, 1)
+	require.Equal(t, subscription, integrations[0].Subscriptions[0])
+
+	updatedSubscription := apimodels.EventSubscription{
+		ID:    "sub-id",
+		Event: "a-new-topic",
+		Filter: apimodels.EventSubscriptionFilter{
+			Projects: []string{"new-project"},
+			Stages:   []string{"a-new-stage"},
+			Services: []string{"a-new-service"},
+		},
+	}
+
+	err = mdbrepo.CreateOrUpdateSubscription("i1", updatedSubscription)
+	require.Nil(t, err)
+
+	integrations, err = mdbrepo.GetUniformIntegrations(models.GetUniformIntegrationsParams{ID: "i1"})
+	require.Nil(t, err)
+	require.Len(t, integrations, 1)
+	require.Len(t, integrations[0].Subscriptions, 1)
+	require.Equal(t, updatedSubscription, integrations[0].Subscriptions[0])
+}
+
+func TestMongoDBUniformRepo_ConcurrentlyAddSubscriptions(t *testing.T) {
+	nrRoutines := 100
+	testIntegration := generateIntegrations()[0]
+
+	testIntegration.Subscriptions = []apimodels.EventSubscription{}
+
+	mdbrepo := NewMongoDBUniformRepo(GetMongoDBConnectionInstance())
+
+	err := mdbrepo.SetupTTLIndex(1 * time.Minute)
+	require.Nil(t, err)
+
+	// insert our integration entities
+	err = mdbrepo.CreateOrUpdateUniformIntegration(testIntegration)
+	require.Nil(t, err)
+
+	wg := &sync.WaitGroup{}
+	wg.Add(nrRoutines)
+
+	// concurrently add different subscriptions
+	for i := 0; i < nrRoutines; i++ {
+		go func(idx int) {
+			newID := fmt.Sprintf("id-%d", idx)
+			projectName := fmt.Sprintf("project-%d", idx)
+			err = mdbrepo.CreateOrUpdateSubscription("i1", apimodels.EventSubscription{
+				ID:    newID,
+				Event: "a-topic",
+				Filter: apimodels.EventSubscriptionFilter{
+					Projects: []string{projectName},
+					Stages:   []string{"a-stage"},
+					Services: []string{"a-service"},
+				},
+			})
+			require.Nil(t, err)
+			wg.Done()
+		}(i)
+	}
+
+	wg.Wait()
+	integrations, err := mdbrepo.GetUniformIntegrations(models.GetUniformIntegrationsParams{ID: "i1"})
+	require.Nil(t, err)
+	require.Len(t, integrations, 1)
+	// verify that no subscription has been lost
+	require.Equal(t, integrations[0].Subscriptions, nrRoutines)
+}
+
+func TestMongoDBUniformRepo_ConcurrentlyUpdateSubscription(t *testing.T) {
+	nrRoutines := 100
+	testIntegration := generateIntegrations()[0]
+
+	testIntegration.Subscriptions = []apimodels.EventSubscription{}
+
+	mdbrepo := NewMongoDBUniformRepo(GetMongoDBConnectionInstance())
+
+	err := mdbrepo.SetupTTLIndex(1 * time.Minute)
+	require.Nil(t, err)
+
+	// insert our integration entities
+	err = mdbrepo.CreateOrUpdateUniformIntegration(testIntegration)
+	require.Nil(t, err)
+
+	err = mdbrepo.CreateOrUpdateSubscription("i1", apimodels.EventSubscription{
+		ID:    "sub-id",
+		Event: "a-topic",
+		Filter: apimodels.EventSubscriptionFilter{
+			Projects: []string{"project"},
+			Stages:   []string{"a-stage"},
+			Services: []string{"a-service"},
+		},
+	})
+	require.Nil(t, err)
+
+	wg := &sync.WaitGroup{}
+	wg.Add(nrRoutines)
+
+	// concurrently add the same subscription -> in this case the number of subscriptions should stay the same
+	for i := 0; i < nrRoutines; i++ {
+		go func() {
+			err = mdbrepo.CreateOrUpdateSubscription("i1", apimodels.EventSubscription{
+				ID:    "sub-id",
+				Event: "a-topic",
+				Filter: apimodels.EventSubscriptionFilter{
+					Projects: []string{"project"},
+					Stages:   []string{"a-stage"},
+					Services: []string{"a-service"},
+				},
+			})
+			require.Nil(t, err)
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+	integrations, err := mdbrepo.GetUniformIntegrations(models.GetUniformIntegrationsParams{ID: "i1"})
+	require.Nil(t, err)
+	require.Len(t, integrations, 1)
+	require.Equal(t, integrations[0].Subscriptions, 1)
 }
 
 func TestMongoDBUniformRepo_RemoveByServiceName(t *testing.T) {


### PR DESCRIPTION
Closes #7956

This PR changes the logic of the Uniform mongodb repo implementation to use an append-only approach for adding subscriptions to a registered integration

Also, deleting subscriptions will be done using $pull (also to avoid concurrency issues)

Integration test run: https://github.com/keptn/keptn/runs/6706093301?check_suite_focus=true