### PR TITLE
fix(cli): Print ID of Keptn context after sending events

### DIFF
--- a/cli/cmd/send_event.go
+++ b/cli/cmd/send_event.go
@@ -67,11 +67,13 @@ In addition, the payload of the CloudEvent needs to follow the Keptn spec (https
 		logging.PrintLog(fmt.Sprintf("Connecting to server %s", endPoint.String()), logging.VerboseLevel)
 
 		if !mocking {
-			_, err := api.APIV1().SendEvent(apiEvent)
+			eventContext, err := api.APIV1().SendEvent(apiEvent)
 			if err != nil {
 				logging.PrintLog("Send event was unsuccessful", logging.QuietLevel)
 				return fmt.Errorf("Send event was unsuccessful. %s", *err.Message)
 			}
+
+			logging.PrintLog("ID of Keptn context: "+*eventContext.KeptnContext, logging.InfoLevel)
 
 			return nil
 		}

--- a/cli/cmd/trigger_delivery.go
+++ b/cli/cmd/trigger_delivery.go
@@ -157,6 +157,8 @@ func doTriggerDelivery(deliveryInputData deliveryStruct) error {
 		return fmt.Errorf("trigger delivery was unsuccessful. %s", *err2.Message)
 	}
 
+	logging.PrintLog("ID of Keptn context: "+*eventContext.KeptnContext, logging.InfoLevel)
+
 	if *deliveryInputData.Watch {
 		filter := apiutils.EventFilter{
 			KeptnContext: *eventContext.KeptnContext,

--- a/cli/cmd/trigger_evaluation.go
+++ b/cli/cmd/trigger_evaluation.go
@@ -133,6 +133,8 @@ func doTriggerEvaluation(triggerEvaluationData triggerEvaluationStruct) error {
 			return nil
 		}
 
+		logging.PrintLog("ID of Keptn context: "+*response.KeptnContext, logging.InfoLevel)
+
 		if *triggerEvaluationData.Watch {
 			api, err := internal.APIProvider(endPoint.String(), apiToken)
 			if err != nil {


### PR DESCRIPTION
Closes #8391 
Closes #8377

Previously the CLI relied on the `SendEvent` method of the go-utils to print the ID of the resulting Keptn context - this has - rightfully - been removed from the go-utils recently, so now the CLI is responsible to print the expected output itself - as it should be