### PR TITLE
test(bridge): Fix flaky UI test in project-delete.spec

### DIFF
--- a/bridge/client/app/_components/ktb-danger-zone/ktb-danger-zone.component.html
+++ b/bridge/client/app/_components/ktb-danger-zone/ktb-danger-zone.component.html
@@ -4,7 +4,14 @@
     <h4 class="pt-0 mt-0">Delete {{ data.type }}</h4>
     <div fxLayout="row" fxLayoutAlign="space-between center">
       <span>Once deleted, it will be gone forever. Please be certain.</span>
-      <button dt-button class="danger-button" (click)="openDeletionDialog()">Delete this {{ data.type }}</button>
+      <button
+        dt-button
+        class="danger-button"
+        (click)="openDeletionDialog()"
+        [attr.uitestid]="'ktb-danger-' + data.type + '-button'"
+      >
+        Delete this {{ data.type }}
+      </button>
     </div>
   </div>
 </ng-container>

--- a/bridge/cypress/support/pageobjects/ProjectSettingsPage.ts
+++ b/bridge/cypress/support/pageobjects/ProjectSettingsPage.ts
@@ -456,7 +456,7 @@ class ProjectSettingsPage {
   }
 
   public clickDeleteProjectButton(): this {
-    cy.get('span.dt-button-label').contains('Delete this project').click();
+    cy.byTestId('ktb-danger-project-button').click();
     return this;
   }
 


### PR DESCRIPTION
Sometimes Cypress failed to get the delete-button.
My guess is when `cy.get(...).contains(...)` fetched the elements, the danger zone was not rendered yet.
I introduced a `uitestid` for the delete button, then cypress will look/wait for exactly this one.

![Project delete test -- should delete project and redirect to dashboard (failed)](https://user-images.githubusercontent.com/11599148/177124296-a9ac7a4f-ef81-42a1-b88a-5efdcfc8c03c.png)

Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>