### PR TITLE
fix(installer): Fix Nginx not starting when statistics service is disabled

### DIFF
--- a/installer/manifests/keptn/templates/api-gateway-nginx.yaml
+++ b/installer/manifests/keptn/templates/api-gateway-nginx.yaml
@@ -225,7 +225,7 @@ data:
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
     }
-
+{{- if .Values.statisticsService.enabled }}
     location {{ .Values.prefixPath }}/api/statistics/swagger-ui/swagger.yaml {
       # auth via backend (if the subrequest returns a 2xx response code, the access is allowed. If it returns 401 or 403,
       # the access is denied) before we store the file
@@ -261,7 +261,7 @@ data:
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
     }
-
+{{- end }}
     location {{ .Values.prefixPath }}/api/configuration-service/swagger-ui/swagger.yaml {
       # auth via backend (if the subrequest returns a 2xx response code, the access is allowed. If it returns 401 or 403,
       # the access is denied) before we store the file

--- a/installer/manifests/keptn/values.yaml
+++ b/installer/manifests/keptn/values.yaml
@@ -365,7 +365,7 @@ lighthouseService:
       cpu: "200m"
 
 statisticsService:
-  enabled: false
+  enabled: true
   image:
     repository: docker.io/keptn/statistics-service
     tag: ""


### PR DESCRIPTION
PR to fix problems with having statistics service disabled via the helm chart