### PR TITLE
feat: Add OAuth scopes to swagger and add possibility to disable deprecated APIs

### DIFF
--- a/api/restapi/configure_keptn.go
+++ b/api/restapi/configure_keptn.go
@@ -36,11 +36,14 @@ const envVarLogLevel = "LOG_LEVEL"
 const controlPlaneServiceEnvVar = "CONTROLPLANE_URI"
 
 type EnvConfig struct {
+	HideDeprecated           bool    `envconfig:"HIDE_DEPRECATED" default:"false"`
+	ImportBasePath            string  `envconfig:"IMPORT_BASE_PATH"`
 	MaxAuthEnabled            bool    `envconfig:"MAX_AUTH_ENABLED" default:"true"`
 	MaxAuthRequestsPerSecond  float64 `envconfig:"MAX_AUTH_REQUESTS_PER_SECOND" default:"1"`
 	MaxAuthRequestBurst       int     `envconfig:"MAX_AUTH_REQUESTS_BURST" default:"2"`
 	MaxImportUncompressedSize uint64  `envconfig:"MAX_IMPORT_UNCOMPRESSED_SIZE" default:"52428800"` // 50MB default value
-	ImportBasePath            string  `envconfig:"IMPORT_BASE_PATH"`
+	OAuthEnabled             bool    `envconfig:"OAUTH_ENABLED" default:"false"`
+	OAuthPrefix              string  `envconfig:"OAUTH_PREFIX" default:"keptn:"`
 }
 
 func configureFlags(api *operations.KeptnAPI) {
@@ -116,7 +119,7 @@ func configureAPI(api *operations.KeptnAPI) http.Handler {
 
 	api.ServerShutdown = func() {}
 
-	return setupGlobalMiddleware(api.Serve(setupMiddlewares))
+	return setupGlobalMiddleware(api.Serve(setupMiddlewares), env)
 }
 
 // The TLS configuration before HTTPS server starts.
@@ -149,52 +152,36 @@ func setupMiddlewares(handler http.Handler) http.Handler {
 
 // The middleware configuration happens before anything, this middleware also applies to serving the swagger.yaml document.
 // So this is a good place to plug in a panic handling middleware, logging and metrics
-func setupGlobalMiddleware(handler http.Handler) http.Handler {
-
-	prefixPath := os.Getenv("PREFIX_PATH")
-	if len(prefixPath) > 0 {
-		// Set the prefix-path in the swagger.yaml
-		input, err := ioutil.ReadFile("swagger-ui/swagger.yaml")
-		if err == nil {
-			editedSwagger := strings.Replace(
-				string(input), "basePath: /api/v1",
-				"basePath: "+prefixPath+"/api/v1", -1,
-			)
-			err = ioutil.WriteFile("swagger-ui/swagger.yaml", []byte(editedSwagger), 0644)
-			if err != nil {
-				fmt.Println("Failed to write edited swagger.yaml")
-			}
-		} else {
-			fmt.Println("Failed to set basePath in swagger.yaml")
-		}
-
-		// Set the prefix-path in the index.html
-		input, err = ioutil.ReadFile("swagger-ui/index.html")
-		if err == nil {
-			editedSwagger := strings.Replace(
-				string(input), "const prefixPath = \"\"",
-				"const prefixPath = \""+prefixPath+"\"", -1,
-			)
-			err = ioutil.WriteFile("swagger-ui/index.html", []byte(editedSwagger), 0644)
-			if err != nil {
-				fmt.Println("Failed to write edited index.html")
-			}
-		} else {
-			fmt.Println("Failed to set basePath in index.html")
-		}
+func setupGlobalMiddleware(handler http.Handler, env *EnvConfig) http.Handler {
+	inMemoryIndex := ""
+	b, err := ioutil.ReadFile("swagger-ui/index.html")
+	if err != nil {
+		fmt.Printf("Failed to set conf in index.html %v\n", err)
+	} else {
+		inMemoryIndex = string(b)
 	}
 
-	return http.HandlerFunc(
-		func(w http.ResponseWriter, r *http.Request) {
-			if strings.Index(r.URL.Path, "/swagger-ui/") == 0 {
-				http.StripPrefix("/swagger-ui/", http.FileServer(http.Dir("swagger-ui"))).ServeHTTP(w, r)
+	if env.OAuthEnabled {
+		inMemoryIndex = strings.Replace(inMemoryIndex, "const oauth_prefix = \"\";", "const oauth_prefix = \""+env.OAuthPrefix+"\";", -1)
+		inMemoryIndex = strings.Replace(inMemoryIndex, "const oauth_enabled = false;", "const oauth_enabled = true;", -1)
+	}
+	if env.HideDeprecated {
+		inMemoryIndex = strings.Replace(inMemoryIndex, "const hide_deprecated = false;", "const hide_deprecated = true;", -1)
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Index(r.URL.Path, "/swagger-ui/") == 0 {
+			if (strings.HasSuffix(r.URL.Path, "/swagger-ui/") || strings.HasSuffix(r.URL.Path, "/swagger-ui/index.html")) && inMemoryIndex != "" {
+				w.Write([]byte(inMemoryIndex))
 				return
 			}
-			if strings.Index(r.URL.Path, "/health") == 0 {
-				w.WriteHeader(http.StatusOK)
-				return
-			}
-			handler.ServeHTTP(w, r)
-		},
-	)
+			http.StripPrefix("/swagger-ui/", http.FileServer(http.Dir("swagger-ui"))).ServeHTTP(w, r)
+			return
+		}
+		if strings.Index(r.URL.Path, "/health") == 0 {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		handler.ServeHTTP(w, r)
+	})
 }

--- a/api/restapi/configure_keptn_test.go
+++ b/api/restapi/configure_keptn_test.go
@@ -1,7 +1,12 @@
 package restapi
 
 import (
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,15 +16,24 @@ func Test_getEnvConfig(t *testing.T) {
 	defer os.Unsetenv("MAX_AUTH_ENABLED")
 	defer os.Unsetenv("MAX_AUTH_REQUESTS_PER_SECOND")
 	defer os.Unsetenv("MAX_AUTH_REQUESTS_BURST")
+	defer os.Unsetenv("HIDE_DEPRECATED")
+	defer os.Unsetenv("OAUTH_ENABLED")
+	defer os.Unsetenv("OAUTH_PREFIX")
 	_ = os.Setenv("MAX_AUTH_ENABLED", "false")
 	_ = os.Setenv("MAX_AUTH_REQUESTS_PER_SECOND", "0.5")
 	_ = os.Setenv("MAX_AUTH_REQUESTS_BURST", "1")
+	_ = os.Setenv("HIDE_DEPRECATED", "true")
+	_ = os.Setenv("OAUTH_ENABLED", "true")
+	_ = os.Setenv("OAUTH_PREFIX", "prefix")
 
 	config, err := getEnvConfig()
 	require.Nil(t, err)
 	require.Equal(t, false, config.MaxAuthEnabled)
 	require.Equal(t, 0.5, config.MaxAuthRequestsPerSecond)
 	require.Equal(t, 1, config.MaxAuthRequestBurst)
+	require.Equal(t, true, config.HideDeprecated)
+	require.Equal(t, true, config.OAuthEnabled)
+	require.Equal(t, "prefix", config.OAuthPrefix)
 }
 
 func Test_getEnvConfigUseDefaults(t *testing.T) {
@@ -28,4 +42,157 @@ func Test_getEnvConfigUseDefaults(t *testing.T) {
 	require.Equal(t, true, config.MaxAuthEnabled)
 	require.Equal(t, float64(1), config.MaxAuthRequestsPerSecond)
 	require.Equal(t, 2, config.MaxAuthRequestBurst)
+	require.Equal(t, false, config.HideDeprecated)
+	require.Equal(t, "keptn:", config.OAuthPrefix)
+	require.Equal(t, false, config.OAuthEnabled)
+}
+
+func TestPatchHtmlForOAuth(t *testing.T) {
+	type args struct {
+		readFile     func(string) ([]byte, error)
+		oauthEnabled bool
+		oauthPrefix  string
+		deprecated   bool
+	}
+	html := `const oauth_prefix = "";
+	const oauth_enabled = false;
+	const hide_deprecated = false;`
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "reads from swagger-ui/index.html",
+			args: args{
+				readFile: func(s string) ([]byte, error) {
+					var err error = nil
+					if s == "swagger-ui/index.html" {
+						err = errors.New("Must patch swagger-ui/index.html")
+					}
+					return []byte("ignore me due to error"), err
+				},
+				oauthEnabled: true,
+				oauthPrefix:  "keptn:",
+				deprecated:   true,
+			},
+			want: "",
+		},
+		{
+			name: "do not patch",
+			args: args{
+				readFile:     func(s string) ([]byte, error) { return []byte(html), nil },
+				oauthEnabled: false,
+				oauthPrefix:  "keptn:",
+				deprecated:   false,
+			},
+			want: html,
+		},
+		{
+			name: "patch OAuth",
+			args: args{
+				readFile:     func(s string) ([]byte, error) { return []byte(html), nil },
+				oauthEnabled: true,
+				oauthPrefix:  "prefix:",
+				deprecated:   false,
+			},
+			want: `const oauth_prefix = "prefix:";
+			const oauth_enabled = true;
+			const hide_deprecated = false;`,
+		},
+		{
+			name: "patch Deprecated",
+			args: args{
+				readFile:     func(s string) ([]byte, error) { return []byte(html), nil },
+				oauthEnabled: false,
+				oauthPrefix:  "prefix:",
+				deprecated:   true,
+			},
+			want: `const oauth_prefix = "";
+			const oauth_enabled = false;
+			const hide_deprecated = true;`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config, err := getEnvConfig()
+			require.Nil(t, err)
+			config.HideDeprecated = tt.args.deprecated
+			config.OAuthEnabled = tt.args.oauthEnabled
+			config.OAuthPrefix = tt.args.oauthPrefix
+
+			got := patchHtmlForOAuth(config, tt.args.readFile)
+			require.Equal(t, strip(tt.want), strip(got))
+		})
+	}
+}
+
+func strip(in string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(in, "\t", ""), " ", "")
+}
+
+func TestHTTPHandler_normalIndex(t *testing.T) {
+	req, err := http.NewRequest("GET", "/swagger-ui/index.html", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := httptest.NewRecorder()
+	handlerAPI := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	handle(rr, req, "", handlerAPI)
+	res, _ := ioutil.ReadAll(rr.Body)
+
+	// we get redirected to the file
+	require.Equal(t, rr.Code, 301)
+	require.Equal(t, string(res), "")
+}
+
+func TestHTTPHandler_patchedIndex(t *testing.T) {
+	content := "patched content"
+	req, err := http.NewRequest("GET", "/swagger-ui/index.html", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := httptest.NewRecorder()
+	handlerAPI := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	handle(rr, req, content, handlerAPI)
+	res, _ := ioutil.ReadAll(rr.Body)
+
+	require.Equal(t, rr.Code, 200)
+	require.Equal(t, string(res), content)
+}
+
+func TestHTTPHandler_health(t *testing.T) {
+	req, err := http.NewRequest("GET", "/health", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := httptest.NewRecorder()
+	hasBeenCalled := false
+	handlerAPI := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hasBeenCalled = true
+	})
+	handle(rr, req, "ignored", handlerAPI)
+	res, _ := ioutil.ReadAll(rr.Body)
+
+	require.Equal(t, rr.Code, 200)
+	require.Equal(t, string(res), "")
+	require.Equal(t, hasBeenCalled, false)
+}
+
+func TestHTTPHandler_api(t *testing.T) {
+	req, err := http.NewRequest("GET", "/api", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := httptest.NewRecorder()
+	hasBeenCalled := false
+	handlerAPI := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hasBeenCalled = true
+	})
+	handle(rr, req, "ignored", handlerAPI)
+	res, _ := ioutil.ReadAll(rr.Body)
+
+	require.Equal(t, rr.Code, 200)
+	require.Equal(t, string(res), "")
+	require.Equal(t, hasBeenCalled, true)
 }

--- a/api/swagger-ui/index.html
+++ b/api/swagger-ui/index.html
@@ -74,6 +74,38 @@
       // End Swagger UI call region
 
       window.ui = ui
+
+      // add oauth checks
+      const oauth_prefix = "";
+      const oauth_enabled = false;
+      const hide_deprecated = false;
+
+      if(hide_deprecated) {
+        document.getElementById("swagger-ui").addEventListener('DOMSubtreeModified', function(event){
+          const endpoints = document.getElementsByClassName("opblock-deprecated");
+          for (const e of endpoints){
+            e.style.display = "none"
+          }
+        });
+      }
+
+      document.getElementById("swagger-ui").addEventListener('DOMSubtreeModified', function(event) {
+        if(event.target.className == "oauth-scopes"){
+          // do not propagate
+          return;
+        }
+        const elms = document.getElementsByClassName("oauth-scopes");
+        for (let i = 0; i < elms.length; i++) {
+          const e = elms[i];
+          const origin = e.innerHTML;
+          let r = "";
+          if(oauth_enabled) {
+            r = origin.replace("${prefix}", oauth_prefix);
+          }
+          event.stopPropagation();
+          e.innerHTML = r;
+        }
+      });
     }
     </script>
   </body>

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -34,6 +34,8 @@ paths:
         - Metadata
       operationId: metadata
       summary: Get keptn installation metadata
+      description: >
+        <span class="oauth-scopes">Required OAuth scopes: ${prefix}metadata:read</span>
       responses:
         200:
           description: Success
@@ -50,6 +52,8 @@ paths:
           in: body
           schema:
             $ref: "#/definitions/keptnContextExtendedCE"
+      description: >
+        <span class="oauth-scopes">Required OAuth scopes: ${prefix}events:write</span>
       responses:
         200:
           description: Forwarded

--- a/installer/manifests/keptn/templates/api-service.yaml
+++ b/installer/manifests/keptn/templates/api-service.yaml
@@ -71,6 +71,12 @@ spec:
               value: '{{ (.Values.apiService.maxAuth).requestBurst | default "2"}}'
             - name: LOG_LEVEL
               value: {{ .Values.logLevel | default "info" }}
+            - name: OAUTH_ENABLED
+              value: "{{ or (.Values.bridge.oauth).enabled ((.Values.features).oauth).enabled | default false }}"
+            - name: OAUTH_PREFIX
+              value: "{{ ((.Values.features).oauth).prefix | default "keptn:" }}"
+            - name: HIDE_DEPRECATED
+              value: "{{ ((.Values.features).swagger).hideDeprecated | default false }}"
           {{- include "keptn.common.container-security-context" . | nindent 10 }}
           volumeMounts:
             - mountPath: /data/import-scratch

--- a/installer/manifests/keptn/templates/core.yaml
+++ b/installer/manifests/keptn/templates/core.yaml
@@ -122,7 +122,7 @@ spec:
             - name: PREFIX_PATH
               value: "{{ .Values.prefixPath }}"
             - name: OAUTH_ENABLED
-              value: "{{ .Values.bridge.oauth.enabled }}"
+              value: "{{ or (.Values.bridge.oauth).enabled ((.Values.features).oauth).enabled | default false }}"
             - name: OAUTH_DISCOVERY
               value: "{{ .Values.bridge.oauth.discovery }}"
             # Base URL e.g. https://example.com/

--- a/installer/manifests/keptn/values.yaml
+++ b/installer/manifests/keptn/values.yaml
@@ -35,6 +35,11 @@ features:
   automaticProvisioning:
     serviceURL: ""
     message: ""
+  swagger:
+    hideDeprecated: false
+  oauth:
+    enabled: false
+    prefix: "keptn:"
 
 nats:
   nameOverride: keptn-nats
@@ -165,7 +170,6 @@ bridge:
     allowPrivilegeEscalation: false
     privileged: false
   oauth:
-    enabled: false
     discovery: ""
     secureCookie: false
     trustProxy: ""

--- a/mongodb-datastore/swagger.yaml
+++ b/mongodb-datastore/swagger.yaml
@@ -26,6 +26,8 @@ paths:
         - event
       operationId: getEvents
       summary: Gets events from the data store, either keptnContext or project must be specified
+      description: >
+        <span class="oauth-scopes">Required OAuth scopes: ${prefix}events:read</span>
       parameters:
         - name: keptnContext
           in: query
@@ -118,6 +120,8 @@ paths:
         - event
       operationId: getEventsByType
       summary: Gets events by their type from the mongodb, required filter are either 'data.project:<project-name>' or 'shkeptncontext:<keptn-context-id>'
+      description: >
+        <span class="oauth-scopes">Required OAuth scopes: ${prefix}events:read</span>
       parameters:
         - name: filter
           in: query

--- a/resource-service/handler/project_resource_handler.go
+++ b/resource-service/handler/project_resource_handler.go
@@ -1,10 +1,11 @@
 package handler
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/keptn/keptn/resource-service/errors"
 	"github.com/keptn/keptn/resource-service/models"
-	"net/http"
 )
 
 type IProjectResourceHandler interface {
@@ -29,6 +30,7 @@ func NewProjectResourceHandler(projectResourceManager IResourceManager) *Project
 // CreateProjectResources godoc
 // @Summary      Creates project resources
 // @Description  Create list of new resources for the project
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}resources:write</span>
 // @Tags         Project Resource
 // @Security     ApiKeyAuth
 // @Accept       json
@@ -71,6 +73,7 @@ func (ph *ProjectResourceHandler) CreateProjectResources(c *gin.Context) {
 // GetProjectResources godoc
 // @Summary      Get list of project resources
 // @Description  Get list of project resources
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}resources:read</span>
 // @Tags         Project Resource
 // @Security     ApiKeyAuth
 // @Accept       json
@@ -114,6 +117,7 @@ func (ph *ProjectResourceHandler) GetProjectResources(c *gin.Context) {
 // UpdateProjectResources godoc
 // @Summary      Updates project resources
 // @Description  Update list of new resources for the project
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}resources:write</span>
 // @Tags         Project Resource
 // @Security     ApiKeyAuth
 // @Accept       json
@@ -156,6 +160,7 @@ func (ph *ProjectResourceHandler) UpdateProjectResources(c *gin.Context) {
 // GetProjectResource godoc
 // @Summary      Get project resource
 // @Description  Get project resource
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}resources:read</span>
 // @Tags         Project Resource
 // @Security     ApiKeyAuth
 // @Accept       json
@@ -199,12 +204,13 @@ func (ph *ProjectResourceHandler) GetProjectResource(c *gin.Context) {
 // UpdateProjectResource godoc
 // @Summary      Updates a project resource
 // @Description  Updates a resource for the project
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}resources:write</span>
 // @Tags         Project Resource
 // @Security     ApiKeyAuth
 // @Accept       json
 // @Produce      json
-// @Param        projectName                                                      path    string  true  "The name of the project"
-// @Param        resourceURI                                                path  string  true    "The path of the resource file"
+// @Param        projectName  path    string  true  "The name of the project"
+// @Param        resourceURI  path  string  true    "The path of the resource file"
 // @Param        resources    body      models.UpdateResourcePayload  true  "resource"
 // @Success      200          {string}  models.WriteResourceResponse
 // @Failure      400          {object}  models.Error  "Invalid payload"
@@ -242,12 +248,13 @@ func (ph *ProjectResourceHandler) UpdateProjectResource(c *gin.Context) {
 // DeleteProjectResource godoc
 // @Summary      Deletes a project resource
 // @Description  Deletes a project resource
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}resources:delete</span>
 // @Tags         Project Resource
 // @Security     ApiKeyAuth
 // @Accept       json
 // @Produce      json
-// @Param        projectName                      path    string  true  "The name of the project"
-// @Param        resourceURI                path  string  true    "The path of the resource file"
+// @Param        projectName  path    string  true  "The name of the project"
+// @Param        resourceURI  path  string  true    "The path of the resource file"
 // @Success      200          {string}  models.WriteResourceResponse
 // @Failure      400          {object}  models.Error  "Invalid payload"
 // @Failure      500          {object}  models.Error  "Internal error"

--- a/resource-service/handler/service_resource_handler.go
+++ b/resource-service/handler/service_resource_handler.go
@@ -1,8 +1,9 @@
 package handler
 
 import (
-	"github.com/keptn/keptn/resource-service/errors"
 	"net/http"
+
+	"github.com/keptn/keptn/resource-service/errors"
 
 	"github.com/gin-gonic/gin"
 	"github.com/keptn/keptn/resource-service/models"
@@ -30,17 +31,18 @@ func NewServiceResourceHandler(serviceResourceManager IResourceManager) *Service
 // CreateServiceResources godoc
 // @Summary      Creates service resources
 // @Description  Create list of new resources for the service in the given stage of a project
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}resources:write</span>
 // @Tags         Service Resource
 // @Security     ApiKeyAuth
 // @Accept       json
 // @Produce      json
-// @Param        projectName                                                   path  string  true  "The name of the project"
-// @Param        stageName                                                     path  string  true  "The name of the stage"
-// @Param        serviceName                                                   path  string  true  "The name of the service"
-// @Param        resources    body      models.CreateResourcesPayload  true  "List of resources"
-// @Success      201          {string}  models.WriteResourceResponse
-// @Failure      400          {object}  models.Error  "Invalid payload"
-// @Failure      500          {object}  models.Error  "Internal error"
+// @Param        projectName	path  string  true  "The name of the project"
+// @Param        stageName		path  string  true  "The name of the stage"
+// @Param        serviceName	path  string  true  "The name of the service"
+// @Param        resources		body      models.CreateResourcesPayload  true  "List of resources"
+// @Success      201			{string}  models.WriteResourceResponse
+// @Failure      400			{object}  models.Error  "Invalid payload"
+// @Failure      500			{object}  models.Error  "Internal error"
 // @Router       /project/{projectName}/stage/{stageName}/service/{serviceName}/resource [post]
 func (ph *ServiceResourceHandler) CreateServiceResources(c *gin.Context) {
 	params := &models.CreateResourcesParams{
@@ -76,6 +78,7 @@ func (ph *ServiceResourceHandler) CreateServiceResources(c *gin.Context) {
 // GetServiceResources godoc
 // @Summary      Get list of project resources
 // @Description  Get list of resources for the service in the given stage of a project
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}resources:read</span>
 // @Tags         Service Resource
 // @Security     ApiKeyAuth
 // @Accept       json
@@ -123,6 +126,7 @@ func (ph *ServiceResourceHandler) GetServiceResources(c *gin.Context) {
 // UpdateServiceResources godoc
 // @Summary      Updates service resources
 // @Description  Update list of new resources for the service in the given stage of a project
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}resources:write</span>
 // @Tags         Service Resource
 // @Security     ApiKeyAuth
 // @Accept       json
@@ -169,6 +173,7 @@ func (ph *ServiceResourceHandler) UpdateServiceResources(c *gin.Context) {
 // GetServiceResource godoc
 // @Summary      Get service resource
 // @Description  Get resource for the service in the given stage of a project
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}resources:read</span>
 // @Tags         Service Resource
 // @Security     ApiKeyAuth
 // @Accept       json
@@ -215,6 +220,7 @@ func (ph *ServiceResourceHandler) GetServiceResource(c *gin.Context) {
 // UpdateServiceResource godoc
 // @Summary      Updates a service resource
 // @Description  Updates a resource for the service in the given stage of a project
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}resources:write</span>
 // @Tags         Service Resource
 // @Security     ApiKeyAuth
 // @Accept       json
@@ -262,6 +268,7 @@ func (ph *ServiceResourceHandler) UpdateServiceResource(c *gin.Context) {
 // DeleteServiceResource godoc
 // @Summary      Deletes a service resource
 // @Description  Deletes a resource for the service in the given stage of a project
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}resources:delete</span>
 // @Tags         Service Resource
 // @Security     ApiKeyAuth
 // @Accept       json

--- a/resource-service/handler/stage_resource_handler.go
+++ b/resource-service/handler/stage_resource_handler.go
@@ -1,8 +1,9 @@
 package handler
 
 import (
-	"github.com/keptn/keptn/resource-service/errors"
 	"net/http"
+
+	"github.com/keptn/keptn/resource-service/errors"
 
 	"github.com/gin-gonic/gin"
 	"github.com/keptn/keptn/resource-service/models"
@@ -30,12 +31,13 @@ func NewStageResourceHandler(stageResourceManager IResourceManager) *StageResour
 // CreateStageResources godoc
 // @Summary      Creates stage resources
 // @Description  Create list of new resources for the stage of a project
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}resources:write</span>
 // @Tags         Stage Resource
 // @Security     ApiKeyAuth
 // @Accept       json
 // @Produce      json
-// @Param        projectName                                                   path  string  true  "The name of the project"
-// @Param        stageName                                                     path  string  true  "The name of the stage"
+// @Param        projectName  path  string  true  "The name of the project"
+// @Param        stageName    path  string  true  "The name of the stage"
 // @Param        resources    body      models.CreateResourcesPayload  true  "List of resources"
 // @Success      201          {string}  models.WriteResourceResponse
 // @Failure      400          {object}  models.Error  "Invalid payload"
@@ -74,12 +76,13 @@ func (ph *StageResourceHandler) CreateStageResources(c *gin.Context) {
 // GetStageResources godoc
 // @Summary      Get list of stage resources
 // @Description  Get list of resources for the stage of a project
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}resources:read</span>
 // @Tags         Stage Resource
 // @Security     ApiKeyAuth
 // @Accept       json
 // @Produce      json
-// @Param        projectName                             path  string  true  "The name of the project"
-// @Param        stageName                               path  string  true  "The name of the stage"
+// @Param        projectName  path  string  true  "The name of the project"
+// @Param        stageName    path  string  true  "The name of the stage"
 // @Param        pageSize     query     int     false  "The number of items to return"
 // @Param        nextPageKey  query     string  false  "Pointer to the next set of items"
 // @Success      200          {object}  models.GetResourcesResponse
@@ -163,13 +166,14 @@ func (ph *StageResourceHandler) UpdateStageResources(c *gin.Context) {
 // GetStageResource godoc
 // @Summary      Get stage resource
 // @Description  Get resource for the stage of a project
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}resources:read</span>
 // @Tags         Stage Resource
 // @Security     ApiKeyAuth
 // @Accept       json
 // @Produce      json
-// @Param        projectName                                 path    string  true  "The name of the project"
-// @Param        stageName                                   path    string  true  "The name of the stage"
-// @Param        resourceURI                           path  string  true    "The path of the resource file"
+// @Param        projectName  path    string  true  "The name of the project"
+// @Param        stageName    path    string  true  "The name of the stage"
+// @Param        resourceURI  path  string  true    "The path of the resource file"
 // @Param        gitCommitID  query     string  false  "The commit ID to be checked out"
 // @Success      200          {object}  models.GetResourceResponse
 // @Failure      400          {object}  models.Error  "Invalid payload"
@@ -208,13 +212,14 @@ func (ph *StageResourceHandler) GetStageResource(c *gin.Context) {
 // UpdateStageResource godoc
 // @Summary      Updates a stage resource
 // @Description  Updates a resource for the stage of a project
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}resources:write</span>
 // @Tags         Stage Resource
 // @Security     ApiKeyAuth
 // @Accept       json
 // @Produce      json
-// @Param        projectName                                                      path    string  true  "The name of the project"
-// @Param        stageName                                                        path    string  true  "The name of the stage"
-// @Param        resourceURI                                                path  string  true    "The path of the resource file"
+// @Param        projectName  path    string  true  "The name of the project"
+// @Param        stageName    path    string  true  "The name of the stage"
+// @Param        resourceURI  path  string  true    "The path of the resource file"
 // @Param        resources    body      models.UpdateResourcePayload  true  "resource"
 // @Success      200          {string}  models.WriteResourceResponse
 // @Failure      400          {object}  models.Error  "Invalid payload"
@@ -253,13 +258,14 @@ func (ph *StageResourceHandler) UpdateStageResource(c *gin.Context) {
 // DeleteStageResource godoc
 // @Summary      Deletes a stage resource
 // @Description  Deletes a resource for the stage of a project
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}resources:delete</span>
 // @Tags         Stage Resource
 // @Security     ApiKeyAuth
 // @Accept       json
 // @Produce      json
-// @Param        projectName                      path    string  true  "The name of the project"
-// @Param        stageName                        path    string  true  "The name of the stage"
-// @Param        resourceURI                path  string  true    "The path of the resource file"
+// @Param        projectName  path    string  true  "The name of the project"
+// @Param        stageName    path    string  true  "The name of the stage"
+// @Param        resourceURI  path  string  true    "The path of the resource file"
 // @Success      200          {string}  models.WriteResourceResponse
 // @Failure      400          {object}  models.Error  "Invalid payload"
 // @Failure      500          {object}  models.Error  "Internal error"

--- a/secret-service/pkg/handler/scopehandler.go
+++ b/secret-service/pkg/handler/scopehandler.go
@@ -26,6 +26,7 @@ func NewScopeHandler(backend backend.ScopeManager) *ScopeHandler {
 // GetScopes godoc
 // @Summary      Get scopes
 // @Description  Get scopes
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}secrets:read</span>
 // @Tags         Scopes
 // @Security     ApiKeyAuth
 // @Success      200  {object}  model.GetScopesResponse  "OK"

--- a/secret-service/pkg/handler/secrethandler.go
+++ b/secret-service/pkg/handler/secrethandler.go
@@ -30,6 +30,7 @@ type SecretHandler struct {
 // CreateSecret godoc
 // @Summary      Create a Secret
 // @Description  Create a new Secret
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}secrets:write</span>
 // @Tags         Secrets
 // @Security     ApiKeyAuth
 // @Accept       json
@@ -71,6 +72,7 @@ func (s SecretHandler) CreateSecret(c *gin.Context) {
 // CreateSecret godoc
 // @Summary      Update a Secret
 // @Description  Update an existing Secret
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}secrets:write</span>
 // @Tags         Secrets
 // @Security     ApiKeyAuth
 // @Accept       json
@@ -108,6 +110,7 @@ func (s SecretHandler) UpdateSecret(c *gin.Context) {
 // CreateSecret godoc
 // @Summary      Delete a Secret
 // @Description  Delete an existing Secret
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}secrets:delete</span>
 // @Tags         Secrets
 // @Security     ApiKeyAuth
 // @Param        name   query  string  true  "The name of the secret"
@@ -152,6 +155,7 @@ func (s SecretHandler) DeleteSecret(c *gin.Context) {
 // GetSecrets godoc
 // @Summary      Get secrets
 // @Description  Get secrets
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}secrets:read</span>
 // @Tags         Secrets
 // @Security     ApiKeyAuth
 // @Success      200  {object}  model.GetSecretsResponse  "OK"

--- a/shipyard-controller/handler/evaluationhandler.go
+++ b/shipyard-controller/handler/evaluationhandler.go
@@ -50,6 +50,7 @@ func NewEvaluationHandler(evaluationManager IEvaluationManager) *EvaluationHandl
 // CreateEvaluation triggers a new evaluation
 // @Summary      Trigger a new evaluation
 // @Description  Trigger a new evaluation for a service within a project
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}events:write</span>
 // @Tags         Evaluation
 // @Security     ApiKeyAuth
 // @Accept       json

--- a/shipyard-controller/handler/loghandler.go
+++ b/shipyard-controller/handler/loghandler.go
@@ -25,6 +25,7 @@ func NewLogHandler(logManager ILogManager) *LogHandler {
 // CreateLogEntries persists log entries
 // @Summary      Persist a list of log entries
 // @Description  Persist a list of log entries
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}logs:write</span>
 // @Tags         Log
 // @Security     ApiKeyAuth
 // @Accept       json
@@ -51,6 +52,7 @@ func (lh *LogHandler) CreateLogEntries(context *gin.Context) {
 // GetLogEntries Retrieves log entries based on the provided filter
 // @Summary      Retrieve logs
 // @Description  Retrieve logs
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}logs:read</span>
 // @Tags         Log
 // @Security     ApiKeyAuth
 // @Accept       json
@@ -83,6 +85,7 @@ func (lh *LogHandler) GetLogEntries(context *gin.Context) {
 // @Summary      Delete logs
 // @Deprecated   true
 // @Description  INTERNAL Endpoint: Delete logs
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}logs:delete</span>
 // @Tags         Log
 // @Security     ApiKeyAuth
 // @Accept       json

--- a/shipyard-controller/handler/projecthandler.go
+++ b/shipyard-controller/handler/projecthandler.go
@@ -190,6 +190,7 @@ func NewProjectHandler(projectManager IProjectManager, eventSender common.EventS
 // GetAllProjects godoc
 // @Summary      Get all projects
 // @Description  Get the list of all projects
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}projects:read</span>
 // @Tags         Projects
 // @Security     ApiKeyAuth
 // @Accept       json
@@ -239,6 +240,7 @@ func (ph *ProjectHandler) GetAllProjects(c *gin.Context) {
 // GetProjectByName godoc
 // @Summary      Get a project by name
 // @Description  Get a project by its name
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}projects:read</span>
 // @Tags         Projects
 // @Security     ApiKeyAuth
 // @Accept       json
@@ -269,6 +271,7 @@ func (ph *ProjectHandler) GetProjectByName(c *gin.Context) {
 // CreateProject godoc
 // @Summary      Create a new project
 // @Description  Create a new project
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}projects:write</span>
 // @Tags         Projects
 // @Security     ApiKeyAuth
 // @Accept       json
@@ -345,6 +348,7 @@ func (ph *ProjectHandler) CreateProject(c *gin.Context) {
 // UpdateProject godoc
 // @Summary      Updates a project
 // @Description  Updates project
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}projects:write</span>
 // @Tags         Projects
 // @Security     ApiKeyAuth
 // @Accept       json
@@ -400,6 +404,7 @@ func (ph *ProjectHandler) UpdateProject(c *gin.Context) {
 // DeleteProject godoc
 // @Summary      Delete a project
 // @Description  Delete a project
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}projects:delete</span>
 // @Tags         Projects
 // @Security     ApiKeyAuth
 // @Accept       json

--- a/shipyard-controller/handler/servicehandler.go
+++ b/shipyard-controller/handler/servicehandler.go
@@ -69,6 +69,7 @@ func NewServiceHandler(serviceManager IServiceManager, eventSender common.EventS
 // CreateService godoc
 // @Summary      Create a new service
 // @Description  Create a new service
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}services:write</span>
 // @Tags         Services
 // @Security     ApiKeyAuth
 // @Accept       json
@@ -131,6 +132,7 @@ func (sh *ServiceHandler) CreateService(c *gin.Context) {
 // DeleteService godoc
 // @Summary      Delete a service
 // @Description  Delete a service
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}services:delete</span>
 // @Tags         Services
 // @Security     ApiKeyAuth
 // @Accept       json
@@ -179,6 +181,7 @@ func (sh *ServiceHandler) DeleteService(c *gin.Context) {
 // GetService godoc
 // @Summary      Gets a service by its name
 // @Description  Gets a service by its name
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}services:read</span>
 // @Tags         Services
 // @Security     ApiKeyAuth
 // @Accept       json
@@ -211,6 +214,7 @@ func (sh *ServiceHandler) GetService(c *gin.Context) {
 // GetServices godoc
 // @Summary      Gets all services of a stage in a project
 // @Description  Gets all services of a stage in a project
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}stages:read</span>
 // @Tags         Services
 // @Security     ApiKeyAuth
 // @Accept       json

--- a/shipyard-controller/handler/stagehandler.go
+++ b/shipyard-controller/handler/stagehandler.go
@@ -30,6 +30,7 @@ func NewStageHandler(stageManager IStageManager) *StageHandler {
 // GetAllStages godoc
 // @Summary      Get all stages of a project
 // @Description  Get the list of stages of a project
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}stages:read</span>
 // @Tags         Stage
 // @Security     ApiKeyAuth
 // @Accept       json
@@ -89,6 +90,7 @@ func (sh *StageHandler) GetAllStages(c *gin.Context) {
 // GetStage godoc
 // @Summary      Get a stage
 // @Description  Get a stage of a project
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}stages:read</span>
 // @Tags         Stage
 // @Security     ApiKeyAuth
 // @Accept       json

--- a/shipyard-controller/handler/statehandler.go
+++ b/shipyard-controller/handler/statehandler.go
@@ -31,6 +31,7 @@ func NewStateHandler(stateRepo db.SequenceStateRepo, shipyardController IShipyar
 // GetSequenceState godoc
 // @Summary      Get task sequence execution states
 // @Description  Get task sequence execution states
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}projects:read</span>
 // @Tags         Sequence
 // @Security     ApiKeyAuth
 // @Accept       json
@@ -70,6 +71,7 @@ func (sh *StateHandler) GetSequenceState(c *gin.Context) {
 // ControlSequenceState godoc
 // @Summary      Pause/Resume/Abort a task sequence
 // @Description  Pause/Resume/Abort a task sequence, either for a specific stage, or for all stages involved in the sequence
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}projects:write</span>
 // @Tags         Sequence
 // @Security     ApiKeyAuth
 // @Accept       json

--- a/shipyard-controller/handler/uniformintegrationhandler.go
+++ b/shipyard-controller/handler/uniformintegrationhandler.go
@@ -3,9 +3,10 @@ package handler
 import (
 	"errors"
 	"fmt"
-	logger "github.com/sirupsen/logrus"
 	"net/http"
 	"time"
+
+	logger "github.com/sirupsen/logrus"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -100,6 +101,7 @@ func (u UniformParamsValidator) validateFilterParams(params apimodels.EventSubsc
 // Register creates or updates a uniform integration
 // @Summary      Register a uniform integration
 // @Description  Register a uniform integration
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}integrations:write</span>
 // @Tags         Uniform
 // @Security     ApiKeyAuth
 // @Accept       json
@@ -212,6 +214,7 @@ func (rh *UniformIntegrationHandler) updateExistingIntegration(integration *apim
 // Unregister deletes a uniform integration
 // @Summary      Unregister a uniform integration
 // @Description  Unregister a uniform integration
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}integrations:delete</span>
 // @Tags         Uniform
 // @Security     ApiKeyAuth
 // @Accept       json
@@ -233,6 +236,7 @@ func (rh *UniformIntegrationHandler) Unregister(c *gin.Context) {
 // GetRegistrations Retrieve uniform integrations matching the provided filter
 // @Summary      Retrieve uniform integrations matching the provided filter
 // @Description  Retrieve uniform integrations matching the provided filter
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}integrations:read</span>
 // @Tags         Uniform
 // @Security     ApiKeyAuth
 // @Accept       json
@@ -264,6 +268,7 @@ func (rh *UniformIntegrationHandler) GetRegistrations(c *gin.Context) {
 // KeepAlive returns current registration data of an integration
 // @Summary      Endpoint for sending heartbeat messages sent from Keptn integrations to the control plane
 // @Description  Endpoint for sending heartbeat messages sent from Keptn integrations to the control plane
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}integrations:write</span>
 // @Tags         Uniform
 // @Security     ApiKeyAuth
 // @Accept       json
@@ -293,6 +298,7 @@ func (rh *UniformIntegrationHandler) KeepAlive(c *gin.Context) {
 // CreateSubscription creates a new subscription
 // @Summary      Create a new subscription
 // @Description  Create a new subscription
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}integrations:write</span>
 // @Tags         Uniform
 // @Security     ApiKeyAuth
 // @Accept       json
@@ -340,6 +346,7 @@ func (rh *UniformIntegrationHandler) CreateSubscription(c *gin.Context) {
 // UpdateSubscription updates or creates a subscription
 // @Summary      Update or create a subscription
 // @Description  Update or create a subscription
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}integrations:write</span>
 // @Tags         Uniform
 // @Security     ApiKeyAuth
 // @Accept       json
@@ -396,6 +403,7 @@ func (rh *UniformIntegrationHandler) UpdateSubscription(c *gin.Context) {
 // DeleteSubscription deletes a new subscription
 // @Summary      Delete a subscription
 // @Description  Delete a subscription
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}integrations:delete</span>
 // @Tags         Uniform
 // @Security     ApiKeyAuth
 // @Accept       json
@@ -421,6 +429,7 @@ func (rh *UniformIntegrationHandler) DeleteSubscription(c *gin.Context) {
 // GetSubscription retrieves an already existing subscription
 // @Summary      Retrieve an already existing subscription
 // @Description  Retrieve an already existing subscription
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}integrations:read</span>
 // @Tags         Uniform
 // @Security     ApiKeyAuth
 // @Accept       json
@@ -451,6 +460,7 @@ func (rh *UniformIntegrationHandler) GetSubscription(c *gin.Context) {
 // GetSubscriptions retrieves all subscriptions of a uniform integration
 // @Summary      Retrieve all subscriptions of a uniform integration
 // @Description  Retrieve all subscriptions of a uniform integration
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}integrations:read</span>
 // @Tags         Uniform
 // @Security     ApiKeyAuth
 // @Accept       json

--- a/statistics-service/api/event.go
+++ b/statistics-service/api/event.go
@@ -13,6 +13,7 @@ import (
 // @Deprecated   true
 // @Summary      INTERNAL Endpoint: Handle event
 // @Description  Handle incoming cloud event
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}statistics:write</span>
 // @Tags         Events
 // @Security     ApiKeyAuth
 // @Accept       json

--- a/statistics-service/api/statistics.go
+++ b/statistics-service/api/statistics.go
@@ -16,6 +16,7 @@ import (
 // GetStatistics godoc
 // @Summary      Get statistics
 // @Description  get statistics about Keptn installation
+// @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}statistics:read</span>
 // @Tags         Statistics
 // @Security     ApiKeyAuth
 // @Accept       json


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->
introduces basic documentation about RBAC scopes planned for each API endpoint. 
Furthermore, it allows configuring if the rendering for deprecated endpoints should be rendered or not. 

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #7352

### How to test

Run:
- `helm template keptn .\installer\manifests\keptn --set control-plane.features.oauth.prefix="myPrefix:" --set control-plane.features.oauth.enabled=true  > out.yaml` 
- `helm template keptn .\installer\manifests\keptn --set control-plane.features.oauth.prefix="keptn:" --set control-plane.bridge.oauth.enabled=true  > out2.yaml`
 
and verify the output file are correct.

