### PR TITLE
feat(cp-connector): Connect to NATS only at event source startup

### DIFF
--- a/cp-connector/README.md
+++ b/cp-connector/README.md
@@ -41,9 +41,6 @@ func main() {
 	// 2. create a subscription source
 	subscriptionSource := subscriptionsource.New(keptnAPI.UniformV1())
 	
-	// 2.i inject your favourite logger as follows
-    //subscriptionsource.WithLogger(mylogger)
-	
 	// 3. create an event source (either NATS of HTTP,...)
 	natsConnector:= nats.New("nats://localhost:4222")
 	if err != nil {
@@ -51,6 +48,12 @@ func main() {
 	}
 
 	eventSource := eventsource.New(natsConnector)
+	
+	// inject your favourite logger as follows
+	// eventsource.WithLogger(mylogger) 
+	// or  eventsource.New(natsConnector, eventsource.WithLogger(mylogger))
+	
+	
 	logForwarder := logforwarder.New(keptnAPI.LogsV1())
 
 	// 4. create control plane object and register yourself as an "integration"

--- a/cp-connector/README.md
+++ b/cp-connector/README.md
@@ -40,9 +40,12 @@ func main() {
 
 	// 2. create a subscription source
 	subscriptionSource := subscriptionsource.New(keptnAPI.UniformV1())
-
+	
+	// 2.i inject your favourite logger as follows
+    //subscriptionsource.WithLogger(mylogger)
+	
 	// 3. create an event source (either NATS of HTTP,...)
-	natsConnector, err := nats.Connect("nats://localhost:4222")
+	natsConnector:= nats.New("nats://localhost:4222")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cp-connector/pkg/eventsource/eventsource.go
+++ b/cp-connector/pkg/eventsource/eventsource.go
@@ -73,6 +73,10 @@ func (n *NATSEventSource) Start(ctx context.Context, registrationData types.Regi
 		}
 		return nil
 	}
+	if err := n.connector.Connect(); err != nil {
+		return fmt.Errorf("could not connect event source to NATS: %w", err)
+	}
+
 	if err := n.connector.QueueSubscribeMultiple(n.currentSubjects, n.queueGroup, n.eventProcessFn); err != nil {
 		return fmt.Errorf("could not start NATS event source: %w", err)
 	}

--- a/cp-connector/pkg/eventsource/eventsource.go
+++ b/cp-connector/pkg/eventsource/eventsource.go
@@ -73,9 +73,6 @@ func (n *NATSEventSource) Start(ctx context.Context, registrationData types.Regi
 		}
 		return nil
 	}
-	if err := n.connector.Connect(); err != nil {
-		return fmt.Errorf("could not connect event source to NATS: %w", err)
-	}
 
 	if err := n.connector.QueueSubscribeMultiple(n.currentSubjects, n.queueGroup, n.eventProcessFn); err != nil {
 		return fmt.Errorf("could not start NATS event source: %w", err)

--- a/cp-connector/pkg/eventsource/eventsource_test.go
+++ b/cp-connector/pkg/eventsource/eventsource_test.go
@@ -24,8 +24,6 @@ type NATSConnectorMock struct {
 	PublishCalls                int
 	DisconnectFn                func() error
 	DisconnectCalls             int
-	GetOrCreateConnectionFn     func() (*nats.Conn, error)
-	GetOrCreateConnectionCalls  int
 	UnsubscribeAllFn            func() error
 	UnsubscribeAllCalls         int
 	QueueGroup                  string
@@ -75,14 +73,6 @@ func (ncm *NATSConnectorMock) Disconnect() error {
 	ncm.DisconnectCalls++
 	if ncm.DisconnectFn != nil {
 		return ncm.DisconnectFn()
-	}
-	panic("implement me")
-}
-
-func (ncm *NATSConnectorMock) GetOrCreateConnection() (*nats.Conn, error) {
-	ncm.GetOrCreateConnectionCalls++
-	if ncm.GetOrCreateConnectionFn != nil {
-		return ncm.GetOrCreateConnectionFn()
 	}
 	panic("implement me")
 }

--- a/cp-connector/pkg/nats/nats.go
+++ b/cp-connector/pkg/nats/nats.go
@@ -71,7 +71,7 @@ func New(connectURL string, opts ...func(connector *NatsConnector)) *NatsConnect
 	return nc
 }
 
-// Connect connects a NatsConnector to NATS.
+// Connect connects a NatsConnector to NATS with a nil connection.
 // Note that this will automatically and indefinitely try to reconnect
 // as soon as it looses connection
 func (nc *NatsConnector) Connect() error {
@@ -83,11 +83,11 @@ func (nc *NatsConnector) Connect() error {
 	return nil
 }
 
-// ConnectFromEnv connects a NatsConnector to NATS.
+// NewFromEnv returns a NatsConnector to NATS.
 // The URL is read from the environment variable "NATS_URL"
 // If the URL is not set via the environment variable "NATS_URL",
 // it falls back to the default URL "nats://keptn-nats"
-func ConnectFromEnv() *NatsConnector {
+func NewFromEnv() *NatsConnector {
 	natsURL := os.Getenv(EnvVarNatsURL)
 	if natsURL == "" {
 		natsURL = EnvVarNatsURLDefault

--- a/cp-connector/pkg/nats/nats_test.go
+++ b/cp-connector/pkg/nats/nats_test.go
@@ -24,12 +24,12 @@ func TestConnect(t *testing.T) {
 	require.Nil(t, err)
 }
 
-func TestConnectFromEnv(t *testing.T) {
+func TestNewFromEnv(t *testing.T) {
 	svr, shutdown := runNATSServer()
 	defer shutdown()
 	os.Setenv(nats2.EnvVarNatsURL, svr.ClientURL())
 	defer os.Unsetenv(nats2.EnvVarNatsURL)
-	sub := nats2.ConnectFromEnv()
+	sub := nats2.NewFromEnv()
 	require.NotNil(t, sub)
 }
 

--- a/cp-connector/pkg/nats/nats_test.go
+++ b/cp-connector/pkg/nats/nats_test.go
@@ -15,12 +15,13 @@ import (
 	"time"
 )
 
-func TestConnect(t *testing.T) {
+func TestGetConnection(t *testing.T) {
 	svr, shutdown := runNATSServer()
 	defer shutdown()
 	sub := nats2.New(svr.ClientURL())
-	err := sub.Connect()
 	require.NotNil(t, sub)
+	conn, err := sub.GetOrCreateConnection()
+	require.NotNil(t, conn)
 	require.Nil(t, err)
 }
 
@@ -35,7 +36,8 @@ func TestNewFromEnv(t *testing.T) {
 
 func TestConnectFails(t *testing.T) {
 	nc := nats2.New("nats://something:3456")
-	err := nc.Connect()
+	conn, err := nc.GetOrCreateConnection()
+	require.Nil(t, conn)
 	require.NotNil(t, nc)
 	require.NotNil(t, err)
 }
@@ -44,7 +46,8 @@ func TestDisconnect(t *testing.T) {
 	svr, shutdown := runNATSServer()
 	defer shutdown()
 	nc := nats2.New(svr.ClientURL())
-	err := nc.Connect()
+	conn, err := nc.GetOrCreateConnection()
+	require.NotNil(t, conn)
 	require.NotNil(t, nc)
 	require.Nil(t, err)
 	err = nc.Disconnect()
@@ -67,7 +70,8 @@ func TestSubscribe(t *testing.T) {
 	defer shutdown()
 	nc := nats2.New(svr.ClientURL())
 	require.NotNil(t, nc)
-	err := nc.Connect()
+	conn, err := nc.GetOrCreateConnection()
+	require.NotNil(t, conn)
 	require.Nil(t, err)
 	err = nc.Subscribe("subj", func(msg *nats.Msg) error {
 		received = true
@@ -87,7 +91,8 @@ func TestSubscribeTwice(t *testing.T) {
 	svr, shutdown := runNATSServer()
 	defer shutdown()
 	nc := nats2.New(svr.ClientURL())
-	err := nc.Connect()
+	conn, err := nc.GetOrCreateConnection()
+	require.NotNil(t, conn)
 	require.Nil(t, err)
 	err = nc.Subscribe("subj", func(msg *nats.Msg) error { return nil })
 	require.Nil(t, err)
@@ -99,7 +104,8 @@ func TestSubscribeEmptySubject(t *testing.T) {
 	svr, shutdown := runNATSServer()
 	defer shutdown()
 	nc := nats2.New(svr.ClientURL())
-	err := nc.Connect()
+	conn, err := nc.GetOrCreateConnection()
+	require.NotNil(t, conn)
 	require.Nil(t, err)
 	err = nc.Subscribe("", func(msg *nats.Msg) error { return nil })
 	require.ErrorIs(t, err, nats2.ErrSubEmptySubject)
@@ -109,7 +115,8 @@ func TestSubscribeWithEmptyProcessFn(t *testing.T) {
 	svr, shutdown := runNATSServer()
 	defer shutdown()
 	nc := nats2.New(svr.ClientURL())
-	err := nc.Connect()
+	conn, err := nc.GetOrCreateConnection()
+	require.NotNil(t, conn)
 	require.Nil(t, err)
 	err = nc.Subscribe("subj", nil)
 	require.ErrorIs(t, err, nats2.ErrSubNilMessageProcessor)
@@ -122,7 +129,8 @@ func TestSubscribeMultiple(t *testing.T) {
 	svr, shutdown := runNATSServer()
 	defer shutdown()
 	nc := nats2.New(svr.ClientURL())
-	err := nc.Connect()
+	conn, err := nc.GetOrCreateConnection()
+	require.NotNil(t, conn)
 	require.Nil(t, err)
 	require.NotNil(t, nc)
 
@@ -148,7 +156,8 @@ func TestSubscribeMultipleFails(t *testing.T) {
 	svr, shutdown := runNATSServer()
 	defer shutdown()
 	nc := nats2.New(svr.ClientURL())
-	err := nc.Connect()
+	conn, err := nc.GetOrCreateConnection()
+	require.NotNil(t, conn)
 	require.Nil(t, err)
 	require.NotNil(t, nc)
 
@@ -166,7 +175,8 @@ func TestUnsubscribeAll(t *testing.T) {
 	receivedAfterUnsubscribeAll := false
 
 	nc := nats2.New(svr.ClientURL())
-	err := nc.Connect()
+	conn, err := nc.GetOrCreateConnection()
+	require.NotNil(t, conn)
 
 	require.NoError(t, err)
 
@@ -203,7 +213,8 @@ func TestPublish(t *testing.T) {
 	svr, shutdown := runNATSServer()
 	defer shutdown()
 	nc := nats2.New(svr.ClientURL())
-	err := nc.Connect()
+	conn, err := nc.GetOrCreateConnection()
+	require.NotNil(t, conn)
 	require.Nil(t, err)
 	require.NotNil(t, nc)
 
@@ -242,7 +253,8 @@ func TestPublishWithID(t *testing.T) {
 	svr, shutdown := runNATSServer()
 	defer shutdown()
 	nc := nats2.New(svr.ClientURL())
-	err := nc.Connect()
+	conn, err := nc.GetOrCreateConnection()
+	require.NotNil(t, conn)
 	require.Nil(t, err)
 	require.NotNil(t, nc)
 
@@ -271,7 +283,8 @@ func TestPublishEventMissingType(t *testing.T) {
 	svr, shutdown := runNATSServer()
 	defer shutdown()
 	nc := nats2.New(svr.ClientURL())
-	err := nc.Connect()
+	conn, err := nc.GetOrCreateConnection()
+	require.NotNil(t, conn)
 	require.Nil(t, err)
 	require.NotNil(t, nc)
 	err = nc.Publish(msg)


### PR DESCRIPTION

## This PR
<!-- add the description of the PR here -->

- adds `func New(connectURL string, opts ...func(connector *NatsConnector)) *NatsConnector` 
-  Changes Connect function to be run inside `NATSEventSource.Start`


### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

#7715


