### PR TITLE
feat: [PoC] Try to use distroless images

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -257,49 +257,6 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          install: true
-
-      - name: Build ${{ matrix.config.artifact }} test image
-        if: ((needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (matrix.config.should-run == 'true'))
-        uses: docker/build-push-action@v3
-        with:
-          context: ${{ matrix.config.working-dir }}
-          tags: ${{ matrix.config.artifact }}-test-${{ github.sha }}
-          target: ${{ matrix.config.docker-test-target }}
-          load: true
-          push: false
-
-      - name: Test ${{ matrix.config.artifact }}
-        if: ((needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (matrix.config.should-run == 'true'))
-        env:
-          IMAGE_NAME: ${{ matrix.config.artifact }}-test-${{ github.sha }}
-        run: |
-          docker run --rm -v "$PWD/shared:/shared" $IMAGE_NAME
-
-      - name: Report test coverage for ${{ matrix.config.artifact }}
-        if: matrix.config.should-push-image == 'true'
-        uses: codecov/codecov-action@v3
-        with:
-          fail_ci_if_error: false
-          flags: ${{ matrix.config.artifact }}
-
-      - name: Report test coverage for bridge-server
-        if: matrix.config.should-push-image == 'false' && matrix.config.artifact == 'bridge2' && matrix.config.docker-test-target == 'bridge-server-test'
-        uses: codecov/codecov-action@v3
-        with:
-          fail_ci_if_error: false
-          flags: bridge-server
-
-      - name: Upload Test Screenshots
-        if: always() && matrix.config.artifact == 'bridge2' && matrix.config.docker-test-target == 'builder-test-ui'
-        uses: actions/upload-artifact@v3
-        with:
-          name: bridge-e2e-screenshots
-          path: ./shared/screenshots
-
   unit-tests-cli:
     name: Unit Tests CLI (multi OS/arch)
     needs: prepare_ci_run

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -35,13 +35,13 @@ ARG debugBuild
 RUN if [ ! -z "$debugBuild" ]; then export BUILDFLAGS='-gcflags "all=-N -l"'; fi
 
 RUN sed -i "s/version: develop/version: ${version}/g" /go/src/github.com/keptn/keptn/api/swagger.yaml
+RUN sed -i "s|basePath: /v1|basePath: /api/v1 |g" /go/src/github.com/keptn/keptn/api/swagger.yaml
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
 RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v cmd/api-server/main.go
 
-
-FROM alpine:3.16 as production
+FROM gcr.io/distroless/static-debian11 as production
 ARG version=develop
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.url="https://keptn.sh" \
@@ -51,22 +51,16 @@ LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.licenses="Apache-2.0" \
     org.opencontainers.image.version="${version}"
 
-# we need to install ca-certificates and libc6-compat for go programs to work properly
-RUN apk add --no-cache ca-certificates libc6-compat
-
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /go/src/github.com/keptn/keptn/api/main /api
 COPY --from=builder /go/src/github.com/keptn/keptn/api/swagger-ui /swagger-ui
 COPY --from=builder /go/src/github.com/keptn/keptn/api/swagger.yaml /swagger-ui/swagger.yaml
-
-RUN sed -i "s|basePath: /v1|basePath: /api/v1 |g" /swagger-ui/swagger.yaml
 
 EXPOSE 8080
 
 # required for external tools to detect this as a go binary
 ENV GOTRACEBACK=all
 
-RUN adduser -D nonroot -u 65532
 USER nonroot
 
 # Run the web service on container startup.

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,24 +1,16 @@
-# Use the official Golang image to create a build artifact.
-# This is based on Debian and sets the GOPATH to /go.
 FROM golang:1.18.4-alpine3.16 as builder-base
 
 WORKDIR /go/src/github.com/keptn/keptn/api
 
-# Force the go compiler to use modules
-ENV GO111MODULE=on
 ENV BUILDFLAGS=""
 ENV GOPROXY=https://proxy.golang.org
 
-RUN apk add --no-cache gcc libc-dev git
+RUN apk add --no-cache gcc libc-dev
 
-# Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
-# in case of a change in the dependencies
 COPY go.mod go.sum ./
 
-# Download dependencies
 RUN go mod download
 
-# Copy local code to the container image.
 COPY . .
 
 FROM builder-base as builder-test
@@ -30,16 +22,15 @@ CMD gotestsum --no-color=false -- -coverprofile=coverage.txt -covermode=atomic -
 FROM builder-base as builder
 ARG version=develop
 ARG debugBuild
+ENV CGO_ENABLED=0
 
 # set buildflags for debug build
 RUN if [ ! -z "$debugBuild" ]; then export BUILDFLAGS='-gcflags "all=-N -l"'; fi
 
-RUN sed -i "s/version: develop/version: ${version}/g" /go/src/github.com/keptn/keptn/api/swagger.yaml
-RUN sed -i "s|basePath: /v1|basePath: /api/v1 |g" /go/src/github.com/keptn/keptn/api/swagger.yaml
+RUN sed -i "s/version: develop/version: ${version}/g" ./swagger.yaml
+RUN sed -i "s|basePath: /v1|basePath: /api/v1 |g" ./swagger.yaml
 
-# Build the command inside the container.
-# (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v cmd/api-server/main.go
+RUN go build $BUILDFLAGS -v cmd/api-server/main.go
 
 FROM gcr.io/distroless/static-debian11 as production
 ARG version=develop

--- a/approval-service/Dockerfile
+++ b/approval-service/Dockerfile
@@ -38,7 +38,7 @@ RUN if [ ! -z "$debugBuild" ]; then export BUILDFLAGS='-gcflags "all=-N -l"'; fi
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
 RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o approval-service
 
-FROM alpine:3.16 as production
+FROM gcr.io/distroless/static-debian11 as production
 ARG version=develop
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.url="https://keptn.sh" \
@@ -48,9 +48,6 @@ LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.licenses="Apache-2.0" \
     org.opencontainers.image.version="${version}"
 
-# we need to install ca-certificates and libc6-compat for go programs to work properly
-RUN apk add --no-cache ca-certificates libc6-compat
-
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /go/src/github.com/keptn/keptn/approval-service/approval-service /approval-service
 
@@ -59,7 +56,6 @@ EXPOSE 8080
 # required for external tools to detect this as a go binary
 ENV GOTRACEBACK=all
 
-RUN adduser -D nonroot -u 65532
 USER nonroot
 
 # Run the web service on container startup.

--- a/approval-service/Dockerfile
+++ b/approval-service/Dockerfile
@@ -9,7 +9,7 @@ ENV GO111MODULE=on
 ENV BUILDFLAGS=""
 ENV GOPROXY=https://proxy.golang.org
 
-RUN apk add --no-cache gcc libc-dev git
+RUN apk add --no-cache gcc libc-dev
 
 # Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
 # in case of a change in the dependencies
@@ -30,13 +30,14 @@ CMD gotestsum --no-color=false -- -race -coverprofile=coverage.txt -covermode=at
 FROM builder-base as builder
 ARG version=develop
 ARG debugBuild
+ENV CGO_ENABLED=0
 
 # set buildflags for debug build
 RUN if [ ! -z "$debugBuild" ]; then export BUILDFLAGS='-gcflags "all=-N -l"'; fi
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o approval-service
+RUN go build $BUILDFLAGS -v -o approval-service
 
 FROM gcr.io/distroless/static-debian11 as production
 ARG version=develop

--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -57,7 +57,7 @@ RUN yarn build && \
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM node:14-alpine3.15 as production
+FROM gcr.io/distroless/nodejs:16 as production
 ARG version=develop
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.url="https://keptn.sh" \
@@ -75,15 +75,13 @@ ENV API_TOKEN ""
 WORKDIR /usr/src/app
 
 # copy angular output from angularBuilder
-COPY --from=bridge-builder /usr/src/app/dist /usr/src/app/dist
-COPY --from=bridge-server-builder /usr/src/app/server/dist /usr/src/app/server/dist
-COPY --from=bridge-server-builder /usr/src/app/server/package.json /usr/src/app/server/
-COPY --from=bridge-server-builder /usr/src/app/server/node_modules /usr/src/app/server/node_modules
-
-RUN addgroup mygroup --gid 65532 && adduser -D -G mygroup myuser --uid 65532 && mkdir -p /usr/src/app && chown -R myuser /usr/src/app
+COPY --from=bridge-builder --chown=65532:65532 /usr/src/app/dist /usr/src/app/dist
+COPY --from=bridge-server-builder --chown=65532:65532 /usr/src/app/server/dist /usr/src/app/server/dist
+COPY --from=bridge-server-builder --chown=65532:65532 /usr/src/app/server/package.json /usr/src/app/server/
+COPY --from=bridge-server-builder --chown=65532:65532 /usr/src/app/server/node_modules /usr/src/app/server/node_modules
 
 # Set user
-USER myuser
+USER 65532:65532
 
 EXPOSE 3000
 CMD ["npm", "start", "--prefix", "./server"]

--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -75,13 +75,13 @@ ENV API_TOKEN ""
 WORKDIR /usr/src/app
 
 # copy angular output from angularBuilder
-COPY --from=bridge-builder --chown=65532:65532 /usr/src/app/dist /usr/src/app/dist
-COPY --from=bridge-server-builder --chown=65532:65532 /usr/src/app/server/dist /usr/src/app/server/dist
-COPY --from=bridge-server-builder --chown=65532:65532 /usr/src/app/server/package.json /usr/src/app/server/
-COPY --from=bridge-server-builder --chown=65532:65532 /usr/src/app/server/node_modules /usr/src/app/server/node_modules
+COPY --from=bridge-builder --chown=nonroot /usr/src/app/dist /usr/src/app/dist
+COPY --from=bridge-server-builder --chown=nonroot /usr/src/app/server/dist /usr/src/app/server/dist
+COPY --from=bridge-server-builder --chown=nonroot /usr/src/app/server/package.json /usr/src/app/server/
+COPY --from=bridge-server-builder --chown=nonroot /usr/src/app/server/node_modules /usr/src/app/server/node_modules
 
 # Set user
-USER 65532:65532
+USER nonroot
 
 EXPOSE 3000
 CMD ["npm", "start", "--prefix", "./server"]

--- a/distributor/Dockerfile
+++ b/distributor/Dockerfile
@@ -39,7 +39,7 @@ RUN if [ ! -z "$debugBuild" ]; then export BUILDFLAGS='-gcflags "all=-N -l"'; fi
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-linkmode=external -X main.gitCommit=$gitSha -X main.buildTime=$buildTime" $BUILDFLAGS -v -o distributor ./cmd/
 
-FROM alpine:3.16 as production
+FROM gcr.io/distroless/static-debian11 as production
 ARG version=develop
 
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
@@ -50,15 +50,12 @@ LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.licenses="Apache-2.0" \
     org.opencontainers.image.version="${version}"
 
-RUN apk add --no-cache ca-certificates libc6-compat
-
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /go/src/github.com/keptn/keptn/distributor/distributor /distributor
 
 # required for external tools to detect this as a go binary
 ENV GOTRACEBACK=all
 
-RUN adduser -D nonroot -u 65532
 USER nonroot
 
 # Run the web service on container startup.

--- a/distributor/Dockerfile
+++ b/distributor/Dockerfile
@@ -31,13 +31,14 @@ FROM builder-base as builder
 ARG debugBuild
 ARG buildTime=unknown
 ARG gitSha=unknown
+ENV CGO_ENABLED=0
 
 # set buildflags for debug build
 RUN if [ ! -z "$debugBuild" ]; then export BUILDFLAGS='-gcflags "all=-N -l"'; fi
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-linkmode=external -X main.gitCommit=$gitSha -X main.buildTime=$buildTime" $BUILDFLAGS -v -o distributor ./cmd/
+RUN go build -ldflags "-X main.gitCommit=$gitSha -X main.buildTime=$buildTime" $BUILDFLAGS -v -o distributor ./cmd/
 
 FROM gcr.io/distroless/static-debian11 as production
 ARG version=develop

--- a/helm-service/Dockerfile
+++ b/helm-service/Dockerfile
@@ -5,12 +5,10 @@ FROM golang:1.18.4-alpine3.16 as builder-base
 
 WORKDIR /go/src/github.com/keptn/keptn/helm-service
 
-# Force the go compiler to use modules 
-ENV GO111MODULE=on
 ENV BUILDFLAGS=""
 ENV GOPROXY=https://proxy.golang.org
 
-RUN apk add --no-cache gcc libc-dev git
+RUN apk add --no-cache gcc libc-dev
 
 # Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
 # in case of a change in the dependencies
@@ -35,11 +33,11 @@ ARG SKAFFOLD_GO_GCFLAGS
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v -o helm-service
+RUN GOOS=linux go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v -o helm-service
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM alpine:3.16 as production
+FROM gcr.io/distroless/static-debian11 as production
 ARG version=develop
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.url="https://keptn.sh" \
@@ -49,9 +47,6 @@ LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.licenses="Apache-2.0" \
     org.opencontainers.image.version="${version}"
 
-# we need to install ca-certificates and libc6-compat for go programs to work properly
-RUN apk add --no-cache ca-certificates libc6-compat
-
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /go/src/github.com/keptn/keptn/helm-service/helm-service /helm-service
 
@@ -59,6 +54,8 @@ EXPOSE 8080
 
 # required for external tools to detect this as a go binary
 ENV GOTRACEBACK=all
+
+USER nonroot
 
 # Run the web service on container startup.
 CMD ["/helm-service"]

--- a/jmeter-service/Dockerfile
+++ b/jmeter-service/Dockerfile
@@ -53,7 +53,7 @@ ENV env=production
 ARG JMETER_VERSION="5.4.3"
 ENV JMETER_HOME /opt/apache-jmeter-${JMETER_VERSION}
 ENV	JMETER_BIN	${JMETER_HOME}/bin
-ENV	JMETER_DOWNLOAD_URL  https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-${JMETER_VERSION}.tgz
+ENV	JMETER_DOWNLOAD_URL https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-${JMETER_VERSION}.tgz
 
 # Load additional extensions
 ARG DYNATRACE_EXTENSION_VERSION="1.8.0"

--- a/lighthouse-service/Dockerfile
+++ b/lighthouse-service/Dockerfile
@@ -39,7 +39,7 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM alpine:3.16 as production
+FROM gcr.io/distroless/static-debian11 as production
 ARG version=develop
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.url="https://keptn.sh" \
@@ -49,9 +49,6 @@ LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.licenses="Apache-2.0" \
     org.opencontainers.image.version="${version}"
 
-# we need to install ca-certificates and libc6-compat for go programs to work properly
-RUN apk add --no-cache ca-certificates libc6-compat
-
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /go/src/github.com/keptn/keptn/lighthouse-service/lighthouse-service /lighthouse-service
 
@@ -60,7 +57,6 @@ EXPOSE 8080
 # required for external tools to detect this as a go binary
 ENV GOTRACEBACK=all
 
-RUN adduser -D nonroot -u 65532
 USER nonroot
 
 # Run the web service on container startup.

--- a/lighthouse-service/Dockerfile
+++ b/lighthouse-service/Dockerfile
@@ -1,17 +1,12 @@
-# Use the official Golang image to create a build artifact.
-# This is based on Debian and sets the GOPATH to /go.
-# https://hub.docker.com/_/golang
 FROM golang:1.18.4-alpine3.16 as builder-base
 
 # Copy local code to the container image.
 WORKDIR /go/src/github.com/keptn/keptn/lighthouse-service
 
-# Force the go compiler to use modules
-ENV GO111MODULE=on
 ENV BUILDFLAGS=""
 ENV GOPROXY=https://proxy.golang.org
 
-RUN apk add --no-cache gcc libc-dev git
+RUN apk add --no-cache gcc libc-dev
 
 # Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
 # in case of a change in the dependencies
@@ -29,16 +24,15 @@ RUN go install gotest.tools/gotestsum@v1.7.0
 CMD gotestsum --no-color=false -- -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
 
 FROM builder-base as builder
+ENV CGO_ENABLED=0
 
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v -o lighthouse-service
+RUN GOOS=linux go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v -o lighthouse-service
 
-# Use a Docker multi-stage build to create a lean production image.
-# https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM gcr.io/distroless/static-debian11 as production
 ARG version=develop
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \

--- a/mongodb-datastore/Dockerfile
+++ b/mongodb-datastore/Dockerfile
@@ -40,7 +40,11 @@ RUN sed -i "s/version: develop/version: ${version}/g" /go/src/github.com/keptn/k
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
 RUN cd cmd/mongodb-datastore-server && GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o mongodb-datastore
 
-FROM alpine:3.16 as production
+# Replace contents for api proxy
+RUN sed -i "s|basePath: /|basePath: /api/mongodb-datastore |g" /go/src/github.com/keptn/keptn/mongodb-datastore/swagger.yaml
+RUN sed -i '/paths:/i securityDefinitions:\n  key:\n    type: apiKey\n    in: header\n    name: x-token\nsecurity:\n  - key: []\n' /go/src/github.com/keptn/keptn/mongodb-datastore/swagger.yaml
+
+FROM gcr.io/distroless/static-debian11 as production
 ARG version=develop
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.url="https://keptn.sh" \
@@ -50,25 +54,18 @@ LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.licenses="Apache-2.0" \
     org.opencontainers.image.version="${version}"
 
-# we need to install ca-certificates and libc6-compat for go programs to work properly
-RUN apk add --no-cache ca-certificates libc6-compat
-
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /go/src/github.com/keptn/keptn/mongodb-datastore/cmd/mongodb-datastore-server/mongodb-datastore /mongodb-datastore
 COPY --from=builder /go/src/github.com/keptn/keptn/mongodb-datastore/swagger-ui /swagger-ui
 COPY --from=builder /go/src/github.com/keptn/keptn/mongodb-datastore/swagger.yaml /swagger-ui/swagger-original.yaml
 
 COPY --from=builder /go/src/github.com/keptn/keptn/mongodb-datastore/swagger.yaml /swagger-ui/swagger.yaml
-# Replace contents for api proxy
-RUN sed -i "s|basePath: /|basePath: /api/mongodb-datastore |g" /swagger-ui/swagger.yaml
-RUN sed -i '/paths:/i securityDefinitions:\n  key:\n    type: apiKey\n    in: header\n    name: x-token\nsecurity:\n  - key: []\n' /swagger-ui/swagger.yaml
 
 EXPOSE 8080
 
 # required for external tools to detect this as a go binary
 ENV GOTRACEBACK=all
 
-RUN adduser -D nonroot -u 65532
 USER nonroot
 
 # Run the web service on container startup.

--- a/mongodb-datastore/Dockerfile
+++ b/mongodb-datastore/Dockerfile
@@ -1,11 +1,7 @@
-# Use the official Golang image to create a build artifact.
-# This is based on Debian and sets the GOPATH to /go.
 FROM golang:1.18.4 as builder-base
 
 WORKDIR /go/src/github.com/keptn/keptn/mongodb-datastore
 
-# Force the go compiler to use modules
-ENV GO111MODULE=on
 ENV BUILDFLAGS=""
 ENV GOPROXY=https://proxy.golang.org
 
@@ -30,19 +26,20 @@ CMD gotestsum --no-color=false -- -race -coverprofile=coverage.txt -covermode=at
 FROM builder-base as builder
 ARG version=develop
 ARG debugBuild
+ENV CGO_ENABLED=0
 
 # set buildflags for debug build
 RUN if [ ! -z "$debugBuild" ]; then export BUILDFLAGS='-gcflags "all=-N -l"'; fi
 
-RUN sed -i "s/version: develop/version: ${version}/g" /go/src/github.com/keptn/keptn/mongodb-datastore/swagger.yaml
+RUN sed -i "s/version: develop/version: ${version}/g" ./swagger.yaml
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN cd cmd/mongodb-datastore-server && GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o mongodb-datastore
+RUN cd cmd/mongodb-datastore-server && go build $BUILDFLAGS -v -o mongodb-datastore
 
 # Replace contents for api proxy
-RUN sed -i "s|basePath: /|basePath: /api/mongodb-datastore |g" /go/src/github.com/keptn/keptn/mongodb-datastore/swagger.yaml
-RUN sed -i '/paths:/i securityDefinitions:\n  key:\n    type: apiKey\n    in: header\n    name: x-token\nsecurity:\n  - key: []\n' /go/src/github.com/keptn/keptn/mongodb-datastore/swagger.yaml
+RUN sed -i "s|basePath: /|basePath: /api/mongodb-datastore |g" ./swagger.yaml
+RUN sed -i '/paths:/i securityDefinitions:\n  key:\n    type: apiKey\n    in: header\n    name: x-token\nsecurity:\n  - key: []\n' ./swagger.yaml
 
 FROM gcr.io/distroless/static-debian11 as production
 ARG version=develop
@@ -58,7 +55,6 @@ LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
 COPY --from=builder /go/src/github.com/keptn/keptn/mongodb-datastore/cmd/mongodb-datastore-server/mongodb-datastore /mongodb-datastore
 COPY --from=builder /go/src/github.com/keptn/keptn/mongodb-datastore/swagger-ui /swagger-ui
 COPY --from=builder /go/src/github.com/keptn/keptn/mongodb-datastore/swagger.yaml /swagger-ui/swagger-original.yaml
-
 COPY --from=builder /go/src/github.com/keptn/keptn/mongodb-datastore/swagger.yaml /swagger-ui/swagger.yaml
 
 EXPOSE 8080

--- a/remediation-service/Dockerfile
+++ b/remediation-service/Dockerfile
@@ -37,9 +37,7 @@ ARG SKAFFOLD_GO_GCFLAGS
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
 RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v -o remediation-service
 
-# Use a Docker multi-stage build to create a lean production image.
-# https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM alpine:3.16 as production
+FROM gcr.io/distroless/static-debian11 as production
 ARG version=develop
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.url="https://keptn.sh" \
@@ -49,9 +47,6 @@ LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.licenses="Apache-2.0" \
     org.opencontainers.image.version="${version}"
 
-# we need to install ca-certificates and libc6-compat for go programs to work properly
-RUN apk add --no-cache ca-certificates libc6-compat
-
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /go/src/github.com/keptn/keptn/remediation-service/remediation-service /remediation-service
 
@@ -60,7 +55,6 @@ EXPOSE 8080
 # required for external tools to detect this as a go binary
 ENV GOTRACEBACK=all
 
-RUN adduser -D nonroot -u 65532
 USER nonroot
 
 # Run the web service on container startup.

--- a/remediation-service/Dockerfile
+++ b/remediation-service/Dockerfile
@@ -1,19 +1,12 @@
-# Use the official Golang image to create a build artifact.
-# This is based on Debian and sets the GOPATH to /go.
-# https://hub.docker.com/_/golang
 FROM golang:1.18.4-alpine3.16 as builder-base
 
 WORKDIR /go/src/github.com/keptn/keptn/remediation-service
 
-# Force the go compiler to use modules
-ENV GO111MODULE=on
 ENV BUILDFLAGS=""
 ENV GOPROXY=https://proxy.golang.org
 
-RUN apk add --no-cache gcc libc-dev git
+RUN apk add --no-cache gcc libc-dev
 
-# Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
-# in case of a change in the dependencies
 COPY go.mod go.sum ./
 
 # Download dependencies
@@ -29,13 +22,14 @@ RUN go install gotest.tools/gotestsum@v1.7.0
 CMD gotestsum --no-color=false -- -race -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
 
 FROM builder-base as builder
+ENV CGO_ENABLED=0
 
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v -o remediation-service
+RUN GOOS=linux go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v -o remediation-service
 
 FROM gcr.io/distroless/static-debian11 as production
 ARG version=develop

--- a/resource-service/Dockerfile
+++ b/resource-service/Dockerfile
@@ -50,8 +50,11 @@ RUN sed -i "s/version: develop/version: ${version}/g" docs/swagger.yaml
 # either manually or with a tool like "godep".)
 RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v main.go
 
+# Replace contents for api proxy
+RUN sed -i "s|basePath: /v1|basePath: /api/resource-service/v1 |g" /go/src/github.com/keptn/keptn/resource-service/docs/swagger.yaml
+
 # Use a Docker multi-stage build to create a lean production image.
-FROM alpine:3.16 as production
+FROM gcr.io/distroless/static-debian11 as production
 ARG version=develop
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.url="https://keptn.sh" \
@@ -63,26 +66,17 @@ LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
 
 ENV env=production
 
-# we need to install ca-certificates and libc6-compat for go programs to work properly
-RUN apk add --no-cache ca-certificates libc6-compat
-
-# Install git
-RUN apk --update add --no-cache git
-
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /go/src/github.com/keptn/keptn/resource-service/main /resource-service
 COPY --from=builder /go/src/github.com/keptn/keptn/resource-service/swagger-ui /swagger-ui
 COPY --from=builder /go/src/github.com/keptn/keptn/resource-service/docs/swagger.yaml /swagger-ui/swagger-original.yaml
 COPY --from=builder /go/src/github.com/keptn/keptn/resource-service/docs/swagger.yaml /swagger-ui/swagger.yaml
-# Replace contents for api proxy
-RUN sed -i "s|basePath: /v1|basePath: /api/resource-service/v1 |g" /swagger-ui/swagger.yaml
 
 EXPOSE 8080
 
 # required for external tools to detect this as a go binary
 ENV GOTRACEBACK=all
 
-RUN adduser -D nonroot -u 65532
 USER nonroot
 
 # Run the web service on container startup.

--- a/resource-service/Dockerfile
+++ b/resource-service/Dockerfile
@@ -1,44 +1,37 @@
-# Use the official Golang image to create a build artifact.
-# This is based on Debian and sets the GOPATH to /go.
 FROM golang:1.18.4-alpine3.16 as builder-base
 
 # install additional dependencies
-RUN apk add --no-cache gcc libc-dev git
+RUN apk add --no-cache gcc libc-dev
 
-# Force the go compiler to use modules
-ENV GO111MODULE=on
 ENV BUILDFLAGS=""
 ENV GOPROXY=https://proxy.golang.org
 
-# Pre-Req for gin-gonic/go-swagger: Install swag cli to generate swagger.yaml and swagger.json
 RUN go install github.com/swaggo/swag/cmd/swag@v1.7.0
 
 WORKDIR /go/src/github.com/keptn/keptn/resource-service
 
-# Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
-# in case of a change in the dependencies
 COPY go.mod go.sum ./
 
 # Download dependencies
 RUN go mod download
 
-# Copy local code to the container image.
 COPY . .
 
 FROM builder-base as builder-test
 ENV GOTESTSUM_FORMAT=testname
-
-RUN go install gotest.tools/gotestsum@v1.7.0
+RUN apk add --no-cache git && \
+    go install gotest.tools/gotestsum@v1.7.0
 CMD gotestsum --no-color=false -- -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
 
 FROM builder-base as builder
 ARG version=develop
+ENV CGO_ENABLED=0
 
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
 
 # generate swagger docs
-RUN GOOS=linux swag init
+RUN swag init
 
 # replace github.com/alecthomas/template; with text/template in docs/docs.go
 RUN sed -i "s|github.com/alecthomas/template|text/template|g" docs/docs.go
@@ -48,10 +41,10 @@ RUN sed -i "s/version: develop/version: ${version}/g" docs/swagger.yaml
 # Build the command inside the container. 
 # (You may fetch or manage dependencies here, 
 # either manually or with a tool like "godep".)
-RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v main.go
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v main.go
 
 # Replace contents for api proxy
-RUN sed -i "s|basePath: /v1|basePath: /api/resource-service/v1 |g" /go/src/github.com/keptn/keptn/resource-service/docs/swagger.yaml
+RUN sed -i "s|basePath: /v1|basePath: /api/resource-service/v1 |g" docs/swagger.yaml
 
 # Use a Docker multi-stage build to create a lean production image.
 FROM gcr.io/distroless/static-debian11 as production

--- a/secret-service/Dockerfile
+++ b/secret-service/Dockerfile
@@ -49,9 +49,9 @@ RUN sed -i "s/version: develop/version: ${version}/g" docs/swagger.yaml
 # (You may fetch or manage dependencies here,
 # either manually or with a tool like "godep".)
 RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v main.go
+RUN sed -i "s|basePath: /v1|basePath: /api/secrets/v1 |g" /go/src/github.com/keptn/keptn/secret-service/docs/swagger.yaml
 
-# Use a Docker multi-stage build to create a lean production image.
-FROM alpine:3.16 as production
+FROM gcr.io/distroless/static-debian11 as production
 ARG version=develop
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.url="https://keptn.sh" \
@@ -61,11 +61,7 @@ LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.licenses="Apache-2.0" \
     org.opencontainers.image.version="${version}"
 
-
 ENV env=production
-
-# we need to install ca-certificates and libc6-compat for go programs to work properly
-RUN apk add --no-cache ca-certificates libc6-compat
 
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /go/src/github.com/keptn/keptn/secret-service/main /secret-service
@@ -73,7 +69,6 @@ COPY --from=builder /go/src/github.com/keptn/keptn/secret-service/swagger-ui /sw
 
 COPY --from=builder /go/src/github.com/keptn/keptn/secret-service/docs/swagger.yaml /swagger-ui/swagger-original.yaml
 COPY --from=builder /go/src/github.com/keptn/keptn/secret-service/docs/swagger.yaml /swagger-ui/swagger.yaml
-RUN sed -i "s|basePath: /v1|basePath: /api/secrets/v1 |g" /swagger-ui/swagger.yaml
 
 EXPOSE 8080
 

--- a/secret-service/Dockerfile
+++ b/secret-service/Dockerfile
@@ -1,12 +1,7 @@
-# Use the official Golang image to create a build artifact.
-# This is based on Debian and sets the GOPATH to /go.
 FROM golang:1.18.4-alpine3.16 as builder-base
 
-# install additional dependencies
-RUN apk add --no-cache gcc libc-dev git
+RUN apk add --no-cache gcc libc-dev
 
-# Force the go compiler to use modules
-ENV GO111MODULE=on
 ENV BUILDFLAGS=""
 ENV GOPROXY=https://proxy.golang.org
 
@@ -15,8 +10,6 @@ RUN go install github.com/swaggo/swag/cmd/swag@v1.7.0
 
 WORKDIR /go/src/github.com/keptn/keptn/secret-service
 
-# Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
-# in case of a change in the dependencies
 COPY go.mod go.sum ./
 
 # Download dependencies
@@ -33,6 +26,7 @@ CMD gotestsum --no-color=false -- -coverprofile=coverage.txt -covermode=atomic -
 
 FROM builder-base as builder
 ARG version=develop
+ENV CGO_ENABLED=0
 
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
@@ -45,11 +39,8 @@ RUN sed -i "s|github.com/alecthomas/template|text/template|g" docs/docs.go
 # replace version "develop" with actual version
 RUN sed -i "s/version: develop/version: ${version}/g" docs/swagger.yaml
 
-# Build the command inside the container.
-# (You may fetch or manage dependencies here,
-# either manually or with a tool like "godep".)
-RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v main.go
-RUN sed -i "s|basePath: /v1|basePath: /api/secrets/v1 |g" /go/src/github.com/keptn/keptn/secret-service/docs/swagger.yaml
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v main.go
+RUN sed -i "s|basePath: /v1|basePath: /api/secrets/v1 |g" docs/swagger.yaml
 
 FROM gcr.io/distroless/static-debian11 as production
 ARG version=develop
@@ -79,5 +70,7 @@ ENV GOTRACEBACK=all
 ENV GIN_MODE=release
 
 ADD scopes.yaml /data/scopes.yaml
+
+USER nonroot
 
 CMD ["/secret-service"]

--- a/shipyard-controller/Dockerfile
+++ b/shipyard-controller/Dockerfile
@@ -50,9 +50,9 @@ RUN sed -i "s/version: develop/version: ${version}/g" docs/swagger.yaml
 # (You may fetch or manage dependencies here, 
 # either manually or with a tool like "godep".)
 RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v main.go
+RUN sed -i "s|basePath: /v1|basePath: /api/controlPlane/v1 |g" /go/src/github.com/keptn/keptn/shipyard-controller/docs/swagger.yaml
 
-# Use a Docker multi-stage build to create a lean production image.
-FROM alpine:3.16 as production
+FROM gcr.io/distroless/static-debian11 as production
 ARG version=develop
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.url="https://keptn.sh" \
@@ -62,11 +62,7 @@ LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.licenses="Apache-2.0" \
     org.opencontainers.image.version="${version}"
 
-
 ENV env=production
-
-# we need to install ca-certificates and libc6-compat for go programs to work properly
-RUN apk add --no-cache ca-certificates libc6-compat
 
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /go/src/github.com/keptn/keptn/shipyard-controller/main /shipyard-controller
@@ -74,14 +70,12 @@ COPY --from=builder /go/src/github.com/keptn/keptn/shipyard-controller/swagger-u
 
 COPY --from=builder /go/src/github.com/keptn/keptn/shipyard-controller/docs/swagger.yaml /swagger-ui/swagger-original.yaml
 COPY --from=builder /go/src/github.com/keptn/keptn/shipyard-controller/docs/swagger.yaml /swagger-ui/swagger.yaml
-RUN sed -i "s|basePath: /v1|basePath: /api/controlPlane/v1 |g" /swagger-ui/swagger.yaml
 
 EXPOSE 8080
 
 # required for external tools to detect this as a go binary
 ENV GOTRACEBACK=all
 
-RUN adduser -D nonroot -u 65532
 USER nonroot
 
 # Run the web service on container startup.

--- a/shipyard-controller/Dockerfile
+++ b/shipyard-controller/Dockerfile
@@ -1,12 +1,8 @@
-# Use the official Golang image to create a build artifact.
-# This is based on Debian and sets the GOPATH to /go.
 FROM golang:1.18.4 as builder-base
 
 # install additional dependencies
-RUN apt-get install -y gcc libc-dev git
+RUN apt-get install -y gcc libc-dev
 
-# Force the go compiler to use modules
-ENV GO111MODULE=on
 ENV BUILDFLAGS=""
 ENV GOPROXY=https://proxy.golang.org
 
@@ -15,14 +11,10 @@ RUN go install github.com/swaggo/swag/cmd/swag@v1.7.0
 
 WORKDIR /go/src/github.com/keptn/keptn/shipyard-controller
 
-# Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
-# in case of a change in the dependencies
 COPY go.mod go.sum ./
 
-# Download dependencies
 RUN go mod download
 
-# Copy local code to the container image.
 COPY . .
 
 FROM builder-base as builder-test
@@ -34,6 +26,7 @@ CMD gotestsum --no-color=false -- -coverprofile=coverage.txt -covermode=atomic -
 
 FROM builder-base as builder
 ARG version=develop
+ENV CGO_ENABLED=0
 
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
@@ -49,8 +42,8 @@ RUN sed -i "s/version: develop/version: ${version}/g" docs/swagger.yaml
 # Build the command inside the container. 
 # (You may fetch or manage dependencies here, 
 # either manually or with a tool like "godep".)
-RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v main.go
-RUN sed -i "s|basePath: /v1|basePath: /api/controlPlane/v1 |g" /go/src/github.com/keptn/keptn/shipyard-controller/docs/swagger.yaml
+RUN GOOS=linux go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v main.go
+RUN sed -i "s|basePath: /v1|basePath: /api/controlPlane/v1 |g" docs/swagger.yaml
 
 FROM gcr.io/distroless/static-debian11 as production
 ARG version=develop
@@ -67,7 +60,6 @@ ENV env=production
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /go/src/github.com/keptn/keptn/shipyard-controller/main /shipyard-controller
 COPY --from=builder /go/src/github.com/keptn/keptn/shipyard-controller/swagger-ui /swagger-ui
-
 COPY --from=builder /go/src/github.com/keptn/keptn/shipyard-controller/docs/swagger.yaml /swagger-ui/swagger-original.yaml
 COPY --from=builder /go/src/github.com/keptn/keptn/shipyard-controller/docs/swagger.yaml /swagger-ui/swagger.yaml
 

--- a/statistics-service/Dockerfile
+++ b/statistics-service/Dockerfile
@@ -50,9 +50,9 @@ RUN sed -i "s/version: develop/version: ${version}/g" docs/swagger.yaml
 # (You may fetch or manage dependencies here,
 # either manually or with a tool like "godep".)
 RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v main.go
+RUN sed -i "s|basePath: /v1|basePath: /api/statistics/v1 |g" /go/src/github.com/keptn/keptn/statistics-service/docs/swagger.yaml
 
-# Use a Docker multi-stage build to create a lean production image.
-FROM alpine:3.16 as production
+FROM gcr.io/distroless/static-debian11 as production
 ARG version=develop
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.url="https://keptn.sh" \
@@ -64,23 +64,18 @@ LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
 
 ENV env=production
 
-# we need to install ca-certificates and libc6-compat for go programs to work properly
-RUN apk add --no-cache ca-certificates libc6-compat
-
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /go/src/github.com/keptn/keptn/statistics-service/main /statistics-service
 COPY --from=builder /go/src/github.com/keptn/keptn/statistics-service/swagger-ui /swagger-ui
 
 COPY --from=builder /go/src/github.com/keptn/keptn/statistics-service/docs/swagger.yaml /swagger-ui/swagger-original.yaml
 COPY --from=builder /go/src/github.com/keptn/keptn/statistics-service/docs/swagger.yaml /swagger-ui/swagger.yaml
-RUN sed -i "s|basePath: /v1|basePath: /api/statistics/v1 |g" /swagger-ui/swagger.yaml
 
 EXPOSE 8080
 
 # required for external tools to detect this as a go binary
 ENV GOTRACEBACK=all
 
-RUN adduser -D nonroot -u 65532
 USER nonroot
 
 # Run the web service on container startup.

--- a/statistics-service/Dockerfile
+++ b/statistics-service/Dockerfile
@@ -1,12 +1,8 @@
-# Use the official Golang image to create a build artifact.
-# This is based on Debian and sets the GOPATH to /go.
 FROM golang:1.18.4 as builder-base
 
 # install additional dependencies
-RUN apt-get install -y gcc libc-dev git
+RUN apt-get install -y gcc libc-dev
 
-# Force the go compiler to use modules
-ENV GO111MODULE=on
 ENV BUILDFLAGS=""
 ENV GOPROXY=https://proxy.golang.org
 
@@ -15,11 +11,8 @@ RUN go install github.com/swaggo/swag/cmd/swag@v1.7.0
 
 WORKDIR /go/src/github.com/keptn/keptn/statistics-service
 
-# Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
-# in case of a change in the dependencies
 COPY go.mod go.sum ./
 
-# Download dependencies
 RUN go mod download
 
 # Copy local code to the container image.
@@ -33,7 +26,7 @@ CMD gotestsum --no-color=false -- -race -coverprofile=coverage.txt -covermode=at
 
 FROM builder-base as builder
 ARG version=develop
-
+ENV CGO_ENABLED=0
 
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
@@ -49,8 +42,8 @@ RUN sed -i "s/version: develop/version: ${version}/g" docs/swagger.yaml
 # Build the command inside the container.
 # (You may fetch or manage dependencies here,
 # either manually or with a tool like "godep".)
-RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v main.go
-RUN sed -i "s|basePath: /v1|basePath: /api/statistics/v1 |g" /go/src/github.com/keptn/keptn/statistics-service/docs/swagger.yaml
+RUN GOOS=linux go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v main.go
+RUN sed -i "s|basePath: /v1|basePath: /api/statistics/v1 |g" docs/swagger.yaml
 
 FROM gcr.io/distroless/static-debian11 as production
 ARG version=develop
@@ -67,7 +60,6 @@ ENV env=production
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /go/src/github.com/keptn/keptn/statistics-service/main /statistics-service
 COPY --from=builder /go/src/github.com/keptn/keptn/statistics-service/swagger-ui /swagger-ui
-
 COPY --from=builder /go/src/github.com/keptn/keptn/statistics-service/docs/swagger.yaml /swagger-ui/swagger-original.yaml
 COPY --from=builder /go/src/github.com/keptn/keptn/statistics-service/docs/swagger.yaml /swagger-ui/swagger.yaml
 

--- a/webhook-service/Dockerfile
+++ b/webhook-service/Dockerfile
@@ -37,9 +37,7 @@ ARG SKAFFOLD_GO_GCFLAGS
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
 RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v -o webhook-service
 
-# Use a Docker multi-stage build to create a lean production image.
-# https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM alpine:3.16 as production
+FROM gcr.io/distroless/static-debian11 as production
 ARG version=develop
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.url="https://keptn.sh" \

--- a/webhook-service/Dockerfile
+++ b/webhook-service/Dockerfile
@@ -37,7 +37,7 @@ ARG SKAFFOLD_GO_GCFLAGS
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
 RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v -o webhook-service
 
-FROM gcr.io/distroless/static-debian11 as production
+FROM alpine:3.16 as production
 ARG version=develop
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.url="https://keptn.sh" \

--- a/webhook-service/Dockerfile
+++ b/webhook-service/Dockerfile
@@ -5,21 +5,15 @@ FROM golang:1.18.4-alpine3.16 as builder-base
 
 WORKDIR /go/src/github.com/keptn/keptn/webhook-service
 
-# Force the go compiler to use modules
-ENV GO111MODULE=on
 ENV BUILDFLAGS=""
 ENV GOPROXY=https://proxy.golang.org
 
-RUN apk add --no-cache gcc libc-dev git
+RUN apk add --no-cache gcc libc-dev
 
-# Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
-# in case of a change in the dependencies
 COPY go.mod go.sum ./
 
-# Download dependencies
 RUN go mod download
 
-# Copy local code to the container image.
 COPY . .
 
 FROM builder-base as builder-test
@@ -29,13 +23,14 @@ RUN go install gotest.tools/gotestsum@v1.7.0
 CMD gotestsum --no-color=false -- -race -coverprofile=coverage.txt -covermode=atomic -v ./... && mv ./coverage.txt /shared/coverage.txt
 
 FROM builder-base as builder
+ENV CGO_ENABLED=0
 
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v -o webhook-service
+RUN GOOS=linux go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v -o webhook-service
 
 FROM alpine:3.16 as production
 ARG version=develop


### PR DESCRIPTION
### This PR
- provides distroless based images for most keptn services
- some services could not be moved to distroless because of requirements for some packages like curl or git

## Result
Distroless base images for keptn will not be pursued further. There is not a huge benefit to them image size wise or security wise.

Sources:
https://www.redhat.com/en/blog/why-distroless-containers-arent-security-solution-you-think-they-are
https://hackernoon.com/distroless-containers-hype-or-true-value-2rfl3wat