### PR TITLE
fix(shipyard-controller): Delete project should not return error if the upstream is failing 

### DIFF
--- a/shipyard-controller/handler/projecthandler.go
+++ b/shipyard-controller/handler/projecthandler.go
@@ -423,8 +423,7 @@ func (ph *ProjectHandler) DeleteProject(c *gin.Context) {
 		err := ph.RepositoryProvisioner.DeleteRepository(projectName, namespace)
 		if err != nil {
 			// a failure to clean up the provisioned repo should not prevent the project delete
-			log.Errorf(err.Error())
-			SetFailedDependencyErrorResponse(c, UnableProvisionDeleteGeneric)
+			log.Errorf("Automatic Provisioning error: %s", err.Error())
 		}
 	}
 

--- a/shipyard-controller/handler/projecthandler_test.go
+++ b/shipyard-controller/handler/projecthandler_test.go
@@ -642,6 +642,8 @@ func TestUpdateProject(t *testing.T) {
 
 func TestDeleteProject(t *testing.T) {
 
+	var deleted bool
+
 	type fields struct {
 		ProjectManager        IProjectManager
 		EventSender           common.EventSender
@@ -656,6 +658,7 @@ func TestDeleteProject(t *testing.T) {
 		expectJSONResponse *models.DeleteProjectResponse
 		projectPathParam   string
 		provisioningURL    string
+		projectDeleted     bool
 	}{
 		{
 			name: "Delete Project deleting project fails",
@@ -700,6 +703,7 @@ func TestDeleteProject(t *testing.T) {
 			fields: fields{
 				ProjectManager: &fake.IProjectManagerMock{
 					DeleteFunc: func(projectName string) (string, error) {
+						deleted = true
 						return "a-message", nil
 					},
 				},
@@ -714,12 +718,14 @@ func TestDeleteProject(t *testing.T) {
 			expectHttpStatus:   http.StatusOK,
 			projectPathParam:   "myproject",
 			expectJSONResponse: &models.DeleteProjectResponse{Message: "a-message"},
+			projectDeleted:     true,
 		},
 		{
 			name: "Delete Project with provisioningURL - failure",
 			fields: fields{
 				ProjectManager: &fake.IProjectManagerMock{
 					DeleteFunc: func(projectName string) (string, error) {
+						deleted = true
 						return "a-message", nil
 					},
 				},
@@ -737,6 +743,7 @@ func TestDeleteProject(t *testing.T) {
 			},
 			expectHttpStatus: http.StatusFailedDependency,
 			projectPathParam: "myproject",
+			projectDeleted:   true,
 		},
 		{
 			name: "Delete Project with provisioningURL",
@@ -765,6 +772,7 @@ func TestDeleteProject(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			deleted = false
 			w, c := createGinTestContext()
 
 			handler := NewProjectHandler(tt.fields.ProjectManager, tt.fields.EventSender, tt.fields.EnvConfig, tt.fields.RepositoryProvisioner)
@@ -784,6 +792,7 @@ func TestDeleteProject(t *testing.T) {
 				assert.Equal(t, tt.expectJSONResponse, response)
 			}
 			assert.Equal(t, tt.expectHttpStatus, w.Code)
+			assert.Equal(t, tt.projectDeleted, deleted)
 
 		})
 	}

--- a/shipyard-controller/handler/projecthandler_test.go
+++ b/shipyard-controller/handler/projecthandler_test.go
@@ -741,7 +741,7 @@ func TestDeleteProject(t *testing.T) {
 					},
 				},
 			},
-			expectHttpStatus: http.StatusFailedDependency,
+			expectHttpStatus: http.StatusOK,
 			projectPathParam: "myproject",
 			projectDeleted:   true,
 		},

--- a/shipyard-controller/handler/projectmanager.go
+++ b/shipyard-controller/handler/projectmanager.go
@@ -357,18 +357,18 @@ func (pm *ProjectManager) Delete(projectName string) (string, error) {
 		}
 	}
 
-	if err := pm.ConfigurationStore.DeleteProject(projectName); err != nil {
-		return resultMessage.String(), pm.logAndReturnError(fmt.Sprintf("could not delete project: %s", err.Error()))
-	}
-
 	resultMessage.WriteString(pm.getDeleteInfoMessage(projectName))
 
+	//  clean up  database
 	if err := pm.ProjectMaterializedView.DeleteProject(projectName); err != nil {
 		log.Errorf("could not delete project: %s", err.Error())
 	}
-
 	pm.deleteProjectSequenceCollections(projectName)
 
+	// attempt deleting from local git
+	if err := pm.ConfigurationStore.DeleteProject(projectName); err != nil {
+		return resultMessage.String(), pm.logAndReturnError(fmt.Sprintf("could not delete project: %s", err.Error()))
+	}
 	return resultMessage.String(), nil
 }
 


### PR DESCRIPTION
## This PR
backport of #8204

Fixes #8159