### PR TITLE
fix: Only trigger CLI command docs auto-generation for full release tags

### DIFF
--- a/.github/workflows/send-event-on-release-push.yml
+++ b/.github/workflows/send-event-on-release-push.yml
@@ -2,7 +2,7 @@ name: Update Docs
 on:
   push:
     tags:
-      - "*"
+      - '[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- fixes a bug where also pre-release tags triggered the auto-generation of keptn CLI command docs. This should be fixed now.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #8098 
