### PR TITLE
feat(api): Support simple templating for resource and api tasks in import manifests

### DIFF
--- a/api/handlers/zip_package_test.go
+++ b/api/handlers/zip_package_test.go
@@ -83,7 +83,7 @@ func TestZippedPackage_GetResource(t *testing.T) {
 			name:         "Happy path - access existing resource",
 			resourceName: "api/create-service.json",
 			want: []byte(`{
-    "serviceName": "{{ .context.service }}"
+    "serviceName": "[[ .Context.service ]]"
 }`),
 			wantErr:       false,
 			errorContains: "",

--- a/api/importer/model/execute.go
+++ b/api/importer/model/execute.go
@@ -5,6 +5,7 @@ import "io"
 type TaskContext struct {
 	Project string
 	Task    *ManifestTask
+	Context map[string]string
 }
 
 type APITaskExecution struct {

--- a/api/importer/model/manifest.go
+++ b/api/importer/model/manifest.go
@@ -15,9 +15,10 @@ type ResourceTask struct {
 type ManifestTask struct {
 	*APITask      `yaml:",inline"`
 	*ResourceTask `yaml:",inline"`
-	ID            string `yaml:"id"`
-	Type          string `yaml:"type"`
-	Name          string `yaml:"name"`
+	ID            string            `yaml:"id"`
+	Type          string            `yaml:"type"`
+	Name          string            `yaml:"name"`
+	Context       map[string]string `yaml:"context"`
 }
 
 type ImportManifest struct {

--- a/api/importer/model/parser_test.go
+++ b/api/importer/model/parser_test.go
@@ -112,6 +112,63 @@ func TestUnmarshalManifest(t *testing.T) {
 			expectedErrorContains: "",
 		},
 		{
+			name: "API and resource task manifest with context",
+			inputManifest: strings.NewReader(
+				`
+                apiVersion: v1beta1
+                tasks:
+                  - id: sample-api
+                    type: api
+                    name: Sample API Task
+                    payload: "api/some-payload.json"
+                    action: "keptn-api-v1-endpoint-operation"
+                    context:
+                      key1: value1
+                      key2: value2
+                  - id: sample-resource
+                    type: resource
+                    name: Sample resource task
+                    resource: "resources/webhook.yaml"    # where is the file stored in the package
+                    resourceUri: "webhook.yaml"           # what should the file be called in the upstream repo
+                    stage: "dev"
+                    context:
+                      key3: value3
+                      key2: othervalue2
+                `,
+			),
+			expectedManifest: &ImportManifest{
+				ApiVersion: "v1beta1",
+				Tasks: []*ManifestTask{
+					{
+						APITask: &APITask{
+							Action:      "keptn-api-v1-endpoint-operation",
+							PayloadFile: "api/some-payload.json",
+						},
+						ResourceTask: nil,
+						ID:           "sample-api",
+						Type:         "api",
+						Name:         "Sample API Task",
+						Context:      map[string]string{"key1": "value1", "key2": "value2"},
+					},
+					{
+						APITask: nil,
+						ResourceTask: &ResourceTask{
+							File:      "resources/webhook.yaml",
+							RemoteURI: "webhook.yaml",
+							Stage:     "dev",
+						},
+						ID:      "sample-resource",
+						Type:    "resource",
+						Name:    "Sample resource task",
+						Context: map[string]string{"key3": "value3", "key2": "othervalue2"},
+					},
+				},
+			},
+			expectErr:             false,
+			expectedError:         nil,
+			expectedErrorContains: "",
+		},
+		{
 			name: "Resource task without stage indication manifest",
 			inputManifest: strings.NewReader(
 				`

--- a/api/importer/template.go
+++ b/api/importer/template.go
@@ -1,0 +1,33 @@
+package importer
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"text/template"
+)
+
+func RenderContent(raw io.ReadCloser, context any) (io.ReadCloser, error) {
+	defer raw.Close()
+	bytes, err := io.ReadAll(raw)
+
+	if err != nil {
+		return nil, fmt.Errorf("error reading template: %w", err)
+	}
+
+	t, err := template.New("template").
+		Delims("[[", "]]").
+		Option("missingkey=error").
+		Parse(string(bytes))
+
+	if err != nil {
+		return nil, fmt.Errorf("error parsing template: %w", err)
+	}
+
+	buf := new(strings.Builder)
+	err = t.Execute(buf, context)
+	if err != nil {
+		return nil, fmt.Errorf("error rendering template: %w", err)
+	}
+	return io.NopCloser(strings.NewReader(buf.String())), nil
+}

--- a/api/importer/template_test.go
+++ b/api/importer/template_test.go
@@ -1,0 +1,133 @@
+package importer
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/keptn/keptn/api/test/utils"
+)
+
+func TestRenderContent(t *testing.T) {
+
+	type input struct {
+		template string
+		context  any
+	}
+	type expectation struct {
+		renderedText string
+	}
+
+	tests := []struct {
+		name         string
+		inputs       input
+		expectations expectation
+	}{
+		{
+			name:         "Empty template",
+			inputs:       input{template: "", context: nil},
+			expectations: expectation{renderedText: ""},
+		},
+		{
+			name: "Simple template with [[ ... ]] delimiters",
+			inputs: input{
+				template: "This is [[ .rendered ]], while this is not {{ .rendered }}",
+				context:  map[string]string{"rendered": "awesomely rendered"},
+			},
+			expectations: expectation{renderedText: "This is awesomely rendered, while this is not {{ .rendered }}"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				readCloser := io.NopCloser(strings.NewReader(tt.inputs.template))
+				r, err := RenderContent(readCloser, tt.inputs.context)
+				// Assert that whatever RenderContent returns implements io.ReadCloser (
+				// it has to be substituted to the raw content io.ReadCloser passed down to the executors)
+				assert.Implements(t, (*io.ReadCloser)(nil), r)
+				assert.NoError(t, err)
+				bytes, err := io.ReadAll(r)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectations.renderedText, string(bytes))
+			},
+		)
+	}
+}
+
+func TestErrorRenderContent(t *testing.T) {
+
+	type input struct {
+		template io.ReadCloser
+		context  any
+	}
+	type expectation struct {
+		err           error
+		errorContains string
+	}
+
+	tests := []struct {
+		name         string
+		inputs       input
+		expectations expectation
+	}{
+		{
+			name: "Broken reader",
+			inputs: input{
+				template: io.NopCloser(utils.NewTestReader([]byte("some text"), 0, true)),
+				context:  nil,
+			},
+			expectations: expectation{
+				errorContains: "error reading template: ",
+			},
+		},
+		{
+			name: "Invalid template - unclosed action",
+			inputs: input{
+				template: io.NopCloser(strings.NewReader("invalid template syntax [[ .unclosed_thing")),
+				context:  nil,
+			},
+			expectations: expectation{
+				errorContains: "error parsing template: ",
+			},
+		},
+		{
+			name: "Invalid template - non-exiting function",
+			inputs: input{
+				template: io.NopCloser(strings.NewReader("invalid template syntax [[ non-existing-function ]]")),
+				context:  nil,
+			},
+			expectations: expectation{
+				errorContains: "error parsing template: ",
+			},
+		},
+		{
+			name: "Error rendering template",
+			inputs: input{
+				template: io.NopCloser(strings.NewReader("trying to index non-existing field [[ index .field1 0 ]]")),
+				context:  nil,
+			},
+			expectations: expectation{
+				errorContains: "error rendering template: ",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				r, err := RenderContent(tt.inputs.template, tt.inputs.context)
+				assert.Nil(t, r)
+				assert.Error(t, err)
+				if tt.expectations.err != nil {
+					assert.ErrorIs(t, err, tt.expectations.err)
+				}
+				if tt.expectations.errorContains != "" {
+					assert.ErrorContains(t, err, tt.expectations.errorContains)
+				}
+			},
+		)
+	}
+}

--- a/api/test/data/import/rendered-sample-package/api/create-service.context.yaml
+++ b/api/test/data/import/rendered-sample-package/api/create-service.context.yaml
@@ -1,0 +1,1 @@
+service: some-keptn-service-somewhere

--- a/api/test/data/import/rendered-sample-package/api/create-service.json
+++ b/api/test/data/import/rendered-sample-package/api/create-service.json
@@ -1,0 +1,3 @@
+{
+    "serviceName": "some-keptn-service-somewhere"
+}

--- a/api/test/data/import/rendered-sample-package/api/create-subscription.context.yaml
+++ b/api/test/data/import/rendered-sample-package/api/create-subscription.context.yaml
@@ -1,0 +1,4 @@
+event: sh.keptn.test.api.task.render
+project: some-project
+service: some-super-secret-hush-hush-service
+stage: dev

--- a/api/test/data/import/rendered-sample-package/api/create-subscription.json
+++ b/api/test/data/import/rendered-sample-package/api/create-subscription.json
@@ -1,0 +1,9 @@
+{
+    "event": "sh.keptn.test.api.task.render",
+    "filter": {
+        "projects": ["some-project"],
+        "services": ["some-super-secret-hush-hush-service"],
+        "stages": ["dev"]
+    }
+  }
+

--- a/api/test/data/import/rendered-sample-package/resources/webhook.context.yaml
+++ b/api/test/data/import/rendered-sample-package/resources/webhook.context.yaml
@@ -1,0 +1,3 @@
+event: sh.keptn.test.render
+project: test-render
+subscriptionId: webhook-subscription

--- a/api/test/data/import/rendered-sample-package/resources/webhook.yaml
+++ b/api/test/data/import/rendered-sample-package/resources/webhook.yaml
@@ -1,0 +1,11 @@
+apiVersion: webhookconfig.keptn.sh/v1alpha1
+kind: WebhookConfig
+metadata:
+  name: webhook-configuration
+spec:
+  webhooks:
+    - type: sh.keptn.test.render
+      requests:
+        - curl --request POST https://slack.com/api/test-render/{{ .secret.slack-webhook.token }} # Note: this must not be replaced by us, but by webhook-service
+      subscriptionID: webhook-subscription
+      sendFinished: true

--- a/api/test/data/import/sample-package/api/create-service.json
+++ b/api/test/data/import/sample-package/api/create-service.json
@@ -1,3 +1,3 @@
 {
-    "serviceName": "{{ .context.service }}"
+    "serviceName": "[[ .Context.service ]]"
 }

--- a/api/test/data/import/sample-package/api/create-subscription.json
+++ b/api/test/data/import/sample-package/api/create-subscription.json
@@ -1,9 +1,9 @@
 {
-    "event": "{{ .context.event }}",
+    "event": "[[ .Context.event ]]",
     "filter": {
-        "projects": ["{{ .context.project }}"],
-        "services": ["{{ .context.service "],
-        "stages": ["{{ .context.stage }}"]
+        "projects": ["[[ .Context.project ]]"],
+        "services": ["[[ .Context.service ]]"],
+        "stages": ["[[ .Context.stage ]]"]
     }
   }
 

--- a/api/test/data/import/sample-package/resources/webhook.yaml
+++ b/api/test/data/import/sample-package/resources/webhook.yaml
@@ -4,8 +4,8 @@ metadata:
   name: webhook-configuration
 spec:
   webhooks:
-    - type: [[ .context.event ]]
+    - type: [[ .Context.event ]]
       requests:
-        - curl --request POST https://slack.com/api/[[ .context.project]]/{{ .secret.slack-webhook.token }} # Note: this must not be replaced by us, but by webhook-service
-      subscriptionID: [[ .context.subscriptionId ]]
+        - curl --request POST https://slack.com/api/[[ .Context.project]]/{{ .secret.slack-webhook.token }} # Note: this must not be replaced by us, but by webhook-service
+      subscriptionID: [[ .Context.subscriptionId ]]
       sendFinished: true


### PR DESCRIPTION


Signed-off-by: Paolo Chila <paolo.chila@dynatrace.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- Adds support for simple context definition as a map<string, string> defined at task level
- Support templating both API payloads and resource contents

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

