### PR TITLE
fix(shipyard-controller): Update registration info based on integration name/namespace

### DIFF
--- a/shipyard-controller/db/mongodb_uniform_repo.go
+++ b/shipyard-controller/db/mongodb_uniform_repo.go
@@ -305,6 +305,14 @@ func (mdbrepo *MongoDBUniformRepo) getSearchOptions(params models.GetUniformInte
 		searchOptions["subscriptions.filter.services"] = params.Service
 	}
 
+	if params.Namespace != "" {
+		searchOptions["metadata.kubernetesmetadata.namespace"] = params.Namespace
+	}
+
+	if params.HostName != "" {
+		searchOptions["metadata.hostname"] = params.HostName
+	}
+
 	return searchOptions
 }
 

--- a/shipyard-controller/handler/uniformintegrationhandler.go
+++ b/shipyard-controller/handler/uniformintegrationhandler.go
@@ -123,7 +123,7 @@ func (rh *UniformIntegrationHandler) Register(c *gin.Context) {
 		Namespace: integration.MetaData.KubernetesMetaData.Namespace,
 	})
 
-	integrationInfo := fmt.Sprintf("name=%s, namespace=%s, hostname=%s", integration.Name, integration.MetaData.KubernetesMetaData.Namespace, integration.MetaData.Hostname)
+	integrationInfo := fmt.Sprintf("name=%s, namespace=%s", integration.Name, integration.MetaData.KubernetesMetaData.Namespace)
 	logger.Debugf("Uniform:Register(): Checking for existing integration for %s", integrationInfo)
 	if err == nil && len(existingIntegrations) > 0 {
 		logger.Debugf("Uniform:Register(): Found existing integration for %s with id %s", integrationInfo, existingIntegrations[0].ID)

--- a/shipyard-controller/handler/uniformintegrationhandler.go
+++ b/shipyard-controller/handler/uniformintegrationhandler.go
@@ -125,7 +125,7 @@ func (rh *UniformIntegrationHandler) Register(c *gin.Context) {
 
 	integrationInfo := fmt.Sprintf("name=%s, namespace=%s, hostname=%s", integration.Name, integration.MetaData.KubernetesMetaData.Namespace, integration.MetaData.Hostname)
 	logger.Debugf("Uniform:Register(): Checking for existing integration for %s", integrationInfo)
-	if err == nil && existingIntegrations != nil && len(existingIntegrations) > 0 {
+	if err == nil && len(existingIntegrations) > 0 {
 		logger.Debugf("Uniform:Register(): Found existing integration for %s with id %s", integrationInfo, existingIntegrations[0].ID)
 		integration.ID = existingIntegrations[0].ID
 

--- a/shipyard-controller/handler/uniformintegrationhandler_test.go
+++ b/shipyard-controller/handler/uniformintegrationhandler_test.go
@@ -131,6 +131,9 @@ func TestUniformIntegrationHandler_Register(t *testing.T) {
 			fields: fields{
 				integrationManager: &db_mock.UniformRepoMock{
 					CreateUniformIntegrationFunc: func(integration apimodels.Integration) error { return nil },
+					GetUniformIntegrationsFunc: func(filter models.GetUniformIntegrationsParams) ([]apimodels.Integration, error) {
+						return nil, nil
+					},
 				},
 			},
 			request:         httptest.NewRequest("POST", "/uniform/registration", bytes.NewBuffer(validPayload)),
@@ -152,7 +155,7 @@ func TestUniformIntegrationHandler_Register(t *testing.T) {
 			},
 			request:         httptest.NewRequest("POST", "/uniform/registration", bytes.NewBuffer(validPayload)),
 			wantStatus:      http.StatusOK,
-			wantIntegration: myValidIntegration,
+			wantIntegration: nil,
 			wantFuncs:       []string{"GetUniformIntegrationsCalls", "UpdateLastSeenCalls"},
 		},
 		{
@@ -170,7 +173,7 @@ func TestUniformIntegrationHandler_Register(t *testing.T) {
 			},
 			request:         httptest.NewRequest("POST", "/uniform/registration", bytes.NewBuffer(validPayloadUpdated)),
 			wantStatus:      http.StatusOK,
-			wantIntegration: myValidIntegrationUpdated,
+			wantIntegration: nil,
 			wantFuncs:       []string{"GetUniformIntegrationsCalls", "CreateOrUpdateUniformIntegrationCalls"},
 		},
 		{
@@ -188,7 +191,7 @@ func TestUniformIntegrationHandler_Register(t *testing.T) {
 			},
 			request:         httptest.NewRequest("POST", "/uniform/registration", bytes.NewBuffer(validPayloadUpdated)),
 			wantStatus:      http.StatusInternalServerError,
-			wantIntegration: myValidIntegrationUpdated,
+			wantIntegration: nil,
 			wantFuncs:       []string{"GetUniformIntegrationsCalls", "CreateOrUpdateUniformIntegrationCalls"},
 		},
 		{
@@ -219,6 +222,9 @@ func TestUniformIntegrationHandler_Register(t *testing.T) {
 				integrationManager: &db_mock.UniformRepoMock{
 					CreateUniformIntegrationFunc: func(integration apimodels.Integration) error {
 						return errors.New("oops")
+					},
+					GetUniformIntegrationsFunc: func(filter models.GetUniformIntegrationsParams) ([]apimodels.Integration, error) {
+						return nil, nil
 					},
 				},
 			},

--- a/shipyard-controller/models/uniform.go
+++ b/shipyard-controller/models/uniform.go
@@ -1,11 +1,13 @@
 package models
 
 type GetUniformIntegrationsParams struct {
-	Name    string `form:"name" json:"name"`
-	ID      string `form:"id" json:"id"`
-	Project string `form:"project" json:"project"`
-	Stage   string `form:"stage" json:"stage"`
-	Service string `form:"service" json:"service"`
+	Name      string `form:"name" json:"name"`
+	ID        string `form:"id" json:"id"`
+	Namespace string `form:"namespace" json:"namespace"`
+	HostName  string `form:"hostname" json:"hostname"`
+	Project   string `form:"project" json:"project"`
+	Stage     string `form:"stage" json:"stage"`
+	Service   string `form:"service" json:"service"`
 }
 
 type RegisterResponse struct {


### PR DESCRIPTION
Closes #7996 

This PR removes the outdated logic that created the integration ID differently for integrations that were using the recently `integration.Subscription` property. To make sure that calls to Register() do not result in different integration IDs for updated integrations, the uniform handler will first look for existing integrations based on the integration's name and it's namespace.