### PR TITLE
fix(webhook-service): Do not respond to anything else than .triggered event on pre execution error

### DIFF
--- a/webhook-service/handler/handler.go
+++ b/webhook-service/handler/handler.go
@@ -100,6 +100,10 @@ func (th *TaskHandler) Execute(keptnHandler sdk.IKeptn, event sdk.KeptnEvent) (i
 }
 
 func (th *TaskHandler) onPreExecutionError(keptnHandler sdk.IKeptn, event sdk.KeptnEvent, eventAdapter *lib.EventDataAdapter, err error) (interface{}, *sdk.Error) {
+	// only send .started events for <task>.triggered events
+	if !keptnv2.IsTaskEventType(*event.Type) || !keptnv2.IsTriggeredEventType(*event.Type) {
+		return nil, sdkError(err.Error(), err)
+	}
 	// in this case, send .started and .finished event immediately
 	if err := keptnHandler.SendStartedEvent(event); err != nil {
 		// log the error but continue - we need to try to send the .finished event nevertheless

--- a/webhook-service/handler/handler_test.go
+++ b/webhook-service/handler/handler_test.go
@@ -587,6 +587,27 @@ func TestTaskHandler_Execute_WebhookCannotBeRetrieved(t *testing.T) {
 
 }
 
+func TestTaskHandler_Execute_NotATriggeredEventWebhookCannotBeRetrieved(t *testing.T) {
+	templateEngineMock := &fake.ITemplateEngineMock{}
+	secretReaderMock := &fake.ISecretReaderMock{}
+	curlExecutorMock := &fake.ICurlExecutorMock{}
+	requestValidatorMock := &fake.RequestValidatorMock{}
+
+	taskHandler := handler.NewTaskHandler(templateEngineMock, curlExecutorMock, requestValidatorMock, secretReaderMock)
+
+	fakeKeptn := sdk.NewFakeKeptn(
+		"test-webhook-svc")
+	fakeKeptn.SetResourceHandler(sdk.FailingResourceHandler{})
+	fakeKeptn.AddTaskHandlerWithSubscriptionID("sh.keptn.event.webhook.finished", taskHandler, "my-subscription-id")
+	fakeKeptn.SetAutomaticResponse(false)
+
+	fakeKeptn.NewEvent(newWebhookTriggeredEvent("test/events/test-webhook.finished.json"))
+
+	//verify sent events
+	fakeKeptn.AssertNumberOfEventSent(t, 0)
+
+}
+
 func TestTaskHandler_Execute_NoSubscriptionIDInEvent(t *testing.T) {
 	templateEngineMock := &fake.ITemplateEngineMock{}
 	secretReaderMock := &fake.ISecretReaderMock{}


### PR DESCRIPTION
Closes #8334

This fixes a bug due to which the webhook service was responding with a `started` event if something went wrong with the retrieval of the webhook config (e.g. if the project has. been deleted at the point where the service received the event).