### PR TITLE
fix(bridge): Settings view overflow problem

### DIFF
--- a/bridge/client/app/_views/ktb-settings-view/ktb-settings-view.component.html
+++ b/bridge/client/app/_views/ktb-settings-view/ktb-settings-view.component.html
@@ -1,5 +1,5 @@
 <div fxFlexFill>
-  <div fxFlex fxLayout="row">
+  <div fxFlex fxLayout="row" id="settings-view-flex-row">
     <dt-menu class="submenu" aria-label="Keptn Settings Submenu" fxFlex="0 0 200px">
       <dt-menu-group label="Project configuration">
         <button dtMenuItem aria-label="Open project settings" routerLinkActive="active" routerLink="project">
@@ -37,7 +37,7 @@
         </button>
       </dt-menu-group>
     </dt-menu>
-    <div fxFlex>
+    <div fxFlex="calc(100%-200px)">
       <router-outlet></router-outlet>
     </div>
   </div>

--- a/bridge/client/app/_views/ktb-settings-view/ktb-settings-view.component.scss
+++ b/bridge/client/app/_views/ktb-settings-view/ktb-settings-view.component.scss
@@ -6,3 +6,7 @@
     margin-right: -17px;
   }
 }
+
+#settings-view-flex-row {
+  width: 100%;
+}


### PR DESCRIPTION
## This PR

- Fixes problem where a code block would be bigger than the screen (move outside the screen)

### Related Issues

Fixes #8278

### Notes

`ffFlex` change for `dt-menu` is now identical to other `dt-menu` inside `project-board.component.html`

https://github.com/keptn/keptn/blob/7a17271df64f3fb4947c6147a22ace3e29d16918/bridge/client/app/project-board/project-board.component.html#L66-L68

4k:
![overflow-fix-4k](https://user-images.githubusercontent.com/36239763/177173371-24846977-40cf-4cb9-a85b-6c8aebc473bc.png)

1080p:
![overflow-fix-1080p](https://user-images.githubusercontent.com/36239763/177173384-06325ff5-3cb6-47ed-b587-4b36c4e774fe.png)

Additionally the resizing of the settings-view improved in general:

Before:
![resizing-before](https://user-images.githubusercontent.com/36239763/177173600-89974429-76db-4cbb-af6e-1c1de2757091.png)

Now:
![resizing-after](https://user-images.githubusercontent.com/36239763/177173725-d78d29fa-48ba-456d-ae7c-551a4a232672.png)

Signed-off-by: TannerGilbert <gilberttanner.work@gmail.com>