### PR TITLE
test: use `T.Setenv` to set env vars in tests

### DIFF
--- a/api/handlers/event_test.go
+++ b/api/handlers/event_test.go
@@ -2,6 +2,11 @@ package handlers
 
 import (
 	"errors"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
 	apimodels "github.com/keptn/go-utils/pkg/api/models"
@@ -10,11 +15,6 @@ import (
 	natstest "github.com/nats-io/nats-server/v2/test"
 	nats2 "github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/require"
-	"io"
-	"net/http"
-	"os"
-	"testing"
-	"time"
 
 	"github.com/keptn/keptn/api/models"
 	"github.com/keptn/keptn/api/restapi/operations/event"
@@ -98,8 +98,7 @@ func TestPostEventHandlerFunc(t *testing.T) {
 
 	defer shutdown()
 
-	err := os.Setenv("NATS_URL", natsServer.ClientURL())
-	require.NoError(t, err)
+	t.Setenv("NATS_URL", natsServer.ClientURL())
 
 	natsClient, err := nats2.Connect(natsServer.ClientURL())
 	require.Nil(t, err)
@@ -196,8 +195,7 @@ func Test_getDatastoreURL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := os.Setenv("DATASTORE_URI", tt.datastoreURLEnv)
-			require.NoError(t, err)
+			t.Setenv("DATASTORE_URI", tt.datastoreURLEnv)
 
 			require.Equal(t, tt.want, utils.GetDatastoreURL())
 		})

--- a/api/handlers/metadata_test.go
+++ b/api/handlers/metadata_test.go
@@ -46,8 +46,7 @@ func TestGetMetadataHandlerFunc(t *testing.T) {
 		},
 	}
 
-	err := os.Setenv("SECRET_TOKEN", "testtesttesttesttest")
-	require.NoError(t, err)
+	t.Setenv("SECRET_TOKEN", "testtesttesttesttest")
 
 	returnedStatus := 200
 
@@ -60,8 +59,7 @@ func TestGetMetadataHandlerFunc(t *testing.T) {
 	)
 	defer ts.Close()
 
