### PR TITLE
fix(installer): Upgrade MongoDB to v11 since v10 is offline

### DIFF
--- a/installer/manifests/keptn/charts/control-plane/Chart.yaml
+++ b/installer/manifests/keptn/charts/control-plane/Chart.yaml
@@ -24,7 +24,7 @@ appVersion: latest
 
 dependencies:
   - name: mongodb
-    version: 10.26.4
+    version: 11.1.5
     repository: https://charts.bitnami.com/bitnami
     condition: mongo.enabled
     alias: mongo

--- a/installer/manifests/keptn/charts/control-plane/templates/core.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/core.yaml
@@ -196,7 +196,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: mongodb-credentials
-                  key: mongodb-password
+                  key: mongodb-passwords
             - name: MONGODB_DATABASE
               value: {{ .Values.mongo.auth.bridgeAuthDatabase | default "openid" }}
             - name: CONFIG_DIR

--- a/installer/manifests/keptn/charts/control-plane/templates/mongodb-credentials.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/mongodb-credentials.yaml
@@ -26,21 +26,19 @@
   {{- if index $mongosecret.data "mongodb-user" -}}
     {{- $mongoUser = index $mongosecret.data "mongodb-user" -}}
   {{- end -}}
-{{- end -}}
 
-{{- if $mongosecret -}}
   {{- if index $mongosecret.data "mongodb-password" -}}
     {{- $mongoPassword = index $mongosecret.data "mongodb-password" -}}
   {{- end -}}
-{{- end -}}
 
-{{- if $mongosecret -}}
+  {{- if index $mongosecret.data "mongodb-passwords" -}}
+    {{- $mongoPassword = index $mongosecret.data "mongodb-passwords" -}}
+  {{- end -}}
+
   {{- if index $mongosecret.data "mongodb-root-password" -}}
     {{- $mongoRootPassword = index $mongosecret.data "mongodb-root-password" -}}
   {{- end -}}
-{{- end -}}
 
-{{- if $mongosecret -}}
   {{- if index $mongosecret.data "external_connection_string" -}}
     {{- $mongoExternalConnectionString = index $mongosecret.data "external_connection_string" -}}
   {{- end -}}
@@ -65,7 +63,7 @@ metadata:
 type: Opaque
 data:
   mongodb-user: {{ $mongoUser }}
-  mongodb-password: {{ $mongoPassword }}
+  mongodb-passwords: {{ $mongoPassword }}
   mongodb-root-user: {{ $mongoRootUser }}
   mongodb-root-password: {{ $mongoRootPassword }}
   external_connection_string: {{ $mongoExternalConnectionString }}

--- a/installer/manifests/keptn/charts/control-plane/templates/mongodb-datastore.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/mongodb-datastore.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: mongodb-credentials
-              key: mongodb-password
+              key: mongodb-passwords
         - name: MONGODB_EXTERNAL_CONNECTION_STRING
           valueFrom:
             secretKeyRef:

--- a/installer/manifests/keptn/charts/control-plane/templates/shipyard-controller.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/shipyard-controller.yaml
@@ -66,7 +66,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: mongodb-credentials
-                  key: mongodb-password
+                  key: mongodb-passwords
             - name: MONGODB_DATABASE
               value: {{ .Values.mongo.auth.database | default "keptn" }}
             - name: MONGODB_EXTERNAL_CONNECTION_STRING

--- a/installer/manifests/keptn/charts/control-plane/templates/statistics-service.yaml
+++ b/installer/manifests/keptn/charts/control-plane/templates/statistics-service.yaml
@@ -62,7 +62,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: mongodb-credentials
-                  key: mongodb-password
+                  key: mongodb-passwords
             - name: MONGODB_DATABASE
               value: {{ .Values.mongo.auth.database | default "keptn" }}
             - name: MONGODB_EXTERNAL_CONNECTION_STRING

--- a/installer/manifests/keptn/charts/control-plane/values.yaml
+++ b/installer/manifests/keptn/charts/control-plane/values.yaml
@@ -6,9 +6,11 @@ mongo:
     nameOverride: 'mongo'
     port: 27017
   auth:
-    database: 'keptn'
+    databases:
+      - 'keptn'
     existingSecret: 'mongodb-credentials' # If the password and rootPassword values below are used, remove this field.
-    username: 'keptn'
+    usernames:
+      - 'keptn'
     password: null
     rootUser: 'admin'
     rootPassword: null


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
 - upgrades the MongoDB chart to v11.1.5
 - updates the values for mongo to conform to the new changes that came in with the update



### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes [#6605](https://github.com/keptn/keptn/issues/6605)

### Notes
<!-- any additional notes for this PR -->

It's based on PR https://github.com/keptn/keptn/pull/7444, but for keptn v13.x


