### PR TITLE
test: PoC to reduce CI pipeline timings

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -220,6 +220,7 @@ jobs:
     needs: prepare_ci_run
     runs-on: ubuntu-20.04
     steps:
+
       - name: Create build config file
         env:
           BRANCH: ${{ needs.prepare_ci_run.outputs.BRANCH }}
@@ -246,21 +247,96 @@ jobs:
   ############################################################################
   # Unit tests                                                               #
   ############################################################################
-  unit-tests-microservices:
+  unit-tests-and-build:
     name: Unit Tests and Build
     needs: prepare_ci_run
     runs-on: ubuntu-20.04
     if: needs.prepare_ci_run.outputs.BUILD_MATRIX_EMPTY == 'false'
     strategy:
       matrix: ${{ fromJson(needs.prepare_ci_run.outputs.BUILD_MATRIX) }}
+      fail-fast: false # TODO remove this after all test pass
     env:
       BRANCH: ${{ needs.prepare_ci_run.outputs.BRANCH }}
       VERSION: ${{ needs.prepare_ci_run.outputs.VERSION }}
       DATETIME: ${{ needs.prepare_ci_run.outputs.DATE }}${{ needs.prepare_ci_run.outputs.TIME }}
       GIT_SHA: ${{ needs.prepare_ci_run.outputs.GIT_SHA }}
     steps:
-      - name: Checkout Code
+      - name: Check out code.
         uses: actions/checkout@v3