-	err = os.Setenv("EVENTBROKER_URI", ts.URL)
-	require.NoError(t, err)
+	t.Setenv("EVENTBROKER_URI", ts.URL)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -127,8 +125,7 @@ func Test_metadataHandler_getMetadata(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := os.Setenv("POD_NAMESPACE", "keptn")
-			require.NoError(t, err)
+			t.Setenv("POD_NAMESPACE", "keptn")
 
 			tmpSwaggerFileName := "tmp-swagger.yaml"
 

--- a/api/importer/execute/keptn_endpoints_test.go
+++ b/api/importer/execute/keptn_endpoints_test.go
@@ -1,7 +1,6 @@
 package execute
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,8 +11,8 @@ func TestGetEnvVariablewithDefault(t *testing.T) {
 	const envVar1Value = "VALUE_1"
 	const emptyVarName = "EMPTY_VAR"
 	const defaultValue1 = "MY_DEFAULT_1"
-	os.Setenv(envVar1Name, envVar1Value)
-	os.Setenv(emptyVarName, "")
+	t.Setenv(envVar1Name, envVar1Value)
+	t.Setenv(emptyVarName, "")
 	tests := []struct {
 		name          string
 		envVarName    string
@@ -83,14 +82,12 @@ func TestKeptnEndpointProviderFromEnv(t *testing.T) {
 			},
 			expectedControlPlaneEndpoint: "https://somehost:1234",
 		},
-
 	}
 	for _, tt := range tests {
 		t.Run(
 			tt.name, func(t *testing.T) {
-				os.Clearenv()
 				for k, v := range tt.env {
-					os.Setenv(k, v)
+					t.Setenv(k, v)
 				}
 				sut := KeptnEndpointProviderFromEnv()
 				assert.Equal(t, tt.expectedControlPlaneEndpoint, sut.GetControlPlaneEndpoint())

--- a/api/middleware/tokenauth_test.go
+++ b/api/middleware/tokenauth_test.go
@@ -1,10 +1,10 @@
 package middleware
 
 import (
-	"github.com/keptn/keptn/api/models"
-	"os"
 	"reflect"
 	"testing"
+
+	"github.com/keptn/keptn/api/models"
 )
 
 func TestValidateToken(t *testing.T) {
@@ -38,7 +38,7 @@ func TestValidateToken(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_ = os.Setenv("SECRET_TOKEN", tt.configuredToken)
+			t.Setenv("SECRET_TOKEN", tt.configuredToken)
 			tv := &BasicTokenValidator{}
 			got, err := tv.ValidateToken(tt.args.token)
 			if (err != nil) != tt.wantErr {

--- a/api/restapi/configure_keptn_test.go
+++ b/api/restapi/configure_keptn_test.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 
@@ -13,18 +12,12 @@ import (
 )
 
 func Test_getEnvConfig(t *testing.T) {
-	defer os.Unsetenv("MAX_AUTH_ENABLED")
-	defer os.Unsetenv("MAX_AUTH_REQUESTS_PER_SECOND")
-	defer os.Unsetenv("MAX_AUTH_REQUESTS_BURST")
-	defer os.Unsetenv("HIDE_DEPRECATED")
-	defer os.Unsetenv("OAUTH_ENABLED")
-	defer os.Unsetenv("OAUTH_PREFIX")
-	_ = os.Setenv("MAX_AUTH_ENABLED", "false")
-	_ = os.Setenv("MAX_AUTH_REQUESTS_PER_SECOND", "0.5")
-	_ = os.Setenv("MAX_AUTH_REQUESTS_BURST", "1")
-	_ = os.Setenv("HIDE_DEPRECATED", "true")
-	_ = os.Setenv("OAUTH_ENABLED", "true")
-	_ = os.Setenv("OAUTH_PREFIX", "prefix")
+	t.Setenv("MAX_AUTH_ENABLED", "false")
+	t.Setenv("MAX_AUTH_REQUESTS_PER_SECOND", "0.5")
+	t.Setenv("MAX_AUTH_REQUESTS_BURST", "1")
+	t.Setenv("HIDE_DEPRECATED", "true")
+	t.Setenv("OAUTH_ENABLED", "true")
+	t.Setenv("OAUTH_PREFIX", "prefix")
 
 	config, err := getEnvConfig()
 	require.Nil(t, err)

--- a/cli/cmd/add_resource_test.go
+++ b/cli/cmd/add_resource_test.go
@@ -16,8 +16,8 @@ func init() {
 	logging.InitLoggers(os.Stdout, os.Stdout, os.Stderr)
 }
 
-func setup() {
-	os.Setenv("MOCK_SERVER", "http://some-valid-url.com")
+func setup(t *testing.T) {
+	t.Setenv("MOCK_SERVER", "http://some-valid-url.com")
 	credentialmanager.MockAuthCreds = true
 
 	*addResourceCmdParams.AllStages = false
@@ -26,10 +26,6 @@ func setup() {
 	*addResourceCmdParams.Project = ""
 	*addResourceCmdParams.Resource = ""
 	*addResourceCmdParams.ResourceURI = ""
-}
-
-func teardown() {
-
 }
 
 // testResource writes a default file
@@ -51,8 +47,7 @@ func testResource(t *testing.T, fileName string, fileContent string) func() {
 // TestAddResourceToProjectStageService
 func TestAddResourceToProjectStageService(t *testing.T) {
 
-	setup()
-	defer teardown()
+	setup(t)
 
 	resourceFileName := "testResource.txt"
 	defer testResource(t, resourceFileName, "")()
@@ -68,8 +63,7 @@ func TestAddResourceToProjectStageService(t *testing.T) {
 // TestAddResourceToProjectStageAndAllStages tests that using --stage and --all-stages together doesn't work
 func TestAddResourceToProjectStageAndAllStages(t *testing.T) {
 
-	setup()
-	defer teardown()
+	setup(t)
 
 	resourceFileName := "testResource.txt"
 	defer testResource(t, resourceFileName, "")()
@@ -85,8 +79,7 @@ func TestAddResourceToProjectStageAndAllStages(t *testing.T) {
 // TestAddResourceToProjectAndStage tests that using --project and --stage (without --service) works
 func TestAddResourceToProjectAndStage(t *testing.T) {
 
-	setup()
-	defer teardown()
+	setup(t)
 
 	resourceFileName := "testResource.txt"
 	defer testResource(t, resourceFileName, "")()
@@ -102,8 +95,7 @@ func TestAddResourceToProjectAndStage(t *testing.T) {
 // TestAddResourceAllStagesWithoutService tests that using --all-stages without --service doesn't work
 func TestAddResourceAllStagesWithoutService(t *testing.T) {
 
-	setup()
-	defer teardown()
+	setup(t)
 
 	resourceFileName := "testResource.txt"
 	defer testResource(t, resourceFileName, "")()
@@ -119,8 +111,7 @@ func TestAddResourceAllStagesWithoutService(t *testing.T) {
 // TestAddResourceToProjectServiceAllStages tests that using --project, --service and --all-stages works
 func TestAddResourceToProjectServiceAllStages(t *testing.T) {
 
-	setup()
-	defer teardown()
+	setup(t)
 
 	resourceFileName := "testResource.txt"
 	defer testResource(t, resourceFileName, "")()
@@ -136,8 +127,7 @@ func TestAddResourceToProjectServiceAllStages(t *testing.T) {
 // TestAddResourceToProjectStage
 func TestAddResourceToProjectStage(t *testing.T) {
 
-	setup()
-	defer teardown()
+	setup(t)
 
 	resourceFileName := "testResource.txt"
 	defer testResource(t, resourceFileName, "")()
@@ -153,8 +143,7 @@ func TestAddResourceToProjectStage(t *testing.T) {
 // TestAddResourceToProject
 func TestAddResourceToProject(t *testing.T) {
 
-	setup()
-	defer teardown()
+	setup(t)
 
 	resourceFileName := "testResource.txt"
 	defer testResource(t, resourceFileName, "")()
@@ -170,8 +159,7 @@ func TestAddResourceToProject(t *testing.T) {
 // TestAddResourceToProjectService
 func TestAddResourceToProjectService(t *testing.T) {
 
-	setup()
-	defer teardown()
+	setup(t)
 
 	resourceFileName := "testResource.txt"
 	defer testResource(t, resourceFileName, "")()

--- a/cli/cmd/get_event_approvalTriggered_test.go
+++ b/cli/cmd/get_event_approvalTriggered_test.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 )
@@ -75,7 +74,7 @@ func Test_getApprovalTriggeredEvents(t *testing.T) {
 	)
 	defer ts.Close()
 
-	os.Setenv("MOCK_SERVER", ts.URL)
+	t.Setenv("MOCK_SERVER", ts.URL)
 
 	type args struct {
 		approvalTriggered approvalTriggeredStruct

--- a/cli/cmd/get_event_test.go
+++ b/cli/cmd/get_event_test.go
@@ -33,7 +33,7 @@ func TestGetTriggeredEvent(t *testing.T) {
 	)
 	defer ts.Close()
 
-	os.Setenv("MOCK_SERVER", ts.URL)
+	t.Setenv("MOCK_SERVER", ts.URL)
 
 	var numOfPages *int
 	numOfPages = new(int)

--- a/cli/cmd/root_test.go
+++ b/cli/cmd/root_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -17,6 +16,7 @@ import (
 	"github.com/keptn/keptn/cli/pkg/version"
 	"github.com/mattn/go-shellwords"
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
 )
 
 const unexpectedErrMsg = "unexpected error, got '%v'"
@@ -186,7 +186,7 @@ func Test_runVersionCheck(t *testing.T) {
 	}))
 
 	defer ts.Close()
-	os.Setenv("MOCK_SERVER", ts.URL)
+	t.Setenv("MOCK_SERVER", ts.URL)
 
 	tests := []struct {
 		name             string

--- a/cli/cmd/send_event_approvalFinished_test.go
+++ b/cli/cmd/send_event_approvalFinished_test.go
@@ -91,7 +91,7 @@ func Test_sendApprovalFinishedEvent(t *testing.T) {
 	)
 	defer ts.Close()
 
-	os.Setenv("MOCK_SERVER", ts.URL)
+	t.Setenv("MOCK_SERVER", ts.URL)
 
 	type args struct {
 		sendApprovalFinishedOptions sendApprovalFinishedStruct

--- a/cli/cmd/trigger_delivery_test.go
+++ b/cli/cmd/trigger_delivery_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -13,11 +12,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keptn/keptn/cli/pkg/credentialmanager"
-
 	apimodels "github.com/keptn/go-utils/pkg/api/models"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
+	"github.com/stretchr/testify/require"
 
+	"github.com/keptn/keptn/cli/pkg/credentialmanager"
 	"github.com/keptn/keptn/cli/pkg/logging"
 )
 
@@ -113,7 +112,7 @@ func TestTriggerDelivery(t *testing.T) {
 	)
 	defer ts.Close()
 
-	os.Setenv("MOCK_SERVER", ts.URL)
+	t.Setenv("MOCK_SERVER", ts.URL)
 
 	cmd := fmt.Sprintf("trigger delivery --project=%s --service=%s --stage=%s --sequence=%s "+
 		"--image=%s --values=a.b.c=d --mock --values=c.d=e", "sockshop", "carts", "dev", "artifact-delivery", "docker-registry:5000/keptnexamples/carts:0.9.1")
@@ -183,7 +182,7 @@ func TestTriggerDeliveryNoStageProvided(t *testing.T) {
 	)
 	defer ts.Close()
 
-	os.Setenv("MOCK_SERVER", ts.URL)
+	t.Setenv("MOCK_SERVER", ts.URL)
 
 	cmd := fmt.Sprintf("trigger delivery --project=%s --service=%s --sequence=%s "+
 		"--image=%s:%s --values=a.b.c=d --mock --values=c.d=e", "sockshop", "carts", "artifact-delivery", "docker.io/keptnexamples/carts", "0.9.1")
@@ -272,7 +271,7 @@ func TestTriggerDeliveryNonExistingProject(t *testing.T) {
 		}),
 	)
 	defer ts.Close()
-	os.Setenv("MOCK_SERVER", ts.URL)
+	t.Setenv("MOCK_SERVER", ts.URL)
 
 	tests := []struct {
 		project string
@@ -328,7 +327,7 @@ func TestTriggerDeliveryNonExistingService(t *testing.T) {
 		}),
 	)
 	defer ts.Close()
-	os.Setenv("MOCK_SERVER", ts.URL)
+	t.Setenv("MOCK_SERVER", ts.URL)
 
 	tests := []struct {
 		service string

--- a/cli/cmd/trigger_sequence_test.go
+++ b/cli/cmd/trigger_sequence_test.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/keptn/keptn/cli/pkg/credentialmanager"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -15,6 +14,7 @@ import (
 	apimodels "github.com/keptn/go-utils/pkg/api/models"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 
+	"github.com/keptn/keptn/cli/pkg/credentialmanager"
 	"github.com/keptn/keptn/cli/pkg/logging"
 )
 
@@ -103,7 +103,7 @@ func TestTriggerSequence(t *testing.T) {
 	)
 	defer ts.Close()
 
-	os.Setenv("MOCK_SERVER", ts.URL)
+	t.Setenv("MOCK_SERVER", ts.URL)
 
 	cmd := fmt.Sprintf("trigger sequence %s --project=%s --service=%s --stage=%s --mock", "hello", "hello-world", "demo", "dev")
 	_, err := executeActionCommandC(cmd)
@@ -137,7 +137,7 @@ func TestTriggerSequenceNonExistingProject(t *testing.T) {
 		}),
 	)
 	defer ts.Close()
-	os.Setenv("MOCK_SERVER", ts.URL)
+	t.Setenv("MOCK_SERVER", ts.URL)
 
 	tests := []struct {
 		project string
@@ -195,7 +195,7 @@ func TestTriggerSequenceNonExistingService(t *testing.T) {
 		}),
 	)
 	defer ts.Close()
-	os.Setenv("MOCK_SERVER", ts.URL)
+	t.Setenv("MOCK_SERVER", ts.URL)
 
 	tests := []struct {
 		service string

--- a/distributor/pkg/config/envconfig_test.go
+++ b/distributor/pkg/config/envconfig_test.go
@@ -1,11 +1,11 @@
 package config
 
 import (
-	"github.com/kelseyhightower/envconfig"
-	"github.com/stretchr/testify/assert"
-	"os"
 	"testing"
 	"time"
+
+	"github.com/kelseyhightower/envconfig"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_getProxyRequestURL(t *testing.T) {
@@ -198,19 +198,13 @@ func Test_getPubSubRecipientURL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.args.recipientService != "" {
-				os.Setenv("PUBSUB_RECIPIENT", tt.args.recipientService)
-			} else {
-				os.Unsetenv("PUBSUB_RECIPIENT")
+				t.Setenv("PUBSUB_RECIPIENT", tt.args.recipientService)
 			}
 			if tt.args.port != "" {
-				os.Setenv("PUBSUB_RECIPIENT_PORT", tt.args.port)
-			} else {
-				os.Unsetenv("PUBSUB_RECIPIENT_PORT")
+				t.Setenv("PUBSUB_RECIPIENT_PORT", tt.args.port)
 			}
 			if tt.args.path != "" {
-				os.Setenv("PUBSUB_RECIPIENT_PATH", tt.args.path)
-			} else {
-				os.Unsetenv("PUBSUB_RECIPIENT_PATH")
+				t.Setenv("PUBSUB_RECIPIENT_PATH", tt.args.path)
 			}
 
 			env := EnvConfig{}

--- a/helm-service/pkg/helm/generated_chart_handler_test.go
+++ b/helm-service/pkg/helm/generated_chart_handler_test.go
@@ -3,7 +3,6 @@ package helm
 import (
 	"errors"
 	"log"
-	"os"
 	"strings"
 	"testing"
 
@@ -133,8 +132,8 @@ func Test_getVirtualServicePublicHost(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Setenv("HOSTNAME_TEMPLATE", tt.hostnameTemplate)
-			os.Setenv("INGRESS_HOSTNAME_SUFFIX", tt.hostnameSuffix)
+			t.Setenv("HOSTNAME_TEMPLATE", tt.hostnameTemplate)
+			t.Setenv("INGRESS_HOSTNAME_SUFFIX", tt.hostnameSuffix)
 			got, err := getVirtualServicePublicHost(tt.args.svc, tt.args.project, tt.args.stageName)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getVirtualServicePublicHost() error = %v, wantErr %v", err, tt.wantErr)

--- a/helm-service/pkg/mesh/ingress_config_test.go
+++ b/helm-service/pkg/mesh/ingress_config_test.go
@@ -1,10 +1,10 @@
 package mesh
 
 import (
-	"github.com/keptn/go-utils/pkg/lib/v0_2_0"
-	"os"
 	"reflect"
 	"testing"
+
+	"github.com/keptn/go-utils/pkg/lib/v0_2_0"
 )
 
 func TestGetPublicDeploymentURI(t *testing.T) {
@@ -64,10 +64,10 @@ func TestGetPublicDeploymentURI(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Setenv("INGRESS_HOSTNAME_SUFFIX", tt.ingressHostNameSuffix)
-			os.Setenv("INGRESS_PORT", tt.ingressPort)
-			os.Setenv("INGRESS_PROTOCOL", tt.ingressProtocol)
-			os.Setenv("HOSTNAME_TEMPLATE", tt.hostNameTemplate)
+			t.Setenv("INGRESS_HOSTNAME_SUFFIX", tt.ingressHostNameSuffix)
+			t.Setenv("INGRESS_PORT", tt.ingressPort)
+			t.Setenv("INGRESS_PROTOCOL", tt.ingressProtocol)
+			t.Setenv("HOSTNAME_TEMPLATE", tt.hostNameTemplate)
 			if got := GetPublicDeploymentURI(tt.args.event); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetPublicDeploymentURI() = %v, want %v", got, tt.want)
 			}

--- a/jmeter-service/jmeterUtils_test.go
+++ b/jmeter-service/jmeterUtils_test.go
@@ -3,18 +3,16 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os/exec"
-
-	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
+	"os/exec"
 	"strings"
 	"testing"
 
 	apimodels "github.com/keptn/go-utils/pkg/api/models"
 	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
+	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 )
 
 func Test_executeJMeter(t *testing.T) {
@@ -42,8 +40,8 @@ func Test_executeJMeter(t *testing.T) {
 	)
 	defer ts.Close()
 	checkJmeter()
-	os.Setenv("RESOURCE_SERVICE", ts.URL)
-	os.Setenv("env", "production")
+	t.Setenv("RESOURCE_SERVICE", ts.URL)
+	t.Setenv("env", "production")
 
 	type args struct {
 		testInfo       TestInfo

--- a/lighthouse-service/event_handler/evaluate_sli_handler_test.go
+++ b/lighthouse-service/event_handler/evaluate_sli_handler_test.go
@@ -4,16 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"github.com/keptn/go-utils/pkg/api/models"
-	"github.com/keptn/go-utils/pkg/common/strutils"
-	keptnfake "github.com/keptn/go-utils/pkg/lib/v0_2_0/fake"
-	event_handler_mock "github.com/keptn/keptn/lighthouse-service/event_handler/fake"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"reflect"
 	"sort"
 	"strings"
@@ -21,10 +13,18 @@ import (
 	"testing"
 	"time"
 
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/keptn/go-utils/pkg/api/models"
 	keptnapi "github.com/keptn/go-utils/pkg/api/utils"
+	"github.com/keptn/go-utils/pkg/common/strutils"
 	apimodelsv2 "github.com/keptn/go-utils/pkg/lib"
 	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
+	keptnfake "github.com/keptn/go-utils/pkg/lib/v0_2_0/fake"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	event_handler_mock "github.com/keptn/keptn/lighthouse-service/event_handler/fake"
 )
 
 type operatorParserTest struct {
@@ -3166,7 +3166,7 @@ func TestEvaluateSLIHandler_getPreviousEvaluations(t *testing.T) {
 	)
 	defer ts.Close()
 
-	_ = os.Setenv("MONGODB_DATASTORE", strings.TrimPrefix(ts.URL, "http://"))
+	t.Setenv("MONGODB_DATASTORE", strings.TrimPrefix(ts.URL, "http://"))
 
 	type fields struct {
 		Logger     *keptncommon.Logger

--- a/lighthouse-service/event_handler/handler_test.go
+++ b/lighthouse-service/event_handler/handler_test.go
@@ -2,9 +2,7 @@ package event_handler
 
 import (
 	"context"
-	"github.com/keptn/go-utils/pkg/sdk/connector/types"
 	"net/http"
-	"os"
 	"testing"
 	"time"
 
@@ -21,6 +19,7 @@ import (
 	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 	"github.com/keptn/go-utils/pkg/sdk/connector/controlplane"
+	"github.com/keptn/go-utils/pkg/sdk/connector/types"
 )
 
 func TestNewEventHandler(t *testing.T) {
@@ -102,7 +101,7 @@ func TestNewEventHandler(t *testing.T) {
 				return fake.NewSimpleClientset(), nil
 			}
 			tt.args.event.SetType(tt.eventType)
-			os.Setenv("RESOURCE_SERVICE", configurationServiceURL)
+			t.Setenv("RESOURCE_SERVICE", configurationServiceURL)
 
 			got, err := NewEventHandler(ctx, tt.args.event)
 			if (err != nil) != tt.wantErr {

--- a/lighthouse-service/event_handler/start_evaluation_handler_test.go
+++ b/lighthouse-service/event_handler/start_evaluation_handler_test.go
@@ -116,8 +116,8 @@ func TestStartEvaluationHandler_HandleEvent(t *testing.T) {
 	)
 	defer ts.Close()
 
-	os.Setenv("EVENTBROKER", ts.URL+"/events")
-	os.Setenv("RESOURCE_SERVICE", ts.URL+"/configuration")
+	t.Setenv("EVENTBROKER", ts.URL+"/events")
+	t.Setenv("RESOURCE_SERVICE", ts.URL+"/configuration")
 
 	////////// TEST DEFINITION ///////////
 	type fields struct {

--- a/mongodb-datastore/restapi/configure_mongodb_datastore_test.go
+++ b/mongodb-datastore/restapi/configure_mongodb_datastore_test.go
@@ -2,15 +2,15 @@ package restapi
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	"github.com/keptn/keptn/mongodb-datastore/handlers"
 	"github.com/keptn/keptn/mongodb-datastore/restapi/operations"
 	"github.com/nats-io/nats-server/v2/server"
 	natstest "github.com/nats-io/nats-server/v2/test"
 	logger "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
-	"os"
-	"testing"
-	"time"
 )
 
 // Test_startControlPlane verifies whether the api pre server shutdown is initialized
@@ -23,8 +23,7 @@ func Test_startControlPlaneSuccess(t *testing.T) {
 	defer func() {
 		shutdown()
 	}()
-	err := os.Setenv("NATS_URL", natsServer.ClientURL())
-	require.NoError(t, err)
+	t.Setenv("NATS_URL", natsServer.ClientURL())
 
 	api := &operations.MongodbDatastoreAPI{}
 	eventRequestHandler := handlers.NewEventRequestHandler(nil)

--- a/resource-service/common/credentials_test.go
+++ b/resource-service/common/credentials_test.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	apimodels "github.com/keptn/go-utils/pkg/api/models"
@@ -17,7 +16,7 @@ import (
 )
 
 func TestK8sCredentialReader_ReadSecret(t *testing.T) {
-	_ = os.Setenv("POD_NAMESPACE", "keptn")
+	t.Setenv("POD_NAMESPACE", "keptn")
 	secretReader := NewK8sCredentialReader(fake.NewSimpleClientset(
 		getK8sSecret(),
 	))
@@ -35,7 +34,7 @@ func TestK8sCredentialReader_ReadSecret(t *testing.T) {
 }
 
 func TestK8sCredentialReader_ReadSecretNotFound(t *testing.T) {
-	_ = os.Setenv("POD_NAMESPACE", "keptn")
+	t.Setenv("POD_NAMESPACE", "keptn")
 	secretReader := NewK8sCredentialReader(fake.NewSimpleClientset())
 
 	secret, err := secretReader.GetCredentials("my-other-project")
@@ -45,7 +44,7 @@ func TestK8sCredentialReader_ReadSecretNotFound(t *testing.T) {
 }
 
 func TestK8sCredentialReader_ReadSecretWrongFormat(t *testing.T) {
-	_ = os.Setenv("POD_NAMESPACE", "keptn")
+	t.Setenv("POD_NAMESPACE", "keptn")
 	secretReader := NewK8sCredentialReader(fake.NewSimpleClientset(
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -65,7 +64,7 @@ func TestK8sCredentialReader_ReadSecretWrongFormat(t *testing.T) {
 }
 
 func TestK8sCredentialReader_ReadSecretNoToken(t *testing.T) {
-	_ = os.Setenv("POD_NAMESPACE", "keptn")
+	t.Setenv("POD_NAMESPACE", "keptn")
 	secretReader := NewK8sCredentialReader(fake.NewSimpleClientset(
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -84,7 +83,7 @@ func TestK8sCredentialReader_ReadSecretNoToken(t *testing.T) {
 }
 
 func TestK8sCredentialReader_ReadSecretNoPrivateKey(t *testing.T) {
-	_ = os.Setenv("POD_NAMESPACE", "keptn")
+	t.Setenv("POD_NAMESPACE", "keptn")
 	secretReader := NewK8sCredentialReader(fake.NewSimpleClientset(
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -104,7 +103,7 @@ func TestK8sCredentialReader_ReadSecretNoPrivateKey(t *testing.T) {
 }
 
 func TestK8sCredentialReader_ReadSecretError(t *testing.T) {
-	_ = os.Setenv("POD_NAMESPACE", "keptn")
+	t.Setenv("POD_NAMESPACE", "keptn")
 
 	fakeClient := fake.NewSimpleClientset()
 

--- a/secret-service/pkg/common/utils_test.go
+++ b/secret-service/pkg/common/utils_test.go
@@ -1,13 +1,13 @@
 package common
 
 import (
-	"github.com/stretchr/testify/assert"
-	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_EnvBasedStringSupplier(t *testing.T) {
-	os.Setenv("KEPTN_TEST_ENV_VAR", "KEPTN_TEST_ENV_VAR_VAL")
+	t.Setenv("KEPTN_TEST_ENV_VAR", "KEPTN_TEST_ENV_VAR_VAL")
 	val := EnvBasedStringSupplier("KEPTN_TEST_ENV_VAR", "")()
 	assert.Equal(t, "KEPTN_TEST_ENV_VAR_VAL", val)
 

--- a/shipyard-controller/common/keptn_helpers_test.go
+++ b/shipyard-controller/common/keptn_helpers_test.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"os"
 	"testing"
 
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
@@ -13,7 +12,7 @@ func TestGetKeptnSpecVersion(t *testing.T) {
 	specVersion := GetKeptnSpecVersion()
 	assert.Equal(t, "", specVersion)
 
-	os.Setenv(keptnSpecVersionEnvVar, "0.2.0")
+	t.Setenv(keptnSpecVersionEnvVar, "0.2.0")
 	specVersion = GetKeptnSpecVersion()
 	assert.Equal(t, "0.2.0", specVersion)
 }

--- a/statistics-service/controller/statistics_test.go
+++ b/statistics-service/controller/statistics_test.go
@@ -1,14 +1,13 @@
 package controller
 
 import (
-	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
-	"os"
 	"strconv"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/go-test/deep"
+	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
 
 	"github.com/keptn/keptn/statistics-service/db"
 	"github.com/keptn/keptn/statistics-service/operations"
@@ -418,7 +417,7 @@ func Test_statisticsBucket_AddEvent(t *testing.T) {
 
 func TestStatisticsBucket(t *testing.T) {
 	interval := 5
-	os.Setenv("AGGREGATION_INTERVAL_SECONDS", strconv.FormatInt(int64(interval), 10))
+	t.Setenv("AGGREGATION_INTERVAL_SECONDS", strconv.FormatInt(int64(interval), 10))
 
 	expectedStatistics := &operations.Statistics{
 		From: time.Time{},

--- a/statistics-service/db/statistics_mongodb_repo_test.go
+++ b/statistics-service/db/statistics_mongodb_repo_test.go
@@ -3,16 +3,16 @@ package db
 import (
 	"context"
 	"fmt"
+	"log"
+	"testing"
+	"time"
+
 	"github.com/keptn/keptn/statistics-service/operations"
 	logger "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/tryvium-travels/memongo"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	"log"
-	"os"
-	"testing"
-	"time"
 )
 
 var mongoDbVersion = "4.4.9"
@@ -24,8 +24,8 @@ func setupLocalMongoDB(t *testing.T) func() {
 	}
 	randomDbName := memongo.RandomDatabase()
 
-	os.Setenv("MONGODB_DATABASE", randomDbName)
-	os.Setenv("MONGODB_EXTERNAL_CONNECTION_STRING", fmt.Sprintf("%s/%s", mongoServer.URI(), randomDbName))
+	t.Setenv("MONGODB_DATABASE", randomDbName)
+	t.Setenv("MONGODB_EXTERNAL_CONNECTION_STRING", fmt.Sprintf("%s/%s", mongoServer.URI(), randomDbName))
 
 	var mongoDBClient *mongo.Client
 	mongoDBClient, err = mongo.NewClient(options.Client().ApplyURI(mongoServer.URI()))

--- a/webhook-service/lib/secret_reader_test.go
+++ b/webhook-service/lib/secret_reader_test.go
@@ -1,17 +1,17 @@
 package lib_test
 
 import (
+	"testing"
+
 	"github.com/keptn/keptn/webhook-service/lib"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
-	"os"
-	"testing"
 )
 
 func TestK8sSecretReater_ReadSecret(t *testing.T) {
-	_ = os.Setenv("POD_NAMESPACE", "keptn")
+	t.Setenv("POD_NAMESPACE", "keptn")
 	secretReader := lib.NewK8sSecretReader(fake.NewSimpleClientset(
 		getK8sSecret(map[string]string{
 			"app.kubernetes.io/managed-by": "keptn-secret-service",
@@ -30,7 +30,7 @@ func TestK8sSecretReater_ReadSecret(t *testing.T) {
 }
 
 func TestK8sSecretReater_ReadSecretWithInvalidScope(t *testing.T) {
-	_ = os.Setenv("POD_NAMESPACE", "keptn")
+	t.Setenv("POD_NAMESPACE", "keptn")
 	secretReader := lib.NewK8sSecretReader(fake.NewSimpleClientset(
 		getK8sSecret(map[string]string{}),
 	))


### PR DESCRIPTION
## This PR

This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

### Notes

Reference: https://pkg.go.dev/testing#T.Setenv

