### PR TITLE
revert: Revert nginx-unprivileged update to 1.23.0-alpine back to 1.22.0-alpine

### DIFF
--- a/installer/airgapped/pull_and_retag_images.sh
+++ b/installer/airgapped/pull_and_retag_images.sh
@@ -19,7 +19,7 @@ IMAGES_CONTROL_PLANE_THIRD_PARTY=(
   "nats:2.7.2-alpine"
   "natsio/nats-server-config-reloader:0.6.3"
   "natsio/prometheus-nats-exporter:0.9.1"
-  "nginxinc/nginx-unprivileged:1.23.0-alpine"
+  "nginxinc/nginx-unprivileged:1.22.0-alpine"
 )
 IMAGES_CONTROL_PLANE=(
   "${DOCKER_ORG}/api:${KEPTN_TAG}"

--- a/installer/manifests/keptn/values.yaml
+++ b/installer/manifests/keptn/values.yaml
@@ -87,7 +87,7 @@ apiGatewayNginx:
     privileged: false
   image:
     repository: docker.io/nginxinc/nginx-unprivileged
-    tag: 1.23.0-alpine
+    tag: 1.22.0-alpine
   nodeSelector: {}
   gracePeriod: 60
   preStopHookTime: 20


### PR DESCRIPTION
### This PR
- reverts nginx back to 1.22.0-alpine which is the know-to-work version