### PR TITLE
fix(resource-service): Remove token enforcement

### DIFF
--- a/resource-service/common/credentials_test.go
+++ b/resource-service/common/credentials_test.go
@@ -75,9 +75,8 @@ func TestK8sCredentialReader_ReadSecretNoToken(t *testing.T) {
 		},
 	))
 
-	secret, _ := secretReader.GetCredentials("my-project")
-
-	//require.ErrorIs(t, err, errors.ErrCredentialsTokenMustNotBeEmpty)
+	secret, err := secretReader.GetCredentials("my-project")
+	require.Nil(t, err)
 	require.NotNil(t, secret)
 }
 

--- a/resource-service/common/credentials_test.go
+++ b/resource-service/common/credentials_test.go
@@ -75,10 +75,10 @@ func TestK8sCredentialReader_ReadSecretNoToken(t *testing.T) {
 		},
 	))
 
-	secret, err := secretReader.GetCredentials("my-project")
+	secret, _ := secretReader.GetCredentials("my-project")
 
-	require.ErrorIs(t, err, errors.ErrCredentialsTokenMustNotBeEmpty)
-	require.Nil(t, secret)
+	//require.ErrorIs(t, err, errors.ErrCredentialsTokenMustNotBeEmpty)
+	require.NotNil(t, secret)
 }
 
 func TestK8sCredentialReader_ReadSecretNoPrivateKey(t *testing.T) {

--- a/resource-service/common_models/git.go
+++ b/resource-service/common_models/git.go
@@ -65,8 +65,5 @@ func (g GitCredentials) validateRemoteURIAndToken() error {
 	if err != nil {
 		return kerrors.ErrCredentialsInvalidRemoteURI
 	}
-	if g.Token == "" {
-		return kerrors.ErrCredentialsTokenMustNotBeEmpty
-	}
 	return nil
 }

--- a/resource-service/common_models/git_test.go
+++ b/resource-service/common_models/git_test.go
@@ -66,9 +66,9 @@ func TestGitCredentials_Validate(t *testing.T) {
 			fields: fields{
 				User:       "my-user",
 				PrivateKey: "",
-				RemoteURI:  "https://my.repo",
+				RemoteURI:  "https://my:repo",
 			},
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "token with ssh",

--- a/resource-service/common_models/git_test.go
+++ b/resource-service/common_models/git_test.go
@@ -32,7 +32,7 @@ func TestGitCredentials_Validate(t *testing.T) {
 				Token:     "",
 				RemoteURI: "https://my-repo",
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "invalid URI",
@@ -66,9 +66,9 @@ func TestGitCredentials_Validate(t *testing.T) {
 			fields: fields{
 				User:       "my-user",
 				PrivateKey: "",
-				RemoteURI:  "https://my:repo",
+				RemoteURI:  "https://my.repo",
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "token with ssh",


### PR DESCRIPTION
## This PR

Removes the necessity to enforce a token to set an upstream to a project.

Integration test run: https://github.com/keptn/keptn/runs/7067226222?check_suite_focus=true