### PR TITLE
fix(bridge): Show loading indicator for sequences before filters are applied the first time

### DIFF
--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.html
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.html
@@ -25,7 +25,12 @@
           <div class="container" *ngIf="project.sequences && project.sequences.length !== 0">
             <ng-container [ngTemplateOutlet]="triggerSequenceButton"></ng-container>
           </div>
-          <div class="container" fxFlex fxLayout="column" *ngIf="project.sequences; else loadingSequences">
+          <div
+            class="container"
+            fxFlex
+            fxLayout="column"
+            *ngIf="project.sequences && filteredSequences; else loadingSequences"
+          >
             <div uitestid="keptn-noSequences" *ngIf="project.sequences.length === 0">
               <div fxLayout="row" fxLayoutAlign="start">
                 <dt-icon fxFlex="20px" class="icon" name="information"></dt-icon>

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
@@ -102,7 +102,7 @@ export class KtbSequenceViewComponent implements OnInit, OnDestroy {
     services: [],
   };
 
-  public filteredSequences: Sequence[] = [];
+  public filteredSequences?: Sequence[];
   public loading = false;
   public selectedEventId?: string;
 


### PR DESCRIPTION
## This PR
- fixes showing an empty result before the filters are applied the first time

### Related Issues
Fixes #7943 

### How to test
- Open the sequence screen in the Bridge
- Go to another tab (e.g. service screen)
- Go back to sequence screen
- Should show loading indicator instead of `No sequences found that match your filter criteria.`

Signed-off-by: ermin.muratovic <ermin.muratovic@gmail.com>