### PR TITLE
fix(resource-service): Return 404 with trailing slashes

### DIFF
--- a/resource-service/main.go
+++ b/resource-service/main.go
@@ -2,16 +2,17 @@ package main
 
 import (
 	"context"
-	"github.com/kelseyhightower/envconfig"
-	"github.com/keptn/keptn/resource-service/common"
 	"io/ioutil"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"net/http"
 	"os"
 	"os/signal"
 	"sync"
 	"syscall"
+
+	"github.com/kelseyhightower/envconfig"
+	"github.com/keptn/keptn/resource-service/common"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 
 	"github.com/gin-gonic/gin"
 	"github.com/keptn/go-utils/pkg/common/osutils"
@@ -67,6 +68,8 @@ func main() {
 	engine := gin.Default()
 	engine.UnescapePathValues = false // To be compatible with current configuration-service
 	engine.UseRawPath = true
+	engine.RedirectTrailingSlash = false //issue #8160
+
 	/// setting up middleware to handle graceful shutdown
 	wg := &sync.WaitGroup{}
 	engine.Use(handler.GracefulShutdownMiddleware(wg))


### PR DESCRIPTION
Signed-off-by: Giovanni Liva <giovanni.liva@dynatrace.com>

Fixes #8160

This is a breaking change

### Before

```
curl -X GET "http://keptn.nip.io/api/configuration-service/v1/project/podtato/stage/hardening/service/helloservice/resource/" -H "accept: application/json" -H "x-token: <token>" -v

> GET /api/configuration-service/v1/project/podtato/stage/hardening/service/helloservice/resource/ HTTP/1.1
> Host: keptn.nip.io
> User-Agent: curl/7.68.0
> accept: application/json
> x-token: <token>
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 301 Moved Permanently
< server: istio-envoy
< date: Fri, 01 Jul 2022 05:50:11 GMT
< content-type: text/html; charset=utf-8
< content-length: 100
< location: /v1/project/podtato/stage/hardening/service/helloservice/resource
< x-envoy-upstream-service-time: 4
<
<a href="/v1/project/podtato/stage/hardening/service/helloservice/resource">Moved Permanently</a>.
```

### Now 

```
curl -X GET "http://keptn.nip.io/api/configuration-service/v1/project/podtato/stage/hardening/service/helloservice/resource/" -H "accept: application/json" -H "x-token: <token>" -v

> GET /api/configuration-service/v1/project/podtato/stage/hardening/service/helloservice/resource/ HTTP/1.1
> Host: keptn.nip.io
> User-Agent: curl/7.68.0
> accept: application/json
> x-token: <token>
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 404 Not Found
< server: istio-envoy
< date: Fri, 01 Jul 2022 06:02:50 GMT
< content-type: text/plain
< content-length: 18
< x-envoy-upstream-service-time: 3
<
404 page not found
``` 