### PR TITLE
chore: Use logrus StandardLogger in webhook and remediation service

### DIFF
--- a/remediation-service/main.go
+++ b/remediation-service/main.go
@@ -29,6 +29,6 @@ func main() {
 		sdk.WithTaskHandler(
 			getActionTriggeredEventType,
 			handler.NewGetActionEventHandler()),
-		sdk.WithLogger(logrus.New()),
+		sdk.WithLogger(logrus.StandardLogger()),
 	).Start())
 }

--- a/webhook-service/main.go
+++ b/webhook-service/main.go
@@ -46,7 +46,7 @@ func main() {
 			taskHandler,
 		),
 		sdk.WithAutomaticResponse(false),
-		sdk.WithLogger(log.New()),
+		sdk.WithLogger(log.StandardLogger()),
 	).Start())
 }
 


### PR DESCRIPTION
This PR contains changes to pass the logrus StandardLogger instead of a new one to go-sdk so that changing the log level via `log.SetLevel` has an effect.