### PR TITLE
test(bridge): Fix flaky UI test in dashboard.spec

### DIFF
--- a/bridge/cypress/integration/dashboard.spec.ts
+++ b/bridge/cypress/integration/dashboard.spec.ts
@@ -2,6 +2,7 @@ import DashboardPage from '../support/pageobjects/DashboardPage';
 
 import * as projectsResponse from '../fixtures/projects.mock.json';
 import BasePage from '../support/pageobjects/BasePage';
+import ProjectSettingsPage from '../support/pageobjects/ProjectSettingsPage';
 
 describe('Bridge Dashboard', () => {
   const dashboardPage = new DashboardPage();
@@ -15,8 +16,11 @@ describe('Bridge Dashboard', () => {
   });
 
   it('should trigger loadProjects once per dashboard visit', () => {
-    dashboardPage.visit().clickCreateNewProjectButton(); // 1 call
     const basePage = new BasePage();
+    const projectSettings = new ProjectSettingsPage();
+
+    dashboardPage.visit().clickCreateNewProjectButton(); // 1 call
+    projectSettings.waitForSettingsToBeVisible();
     basePage.clickMainHeaderKeptn(); // 1 call
     cy.wait('@projects').get('@projects.all').should('have.length', 2);
   });

--- a/bridge/cypress/support/pageobjects/ProjectSettingsPage.ts
+++ b/bridge/cypress/support/pageobjects/ProjectSettingsPage.ts
@@ -60,6 +60,11 @@ class ProjectSettingsPage {
     return this;
   }
 
+  public waitForSettingsToBeVisible(): this {
+    cy.get('ktb-project-settings').should('be.visible');
+    return this;
+  }
+
   public setShipyardFile(): this {
     cy.byTestId('ktb-shipyard-file-input').attachFile('shipyard.yaml');
     return this;


### PR DESCRIPTION
There was a flaky UI test that the projects call was not triggered (`should trigger loadProjects once per dashboard visit` in `dashboard.spec.ts`).

Probably the cause: The navigation to the create-project page and then the navigation back. The navigation-back was triggered too early and therefore canceled the navigation to the create page.

Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>