### PR TITLE
fix(cp-connector): Synchronized shutdown of cp-connector during cancelation

### DIFF
--- a/cp-connector/pkg/controlplane/controlplane.go
+++ b/cp-connector/pkg/controlplane/controlplane.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keptn/keptn/cp-connector/pkg/logger"
 	"github.com/keptn/keptn/cp-connector/pkg/subscriptionsource"
 	"github.com/keptn/keptn/cp-connector/pkg/types"
+	"sync"
 )
 
 type EventSender = types.EventSender
@@ -82,13 +83,15 @@ func (cp *ControlPlane) Register(ctx context.Context, integration Integration) e
 	cp.logger.Debugf("Registered with integration ID %s", cp.integrationID)
 	registrationData.ID = cp.integrationID
 
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
 	cp.logger.Debugf("Starting event source for integration ID %s", cp.integrationID)
-	if err := cp.eventSource.Start(ctx, registrationData, eventUpdates); err != nil {
+	if err := cp.eventSource.Start(ctx, registrationData, eventUpdates, wg); err != nil {
 		return err
 	}
 	cp.logger.Debugf("Event source started with data: %+v", registrationData)
 	cp.logger.Debugf("Starting subscription source for integration ID %s", cp.integrationID)
-	if err := cp.subscriptionSource.Start(ctx, registrationData, subscriptionUpdates); err != nil {
+	if err := cp.subscriptionSource.Start(ctx, registrationData, subscriptionUpdates, wg); err != nil {
 		return err
 	}
 	cp.logger.Debug("Subscription source started")
@@ -108,6 +111,7 @@ func (cp *ControlPlane) Register(ctx context.Context, integration Integration) e
 			cp.logger.Debug("Update successful")
 		case <-ctx.Done():
 			cp.logger.Debug("Unregistering")
+			wg.Wait()
 			cp.registered = false
 			return nil
 		}

--- a/cp-connector/pkg/eventsource/eventsource.go
+++ b/cp-connector/pkg/eventsource/eventsource.go
@@ -7,6 +7,7 @@ import (
 	"github.com/keptn/keptn/cp-connector/pkg/types"
 	"reflect"
 	"sort"
+	"sync"
 
 	"github.com/keptn/go-utils/pkg/api/models"
 	"github.com/keptn/keptn/cp-connector/pkg/logger"
@@ -18,7 +19,7 @@ import (
 // to get events from the Keptn Control Plane
 type EventSource interface {
 	// Start triggers the execution of the EventSource
-	Start(context.Context, types.RegistrationData, chan types.EventUpdate) error
+	Start(context.Context, types.RegistrationData, chan types.EventUpdate, *sync.WaitGroup) error
 	// OnSubscriptionUpdate can be called to tell the EventSource that
 	// the current subscriptions have been changed
 	OnSubscriptionUpdate([]string)
@@ -60,7 +61,7 @@ func WithLogger(logger logger.Logger) func(*NATSEventSource) {
 	}
 }
 
-func (n *NATSEventSource) Start(ctx context.Context, registrationData types.RegistrationData, eventChannel chan types.EventUpdate) error {
+func (n *NATSEventSource) Start(ctx context.Context, registrationData types.RegistrationData, eventChannel chan types.EventUpdate, wg *sync.WaitGroup) error {
 	n.queueGroup = registrationData.Name
 	n.eventProcessFn = func(event *nats.Msg) error {
 		keptnEvent := models.KeptnContextExtendedCE{}
@@ -83,6 +84,7 @@ func (n *NATSEventSource) Start(ctx context.Context, registrationData types.Regi
 			return
 		}
 		n.logger.Debug("Unsubscribed from NATS")
+		wg.Done()
 	}()
 	return nil
 }

--- a/cp-connector/pkg/fake/eventsource.go
+++ b/cp-connector/pkg/fake/eventsource.go
@@ -3,18 +3,19 @@ package fake
 import (
 	"context"
 	"github.com/keptn/keptn/cp-connector/pkg/types"
+	"sync"
 )
 
 type EventSourceMock struct {
-	StartFn                func(context.Context, types.RegistrationData, chan types.EventUpdate) error
+	StartFn                func(context.Context, types.RegistrationData, chan types.EventUpdate, *sync.WaitGroup) error
 	OnSubscriptionUpdateFn func([]string)
 	SenderFn               func() types.EventSender
 	StopFn                 func() error
 }
 
-func (e *EventSourceMock) Start(ctx context.Context, data types.RegistrationData, ces chan types.EventUpdate) error {
+func (e *EventSourceMock) Start(ctx context.Context, data types.RegistrationData, ces chan types.EventUpdate, wg *sync.WaitGroup) error {
 	if e.StartFn != nil {
-		return e.StartFn(ctx, data, ces)
+		return e.StartFn(ctx, data, ces, wg)
 	}
 	panic("implement me")
 }

--- a/cp-connector/pkg/fake/subscriptionsource.go
+++ b/cp-connector/pkg/fake/subscriptionsource.go
@@ -4,16 +4,17 @@ import (
 	"context"
 	"github.com/keptn/go-utils/pkg/api/models"
 	"github.com/keptn/keptn/cp-connector/pkg/types"
+	"sync"
 )
 
 type SubscriptionSourceMock struct {
-	StartFn    func(ctx context.Context, data types.RegistrationData, c chan []models.EventSubscription) error
+	StartFn    func(context.Context, types.RegistrationData, chan []models.EventSubscription, *sync.WaitGroup) error
 	RegisterFn func(integration models.Integration) (string, error)
 }
 
-func (u *SubscriptionSourceMock) Start(ctx context.Context, data types.RegistrationData, c chan []models.EventSubscription) error {
+func (u *SubscriptionSourceMock) Start(ctx context.Context, data types.RegistrationData, c chan []models.EventSubscription, wg *sync.WaitGroup) error {
 	if u.StartFn != nil {
-		return u.StartFn(ctx, data, c)
+		return u.StartFn(ctx, data, c, wg)
 	}
 	panic("implement me")
 }

--- a/cp-connector/pkg/subscriptionsource/subscriptionsource.go
+++ b/cp-connector/pkg/subscriptionsource/subscriptionsource.go
@@ -3,6 +3,7 @@ package subscriptionsource
 import (
 	"context"
 	"github.com/keptn/keptn/cp-connector/pkg/types"
+	"sync"
 	"time"
 
 	"github.com/benbjohnson/clock"
@@ -12,7 +13,7 @@ import (
 )
 
 type SubscriptionSource interface {
-	Start(context.Context, types.RegistrationData, chan []models.EventSubscription) error
+	Start(context.Context, types.RegistrationData, chan []models.EventSubscription, *sync.WaitGroup) error
 	Register(integration models.Integration) (string, error)
 }
 
@@ -60,7 +61,7 @@ func New(uniformAPI api.UniformV1Interface, options ...func(source *UniformSubsc
 }
 
 // Start triggers the execution of the UniformSubscriptionSource
-func (s *UniformSubscriptionSource) Start(ctx context.Context, registrationData types.RegistrationData, subscriptionChannel chan []models.EventSubscription) error {
+func (s *UniformSubscriptionSource) Start(ctx context.Context, registrationData types.RegistrationData, subscriptionChannel chan []models.EventSubscription, wg *sync.WaitGroup) error {
 	s.logger.Debugf("UniformSubscriptionSource: Starting to fetch subscriptions for Integration ID %s", registrationData.ID)
 	ticker := s.clock.Ticker(s.fetchInterval)
 	go func() {
@@ -68,6 +69,7 @@ func (s *UniformSubscriptionSource) Start(ctx context.Context, registrationData 
 		for {
 			select {
 			case <-ctx.Done():
+				wg.Done()
 				return
 			case <-ticker.C:
 				s.ping(registrationData.ID, subscriptionChannel)
@@ -112,7 +114,7 @@ func NewFixedSubscriptionSource(options ...func(source *FixedSubscriptionSource)
 	return fss
 }
 
-func (s FixedSubscriptionSource) Start(ctx context.Context, data types.RegistrationData, c chan []models.EventSubscription) error {
+func (s FixedSubscriptionSource) Start(ctx context.Context, data types.RegistrationData, c chan []models.EventSubscription, wg *sync.WaitGroup) error {
 	go func() { c <- s.fixedSubscriptions }()
 	return nil
 }


### PR DESCRIPTION
This PR contains changes for `cp-connector` lib to do a synchronized shutdown whenever the context is canceled.