### PR TITLE
feat(api): Add create-secret api action to import endpoint

### DIFF
--- a/api/deploy/service.yaml
+++ b/api/deploy/service.yaml
@@ -37,6 +37,8 @@ spec:
               value: mongodb-datastore:8080
             - name: CONTROLPLANE_URI
               value: shipyard-controller:8080
+            - name: SECRET_SERVICE_URI
+              value: secret-service:8080
             - name: IMPORT_BASE_PATH
               value: "/data/import-scratch"
             - name: SECRET_TOKEN

--- a/api/importer/execute/default_api.go
+++ b/api/importer/execute/default_api.go
@@ -34,23 +34,6 @@ type requestFactory interface {
 	CreateRequest(tCtx model.TaskContext, host string, body io.Reader) (*http.Request, error)
 }
 
-type noRenderRequestFactory struct {
-	httpMethod string
-	path       string
-}
-
-func (dr *noRenderRequestFactory) CreateRequest(
-	tCtx model.TaskContext, host string, body io.Reader,
-) (*http.Request, error) {
-	req, err := http.NewRequest(dr.httpMethod, host+dr.path, body)
-
-	if err != nil {
-		return nil, fmt.Errorf("error composing request for api call %s: %w", tCtx.Task.ID, err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	return req, nil
-}
-
 type projectRenderRequestFactory struct {
 	httpMethod string
 	path       string

--- a/api/importer/execute/default_api.go
+++ b/api/importer/execute/default_api.go
@@ -34,6 +34,23 @@ type requestFactory interface {
 	CreateRequest(tCtx model.TaskContext, host string, body io.Reader) (*http.Request, error)
 }
 
+type noRenderRequestFactory struct {
+	httpMethod string
+	path       string
+}
+
+func (dr *noRenderRequestFactory) CreateRequest(
+	tCtx model.TaskContext, host string, body io.Reader,
+) (*http.Request, error) {
+	req, err := http.NewRequest(dr.httpMethod, host+dr.path, body)
+
+	if err != nil {
+		return nil, fmt.Errorf("error composing request for api call %s: %w", tCtx.Task.ID, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return req, nil
+}
+
 type projectRenderRequestFactory struct {
 	httpMethod string
 	path       string
@@ -104,7 +121,7 @@ func (ep *defaultEndpointHandler) ExecuteAPI(doer httpdoer, ate model.APITaskExe
 	}
 
 	return responseBody, fmt.Errorf(
-		"received unsuccessful http status <%d: %s>:%w", response.StatusCode,
+		"received unsuccessful http status <%d: %s>: %w", response.StatusCode,
 		response.Status, ErrTaskFailed,
 	)
 }

--- a/api/importer/execute/default_api_test.go
+++ b/api/importer/execute/default_api_test.go
@@ -663,6 +663,8 @@ func Test_noRenderRequestFactory_CreateRequest(t *testing.T) {
 					if tt.errorContains != "" {
 						assert.ErrorContains(t, err, tt.errorContains)
 					}
+				} else {
+					assert.NoError(t, err)
 				}
 			},
 		)

--- a/api/importer/execute/executor.go
+++ b/api/importer/execute/executor.go
@@ -62,7 +62,7 @@ func (kae *KeptnAPIExecutor) registerEndpoints(kep KeptnEndpointProvider) {
 	}
 
 	kae.endpointMappings["keptn-api-v1-uniform-create-secret"] = &defaultEndpointHandler{
-		requestFactory: &noRenderRequestFactory{
+		requestFactory: &projectRenderRequestFactory{
 			httpMethod: http.MethodPost,
 			path:       "/v1/secret",
 		},

--- a/api/importer/execute/executor.go
+++ b/api/importer/execute/executor.go
@@ -28,8 +28,12 @@ type KeptnAPIExecutor struct {
 type KeptnControlPlaneEndpointProvider interface {
 	GetControlPlaneEndpoint() string
 }
+type KeptnSecretsEndpointProvider interface {
+	GetSecretsServiceEndpoint() string
+}
 type KeptnEndpointProvider interface {
 	KeptnControlPlaneEndpointProvider
+	KeptnSecretsEndpointProvider
 }
 
 func NewKeptnExecutor(kep KeptnEndpointProvider) *KeptnAPIExecutor {
@@ -55,6 +59,14 @@ func (kae *KeptnAPIExecutor) registerEndpoints(kep KeptnEndpointProvider) {
 			path:       `/v1/project/[[project]]/service`,
 		},
 		endpoint: kep.GetControlPlaneEndpoint(),
+	}
+
+	kae.endpointMappings["keptn-api-v1-uniform-create-secret"] = &defaultEndpointHandler{
+		requestFactory: &noRenderRequestFactory{
+			httpMethod: http.MethodPost,
+			path:       "/v1/secret",
+		},
+		endpoint: kep.GetSecretsServiceEndpoint(),
 	}
 }
 

--- a/api/importer/execute/fake/executor_mock.go
+++ b/api/importer/execute/fake/executor_mock.go
@@ -17,6 +17,9 @@ import (
 // 			GetControlPlaneEndpointFunc: func() string {
 // 				panic("mock out the GetControlPlaneEndpoint method")
 // 			},
+// 			GetSecretsServiceEndpointFunc: func() string {
+// 				panic("mock out the GetSecretsServiceEndpoint method")
+// 			},
 // 		}
 //
 // 		// use mockedKeptnEndpointProvider in code that requires execute.KeptnEndpointProvider
@@ -27,13 +30,20 @@ type KeptnEndpointProviderMock struct {
 	// GetControlPlaneEndpointFunc mocks the GetControlPlaneEndpoint method.
 	GetControlPlaneEndpointFunc func() string
 
+	// GetSecretsServiceEndpointFunc mocks the GetSecretsServiceEndpoint method.
+	GetSecretsServiceEndpointFunc func() string
+
 	// calls tracks calls to the methods.
 	calls struct {
 		// GetControlPlaneEndpoint holds details about calls to the GetControlPlaneEndpoint method.
 		GetControlPlaneEndpoint []struct {
 		}
+		// GetSecretsServiceEndpoint holds details about calls to the GetSecretsServiceEndpoint method.
+		GetSecretsServiceEndpoint []struct {
+		}
 	}
-	lockGetControlPlaneEndpoint sync.RWMutex
+	lockGetControlPlaneEndpoint   sync.RWMutex
+	lockGetSecretsServiceEndpoint sync.RWMutex
 }
 
 // GetControlPlaneEndpoint calls GetControlPlaneEndpointFunc.
@@ -59,6 +69,32 @@ func (mock *KeptnEndpointProviderMock) GetControlPlaneEndpointCalls() []struct {
 	mock.lockGetControlPlaneEndpoint.RLock()
 	calls = mock.calls.GetControlPlaneEndpoint
 	mock.lockGetControlPlaneEndpoint.RUnlock()
+	return calls
+}
+
+// GetSecretsServiceEndpoint calls GetSecretsServiceEndpointFunc.
+func (mock *KeptnEndpointProviderMock) GetSecretsServiceEndpoint() string {
+	if mock.GetSecretsServiceEndpointFunc == nil {
+		panic("KeptnEndpointProviderMock.GetSecretsServiceEndpointFunc: method is nil but KeptnEndpointProvider.GetSecretsServiceEndpoint was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockGetSecretsServiceEndpoint.Lock()
+	mock.calls.GetSecretsServiceEndpoint = append(mock.calls.GetSecretsServiceEndpoint, callInfo)
+	mock.lockGetSecretsServiceEndpoint.Unlock()
+	return mock.GetSecretsServiceEndpointFunc()
+}
+
+// GetSecretsServiceEndpointCalls gets all the calls that were made to GetSecretsServiceEndpoint.
+// Check the length with:
+//     len(mockedKeptnEndpointProvider.GetSecretsServiceEndpointCalls())
+func (mock *KeptnEndpointProviderMock) GetSecretsServiceEndpointCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockGetSecretsServiceEndpoint.RLock()
+	calls = mock.calls.GetSecretsServiceEndpoint
+	mock.lockGetSecretsServiceEndpoint.RUnlock()
 	return calls
 }
 

--- a/api/importer/execute/keptn_endpoints.go
+++ b/api/importer/execute/keptn_endpoints.go
@@ -18,11 +18,6 @@ func (_ StaticKeptnEndpointProvider) GetControlPlaneEndpoint() string {
 	return utils.SanitizeURL(defaultControlPlaneEndpoint)
 }
 
-// GetSecretsServiceEndpoint returns the default secrets service endpoint
-func (_ StaticKeptnEndpointProvider) GetSecretsServiceEndpoint() string {
-	return utils.SanitizeURL(defaultSecretServiceEndpoint)
-}
-
 type configurableKeptnEndpointProvider struct {
 	controlPlane  string
 	secretService string

--- a/api/importer/execute/keptn_endpoints.go
+++ b/api/importer/execute/keptn_endpoints.go
@@ -7,6 +7,7 @@ import (
 )
 
 const defaultControlPlaneEndpoint = "http://shipyard-controller:8080"
+const defaultSecretServiceEndpoint = "http://secret-service:8080"
 
 // StaticKeptnEndpointProvider is a completely static implementation of the KeptnEndpointProvider interface.
 // This is meant to be used when we are running in the same namespace as the other keptn services
@@ -17,8 +18,14 @@ func (_ StaticKeptnEndpointProvider) GetControlPlaneEndpoint() string {
 	return utils.SanitizeURL(defaultControlPlaneEndpoint)
 }
 
+// GetSecretsServiceEndpoint returns the default secrets service endpoint
+func (_ StaticKeptnEndpointProvider) GetSecretsServiceEndpoint() string {
+	return utils.SanitizeURL(defaultSecretServiceEndpoint)
+}
+
 type configurableKeptnEndpointProvider struct {
-	controlPlane string
+	controlPlane  string
+	secretService string
 }
 
 func getEnvVariablewithDefault(envVarName string, defaultValue string) string {
@@ -32,10 +39,17 @@ func getEnvVariablewithDefault(envVarName string, defaultValue string) string {
 func KeptnEndpointProviderFromEnv() *configurableKeptnEndpointProvider {
 
 	const controlPlaneServiceEnvVar = "CONTROLPLANE_URI"
+	const secretServiceEnvVar = "SECRET_SERVICE_URI"
+
 	kep := new(configurableKeptnEndpointProvider)
 	kep.controlPlane = utils.SanitizeURL(
 		getEnvVariablewithDefault(
 			controlPlaneServiceEnvVar, defaultControlPlaneEndpoint,
+		),
+	)
+	kep.secretService = utils.SanitizeURL(
+		getEnvVariablewithDefault(
+			secretServiceEnvVar, defaultSecretServiceEndpoint,
 		),
 	)
 
@@ -44,4 +58,8 @@ func KeptnEndpointProviderFromEnv() *configurableKeptnEndpointProvider {
 
 func (kep *configurableKeptnEndpointProvider) GetControlPlaneEndpoint() string {
 	return kep.controlPlane
+}
+
+func (kep *configurableKeptnEndpointProvider) GetSecretsServiceEndpoint() string {
+	return kep.secretService
 }

--- a/api/importer/execute/keptn_endpoints_test.go
+++ b/api/importer/execute/keptn_endpoints_test.go
@@ -52,35 +52,43 @@ func TestGetEnvVariablewithDefault(t *testing.T) {
 
 func TestKeptnEndpointProviderFromEnv(t *testing.T) {
 	tests := []struct {
-		name                         string
-		env                          map[string]string
-		expectedControlPlaneEndpoint string
+		name                          string
+		env                           map[string]string
+		expectedControlPlaneEndpoint  string
+		expectedSecretServiceEndpoint string
 	}{
 		{
-			name:                         "No Env setup - get default value",
-			env:                          map[string]string{},
-			expectedControlPlaneEndpoint: defaultControlPlaneEndpoint,
+			name:                          "No Env setup - get default value",
+			env:                           map[string]string{},
+			expectedControlPlaneEndpoint:  defaultControlPlaneEndpoint,
+			expectedSecretServiceEndpoint: defaultSecretServiceEndpoint,
 		},
 		{
 			name: "Set custom control plane without scheme",
 			env: map[string]string{
-				"CONTROLPLANE_URI": "somehost:1234",
+				"CONTROLPLANE_URI":   "somehost:1234",
+				"SECRET_SERVICE_URI": "verysecret.host:9876",
 			},
-			expectedControlPlaneEndpoint: "http://somehost:1234",
+			expectedControlPlaneEndpoint:  "http://somehost:1234",
+			expectedSecretServiceEndpoint: "http://verysecret.host:9876",
 		},
 		{
 			name: "Set custom control plane with http scheme",
 			env: map[string]string{
-				"CONTROLPLANE_URI": "http://somehost:1234",
+				"CONTROLPLANE_URI":   "http://somehost:1234",
+				"SECRET_SERVICE_URI": "http://verysecret.host:9876",
 			},
-			expectedControlPlaneEndpoint: "http://somehost:1234",
+			expectedControlPlaneEndpoint:  "http://somehost:1234",
+			expectedSecretServiceEndpoint: "http://verysecret.host:9876",
 		},
 		{
 			name: "Set custom control plane with https scheme",
 			env: map[string]string{
-				"CONTROLPLANE_URI": "https://somehost:1234",
+				"CONTROLPLANE_URI":   "https://somehost:1234",
+				"SECRET_SERVICE_URI": "https://verysecret.host:9876",
 			},
-			expectedControlPlaneEndpoint: "https://somehost:1234",
+			expectedControlPlaneEndpoint:  "https://somehost:1234",
+			expectedSecretServiceEndpoint: "https://verysecret.host:9876",
 		},
 	}
 	for _, tt := range tests {
@@ -91,6 +99,7 @@ func TestKeptnEndpointProviderFromEnv(t *testing.T) {
 				}
 				sut := KeptnEndpointProviderFromEnv()
 				assert.Equal(t, tt.expectedControlPlaneEndpoint, sut.GetControlPlaneEndpoint())
+				assert.Equal(t, tt.expectedSecretServiceEndpoint, sut.GetSecretsServiceEndpoint())
 			},
 		)
 	}

--- a/installer/manifests/keptn/templates/api-service.yaml
+++ b/installer/manifests/keptn/templates/api-service.yaml
@@ -48,6 +48,8 @@ spec:
               value: mongodb-datastore:8080
             - name: CONTROLPLANE_URI
               value: shipyard-controller:8080
+            - name: SECRET_SERVICE_URI
+              value: secret-service:8080
             - name: IMPORT_BASE_PATH
               value: "/data/import-scratch"
             - name: SECRET_TOKEN


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- adds the `create-secret` API action to the import endpoint
