### PR TITLE
fix: Change name label to respect the nameOverride

### DIFF
--- a/helm-service/chart/README.md
+++ b/helm-service/chart/README.md
@@ -1,42 +1,41 @@
-
 Helm-service
 ===========
 
 Helm Chart for the keptn helm-service
 
-
 ## Configuration
 
 The following table lists the configurable parameters of the Helm-service chart and their default values.
 
-| Parameter                | Description             | Default        |
-| ------------------------ | ----------------------- | -------------- |
-| `helmservice.image.repository` | Container image name | `"docker.io/keptn/helm-service"` |
-| `helmservice.image.pullPolicy` | Kubernetes image pull policy | `"IfNotPresent"` |
-| `helmservice.image.tag` | Container tag | `""` |
-| `helmservice.service.enabled` | Creates a kubernetes service for the helm-service | `true` |
-| `distributor.stageFilter` | Sets the stage this helm service belongs to | `""` |
-| `distributor.serviceFilter` | Sets the service this helm service belongs to | `""` |
-| `distributor.projectFilter` | Sets the project this helm service belongs to | `""` |
-| `distributor.image.repository` | Container image name | `"docker.io/keptn/distributor"` |
-| `distributor.image.pullPolicy` | Kubernetes image pull policy | `"IfNotPresent"` |
-| `distributor.image.tag` | Container tag | `""` |
-| `remoteControlPlane.enabled` | Enables remote execution plane mode | `false` |
-| `remoteControlPlane.api.protocol` | Used protocol (http, https | `"https"` |
-| `remoteControlPlane.api.hostname` | Hostname of the control plane cluster (and port) | `""` |
-| `remoteControlPlane.api.apiValidateTls` | Defines if the control plane certificate should be validated | `true` |
-| `remoteControlPlane.api.token` | Keptn api token | `""` |
-| `imagePullSecrets` | Secrets to use for container registry credentials | `[]` |
-| `serviceAccount.create` | Enables the service account creation | `true` |
-| `serviceAccount.annotations` | Annotations to add to the service account | `{}` |
-| `serviceAccount.name` | The name of the service account to use. | `""` |
-| `podAnnotations` | Annotations to add to the created pods | `{}` |
-| `podSecurityContext` | Set the pod security context (e.g. fsgroups) | `{}` |
-| `securityContext` | Set the security context (e.g. runasuser) | `{}` |
-| `resources` | Resource limits and requests | `{}` |
-| `nodeSelector` | Node selector configuration | `{}` |
-| `tolerations` | Tolerations for the pods | `[]` |
-| `affinity` | Affinity rules | `{}` |
+| Parameter                               | Description                                                  | Default                          |
+|-----------------------------------------|--------------------------------------------------------------|----------------------------------|
+| `nameOverride`                          | Override the name label and distributor subscription name    | `""`                             |
+| `helmservice.image.repository`          | Container image name                                         | `"docker.io/keptn/helm-service"` |
+| `helmservice.image.pullPolicy`          | Kubernetes image pull policy                                 | `"IfNotPresent"`                 |
+| `helmservice.image.tag`                 | Container tag                                                | `""`                             |
+| `helmservice.service.enabled`           | Creates a kubernetes service for the helm-service            | `true`                           |
+| `distributor.stageFilter`               | Sets the stage this helm service belongs to                  | `""`                             |
+| `distributor.serviceFilter`             | Sets the service this helm service belongs to                | `""`                             |
+| `distributor.projectFilter`             | Sets the project this helm service belongs to                | `""`                             |
+| `distributor.image.repository`          | Container image name                                         | `"docker.io/keptn/distributor"`  |
+| `distributor.image.pullPolicy`          | Kubernetes image pull policy                                 | `"IfNotPresent"`                 |
+| `distributor.image.tag`                 | Container tag                                                | `""`                             |
+| `remoteControlPlane.enabled`            | Enables remote execution plane mode                          | `false`                          |
+| `remoteControlPlane.api.protocol`       | Used protocol (http, https                                   | `"https"`                        |
+| `remoteControlPlane.api.hostname`       | Hostname of the control plane cluster (and port)             | `""`                             |
+| `remoteControlPlane.api.apiValidateTls` | Defines if the control plane certificate should be validated | `true`                           |
+| `remoteControlPlane.api.token`          | Keptn api token                                              | `""`                             |
+| `imagePullSecrets`                      | Secrets to use for container registry credentials            | `[]`                             |
+| `serviceAccount.create`                 | Enables the service account creation                         | `true`                           |
+| `serviceAccount.annotations`            | Annotations to add to the service account                    | `{}`                             |
+| `serviceAccount.name`                   | The name of the service account to use.                      | `""`                             |
+| `podAnnotations`                        | Annotations to add to the created pods                       | `{}`                             |
+| `podSecurityContext`                    | Set the pod security context (e.g. fsgroups)                 | `{}`                             |
+| `securityContext`                       | Set the security context (e.g. runasuser)                    | `{}`                             |
+| `resources`                             | Resource limits and requests                                 | `{}`                             |
+| `nodeSelector`                          | Node selector configuration                                  | `{}`                             |
+| `tolerations`                           | Tolerations for the pods                                     | `[]`                             |
+| `affinity`                              | Affinity rules                                               | `{}`                             |
 
 
 

--- a/helm-service/chart/templates/deployment.yaml
+++ b/helm-service/chart/templates/deployment.yaml
@@ -3,12 +3,12 @@ kind: Deployment
 metadata:
   name: {{ include "helm-service.fullname" . }}
   labels: {{- include "keptn.common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/name: helm-service
+    app.kubernetes.io/name: {{ include "helm-service.name" . }}
 spec:
   replicas: 1
   selector:
     matchLabels: {{- include "keptn.common.labels.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/name: helm-service
+      app.kubernetes.io/name: {{ include "helm-service.name" . }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -16,7 +16,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels: {{- include "keptn.common.labels.standard" . | nindent 8 }}
-        app.kubernetes.io/name: helm-service
+        app.kubernetes.io/name: {{ include "helm-service.name" . }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/helm-service/chart/templates/service.yaml
+++ b/helm-service/chart/templates/service.yaml
@@ -4,12 +4,12 @@ kind: Service
 metadata:
   name: {{ include "helm-service.fullname" . }}
   labels: {{- include "keptn.common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/name: helm-service
+    app.kubernetes.io/name: {{ include "helm-service.name" . }}
 spec:
   type: ClusterIP
   ports:
     - port: 8080
       protocol: TCP
   selector: {{- include "keptn.common.labels.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/name: helm-service
+    app.kubernetes.io/name: {{ include "helm-service.name" . }}
   {{- end }}

--- a/helm-service/chart/templates/serviceaccount.yaml
+++ b/helm-service/chart/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   name: {{ include "helm-service.serviceAccountName" . }}
   labels: {{- include "keptn.common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/name: helm-service
+    app.kubernetes.io/name: {{ include "helm-service.name" . }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
@@ -15,7 +15,7 @@ kind: ClusterRoleBinding
 metadata:
   name: keptn-{{ .Release.Namespace }}-helm-service-cluster-admin
   labels: {{- include "keptn.common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/name: helm-service
+    app.kubernetes.io/name: {{ include "helm-service.name" . }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}

--- a/helm-service/chart/templates/tests/test-api-connection.yaml
+++ b/helm-service/chart/templates/tests/test-api-connection.yaml
@@ -4,7 +4,7 @@ kind: Pod
 metadata:
   name: "{{ include "helm-service.fullname" . }}-test-api-connection"
   labels: {{- include "keptn.common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/name: helm-service
+    app.kubernetes.io/name: {{ include "helm-service.name" . }}
   annotations:
     "helm.sh/hook": test
 spec:

--- a/helm-service/chart/values.yaml
+++ b/helm-service/chart/values.yaml
@@ -1,3 +1,5 @@
+nameOverride:
+
 helmservice:
   image:
     repository: docker.io/keptn/helm-service # Container Image Name

--- a/jmeter-service/chart/README.md
+++ b/jmeter-service/chart/README.md
@@ -9,34 +9,35 @@ Helm Chart for the keptn jmeter-service
 
 The following table lists the configurable parameters of the Jmeter-service chart and their default values.
 
-| Parameter                | Description             | Default        |
-| ------------------------ | ----------------------- | -------------- |
-| `jmeterservice.image.repository` | Container image name | `"docker.io/keptn/jmeter-service"` |
-| `jmeterservice.image.pullPolicy` | Kubernetes image pull policy | `"IfNotPresent"` |
-| `jmeterservice.image.tag` | Container tag | `""` |
-| `jmeterservice.service.enabled` | Creates a kubernetes service for the jmeter-service | `true` |
-| `distributor.stageFilter` | Sets the stage this helm service belongs to | `""` |
-| `distributor.serviceFilter` | Sets the service this helm service belongs to | `""` |
-| `distributor.projectFilter` | Sets the project this helm service belongs to | `""` |
-| `distributor.image.repository` | Container image name | `"docker.io/keptn/distributor"` |
-| `distributor.image.pullPolicy` | Kubernetes image pull policy | `"IfNotPresent"` |
-| `distributor.image.tag` | Container tag | `""` |
-| `remoteControlPlane.enabled` | Enables remote execution plane mode | `false` |
-| `remoteControlPlane.api.protocol` | Used protocol (http, https | `"https"` |
-| `remoteControlPlane.api.hostname` | Hostname of the control plane cluster (and port) | `""` |
-| `remoteControlPlane.api.apiValidateTls` | Defines if the control plane certificate should be validated | `true` |
-| `remoteControlPlane.api.token` | Keptn api token | `""` |
-| `imagePullSecrets` | Secrets to use for container registry credentials | `[]` |
-| `serviceAccount.create` | Enables the service account creation | `true` |
-| `serviceAccount.annotations` | Annotations to add to the service account | `{}` |
-| `serviceAccount.name` | The name of the service account to use. | `""` |
-| `podAnnotations` | Annotations to add to the created pods | `{}` |
-| `podSecurityContext` | Set the pod security context (e.g. fsgroups) | `{}` |
-| `securityContext` | Set the security context (e.g. runasuser) | `{}` |
-| `resources` | Resource limits and requests | `{}` |
-| `nodeSelector` | Node selector configuration | `{}` |
-| `tolerations` | Tolerations for the pods | `[]` |
-| `affinity` | Affinity rules | `{}` |
+| Parameter                               | Description                                                  | Default                            |
+|-----------------------------------------|--------------------------------------------------------------|------------------------------------|
+| `nameOverride`                          | Override the name label and distributor subscription name    | `""`                               |
+| `jmeterservice.image.repository`        | Container image name                                         | `"docker.io/keptn/jmeter-service"` |
+| `jmeterservice.image.pullPolicy`        | Kubernetes image pull policy                                 | `"IfNotPresent"`                   |
+| `jmeterservice.image.tag`               | Container tag                                                | `""`                               |
+| `jmeterservice.service.enabled`         | Creates a kubernetes service for the jmeter-service          | `true`                             |
+| `distributor.stageFilter`               | Sets the stage this helm service belongs to                  | `""`                               |
+| `distributor.serviceFilter`             | Sets the service this helm service belongs to                | `""`                               |
+| `distributor.projectFilter`             | Sets the project this helm service belongs to                | `""`                               |
+| `distributor.image.repository`          | Container image name                                         | `"docker.io/keptn/distributor"`    |
+| `distributor.image.pullPolicy`          | Kubernetes image pull policy                                 | `"IfNotPresent"`                   |
+| `distributor.image.tag`                 | Container tag                                                | `""`                               |
+| `remoteControlPlane.enabled`            | Enables remote execution plane mode                          | `false`                            |
+| `remoteControlPlane.api.protocol`       | Used protocol (http, https                                   | `"https"`                          |
+| `remoteControlPlane.api.hostname`       | Hostname of the control plane cluster (and port)             | `""`                               |
+| `remoteControlPlane.api.apiValidateTls` | Defines if the control plane certificate should be validated | `true`                             |
+| `remoteControlPlane.api.token`          | Keptn api token                                              | `""`                               |
+| `imagePullSecrets`                      | Secrets to use for container registry credentials            | `[]`                               |
+| `serviceAccount.create`                 | Enables the service account creation                         | `true`                             |
+| `serviceAccount.annotations`            | Annotations to add to the service account                    | `{}`                               |
+| `serviceAccount.name`                   | The name of the service account to use.                      | `""`                               |
+| `podAnnotations`                        | Annotations to add to the created pods                       | `{}`                               |
+| `podSecurityContext`                    | Set the pod security context (e.g. fsgroups)                 | `{}`                               |
+| `securityContext`                       | Set the security context (e.g. runasuser)                    | `{}`                               |
+| `resources`                             | Resource limits and requests                                 | `{}`                               |
+| `nodeSelector`                          | Node selector configuration                                  | `{}`                               |
+| `tolerations`                           | Tolerations for the pods                                     | `[]`                               |
+| `affinity`                              | Affinity rules                                               | `{}`                               |
 
 
 

--- a/jmeter-service/chart/templates/deployment.yaml
+++ b/jmeter-service/chart/templates/deployment.yaml
@@ -3,12 +3,12 @@ kind: Deployment
 metadata:
   name: {{ include "jmeter-service.fullname" . }}
   labels: {{- include "keptn.common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/name: jmeter-service
+    app.kubernetes.io/name: {{ include "jmeter-service.name" . }}
 spec:
   replicas: 1
   selector:
     matchLabels: {{- include "keptn.common.labels.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/name: jmeter-service
+      app.kubernetes.io/name: {{ include "jmeter-service.name" . }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -16,7 +16,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels: {{- include "keptn.common.labels.standard" . | nindent 8 }}
-        app.kubernetes.io/name: jmeter-service
+        app.kubernetes.io/name: {{ include "jmeter-service.name" . }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/jmeter-service/chart/templates/service.yaml
+++ b/jmeter-service/chart/templates/service.yaml
@@ -4,12 +4,12 @@ kind: Service
 metadata:
   name: {{ include "jmeter-service.fullname" . }}
   labels: {{- include "keptn.common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/name: jmeter-service
+    app.kubernetes.io/name: {{ include "jmeter-service.name" . }}
 spec:
   type: ClusterIP
   ports:
     - port: 8080
       protocol: TCP
   selector: {{- include "keptn.common.labels.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/name: jmeter-service
+    app.kubernetes.io/name: {{ include "jmeter-service.name" . }}
   {{- end }}

--- a/jmeter-service/chart/templates/serviceaccount.yaml
+++ b/jmeter-service/chart/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   name: {{ include "jmeter-service.serviceAccountName" . }}
   labels: {{- include "keptn.common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/name: jmeter-service
+    app.kubernetes.io/name: {{ include "jmeter-service.name" . }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}

--- a/jmeter-service/chart/templates/tests/test-api-connection.yaml
+++ b/jmeter-service/chart/templates/tests/test-api-connection.yaml
@@ -4,7 +4,7 @@ kind: Pod
 metadata:
   name: "{{ include "jmeter-service.fullname" . }}-test-api-connection"
   labels: {{- include "keptn.common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/name: jmeter-service
+    app.kubernetes.io/name: {{ include "jmeter-service.name" . }}
   annotations:
     "helm.sh/hook": test
 spec:

--- a/jmeter-service/chart/values.yaml
+++ b/jmeter-service/chart/values.yaml
@@ -1,3 +1,5 @@
+nameOverride:
+
 jmeterservice:
   image:
     repository: docker.io/keptn/jmeter-service # Container Image Name


### PR DESCRIPTION
### This PR
- fixes a bug that prevented user from configuring multiple execution planes by allowing users to override the name of helm/jmeter svc which in turn puts the services into separate pubsub groups in NATS

Fixes #8055 
Integration test run: https://github.com/keptn/keptn/actions/runs/2590089094