### PR TITLE
chore(installer): Moved automaticProvisionMsg under features

### DIFF
--- a/installer/manifests/keptn/templates/api-service.yaml
+++ b/installer/manifests/keptn/templates/api-service.yaml
@@ -58,7 +58,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: AUTOMATIC_PROVISIONING_URL
-              value: {{ .Values.features.automaticProvisioning.serviceURL | default "" | quote }}
+              value: {{ ((.Values.features).automaticProvisioning).serviceURL | default "" | quote }}
             - name: MAX_AUTH_ENABLED
               value: {{ (.Values.apiService.maxAuth).enabled | default true | quote }}
             - name: MAX_AUTH_REQUESTS_PER_SECOND

--- a/installer/manifests/keptn/templates/api-service.yaml
+++ b/installer/manifests/keptn/templates/api-service.yaml
@@ -58,7 +58,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: AUTOMATIC_PROVISIONING_URL
-              value: {{ (.Values.features).automaticProvisioningURL | default "" | quote }}
+              value: {{ .Values.features.automaticProvisioning.serviceURL | default "" | quote }}
             - name: MAX_AUTH_ENABLED
               value: {{ (.Values.apiService.maxAuth).enabled | default true | quote }}
             - name: MAX_AUTH_REQUESTS_PER_SECOND

--- a/installer/manifests/keptn/templates/core.yaml
+++ b/installer/manifests/keptn/templates/core.yaml
@@ -169,7 +169,7 @@ spec:
             - name: CONFIG_DIR
               value: "/config"
             - name: AUTOMATIC_PROVISIONING_MSG
-              value: {{ .Values.bridge.automaticProvisioningMsg | default "" | quote }}
+              value: {{ .Values.features.automaticProvisioning.message | default "" | quote }}
             - name: AUTH_MSG
               value: {{ .Values.bridge.authMsg | default "" | quote }}
             - name: RESOURCE_SERVICE_ENABLED

--- a/installer/manifests/keptn/templates/core.yaml
+++ b/installer/manifests/keptn/templates/core.yaml
@@ -169,7 +169,7 @@ spec:
             - name: CONFIG_DIR
               value: "/config"
             - name: AUTOMATIC_PROVISIONING_MSG
-              value: {{ .Values.features.automaticProvisioning.message | default "" | quote }}
+              value: {{ ((.Values.features).automaticProvisioning).message | default "" | quote }}
             - name: AUTH_MSG
               value: {{ .Values.bridge.authMsg | default "" | quote }}
             - name: RESOURCE_SERVICE_ENABLED

--- a/installer/manifests/keptn/templates/shipyard-controller.yaml
+++ b/installer/manifests/keptn/templates/shipyard-controller.yaml
@@ -82,7 +82,7 @@ spec:
             - name: LOG_LEVEL
               value: {{ .Values.logLevel | default "info" }}
             - name: AUTOMATIC_PROVISIONING_URL
-              value: {{ (.Values.features).automaticProvisioningURL | default "" | quote }}
+              value: {{ (.Values.features).automaticProvisioning.serviceURL | default "" | quote }}
             - name: DISABLE_LEADER_ELECTION
               {{- if  lt .Capabilities.KubeVersion.Minor "14"}}
               value: {{ true | quote }}

--- a/installer/manifests/keptn/templates/shipyard-controller.yaml
+++ b/installer/manifests/keptn/templates/shipyard-controller.yaml
@@ -82,7 +82,7 @@ spec:
             - name: LOG_LEVEL
               value: {{ .Values.logLevel | default "info" }}
             - name: AUTOMATIC_PROVISIONING_URL
-              value: {{ (.Values.features).automaticProvisioning.serviceURL | default "" | quote }}
+              value: {{ ((.Values.features).automaticProvisioning).serviceURL | default "" | quote }}
             - name: DISABLE_LEADER_ELECTION
               {{- if  lt .Capabilities.KubeVersion.Minor "14"}}
               value: {{ true | quote }}

--- a/installer/manifests/keptn/values.yaml
+++ b/installer/manifests/keptn/values.yaml
@@ -32,7 +32,9 @@ prefixPath: ""
 keptnSpecVersion: latest
 
 features:
-  automaticProvisioningURL: ""
+  automaticProvisioning:
+    serviceURL: ""
+    message: ""
 
 nats:
   nameOverride: keptn-nats
@@ -176,7 +178,6 @@ bridge:
     scope: ""
     userIdentifier: ""
     mongoConnectionString: ""
-  automaticProvisioningMsg: ""
   authMsg: ""
   d3heatmap:
     enabled: false


### PR DESCRIPTION
```
features:
  automaticProvisioning:
    serviceURL: ""
    message: ""
```

### Related Issues

Closes #7752 


### How to test
<!-- if applicable, add testing instructions under this section -->
the helm chart is generated with the correct substitutions, eg. bridge and shipyard env vars 
https://github.com/keptn/keptn/runs/6999271761?check_suite_focus=true#step:3:2122 
https://github.com/keptn/keptn/runs/6999271761?check_suite_focus=true#step:3:2772