### PR TITLE
chore: Remove reference to removed test

### DIFF
--- a/test/go-tests/testsuite_gke_test.go
+++ b/test/go-tests/testsuite_gke_test.go
@@ -23,7 +23,6 @@ func Test_GKE(t *testing.T) {
 	t.Run("Test_SSHPublicKeyAuth", Test_SSHPublicKeyAuth)
 	t.Run("Test_ProxyAuth", Test_ProxyAuth)
 
-	t.Run("Test_ZeroDownTimeTriggerSequence", Test_ZeroDownTimeTriggerSequence)
 	// Platform-specific Tests
 	t.Run("Test_QualityGates", Test_QualityGates)
 	t.Run("Test_QualityGates_SLIWrongFinishedPayloadSend", Test_QualityGates_SLIWrongFinishedPayloadSend)


### PR DESCRIPTION
This PR fixes the integration tests by removing a leftover reference to a test that has recently been removed