### PR TITLE
test(bridge): Potentially fix flaky heatmap UI tests

### DIFF
--- a/bridge/cypress/integration/evaluation-heatmap.spec.ts
+++ b/bridge/cypress/integration/evaluation-heatmap.spec.ts
@@ -1,7 +1,8 @@
 import { HeatmapComponentPage, range } from '../support/pageobjects/HeatmapComponentPage';
 
-describe('evaluation-heatmap', () => {
-  const heatmap = new HeatmapComponentPage();
+const heatmap = new HeatmapComponentPage();
+
+describe('evaluation-heatmap intercept default', () => {
   beforeEach(() => {
     heatmap.intercept().visitPageWithHeatmapComponent();
   });
@@ -11,13 +12,13 @@ describe('evaluation-heatmap', () => {
   it('should be expandable and collapsable', () => {
     heatmap
       .assertNumberOfRows(10)
-      .assertExpandExists(true)
+      .assertExpandVisible(true)
       .clickExpandButton()
       .assertNumberOfRows(13)
-      .assertExpandExists(true)
+      .assertExpandVisible(true)
       .clickExpandButton()
       .assertNumberOfRows(10)
-      .assertExpandExists(true);
+      .assertExpandVisible(true);
   });
   it('should set correct color classes', () => {
     heatmap
@@ -30,9 +31,7 @@ describe('evaluation-heatmap', () => {
   it('should have a primary and one secondary highlight', () => {
     heatmap.assertPrimaryHighlight(1).assertSecondaryHighlight(1);
   });
-  it('should have a primary and two secondary highlights', () => {
-    heatmap.interceptWithTwoHighlights().assertPrimaryHighlight(1).assertSecondaryHighlight(2);
-  });
+
   it('should truncate long metric names', () => {
     const longName = 'A very long metric name so long it gets cut somewhere along the way';
     const shortName = 'A very long metric name ...';
@@ -56,13 +55,7 @@ describe('evaluation-heatmap', () => {
   it('should not show secondary highlight if clicked evaluation has no other to compare', () => {
     heatmap.clickScore('25ab0f26-e6d8-48d5-a08f-08c8a136a688').assertPrimaryHighlight(1).assertSecondaryHighlight(0);
   });
-  it('should reduce X elements on many evaluations', () => {
-    const labels = range(1, 44, 2).map((value) => `2022-02-01 03:46 (${value})`);
-    heatmap.interceptWithManyEvaluations().assertXAxisTickLength(22).assertXAxisTickLabels(labels);
-  });
-  it('should not show expand button if indicator results with score are less than 10', () => {
-    heatmap.interceptWith10Metrics().assertExpandExists(false);
-  });
+
   it('should set tiles disabled/enabled via legend', () => {
     heatmap
       .clickLegendCircle('pass')
@@ -100,5 +93,32 @@ describe('evaluation-heatmap', () => {
       .clickMetric('go_routines3a', '182d10b8-b68d-49d4-86cd-5521352d7a42')
       .assertTooltipIsVisible(true)
       .assertTooltipIs('metric');
+  });
+});
+
+describe('evaluation-heatmap intercept dynamic', () => {
+  beforeEach(() => {
+    heatmap.intercept();
+  });
+
+  it('should have a primary and two secondary highlights', () => {
+    heatmap
+      .interceptWithTwoHighlights()
+      .visitPageWithHeatmapComponent()
+      .assertPrimaryHighlight(1)
+      .assertSecondaryHighlight(2);
+  });
+
+  it('should reduce X elements on many evaluations', () => {
+    const labels = range(1, 44, 2).map((value) => `2022-02-01 03:46 (${value})`);
+    heatmap
+      .interceptWithManyEvaluations()
+      .visitPageWithHeatmapComponent()
+      .assertXAxisTickLength(22)
+      .assertXAxisTickLabels(labels);
+  });
+
+  it('should not show expand button if indicator results with score are less than 10', () => {
+    heatmap.interceptWith10Metrics().visitPageWithHeatmapComponent().assertExpandVisible(false);
   });
 });

--- a/bridge/cypress/support/intercept.ts
+++ b/bridge/cypress/support/intercept.ts
@@ -363,5 +363,5 @@ export function interceptHeatmapComponent(): void {
   cy.intercept('GET', 'api/mongodb-datastore/event/type/sh.keptn.event.evaluation.finished?*', {
     statusCode: 200,
     fixture: 'get.sockshop.service.carts.evaluations.heatmap.mock.json',
-  });
+  }).as('heatmapEvaluations');
 }

--- a/bridge/cypress/support/pageobjects/HeatmapComponentPage.ts
+++ b/bridge/cypress/support/pageobjects/HeatmapComponentPage.ts
@@ -14,7 +14,7 @@ export class HeatmapComponentPage {
     cy.intercept('GET', 'api/mongodb-datastore/event/type/sh.keptn.event.evaluation.finished?*', {
       statusCode: 200,
       fixture: 'get.sockshop.service.carts.evaluations.heatmap.manyscores.mock.json',
-    });
+    }).as('heatmapEvaluations');
     return this;
   }
 
@@ -22,7 +22,7 @@ export class HeatmapComponentPage {
     cy.intercept('GET', 'api/mongodb-datastore/event/type/sh.keptn.event.evaluation.finished?*', {
       statusCode: 200,
       fixture: 'get.sockshop.service.carts.evaluations.heatmap.10metrics.mock.json',
-    });
+    }).as('heatmapEvaluations');
     return this;
   }
 
@@ -30,12 +30,14 @@ export class HeatmapComponentPage {
     cy.intercept('GET', 'api/mongodb-datastore/event/type/sh.keptn.event.evaluation.finished?*', {
       statusCode: 200,
       fixture: 'get.sockshop.service.carts.evaluations.heatmap.twohighlights.mock.json',
-    });
+    }).as('heatmapEvaluations');
     return this;
   }
 
   visitPageWithHeatmapComponent(): this {
-    cy.visit('/project/sockshop/service/carts/context/da740469-9920-4e0c-b304-0fd4b18d17c2/stage/staging');
+    cy.visit('/project/sockshop/service/carts/context/da740469-9920-4e0c-b304-0fd4b18d17c2/stage/staging').wait(
+      '@heatmapEvaluations'
+    );
     return this;
   }
 
@@ -167,8 +169,8 @@ export class HeatmapComponentPage {
     return this;
   }
 
-  assertExpandExists(exists: boolean): this {
-    cy.get('ktb-heatmap button.show-more-button').should(!exists ? 'not.exist' : 'exist');
+  assertExpandVisible(visible: boolean): this {
+    cy.get('ktb-heatmap button.show-more-button').should(visible ? 'be.visible' : 'not.be.visible');
     return this;
   }
 }


### PR DESCRIPTION
For the legend, there is a flaky UI test. To tackle that, we are waiting until the evaluations are loaded and only after then we are accessing the legend. Else the legend is repositioned (before and after evaluations fetch/render)
```
"should set tiles disabled/enabled via legend"

 should set tiles disabled/enabled via legend:
     CypressError: Timed out retrying after 4050ms: `cy.click()` failed because this element is detached from the DOM.

`<text x="10" class="legend-text">pass</text>`

Cypress requires elements be attached in the DOM to interact with them.

The previous command that ran was:

  > `cy.contains()`
```

Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>