### PR TITLE
fix(distributor): Limit payload size sent to the distributor's API proxy

### DIFF
--- a/distributor/README.md
+++ b/distributor/README.md
@@ -21,6 +21,7 @@ Additional environment variables configure other information for the distributor
 - `API_PROXY_PORT` - Port on which the distributor listens for incoming Keptn API requests by its execution plane service. default = `8081`.
 - `API_PROXY_PATH` - Path on which the distributor listens for incoming Keptn API requests by its execution plane service. default = `/`.
 - `API_PROXY_HTTP_TIMEOUT` - Timeout value (in seconds) for the API Proxy's HTTP Client. default = `30`.
+- `API_PROXY_MAX_PAYLOAD_BYTES_KB` - Maximum request body size for requests sent via the distributor's API proxy. default = `64`.
 - `HTTP_POLLING_INTERVAL` - Interval (in seconds) in which the distributor checks for new triggered events on the Keptn API. default = `10`
 - `EVENT_FORWARDING_PATH` - Path on which the distributor listens for incoming events from its execution plane service. default = `/event`
 - `HTTP_SSL_VERIFY` - Determines whether the distributor should check the validity of SSL certificates when sending requests to a Keptn API endpoint via HTTPS. default = `true`

--- a/distributor/cmd/main.go
+++ b/distributor/cmd/main.go
@@ -67,7 +67,7 @@ func main() {
 
 	controlPlane := controlplane.New(apiset.UniformV1(), env.PubSubConnectionType(), env)
 	uniformWatch := watch.New(controlPlane, env)
-	forwarder := forwarder.New(apiset.APIV1(), httpClient, env)
+	forwarder := forwarder.New(apiset.APIV1(), httpClient, env, forwarder.WithMaxBytes(env.GetAPIProxyMaxBytes()))
 
 	// Start event forwarder
 	logger.Info("Starting Event Forwarder")

--- a/distributor/pkg/config/envconfig.go
+++ b/distributor/pkg/config/envconfig.go
@@ -14,41 +14,42 @@ import (
 )
 
 type EnvConfig struct {
-	KeptnAPIEndpoint       string        `envconfig:"KEPTN_API_ENDPOINT" default:""`
-	KeptnAPIToken          string        `envconfig:"KEPTN_API_TOKEN" default:""`
-	APIProxyPort           int           `envconfig:"API_PROXY_PORT" default:"8081"`
-	APIProxyPath           string        `envconfig:"API_PROXY_PATH" default:"/"`
-	APIProxyHTTPTimeout    string        `envconfig:"API_PROXY_HTTP_TIMEOUT" default:"30"`
-	HTTPPollingInterval    string        `envconfig:"HTTP_POLLING_INTERVAL" default:"10"`
-	EventForwardingPath    string        `envconfig:"EVENT_FORWARDING_PATH" default:"/event"`
-	VerifySSL              bool          `envconfig:"HTTP_SSL_VERIFY" default:"true"`
-	PubSubURL              string        `envconfig:"PUBSUB_URL" default:"nats://keptn-nats"`
-	PubSubTopic            string        `envconfig:"PUBSUB_TOPIC" default:""`
-	PubSubRecipient        string        `envconfig:"PUBSUB_RECIPIENT" default:"http://127.0.0.1"`
-	PubSubRecipientPort    string        `envconfig:"PUBSUB_RECIPIENT_PORT" default:"8080"`
-	PubSubRecipientPath    string        `envconfig:"PUBSUB_RECIPIENT_PATH" default:""`
-	PubSubGroup            string        `envconfig:"PUBSUB_GROUP" default:""`
-	ProjectFilter          string        `envconfig:"PROJECT_FILTER" default:""`
-	StageFilter            string        `envconfig:"STAGE_FILTER" default:""`
-	ServiceFilter          string        `envconfig:"SERVICE_FILTER" default:""`
-	DisableRegistration    bool          `envconfig:"DISABLE_REGISTRATION" default:"false"`
-	RegistrationInterval   string        `envconfig:"REGISTRATION_INTERVAL" default:"10s"`
-	Location               string        `envconfig:"LOCATION" default:""`
-	DistributorVersion     string        `envconfig:"DISTRIBUTOR_VERSION" default:"0.9.0"` // TODO: set this automatically
-	Version                string        `envconfig:"VERSION" default:""`
-	K8sDeploymentName      string        `envconfig:"K8S_DEPLOYMENT_NAME" default:""`
-	K8sDeploymentComponent string        `envconfig:"K8S_DEPLOYMENT_COMPONENT" default:""`
-	K8sNamespace           string        `envconfig:"K8S_NAMESPACE" default:""`
-	K8sPodName             string        `envconfig:"K8S_POD_NAME" default:""`
-	K8sNodeName            string        `envconfig:"K8S_NODE_NAME" default:""`
-	MaxHeartBeatRetries    int           `envconfig:"MAX_HEARTBEAT_RETRIES" default:"10"`
-	HeartbeatInterval      time.Duration `envconfig:"HEARTBEAT_INTERVAL" default:"10s"`
-	MaxRegistrationRetries int           `envconfig:"MAX_REGISTRATION_RETRIES" default:"10"`
-	OAuthClientID          string        `envconfig:"OAUTH_CLIENT_ID" default:""`
-	OAuthClientSecret      string        `envconfig:"OAUTH_CLIENT_SECRET" default:""`
-	OAuthScopes            []string      `envconfig:"OAUTH_SCOPES" default:""`
-	OAuthDiscovery         string        `envconfig:"OAUTH_DISCOVERY" default:""`
-	OauthTokenURL          string        `envconfig:"OAUTH_TOKEN_URL" default:""`
+	KeptnAPIEndpoint          string        `envconfig:"KEPTN_API_ENDPOINT" default:""`
+	KeptnAPIToken             string        `envconfig:"KEPTN_API_TOKEN" default:""`
+	APIProxyPort              int           `envconfig:"API_PROXY_PORT" default:"8081"`
+	APIProxyPath              string        `envconfig:"API_PROXY_PATH" default:"/"`
+	APIProxyMaxPayloadBytesKB int           `envconfig:"API_PROXY_MAX_PAYLOAD_BYTES_KB" default:"64"`
+	APIProxyHTTPTimeout       string        `envconfig:"API_PROXY_HTTP_TIMEOUT" default:"30"`
+	HTTPPollingInterval       string        `envconfig:"HTTP_POLLING_INTERVAL" default:"10"`
+	EventForwardingPath       string        `envconfig:"EVENT_FORWARDING_PATH" default:"/event"`
+	VerifySSL                 bool          `envconfig:"HTTP_SSL_VERIFY" default:"true"`
+	PubSubURL                 string        `envconfig:"PUBSUB_URL" default:"nats://keptn-nats"`
+	PubSubTopic               string        `envconfig:"PUBSUB_TOPIC" default:""`
+	PubSubRecipient           string        `envconfig:"PUBSUB_RECIPIENT" default:"http://127.0.0.1"`
+	PubSubRecipientPort       string        `envconfig:"PUBSUB_RECIPIENT_PORT" default:"8080"`
+	PubSubRecipientPath       string        `envconfig:"PUBSUB_RECIPIENT_PATH" default:""`
+	PubSubGroup               string        `envconfig:"PUBSUB_GROUP" default:""`
+	ProjectFilter             string        `envconfig:"PROJECT_FILTER" default:""`
+	StageFilter               string        `envconfig:"STAGE_FILTER" default:""`
+	ServiceFilter             string        `envconfig:"SERVICE_FILTER" default:""`
+	DisableRegistration       bool          `envconfig:"DISABLE_REGISTRATION" default:"false"`
+	RegistrationInterval      string        `envconfig:"REGISTRATION_INTERVAL" default:"10s"`
+	Location                  string        `envconfig:"LOCATION" default:""`
+	DistributorVersion        string        `envconfig:"DISTRIBUTOR_VERSION" default:"0.9.0"` // TODO: set this automatically
+	Version                   string        `envconfig:"VERSION" default:""`
+	K8sDeploymentName         string        `envconfig:"K8S_DEPLOYMENT_NAME" default:""`
+	K8sDeploymentComponent    string        `envconfig:"K8S_DEPLOYMENT_COMPONENT" default:""`
+	K8sNamespace              string        `envconfig:"K8S_NAMESPACE" default:""`
+	K8sPodName                string        `envconfig:"K8S_POD_NAME" default:""`
+	K8sNodeName               string        `envconfig:"K8S_NODE_NAME" default:""`
+	MaxHeartBeatRetries       int           `envconfig:"MAX_HEARTBEAT_RETRIES" default:"10"`
+	HeartbeatInterval         time.Duration `envconfig:"HEARTBEAT_INTERVAL" default:"10s"`
+	MaxRegistrationRetries    int           `envconfig:"MAX_REGISTRATION_RETRIES" default:"10"`
+	OAuthClientID             string        `envconfig:"OAUTH_CLIENT_ID" default:""`
+	OAuthClientSecret         string        `envconfig:"OAUTH_CLIENT_SECRET" default:""`
+	OAuthScopes               []string      `envconfig:"OAUTH_SCOPES" default:""`
+	OAuthDiscovery            string        `envconfig:"OAUTH_DISCOVERY" default:""`
+	OauthTokenURL             string        `envconfig:"OAUTH_TOKEN_URL" default:""`
 }
 
 func (env *EnvConfig) PubSubConnectionType() ConnectionType {
@@ -199,6 +200,13 @@ func (env *EnvConfig) GetAPIProxyHTTPTimeout() time.Duration {
 		timeout = DefaultAPIProxyHTTPTimeout
 	}
 	return time.Duration(timeout) * time.Second
+}
+
+func (env *EnvConfig) GetAPIProxyMaxBytes() int64 {
+	if env.APIProxyMaxPayloadBytesKB > 0 {
+		return int64(env.APIProxyMaxPayloadBytesKB << 10)
+	}
+	return 0
 }
 
 func queryEscapeConfigurationServiceURI(path string, value string) string {

--- a/distributor/pkg/config/envconfig_test.go
+++ b/distributor/pkg/config/envconfig_test.go
@@ -358,3 +358,37 @@ func TestEnvConfig_GetAPIProxyHTTPTimeout(t *testing.T) {
 		})
 	}
 }
