### PR TITLE
test(bridge): Remove not needed and flaky UI test

### DIFF
--- a/bridge/cypress/integration/project-settings.spec.ts
+++ b/bridge/cypress/integration/project-settings.spec.ts
@@ -37,34 +37,6 @@ describe('Git upstream extended settings project https test', () => {
       .assertHttpsFormExists(false);
   });
 
-  it('should show "Git upstream repository" headline only once', () => {
-    const project: IProject = {
-      projectName: 'sockshop',
-      stages: [],
-      gitCredentials: {
-        user: 'myGitUser',
-        remoteURL: 'https://myGitURL.com',
-        https: {
-          token: '',
-          insecureSkipTLS: true,
-          proxy: {
-            scheme: 'https',
-            url: 'myProxyUrl:5000',
-            user: 'myProxyUser',
-          },
-        },
-      },
-      shipyardVersion: '0.14',
-      creationDate: '',
-      shipyard: '',
-    };
-    projectSettingsPage
-      .interceptSettings(true)
-      .interceptProject(project)
-      .visitSettings('sockshop')
-      .assertGitUpstreamHeadlineExistsOnce();
-  });
-
   it('should select HTTPS and fill out inputs', () => {
     const project: IProject = {
       projectName: 'sockshop',

--- a/bridge/cypress/support/pageobjects/ProjectSettingsPage.ts
+++ b/bridge/cypress/support/pageobjects/ProjectSettingsPage.ts
@@ -370,11 +370,6 @@ class ProjectSettingsPage {
     return this;
   }
 
-  public assertGitUpstreamHeadlineExistsOnce(): this {
-    cy.get('ktb-project-settings').find('h2').filter(':contains("Git upstream repository")').should('have.length', 1);
-    return this;
-  }
-
   public assertSshFormExists(status: boolean): this {
     cy.get('ktb-project-settings-git-ssh').should(status ? 'exist' : 'not.exist');
     return this;


### PR DESCRIPTION
A UI test failed that a certain HTML element could not be found, even though the screenshot showed that the element is here. We don't really need this test anyway so I removed it.

Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>