### PR TITLE
fix(shipyard-controller): Project should be deleted even if upstream delete fails

### DIFF
--- a/shipyard-controller/handler/projecthandler.go
+++ b/shipyard-controller/handler/projecthandler.go
@@ -424,7 +424,6 @@ func (ph *ProjectHandler) DeleteProject(c *gin.Context) {
 		if err != nil {
 			// a failure to clean up the provisioned repo should not prevent the project delete
 			log.Errorf(err.Error())
-			SetFailedDependencyErrorResponse(c, UnableProvisionDeleteGeneric)
 		}
 	}
 

--- a/shipyard-controller/handler/projecthandler.go
+++ b/shipyard-controller/handler/projecthandler.go
@@ -423,7 +423,7 @@ func (ph *ProjectHandler) DeleteProject(c *gin.Context) {
 		err := ph.RepositoryProvisioner.DeleteRepository(projectName, namespace)
 		if err != nil {
 			// a failure to clean up the provisioned repo should not prevent the project delete
-			log.Errorf(err.Error())
+			log.Errorf("Automatic Provisioning error: %s", err.Error())
 		}
 	}
 

--- a/shipyard-controller/handler/projecthandler_test.go
+++ b/shipyard-controller/handler/projecthandler_test.go
@@ -750,7 +750,7 @@ func TestDeleteProject(t *testing.T) {
 					},
 				},
 			},
-			expectHttpStatus: http.StatusFailedDependency,
+			expectHttpStatus: http.StatusOK,
 			projectPathParam: "myproject",
 			projectDeleted:   true,
 		},

--- a/shipyard-controller/handler/projecthandler_test.go
+++ b/shipyard-controller/handler/projecthandler_test.go
@@ -651,6 +651,8 @@ func TestUpdateProject(t *testing.T) {
 
 func TestDeleteProject(t *testing.T) {
 
+	var deleted bool
+
 	type fields struct {
 		ProjectManager        IProjectManager
 		EventSender           common.EventSender
@@ -665,6 +667,7 @@ func TestDeleteProject(t *testing.T) {
 		expectJSONResponse *models.DeleteProjectResponse
 		projectPathParam   string
 		provisioningURL    string
+		projectDeleted     bool
 	}{
 		{
 			name: "Delete Project deleting project fails",
@@ -709,6 +712,7 @@ func TestDeleteProject(t *testing.T) {
 			fields: fields{
 				ProjectManager: &fake.IProjectManagerMock{
 					DeleteFunc: func(projectName string) (string, error) {
+						deleted = true
 						return "a-message", nil
 					},
 				},
@@ -723,12 +727,14 @@ func TestDeleteProject(t *testing.T) {
 			expectHttpStatus:   http.StatusOK,
 			projectPathParam:   "myproject",
 			expectJSONResponse: &models.DeleteProjectResponse{Message: "a-message"},
+			projectDeleted:     true,
 		},
 		{
 			name: "Delete Project with provisioningURL - failure",
 			fields: fields{
 				ProjectManager: &fake.IProjectManagerMock{
 					DeleteFunc: func(projectName string) (string, error) {
+						deleted = true
 						return "a-message", nil
 					},
 				},
@@ -746,6 +752,7 @@ func TestDeleteProject(t *testing.T) {
 			},
 			expectHttpStatus: http.StatusFailedDependency,
 			projectPathParam: "myproject",
+			projectDeleted:   true,
 		},
 		{
 			name: "Delete Project with provisioningURL",
@@ -774,6 +781,7 @@ func TestDeleteProject(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			deleted = false
 			w, c := createGinTestContext()
 
 			handler := NewProjectHandler(tt.fields.ProjectManager, tt.fields.EventSender, tt.fields.EnvConfig, tt.fields.RepositoryProvisioner)
@@ -793,6 +801,7 @@ func TestDeleteProject(t *testing.T) {
 				assert.Equal(t, tt.expectJSONResponse, response)
 			}
 			assert.Equal(t, tt.expectHttpStatus, w.Code)
+			assert.Equal(t, tt.projectDeleted, deleted)
 
 		})
 	}

--- a/shipyard-controller/handler/projectmanager.go
+++ b/shipyard-controller/handler/projectmanager.go
@@ -357,18 +357,18 @@ func (pm *ProjectManager) Delete(projectName string) (string, error) {
 		}
 	}
 
-	if err := pm.ConfigurationStore.DeleteProject(projectName); err != nil {
-		return resultMessage.String(), pm.logAndReturnError(fmt.Sprintf("could not delete project: %s", err.Error()))
-	}
-
 	resultMessage.WriteString(pm.getDeleteInfoMessage(projectName))
 
+	//  clean up  database
 	if err := pm.ProjectMaterializedView.DeleteProject(projectName); err != nil {
 		log.Errorf("could not delete project: %s", err.Error())
 	}
-
 	pm.deleteProjectSequenceCollections(projectName)
 
+	// attempt deleting from local git
+	if err := pm.ConfigurationStore.DeleteProject(projectName); err != nil {
+		return resultMessage.String(), pm.logAndReturnError(fmt.Sprintf("could not delete project: %s", err.Error()))
+	}
 	return resultMessage.String(), nil
 }
 


### PR DESCRIPTION

## This PR
<!-- add the description of the PR here -->

- removes return in case deletion of provisioned upstream fail
- attempt removing configurations only after the DB is cleaned up, to avoid failure in case the upstream has been manually removed/ wrongly reconfigured  

Fixes #8159

integration test https://github.com/keptn/keptn/actions/runs/2568940174