+
+      - name: Set up Go 1.x
+        if: matrix.config.artifact != 'bridge2'
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Set up gotestsum
+        if: matrix.config.artifact != 'bridge2'
+        run: go install gotest.tools/gotestsum@v1.8.1
+
+      - name: Test ${{ matrix.config.artifact }} # TODO add back -race
+        if: matrix.config.artifact != 'bridge2' && ((needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (matrix.config.should-run == 'true'))
+        working-directory: ./${{ matrix.config.artifact}}
+        run: |
+          go mod download
+          gotestsum --no-color=false --format=testname -- -v ./... 
+
+    #######################################################################
+          # TESTS FOR BRIDGE
+    #######################################################################
+      - name: Install yarn
+        if: matrix.config.artifact == 'bridge2'
+        working-directory: bridge
+        run: |
+          if [[ '${{ matrix.config.docker-test-target }}' == 'bridge-server-test' ]]; then
+            cd ./server 
+          fi
+          yarn install --frozen-lockfile 
+
+      - name: Bridge lint checks
+        if: matrix.config.artifact == 'bridge2' && matrix.config.docker-test-target == 'builder-code-style'
+        working-directory: bridge
+        run: yarn prettier:check && yarn lint:check
+
+      - name: UI-Test
+        if: matrix.config.docker-test-target == 'builder-test-ui'
+        run: |
+         ./cypress/run-tests.sh   
+
+      - name: Bridge unit test
+        if: matrix.config.artifact == 'bridge2' && matrix.config.docker-test-target != 'builder-test-ui'
+        working-directory: bridge
+        run: |
+          if [[ '${{ matrix.config.docker-test-target }}' == 'bridge-server-test' ]]; then
+            cd ./server 
+          fi
+          yarn test
+
+      - name: Report test coverage for bridge-server
+        if: matrix.config.should-push-image == 'false' && matrix.config.artifact == 'bridge2' && matrix.config.docker-test-target == 'bridge-server-test'
+        uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: false
+          flags: bridge-server
+
+      - name: Upload Test Screenshots
+        if: always() && matrix.config.artifact == 'bridge2' && matrix.config.docker-test-target == 'builder-test-ui'
+        uses: actions/upload-artifact@v3
+        with:
+          name: bridge-e2e-screenshots
+          path: ./shared/screenshots
+
+    # REPORT COVERAGE
+      - name: Report test coverage for ${{ matrix.config.artifact }}
+        if: matrix.config.should-push-image == 'true'
+        uses: codecov/codecov-action@v3
+        with:
+            fail_ci_if_error: false
+            flags: ${{ matrix.config.artifact }}
+
+    #######################################################################
+    # BUILD PRODUCTION IMAGES
+    #######################################################################
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -277,47 +353,6 @@ jobs:
         with:
           username: ${{ secrets.REGISTRY_USER }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
-
-      - name: Build ${{ matrix.config.artifact }} test image
-        if: ((needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (matrix.config.should-run == 'true'))
-        uses: docker/build-push-action@v3
-        with:
-          context: ${{ matrix.config.working-dir }}
-          tags: ${{ matrix.config.artifact }}-test-${{ github.sha }}
-          target: ${{ matrix.config.docker-test-target }}
-          load: true
-          push: false
-          builder: ${{ steps.buildx.outputs.name }}
-          cache-from: type=gha, scope=${{ github.workflow }}
-          cache-to: type=gha, scope=${{ github.workflow }}
-
-      - name: Test ${{ matrix.config.artifact }}
-        if: ((needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (matrix.config.should-run == 'true'))
-        env:
-          IMAGE_NAME: ${{ matrix.config.artifact }}-test-${{ github.sha }}
-        run: |
-          docker run --rm -v "$PWD/shared:/shared" $IMAGE_NAME
-
-      - name: Report test coverage for ${{ matrix.config.artifact }}
-        if: matrix.config.should-push-image == 'true'
-        uses: codecov/codecov-action@v3
-        with:
-          fail_ci_if_error: false
-          flags: ${{ matrix.config.artifact }}
-
-      - name: Report test coverage for bridge-server
-        if: matrix.config.should-push-image == 'false' && matrix.config.artifact == 'bridge2' && matrix.config.docker-test-target == 'bridge-server-test'
-        uses: codecov/codecov-action@v3
-        with:
-          fail_ci_if_error: false
-          flags: bridge-server
-
-      - name: Upload Test Screenshots
-        if: always() && matrix.config.artifact == 'bridge2' && matrix.config.docker-test-target == 'builder-test-ui'
-        uses: actions/upload-artifact@v3
-        with:
-          name: bridge-e2e-screenshots
-          path: ./shared/screenshots
 
       - id: docker_build_image
         name: "Docker Build keptn/${{ matrix.config.artifact }}"
@@ -402,7 +437,7 @@ jobs:
 
   helm_charts_upload:
     name: Publish helm charts to dev repo
-    needs: [prepare_ci_run, helm_charts_build]
+    needs: [prepare_ci_run, helm_charts_build, unit-tests-and-build]
     if: ((needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (needs.prepare_ci_run.outputs.BUILD_INSTALLER == 'true')) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository))
     runs-on: ubuntu-20.04
     steps:
@@ -454,7 +489,7 @@ jobs:
       - calculate-queue-time
       - prepare_ci_run
       - store-output-in-build-config
-      - unit-tests-microservices
+      - unit-tests-and-build
       - unit-tests-cli
       - build-cli
       - helm_charts_build

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -264,6 +264,7 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        id: buildx
         with:
           install: true
 
@@ -330,6 +331,9 @@ jobs:
             gitSha=${{ needs.prepare_ci_run.outputs.GIT_SHA }}
           push: ${{ matrix.config.should-push-image == 'true' && (( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository ) || ( github.event_name == 'push' )) && github.actor != 'renovate[bot]' && github.actor != 'dependabot[bot]' }}
           pull: true
+          builder: ${{ steps.buildx.outputs.name }}
+          cache-from: type=gha, scope=${{ github.workflow }}
+          cache-to: type=gha, scope=${{ github.workflow }}
 
   unit-tests-cli:
     name: Unit Tests CLI (multi OS/arch)

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -247,12 +247,17 @@ jobs:
   # Unit tests                                                               #
   ############################################################################
   unit-tests-microservices:
-    name: Unit Tests Microservices
+    name: Unit Tests and Build
     needs: prepare_ci_run
     runs-on: ubuntu-20.04
     if: needs.prepare_ci_run.outputs.BUILD_MATRIX_EMPTY == 'false'
     strategy:
       matrix: ${{ fromJson(needs.prepare_ci_run.outputs.BUILD_MATRIX) }}
+    env:
+      BRANCH: ${{ needs.prepare_ci_run.outputs.BRANCH }}
+      VERSION: ${{ needs.prepare_ci_run.outputs.VERSION }}
+      DATETIME: ${{ needs.prepare_ci_run.outputs.DATE }}${{ needs.prepare_ci_run.outputs.TIME }}
+      GIT_SHA: ${{ needs.prepare_ci_run.outputs.GIT_SHA }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -261,6 +266,16 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           install: true
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        # only run docker login on pushes; also for PRs, but only if this is not a fork
+        if: ( github.actor != 'renovate[bot]' && github.actor != 'dependabot[bot]' ) && (matrix.config.should-push-image == 'true' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository))
+        # note: GH does not allow to access secrets for PRs from a forked repositories due to security reasons
+        # that's fine, but it means we can't push images to dockerhub
+        with:
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: Build ${{ matrix.config.artifact }} test image
         if: ((needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (matrix.config.should-run == 'true'))
@@ -299,6 +314,22 @@ jobs:
         with:
           name: bridge-e2e-screenshots
           path: ./shared/screenshots
+
+      - id: docker_build_image
+        name: "Docker Build keptn/${{ matrix.config.artifact }}"
+        if: matrix.config.should-push-image == 'true' && ( matrix.config.should-run == 'true' || needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true' )
+        uses: docker/build-push-action@v3
+        with:
+          context: ${{ matrix.config.working-dir }}
+          tags: |
+            keptndev/${{ matrix.config.artifact }}:${{ env.VERSION }}
+            keptndev/${{ matrix.config.artifact }}:${{ env.VERSION }}.${{ env.DATETIME }}
+          build-args: |
+            version=${{ env.VERSION }}
+            buildTime=${{ needs.prepare_ci_run.outputs.DATETIME }}
+            gitSha=${{ needs.prepare_ci_run.outputs.GIT_SHA }}
+          push: ${{ matrix.config.should-push-image == 'true' && (( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository ) || ( github.event_name == 'push' )) && github.actor != 'renovate[bot]' && github.actor != 'dependabot[bot]' }}
+          pull: true
 
   unit-tests-cli:
     name: Unit Tests CLI (multi OS/arch)
@@ -409,54 +440,6 @@ jobs:
         git commit --signoff -m "Keptn Dev Version $RELEASE_TAG"
         git push
 
-  ############################################################################
-  # Build Docker Images                                                      #
-  ############################################################################
-  docker_build:
-    name: Docker Build
-    needs: [prepare_ci_run]
-    runs-on: ubuntu-20.04
-    if: needs.prepare_ci_run.outputs.BUILD_MATRIX_EMPTY == 'false'
-    strategy:
-      matrix: ${{ fromJson(needs.prepare_ci_run.outputs.BUILD_MATRIX) }}
-    env:
-      BRANCH: ${{ needs.prepare_ci_run.outputs.BRANCH }}
-      VERSION: ${{ needs.prepare_ci_run.outputs.VERSION }}
-      DATETIME: ${{ needs.prepare_ci_run.outputs.DATE }}${{ needs.prepare_ci_run.outputs.TIME }}
-      GIT_SHA: ${{ needs.prepare_ci_run.outputs.GIT_SHA }}
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        # only run docker login on pushes; also for PRs, but only if this is not a fork
-        if: ( github.actor != 'renovate[bot]' && github.actor != 'dependabot[bot]' ) && (matrix.config.should-push-image == 'true' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository))
-        # note: GH does not allow to access secrets for PRs from a forked repositories due to security reasons
-        # that's fine, but it means we can't push images to dockerhub
-        with:
-          username: ${{ secrets.REGISTRY_USER }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-
-      - id: docker_build_image
-        name: "Docker Build keptn/${{ matrix.config.artifact }}"
-        if: matrix.config.should-push-image == 'true' && ( matrix.config.should-run == 'true' || needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true' )
-        uses: docker/build-push-action@v3
-        with:
-          context: ${{ matrix.config.working-dir }}
-          tags: |
-            keptndev/${{ matrix.config.artifact }}:${{ env.VERSION }}
-            keptndev/${{ matrix.config.artifact }}:${{ env.VERSION }}.${{ env.DATETIME }}
-          build-args: |
-            version=${{ env.VERSION }}
-            buildTime=${{ needs.prepare_ci_run.outputs.DATETIME }}
-            gitSha=${{ needs.prepare_ci_run.outputs.GIT_SHA }}
-          push: ${{ matrix.config.should-push-image == 'true' && (( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository ) || ( github.event_name == 'push' )) && github.actor != 'renovate[bot]' && github.actor != 'dependabot[bot]' }}
-          pull: true
-
   calculate-total-runtime:
     name: End-of-Pipeline Metrics
     if: always() && (( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository ) || ( github.event_name == 'push' ))
@@ -469,7 +452,7 @@ jobs:
       - build-cli
       - helm_charts_build
       - helm_charts_upload
-      - docker_build
+
     uses: ./.github/workflows/end-of-pipeline-metrics.yml
     with:
       workflow_name: "CI"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -287,6 +287,9 @@ jobs:
           target: ${{ matrix.config.docker-test-target }}
           load: true
           push: false
+          builder: ${{ steps.buildx.outputs.name }}
+          cache-from: type=gha, scope=${{ github.workflow }}
+          cache-to: type=gha, scope=${{ github.workflow }}
 
       - name: Test ${{ matrix.config.artifact }}
         if: ((needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (matrix.config.should-run == 'true'))


### PR DESCRIPTION
Signed-off-by: RealAnna <anna.reale@dynatrace.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

 [ Attempt to reintroduce docker caching](https://github.com/keptn/keptn/pull/8465/commits/177be4db41aad80528b3086f4949f8e6361760ae)
-uses https://github.com/docker/build-push-action/issues/252#issuecomment-889339470 

[ Caching in between test and prod builds](https://github.com/keptn/keptn/pull/8465/commits/cf7256124dcfc69dfe23bbf65d2c9d0f04c28543)

 Research other projects' workflows to see if there are better approaches to docker builds:
[dynatrace-operator]( https://github.com/Dynatrace/dynatrace-operator/blob/master/.github/workflows/ci.yaml#L18
 ) does test directly on the runner, not in a container... 
[ They also use helm unit testing! ](https://github.com/quintush/helm-unittest)
[Try to move together builds and unit test runs to decrease wait time in between each step and decrease job count
](https://github.com/keptn/keptn/pull/8465/commits/5f70798743f8a99134232ebb62f0ca7073572d6f)


### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Closes #8371 

### Notes
<!-- any additional notes for this PR -->

running test outside docker containers using --race showed multiple errors (mostly data races but one of jmeter test needs jmeter installed and thus fails, we should remove it):
https://github.com/keptn/keptn/runs/7428255474?check_suite_focus=true 

### Follow-up Tasks
Discuss with the team and make a ticket to merge chosen changes

### How to test
<!-- if applicable, add testing instructions under this section -->
Here are CI runs with the 3 setups: 
[reference CI build everything](https://github.com/keptn/keptn/actions/runs/2547905088) ~ 24m
[adding cache to production images](https://github.com/keptn/keptn/actions/runs/2698439681) ~ 21m  (bridge test took 19m test image build 5m 28s) 
[ merging test and build ](https://github.com/keptn/keptn/actions/runs/2697200931) ~19m
[adding cache to test images](https://github.com/keptn/keptn/actions/runs/2697351910 ) ~17m  (bridge test took 15m test image build 4m 36s )

[running test directly on the runner](https://github.com/keptn/keptn/actions/runs/2704598098) (shippy our bottleneck after bridge took ~1m less)
[running also bridge tests as git actions](https://github.com/keptn/keptn/actions/runs/2705575147)  ~ 15m 25s (bridge server now 41 s against ~2m while bridge test 12m 47s against 15m !)