### PR TITLE
chore(bridge): Remove no Git upstream is set warning

### DIFF
--- a/bridge/client/app/_views/ktb-dashboard-view/ktb-project-list/ktb-project-tile.component.html
+++ b/bridge/client/app/_views/ktb-dashboard-view/ktb-project-list/ktb-project-tile.component.html
@@ -49,10 +49,9 @@
       <div class="mb-2" fxLayout="row" fxLayoutAlign="flex-start start">
         <dt-icon class="warning mr-1" [name]="'incident'"></dt-icon>
         <p class="small m-0" uitestid="keptn-project-tile-gitRemoteUri-noUpstreamConfigured">
-          Keptn will not support a project without Git upstream repository in future releases.<br />
           <a
             [routerLink]="['/project', project.projectName, 'settings', 'project']"
-            uitestid="keptn-project-tile-gitRemoteUri-setUpstream"
+            [attr.uitestid]="'keptn-project-' + project.projectName + '-tile-gitRemoteUri-setUpstream'"
             >Set the Git upstream of your project</a
           >
         </p>

--- a/bridge/cypress/fixtures/projects.mock.json
+++ b/bridge/cypress/fixtures/projects.mock.json
@@ -426,7 +426,7 @@
     {
       "creationDate": "1631870924824247750",
       "gitCredentials": {
-        "remoteURL": "https://github.com/laneli/my-error-project",
+        "remoteURL": "",
         "user": "laneli"
       },
       "projectName": "my-error-project",

--- a/bridge/cypress/integration/dashboard.spec.ts
+++ b/bridge/cypress/integration/dashboard.spec.ts
@@ -47,4 +47,8 @@ describe('Bridge Dashboard', () => {
     const basePage = new BasePage();
     basePage.clickOpenUserMenu().assertAuthCommandCopyToClipboardValue('Hello handsome');
   });
+
+  it.only('should show "Set the Git upstream of your project" message if Github remote URL is empty string', () => {
+    dashboardPage.visit().assertEmptyGitRemoteUrl('my-error-project');
+  });
 });

--- a/bridge/cypress/integration/dashboard.spec.ts
+++ b/bridge/cypress/integration/dashboard.spec.ts
@@ -48,7 +48,7 @@ describe('Bridge Dashboard', () => {
     basePage.clickOpenUserMenu().assertAuthCommandCopyToClipboardValue('Hello handsome');
   });
 
-  it.only('should show "Set the Git upstream of your project" message if Github remote URL is empty string', () => {
+  it('should show "Set the Git upstream of your project" message if Github remote URL is empty string', () => {
     dashboardPage.visit().assertEmptyGitRemoteUrl('my-error-project');
   });
 });

--- a/bridge/cypress/support/pageobjects/DashboardPage.ts
+++ b/bridge/cypress/support/pageobjects/DashboardPage.ts
@@ -61,6 +61,13 @@ class DashboardPage {
     cy.byTestId(`ktb-project-${projectName}`).find('dt-tag a').contains(stageName).click();
     return new EnvironmentPage();
   }
+
+  public assertEmptyGitRemoteUrl(projectName: string): this {
+    cy.byTestId(`keptn-project-${projectName}-tile-gitRemoteUri-setUpstream`).should(
+      'have.text',
+      'Set the Git upstream of your project'
+    );
+  }
 }
 
 export default DashboardPage;

--- a/bridge/cypress/support/pageobjects/DashboardPage.ts
+++ b/bridge/cypress/support/pageobjects/DashboardPage.ts
@@ -67,6 +67,7 @@ class DashboardPage {
       'have.text',
       'Set the Git upstream of your project'
     );
+    return this;
   }
 }
 


### PR DESCRIPTION
## This PR

- Removes “Keptn will not support a project without Git upstream repository in future releases.” warning message
- Adds UI test for “Set the Git upstream of your project” message

### Related Issues

Resolves #8424

Signed-off-by: TannerGilbert <gilberttanner.work@gmail.com>
