### PR TITLE
feat(bridge): Refactor project classes into interfaces

### DIFF
--- a/bridge/client/app/_interfaces/project-result.ts
+++ b/bridge/client/app/_interfaces/project-result.ts
@@ -1,7 +1,0 @@
-import { ProjectResult as pr } from '../../../shared/interfaces/project-result';
-import { Project } from '../_models/project';
-
-export interface ProjectResult extends pr {
-  projects: Project[];
-  totalCount: number;
-}

--- a/bridge/client/app/_models/project.ts
+++ b/bridge/client/app/_models/project.ts
@@ -4,12 +4,20 @@ import { DeploymentInformation, Service } from './service';
 import { Trace } from './trace';
 import { EventTypes } from '../../../shared/interfaces/event-types';
 import { Sequence } from './sequence';
-import { Project as pj } from '../../../shared/models/project';
 import { Approval } from '../_interfaces/approval';
 import { IGitDataExtended } from '../_interfaces/git-upstream';
 import { isGitInputWithHTTPS } from '../_utils/git-upstream.utils';
+import { IProject } from '../../../shared/interfaces/project';
 
-export class Project extends pj {
+export class Project implements IProject {
+  projectName = '';
+  gitUser?: string | undefined;
+  gitRemoteURI?: string | undefined;
+  shipyardVersion?: string | undefined;
+  gitProxyScheme?: 'https' | 'http' | undefined;
+  gitProxyUrl?: string | undefined;
+  gitProxyUser?: string | undefined;
+  gitProxyInsecure = false;
   private _gitUpstream?: IGitDataExtended;
   public allSequencesLoaded = false;
   public projectDetailsLoaded = false; // true if project was fetched via project endpoint of bridge server

--- a/bridge/client/app/_services/api.service.mock.ts
+++ b/bridge/client/app/_services/api.service.mock.ts
@@ -6,7 +6,6 @@ import { KeptnInfoResult } from '../../../shared/interfaces/keptn-info-result';
 import moment from 'moment';
 import { KeptnVersions } from '../../../shared/interfaces/keptn-versions';
 import { Project } from '../_models/project';
-import { ProjectResult } from '../_interfaces/project-result';
 import { UniformRegistrationResult } from '../../../shared/interfaces/uniform-registration-result';
 import { UniformRegistrationInfo } from '../../../shared/interfaces/uniform-registration-info';
 import { UniformSubscription } from '../_models/uniform-subscription';
@@ -43,6 +42,7 @@ import { SequenceFilterMock } from './_mockData/sequence-filter.mock';
 import { TriggerResponse, TriggerSequenceData } from '../_models/trigger-sequence';
 import { IGitHttps, IGitSsh } from '../_interfaces/git-upstream';
 import { IService } from '../../../shared/interfaces/service';
+import { IProjectResult } from '../../../shared/interfaces/project-result';
 
 @Injectable({
   providedIn: null,
@@ -143,9 +143,9 @@ export class ApiServiceMock extends ApiService {
     return this.getProject(projectName);
   }
 
-  public getProjects(pageSize?: number): Observable<ProjectResult> {
+  public getProjects(pageSize?: number): Observable<IProjectResult> {
     const projects = [...ProjectsMock];
-    const result: ProjectResult = {
+    const result: IProjectResult = {
       projects: projects,
       totalCount: projects.length,
     };

--- a/bridge/client/app/_services/api.service.ts
+++ b/bridge/client/app/_services/api.service.ts
@@ -13,7 +13,6 @@ import { Secret } from '../_models/secret';
 import { KeptnInfoResult } from '../../../shared/interfaces/keptn-info-result';
 import { KeptnVersions } from '../../../shared/interfaces/keptn-versions';
 import { EventResult } from '../_interfaces/event-result';
-import { ProjectResult } from '../_interfaces/project-result';
 import { UniformSubscription } from '../_models/uniform-subscription';
 import { WebhookConfig } from '../../../shared/interfaces/webhook-config';
 import { UniformRegistrationInfo } from '../../../shared/interfaces/uniform-registration-info';
@@ -33,6 +32,7 @@ import { ICustomSequences } from '../../../shared/interfaces/custom-sequences';
 import { environment } from '../../environments/environment';
 import { WindowConfig } from '../../environments/environment.dynamic';
 import { IService } from '../../../shared/interfaces/service';
+import { IProjectResult } from '../../../shared/interfaces/project-result';
 
 @Injectable({
   providedIn: 'root',
@@ -198,13 +198,13 @@ export class ApiService {
     return this.http.get<Project>(url);
   }
 
-  public getProjects(pageSize?: number): Observable<ProjectResult> {
+  public getProjects(pageSize?: number): Observable<IProjectResult> {
     const url = `${this._baseUrl}/controlPlane/v1/project`;
     const params = {
       disableUpstreamSync: 'true',
       ...(pageSize && { pageSize: pageSize.toString() }),
     };
-    return this.http.get<ProjectResult>(url, { params });
+    return this.http.get<IProjectResult>(url, { params });
   }
 
   public getUniformRegistrations(uniformDates: { [key: string]: string }): Observable<UniformRegistrationResult[]> {

--- a/bridge/cypress/integration/project-settings.spec.ts
+++ b/bridge/cypress/integration/project-settings.spec.ts
@@ -1,13 +1,13 @@
 import NewProjectCreatePage from '../support/pageobjects/NewProjectCreatePage';
-import { Project } from '../../shared/models/project';
 import BasePage from '../support/pageobjects/BasePage';
 import { interceptFailedMetadata } from '../support/intercept';
+import { IProject } from '../../shared/interfaces/project';
 
 describe('Git upstream extended settings project https test', () => {
   const projectSettingsPage = new NewProjectCreatePage();
 
   it('should not show https or ssh form if resource service is disabled', () => {
-    const project: Project = {
+    const project: IProject = {
       projectName: 'sockshop',
       stages: [],
       gitUser: 'myGitUser',
@@ -29,7 +29,7 @@ describe('Git upstream extended settings project https test', () => {
   });
 
   it('should show "Git upstream repository" headline only once', () => {
-    const project: Project = {
+    const project: IProject = {
       projectName: 'sockshop',
       stages: [],
       gitUser: 'myGitUser',
@@ -47,7 +47,7 @@ describe('Git upstream extended settings project https test', () => {
   });
 
   it('should select HTTPS and fill out inputs', () => {
-    const project: Project = {
+    const project: IProject = {
       projectName: 'sockshop',
       stages: [],
       gitUser: 'myGitUser',
@@ -78,7 +78,7 @@ describe('Git upstream extended settings project https test', () => {
 
   it('should submit https form and show notification', () => {
     const basePage = new BasePage();
-    const project: Project = {
+    const project: IProject = {
       projectName: 'sockshop',
       stages: [],
       gitUser: 'myGitUser',
@@ -95,7 +95,7 @@ describe('Git upstream extended settings project https test', () => {
 
   it('should submit ssh form and show notification', () => {
     const basePage = new BasePage();
-    const project: Project = {
+    const project: IProject = {
       projectName: 'sockshop',
       stages: [],
       gitProxyInsecure: false,
@@ -111,7 +111,7 @@ describe('Git upstream extended settings project https test', () => {
   });
 
   it('should select SSH', () => {
-    const project: Project = {
+    const project: IProject = {
       projectName: 'sockshop',
       stages: [],
       gitProxyInsecure: false,
@@ -140,7 +140,7 @@ describe('Automatic provisioning enabled test', () => {
   });
 
   it('should select no upstream radio button as default when no upstream was configured for a project', () => {
-    const project: Project = {
+    const project: IProject = {
       projectName: 'sockshop',
       stages: [],
       gitUser: '',
@@ -161,7 +161,7 @@ describe('Automatic provisioning enabled test', () => {
   });
 
   it('should select https radio button as default if filled in and disable no upstream radio button', () => {
-    const project: Project = {
+    const project: IProject = {
       projectName: 'sockshop',
       stages: [],
       gitUser: 'myGitUser',
@@ -188,7 +188,7 @@ describe('Automatic provisioning enabled test', () => {
   });
 
   it('should select ssh radio button as default if filled in and disable no upstream radio button', () => {
-    const project: Project = {
+    const project: IProject = {
       projectName: 'sockshop',
       stages: [],
       gitProxyInsecure: false,
@@ -216,7 +216,7 @@ describe('Automatic provisioning enabled test', () => {
 describe('Project settings with invalid metadata', () => {
   const projectSettingsPage = new NewProjectCreatePage();
   it('should show error if metadata endpoint does not return data', () => {
-    const project: Project = {
+    const project: IProject = {
       projectName: 'sockshop',
       stages: [],
       gitProxyInsecure: false,

--- a/bridge/server/interfaces/project-result.ts
+++ b/bridge/server/interfaces/project-result.ts
@@ -1,6 +1,0 @@
-import { ProjectResult as pr } from '../../shared/interfaces/project-result';
-import { Project } from '../models/project';
-
-export interface ProjectResult extends pr {
-  projects: Project[];
-}

--- a/bridge/server/models/project.ts
+++ b/bridge/server/models/project.ts
@@ -1,7 +1,7 @@
 import { Stage } from './stage';
-import { Project as pj } from '../../shared/models/project';
+import { IProject } from '../../shared/interfaces/project';
 
-export class Project extends pj {
+export class Project implements IProject {
   stages: Stage[] = [];
 
   public static fromJSON(data: unknown): Project {
@@ -9,4 +9,7 @@ export class Project extends pj {
     project.stages = project.stages.map((stage) => Stage.fromJSON(stage));
     return project;
   }
+
+  gitProxyInsecure = false;
+  projectName = '';
 }

--- a/bridge/server/services/api-service.ts
+++ b/bridge/server/services/api-service.ts
@@ -7,13 +7,13 @@ import { UniformRegistration } from '../models/uniform-registration';
 import { UniformRegistrationLogResponse } from '../../shared/interfaces/uniform-registration-log';
 import { Resource, ResourceResponse } from '../../shared/interfaces/resource';
 import https from 'https';
-import { ProjectResult } from '../interfaces/project-result';
 import { UniformSubscription } from '../../shared/interfaces/uniform-subscription';
 import { Secret } from '../../shared/interfaces/secret';
 import { KeptnService } from '../../shared/models/keptn-service';
 import { IStage } from '../../shared/interfaces/stage';
 import { SequenceOptions, TraceOptions } from './data-service';
 import { ComponentLogger } from '../utils/logger';
+import { IProjectResult } from '../../shared/interfaces/project-result';
 
 export class ApiService {
   private readonly axios: AxiosInstance;
@@ -43,8 +43,8 @@ export class ApiService {
     }
   }
 
-  public getProjects(accessToken: string | undefined): Promise<AxiosResponse<ProjectResult>> {
-    return this.axios.get<ProjectResult>(`${this.baseUrl}/controlPlane/v1/project`, this.getAuthHeaders(accessToken));
+  public getProjects(accessToken: string | undefined): Promise<AxiosResponse<IProjectResult>> {
+    return this.axios.get<IProjectResult>(`${this.baseUrl}/controlPlane/v1/project`, this.getAuthHeaders(accessToken));
   }
 
   public getProject(accessToken: string | undefined, projectName: string): Promise<AxiosResponse<Project>> {

--- a/bridge/shared/interfaces/project-result.ts
+++ b/bridge/shared/interfaces/project-result.ts
@@ -1,6 +1,6 @@
-import { Project } from '../models/project';
+import { IProject } from './project';
 
-export interface ProjectResult {
-  projects: Project[];
+export interface IProjectResult {
+  projects: IProject[];
   totalCount: number;
 }

--- a/bridge/shared/interfaces/project.ts
+++ b/bridge/shared/interfaces/project.ts
@@ -1,13 +1,13 @@
-import { Stage } from './stage';
+import { IStage } from './stage';
 
-export class Project {
-  projectName!: string;
+export interface IProject {
+  projectName: string;
   gitUser?: string;
   gitRemoteURI?: string;
   shipyardVersion?: string;
   gitProxyScheme?: 'https' | 'http';
   gitProxyUrl?: string;
   gitProxyUser?: string;
-  gitProxyInsecure = false;
-  stages: Stage[] = [];
+  gitProxyInsecure: boolean;
+  stages: IStage[];
 }


### PR DESCRIPTION
## This PR
The bridge wrongly uses classes instead of interfaces fetching responses from the API.
- Refactor imports and unit tests

### Related Issues
Adds to #8023 