+
+func TestEnvConfig_GetAPIProxyMaxBytes(t *testing.T) {
+	type fields struct {
+		APIProxyMaxBytesKB int
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   int64
+	}{
+		{
+			name: "64KB",
+			fields: fields{
+				APIProxyMaxBytesKB: 64,
+			},
+			want: 65536,
+		},
+		{
+			name: "no limit",
+			fields: fields{
+				APIProxyMaxBytesKB: 0,
+			},
+			want: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := &EnvConfig{
+				APIProxyMaxPayloadBytesKB: tt.fields.APIProxyMaxBytesKB,
+			}
+			assert.Equalf(t, tt.want, env.GetAPIProxyMaxBytes(), "GetAPIProxyMaxBytes()")
+		})
+	}
+}

--- a/installer/manifests/keptn/templates/_helpers.tpl
+++ b/installer/manifests/keptn/templates/_helpers.tpl
@@ -147,6 +147,8 @@ lifecycle:
   value: "{{ (((.Values.distributor).config).oauth).tokenURL }}"
 - name: OAUTH_SCOPES
   value: "{{ (((.Values.distributor).config).oauth).scopes }}"
+- name: API_PROXY_MAX_PAYLOAD_BYTES_KB
+  value: "{{ (((.Values.distributor).config).proxy).maxPayloadBytesKB | default "64" | quote }}"
 {{- end }}
 
 {{- define "keptn.common.security-context-seccomp" -}}

--- a/installer/manifests/keptn/values.yaml
+++ b/installer/manifests/keptn/values.yaml
@@ -203,6 +203,7 @@ distributor:
   config:
     proxy:
       httpTimeout: "30"
+      maxPayloadBytesKB: "64"
     queueGroup:
       enabled: true
     oauth:


### PR DESCRIPTION
Closes #8196 

This PR introduces a maximum request payload size for the distributor. The value can be configured via the helm values by setting the `distributor.config.proxy.maxPayloadBytesKB` value (default = `64`).



 