### PR TITLE
ci: Skip CI build on release commits

### DIFF
--- a/.versionrc.json
+++ b/.versionrc.json
@@ -1,6 +1,6 @@
 {
   "preMajor": true,
-  "releaseCommitMessageFormat": "build(release): {{currentTag}}",
+  "releaseCommitMessageFormat": "build(release): {{currentTag}} [skip ci]",
   "bumpFiles": [
     {
       "filename": "VERSION.txt",


### PR DESCRIPTION
### This PR
- adds a small feature to skip CI builds for release commits