### PR TITLE
feat(cp-connector): Injectable logger implementation

### DIFF
--- a/cp-connector/pkg/controlplane/controlplane.go
+++ b/cp-connector/pkg/controlplane/controlplane.go
@@ -41,12 +41,19 @@ type ControlPlane struct {
 	logForwarder         logforwarder.LogForwarder
 }
 
+// WithLogger sets the logger to use
+func WithLogger(logger logger.Logger) func(plane *ControlPlane) {
+	return func(ns *ControlPlane) {
+		ns.logger = logger
+	}
+}
+
 // New creates a new ControlPlane
 // It is using a SubscriptionSource source to get information about current uniform subscriptions
 // as well as an EventSource to actually receive events from Keptn
 // and a LogForwarder to forward error logs
-func New(subscriptionSource subscriptionsource.SubscriptionSource, eventSource eventsource.EventSource, logForwarder logforwarder.LogForwarder) *ControlPlane {
-	return &ControlPlane{
+func New(subscriptionSource subscriptionsource.SubscriptionSource, eventSource eventsource.EventSource, logForwarder logforwarder.LogForwarder, opts ...func(plane *ControlPlane)) *ControlPlane {
+	cp := &ControlPlane{
 		subscriptionSource:   subscriptionSource,
 		eventSource:          eventSource,
 		currentSubscriptions: []models.EventSubscription{},
@@ -54,6 +61,10 @@ func New(subscriptionSource subscriptionsource.SubscriptionSource, eventSource e
 		logForwarder:         logForwarder,
 		registered:           false,
 	}
+	for _, o := range opts {
+		o(cp)
+	}
+	return cp
 }
 
 // Register is initially used to register the Keptn integration to the Control Plane

--- a/cp-connector/pkg/eventsource/eventsource.go
+++ b/cp-connector/pkg/eventsource/eventsource.go
@@ -40,12 +40,23 @@ type NATSEventSource struct {
 }
 
 // New creates a new NATSEventSource
-func New(natsConnector natseventsource.NATS) *NATSEventSource {
-	return &NATSEventSource{
+func New(natsConnector natseventsource.NATS, opts ...func(source *NATSEventSource)) *NATSEventSource {
+	e := &NATSEventSource{
 		currentSubjects: []string{},
 		connector:       natsConnector,
 		eventProcessFn:  func(event *nats.Msg) error { return nil },
 		logger:          logger.NewDefaultLogger(),
+	}
+	for _, o := range opts {
+		o(e)
+	}
+	return e
+}
+
+// WithLogger sets the logger to use
+func WithLogger(logger logger.Logger) func(*NATSEventSource) {
+	return func(ns *NATSEventSource) {
+		ns.logger = logger
 	}
 }
 

--- a/cp-connector/pkg/logforwarder/logforwarder.go
+++ b/cp-connector/pkg/logforwarder/logforwarder.go
@@ -24,10 +24,21 @@ type LogForwardingHandler struct {
 	logger logger.Logger
 }
 
-func New(logApi api.LogsV1Interface) *LogForwardingHandler {
-	return &LogForwardingHandler{
+func New(logApi api.LogsV1Interface, opts ...func(handler *LogForwardingHandler)) *LogForwardingHandler {
+	l := &LogForwardingHandler{
 		logApi: logApi,
 		logger: logger.NewDefaultLogger(),
+	}
+	for _, o := range opts {
+		o(l)
+	}
+	return l
+}
+
+// WithLogger sets the logger to use
+func WithLogger(logger logger.Logger) func(*LogForwardingHandler) {
+	return func(lfh *LogForwardingHandler) {
+		lfh.logger = logger
 	}
 }
 

--- a/cp-connector/pkg/nats/nats.go
+++ b/cp-connector/pkg/nats/nats.go
@@ -48,19 +48,30 @@ type NatsConnector struct {
 	logger        logger.Logger
 }
 
+// WithLogger sets the logger to use
+func WithLogger(logger logger.Logger) func(*NatsConnector) {
+	return func(n *NatsConnector) {
+		n.logger = logger
+	}
+}
+
 // Connect connects a NatsConnector to NATS.
 // Note that this will automatically and indefinitely try to reconnect
 // as soon as it looses connection
-func Connect(connectURL string) (*NatsConnector, error) {
+func Connect(connectURL string, opts ...func(connector *NatsConnector)) (*NatsConnector, error) {
 	conn, err := nats.Connect(connectURL, nats.MaxReconnects(-1))
 	if err != nil {
 		return nil, fmt.Errorf("could not connect to NATS: %w", err)
 	}
-	return &NatsConnector{
+	n := &NatsConnector{
 		conn:          conn,
 		subscriptions: make(map[string]*nats.Subscription),
 		logger:        logger.NewDefaultLogger(),
-	}, nil
+	}
+	for _, o := range opts {
+		o(n)
+	}
+	return n, nil
 }
 
 // ConnectFromEnv connects a NatsConnector to NATS.

--- a/cp-connector/pkg/subscriptionsource/subscriptionsource.go
+++ b/cp-connector/pkg/subscriptionsource/subscriptionsource.go
@@ -43,13 +43,20 @@ func WithFetchInterval(interval time.Duration) func(s *UniformSubscriptionSource
 	}
 }
 
+// WithLogger sets the logger to use
+func WithLogger(logger logger.Logger) func(s *UniformSubscriptionSource) {
+	return func(s *UniformSubscriptionSource) {
+		s.logger = logger
+	}
+}
+
 // New creates a new UniformSubscriptionSource
 func New(uniformAPI api.UniformV1Interface, options ...func(source *UniformSubscriptionSource)) *UniformSubscriptionSource {
-	subscriptionSource := &UniformSubscriptionSource{uniformAPI: uniformAPI, clock: clock.New(), fetchInterval: time.Second * 5, logger: logger.NewDefaultLogger()}
+	s := &UniformSubscriptionSource{uniformAPI: uniformAPI, clock: clock.New(), fetchInterval: time.Second * 5, logger: logger.NewDefaultLogger()}
 	for _, o := range options {
-		o(subscriptionSource)
+		o(s)
 	}
-	return subscriptionSource
+	return s
 }
 
 // Start triggers the execution of the UniformSubscriptionSource


### PR DESCRIPTION
closes #7681 

This PR adds the possibility to inject a custom logger implementation into the components of `cp-connector`