### PR TITLE
fix(cli): Skip version check for auth sub command

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -143,21 +143,17 @@ func runVersionCheck(vChecker *version.VersionChecker, flags []string, cliConfig
 	}
 }
 
-// skipVersionCheck checks if the subcommand requires to skip the version check step
-// (for now this is true in case of  `install` or `--oauth`)
-// args here does not contain the main command
-// e.g., For `keptn -q install`, args would be just ['-q', 'install']
+// skipVersionCheck checks if the subcommand requires to skip the version check step.
+// For now this is true in case of  `install` or `auth` subcommand)
 func skipVersionCheck(args []string) bool {
 	for _, arg := range args {
 		switch {
-		case arg == "--oauth":
+		case arg == "auth":
 			return true
 		case strings.HasPrefix(arg, "-"):
 			continue
 		case arg == "install":
 			return true
-		default:
-			return false
 		}
 	}
 	return false

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -148,10 +148,10 @@ func runVersionCheck(vChecker *version.VersionChecker, flags []string, cliConfig
 func skipVersionCheck(args []string) bool {
 	for _, arg := range args {
 		switch {
-		case arg == "auth":
-			return true
 		case strings.HasPrefix(arg, "-"):
 			continue
+		case arg == "auth":
+			return true
 		case arg == "install":
 			return true
 		}

--- a/cli/cmd/root_test.go
+++ b/cli/cmd/root_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -346,6 +347,45 @@ func Test_runVersionCheck(t *testing.T) {
 			if tt.doNotWantOutput != "" && strings.Contains(out, tt.doNotWantOutput) {
 				t.Errorf("unexpected output: '%s', output should not contain '%s'", out, tt.doNotWantOutput)
 			}
+		})
+	}
+}
+
+func Test_skipVersionCheck(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{
+			name: "skip version check for install command",
+			args: []string{"install"},
+			want: true,
+		},
+		{
+			name: "skip version check for install command",
+			args: []string{"--option", "install"},
+			want: true,
+		},
+		{
+			name: "skip version check for auth command",
+			args: []string{"auth"},
+			want: true,
+		},
+		{
+			name: "skip version check for auth command",
+			args: []string{"--option", "auth"},
+			want: true,
+		},
+		{
+			name: "don't skip version check",
+			args: []string{"--option", "something"},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, skipVersionCheck(tt.args), "skipVersionCheck(%v)", tt.args)
 		})
 	}
 }


### PR DESCRIPTION
fixes #7882 

This PR contains changes that causes the cli to skip the version check when the `auth` sub command is executed.
This makes the oauth handling more robust since there will be no intermediate call to the api when e.g. `keptn auth --oauth-logout` is executed with expired credentials.