### PR TITLE
chore: Update go utils refs

### DIFF
--- a/remediation-service/go.mod
+++ b/remediation-service/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/ghodss/yaml v1.0.0
-	github.com/keptn/go-utils v0.16.1-0.20220628071524-fc5b6f967e50
+	github.com/keptn/go-utils v0.16.1-0.20220704125708-1c3b8fd8f1c3
 	github.com/sirupsen/logrus v1.8.1
 )
 

--- a/remediation-service/go.sum
+++ b/remediation-service/go.sum
@@ -133,8 +133,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
-github.com/keptn/go-utils v0.16.1-0.20220628071524-fc5b6f967e50 h1:G+gUkBup8pi5Mwg8il8ndr1csnYNenzgSpo/JfY1zJE=
-github.com/keptn/go-utils v0.16.1-0.20220628071524-fc5b6f967e50/go.mod h1:EPhgzrqJYbHzK8qbWDDKihWeRJKIkVGR7vi+jaAPftw=
+github.com/keptn/go-utils v0.16.1-0.20220704125708-1c3b8fd8f1c3 h1:e4l7rT1fKpH1gSj0BYLiAlvNt28WSva1Tv1mCMaW9Ek=
+github.com/keptn/go-utils v0.16.1-0.20220704125708-1c3b8fd8f1c3/go.mod h1:EPhgzrqJYbHzK8qbWDDKihWeRJKIkVGR7vi+jaAPftw=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.14.4 h1:eijASRJcobkVtSt81Olfh7JX43osYLwy5krOJo6YEu4=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/remediation-service/main.go
+++ b/remediation-service/main.go
@@ -29,6 +29,6 @@ func main() {
 		sdk.WithTaskHandler(
 			getActionTriggeredEventType,
 			handler.NewGetActionEventHandler()),
-		sdk.WithLogger(logrus.New()),
+		sdk.WithLogger(logrus.StandardLogger()),
 	).Start())
 }

--- a/webhook-service/go.mod
+++ b/webhook-service/go.mod
@@ -3,7 +3,7 @@ module github.com/keptn/keptn/webhook-service
 go 1.18
 
 require (
-	github.com/keptn/go-utils v0.16.1-0.20220628071524-fc5b6f967e50
+	github.com/keptn/go-utils v0.16.1-0.20220704125708-1c3b8fd8f1c3
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.5

--- a/webhook-service/go.sum
+++ b/webhook-service/go.sum
@@ -176,8 +176,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
-github.com/keptn/go-utils v0.16.1-0.20220628071524-fc5b6f967e50 h1:G+gUkBup8pi5Mwg8il8ndr1csnYNenzgSpo/JfY1zJE=
-github.com/keptn/go-utils v0.16.1-0.20220628071524-fc5b6f967e50/go.mod h1:EPhgzrqJYbHzK8qbWDDKihWeRJKIkVGR7vi+jaAPftw=
+github.com/keptn/go-utils v0.16.1-0.20220704125708-1c3b8fd8f1c3 h1:e4l7rT1fKpH1gSj0BYLiAlvNt28WSva1Tv1mCMaW9Ek=
+github.com/keptn/go-utils v0.16.1-0.20220704125708-1c3b8fd8f1c3/go.mod h1:EPhgzrqJYbHzK8qbWDDKihWeRJKIkVGR7vi+jaAPftw=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.14.4 h1:eijASRJcobkVtSt81Olfh7JX43osYLwy5krOJo6YEu4=

--- a/webhook-service/main.go
+++ b/webhook-service/main.go
@@ -46,7 +46,7 @@ func main() {
 			taskHandler,
 		),
 		sdk.WithAutomaticResponse(false),
-		sdk.WithLogger(log.New()),
+		sdk.WithLogger(log.StandardLogger()),
 	).Start())
 }
 


### PR DESCRIPTION
this PR updates go utils in webhook service and remmediation service to include changes from this PR: https://github.com/keptn/go-utils/pull/494
Also, the global standard instance of the logrus logger instead of a new one is passed to the sdk 