### PR TITLE
feat(bridge): Show user info for OAuth "Insufficient permission " error message

### DIFF
--- a/bridge/client/app/_interceptors/http-error-interceptor.spec.ts
+++ b/bridge/client/app/_interceptors/http-error-interceptor.spec.ts
@@ -169,7 +169,10 @@ describe('HttpErrorInterceptorService', () => {
     testRequest.error(errorEvent, { status: 403 });
 
     // then
-    expect(spy).toHaveBeenCalledWith(NotificationType.ERROR, 'You do not have the permissions to perform this action.');
+    expect(spy).toHaveBeenCalledWith(
+      NotificationType.ERROR,
+      'User does not have the permissions to perform this action.'
+    );
   });
 
   it('should not show any notification when a secret already exists', () => {

--- a/bridge/client/app/_interceptors/http-error-interceptor.ts
+++ b/bridge/client/app/_interceptors/http-error-interceptor.ts
@@ -1,24 +1,29 @@
-import { Inject, Injectable } from '@angular/core';
+import { Inject, Injectable, OnDestroy } from '@angular/core';
 import { HttpErrorResponse, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
-import { EMPTY, NEVER, Observable, throwError } from 'rxjs';
-import { catchError, retryWhen } from 'rxjs/operators';
+import { EMPTY, NEVER, Observable, Subject, throwError } from 'rxjs';
+import { catchError, retryWhen, takeUntil } from 'rxjs/operators';
 import { genericRetryStrategy, RetryParams } from './http-generic-retry-strategy';
 import { Location } from '@angular/common';
 import { RETRY_ON_HTTP_ERROR } from '../_utils/app.utils';
 import { NotificationsService } from '../_services/notifications.service';
 import { NotificationType } from '../_models/notification';
 import { AuthType } from '../../../shared/models/auth-type';
+import { DataService } from '../_services/data.service';
 
 @Injectable({
   providedIn: 'root',
 })
-export class HttpErrorInterceptor implements HttpInterceptor {
+export class HttpErrorInterceptor implements HttpInterceptor, OnDestroy {
+  private readonly unsubscribe$ = new Subject<void>();
+
   private isReloading = false;
   private isAuthorizedErrorShown = false;
+  private keptnInfo$ = this.dataService.keptnInfo;
 
   constructor(
     private readonly location: Location,
     private readonly notificationService: NotificationsService,
+    private readonly dataService: DataService,
     @Inject(RETRY_ON_HTTP_ERROR) private hasRetry: boolean
   ) {}
 
@@ -40,10 +45,14 @@ export class HttpErrorInterceptor implements HttpInterceptor {
     }
 
     if (response.status === 403) {
-      this.notificationService.addNotification(
-        NotificationType.ERROR,
-        'You do not have the permissions to perform this action.'
-      );
+      this.keptnInfo$.pipe(takeUntil(this.unsubscribe$)).subscribe((keptnInfo) => {
+        this.notificationService.addNotification(
+          NotificationType.ERROR,
+          `${
+            keptnInfo?.bridgeInfo.user ? keptnInfo?.bridgeInfo.user : 'User'
+          } does not have the permissions to perform this action.`
+        );
+      });
       return throwError(() => response);
     }
 
@@ -102,5 +111,10 @@ export class HttpErrorInterceptor implements HttpInterceptor {
     this.notificationService.addNotification(NotificationType.ERROR, errorInfo);
 
     return throwError(() => error);
+  }
+
+  ngOnDestroy(): void {
+    this.unsubscribe$.next();
+    this.unsubscribe$.complete();
   }
 }

--- a/bridge/cypress/integration/auth.spec.ts
+++ b/bridge/cypress/integration/auth.spec.ts
@@ -75,6 +75,8 @@ describe('Test OAuth', () => {
   });
 
   it('should show a message for 403 response', () => {
+    const user = 'claus.keptn-dev@ruxitlabs.com';
+
     cy.intercept('/api/bridgeInfo', { fixture: 'bridgeInfo.mock' });
     cy.intercept('/api/controlPlane/v1/project?disableUpstreamSync=true&pageSize=50', { statusCode: 403 }).as(
       'projects'
@@ -82,6 +84,6 @@ describe('Test OAuth', () => {
     cy.task('setExpectedErrorCount', 1);
 
     cy.visit('/').wait('@projects');
-    basePage.notificationErrorVisible('You do not have the permissions to perform this action.');
+    basePage.notificationErrorVisible(`${user} does not have the permissions to perform this action.`);
   });
 });


### PR DESCRIPTION
## This PR

- Adds user info to the `Insufficient permission` error message for OAuth authentication.

### Related Issues

Fixes #7783

Signed-off-by: TannerGilbert <gilberttanner.work@gmail.com>
