### PR TITLE
fix(shipyard-controller): Return `ErrProjectNotFound` instead of `nil, nil` when project is not in the db

### DIFF
--- a/shipyard-controller/db/mongodb_project_repo.go
+++ b/shipyard-controller/db/mongodb_project_repo.go
@@ -62,8 +62,11 @@ func (mdbrepo *MongoDBProjectsRepo) GetProject(projectName string) (*apimodels.E
 
 	projectCollection := mdbrepo.getProjectsCollection()
 	result := projectCollection.FindOne(ctx, bson.M{"projectName": projectName})
-	if result.Err() != nil && result.Err() == mongo.ErrNoDocuments {
-		return nil, nil
+	if result.Err() != nil {
+		if result.Err() == mongo.ErrNoDocuments {
+			return nil, ErrProjectNotFound
+		}
+		return nil, result.Err()
 	}
 	projectResult := &apimodels.ExpandedProject{}
 	err = result.Decode(projectResult)

--- a/shipyard-controller/db/mongodb_project_repo_test.go
+++ b/shipyard-controller/db/mongodb_project_repo_test.go
@@ -1,0 +1,77 @@
+package db
+
+import (
+	"fmt"
+	apimodels "github.com/keptn/go-utils/pkg/api/models"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestMongoDBProjectsRepo_InsertAndRetrieve(t *testing.T) {
+	r := NewMongoDBProjectsRepo(GetMongoDBConnectionInstance())
+
+	err := r.CreateProject(&apimodels.ExpandedProject{
+		ProjectName: "my-project",
+	})
+
+	require.Nil(t, err)
+
+	prj, err := r.GetProject("my-project")
+
+	require.Nil(t, err)
+	require.NotNil(t, prj)
+
+	err = r.DeleteProject("my-project")
+	require.Nil(t, err)
+
+	prj, err = r.GetProject("my-project")
+
+	require.ErrorIs(t, err, ErrProjectNotFound)
+	require.Nil(t, prj)
+}
+
+func TestMongoDBProjectsRepo_InsertAndRetrieveMultiple(t *testing.T) {
+	r := NewMongoDBProjectsRepo(GetMongoDBConnectionInstance())
+
+	nrProjects := 5
+
+	for i := 0; i < nrProjects; i++ {
+		projectName := fmt.Sprintf("project-%d", i)
+		err := r.CreateProject(&apimodels.ExpandedProject{
+			ProjectName: projectName,
+		})
+
+		require.Nil(t, err)
+	}
+
+	prj, err := r.GetProjects()
+
+	require.Nil(t, err)
+	require.NotNil(t, prj)
+	require.Len(t, prj, 5)
+}
+
+func TestMongoDBProjectsRepo_UpdateProject(t *testing.T) {
+	r := NewMongoDBProjectsRepo(GetMongoDBConnectionInstance())
+
+	err := r.CreateProject(&apimodels.ExpandedProject{
+		ProjectName: "my-project",
+	})
+
+	require.Nil(t, err)
+
+	updatedProject := &apimodels.ExpandedProject{
+		ProjectName: "my-project",
+		Shipyard:    "shipyard-content",
+	}
+	err = r.UpdateProject(updatedProject)
+
+	require.Nil(t, err)
+
+	prj, err := r.GetProject("my-project")
+
+	require.Nil(t, err)
+	require.NotNil(t, prj)
+
+	require.Equal(t, updatedProject, prj)
+}

--- a/shipyard-controller/handler/projectmanager.go
+++ b/shipyard-controller/handler/projectmanager.go
@@ -86,7 +86,7 @@ func (pm *ProjectManager) GetByName(projectName string) (*apimodels.ExpandedProj
 func (pm *ProjectManager) Create(params *models.CreateProjectParams) (error, common.RollbackFunc) {
 
 	if err := pm.checkForExistingProject(params); err != nil {
-		return err, nilRollback
+		return fmt.Errorf("could not create project '%s': %w", *params.Name, err), nilRollback
 	}
 
 	err := pm.updateGITRepositorySecret(*params.Name, decodeGitCredentials(params.GitCredentials))
@@ -165,7 +165,7 @@ func (pm *ProjectManager) checkForExistingProject(params *models.CreateProjectPa
 	existingProject, err := pm.ProjectMaterializedView.GetProject(*params.Name)
 	if err != nil && err != db.ErrProjectNotFound {
 		log.Errorf("Error occurred while getting project: %s", err.Error())
-		return fmt.Errorf("failed to get project: '%s'", *params.Name)
+		return fmt.Errorf("failed to get information for project '%s'", *params.Name)
 	}
 	if existingProject != nil {
 		return ErrProjectAlreadyExists

--- a/shipyard-controller/handler/projectmanager.go
+++ b/shipyard-controller/handler/projectmanager.go
@@ -86,7 +86,7 @@ func (pm *ProjectManager) GetByName(projectName string) (*apimodels.ExpandedProj
 func (pm *ProjectManager) Create(params *models.CreateProjectParams) (error, common.RollbackFunc) {
 
 	existingProject, err := pm.ProjectMaterializedView.GetProject(*params.Name)
-	if err != nil {
+	if err != nil && err != db.ErrProjectNotFound {
 		log.Errorf("Error occurred while getting project: %s", err.Error())
 		return fmt.Errorf("failed to get project: '%s'", *params.Name), nilRollback
 	}

--- a/shipyard-controller/handler/projectmanager.go
+++ b/shipyard-controller/handler/projectmanager.go
@@ -165,7 +165,7 @@ func (pm *ProjectManager) checkForExistingProject(params *models.CreateProjectPa
 	existingProject, err := pm.ProjectMaterializedView.GetProject(*params.Name)
 	if err != nil && err != db.ErrProjectNotFound {
 		log.Errorf("Error occurred while getting project: %s", err.Error())
-		return fmt.Errorf("failed to get information for project '%s'", *params.Name)
+		return fmt.Errorf("failed to get information for project '%s': %w", *params.Name, err)
 	}
 	if existingProject != nil {
 		return ErrProjectAlreadyExists


### PR DESCRIPTION
Closes #8242

Note: The section of the shipyard retriever mentioned in the bug ticket now can rely on the project not being nil in case no error is returned by `projectRepo.GetProject()`.  Previously this returned `nil, nil`, which caused the nil pointer access shipyard retriever