### PR TITLE
fix(shipyard-controller): Handling error messages

### DIFF
--- a/shipyard-controller/common/configurationstore.go
+++ b/shipyard-controller/common/configurationstore.go
@@ -11,10 +11,6 @@ import (
 
 type configStoreErrType int
 
-var ErrConfigStoreInvalidToken = errors.New("invalid git token")
-var ErrConfigStoreUpstreamNotFound = errors.New("upstream repository not found")
-var ErrServiceNotFound = errors.New("service not found")
-
 const configServiceSvcDoesNotExistErrorMsg = "service does not exists" // [sic] this is what we get from the configuration service
 const resourceServiceSvcDoesNotExistErrorMsg = "service not found"
 

--- a/shipyard-controller/common/error.go
+++ b/shipyard-controller/common/error.go
@@ -1,9 +1,17 @@
-package handler
+package common
 
 import (
 	"errors"
 	"fmt"
 )
+
+var ErrConfigStoreInvalidToken = errors.New("invalid git token")
+
+var ErrConfigStoreUpstreamNotFound = errors.New("upstream repository not found")
+
+var ErrSequenceWithTriggeredIDAlreadyExists = errors.New("sequence with the same triggeredID already exists")
+
+var ErrOpenRemediationNotFound = errors.New("open remediation not found")
 
 var ErrProjectAlreadyExists = errors.New("project already exists")
 

--- a/shipyard-controller/db/mongodb_project_mv_repo.go
+++ b/shipyard-controller/db/mongodb_project_mv_repo.go
@@ -378,7 +378,7 @@ func (mv *MongoDBProjectMVRepo) GetService(projectName, stageName, serviceName s
 		return nil, err
 	}
 	if project == nil {
-		return nil, ErrProjectNotFound
+		return nil, common.ErrProjectNotFound
 	}
 
 	for _, stg := range project.Stages {
@@ -388,10 +388,10 @@ func (mv *MongoDBProjectMVRepo) GetService(projectName, stageName, serviceName s
 					return svc, nil
 				}
 			}
-			return nil, ErrServiceNotFound
+			return nil, common.ErrServiceNotFound
 		}
 	}
-	return nil, ErrStageNotFound
+	return nil, common.ErrStageNotFound
 }
 
 // DeleteService deletes a service
@@ -447,7 +447,7 @@ func (mv *MongoDBProjectMVRepo) UpdateEventOfService(e apimodels.KeptnContextExt
 		return err
 	} else if existingProject == nil {
 		log.Errorf("Could not update service %s in stage %s in project %s: Project not found.", eventData.Service, eventData.Stage, eventData.Project)
-		return ErrProjectNotFound
+		return common.ErrProjectNotFound
 	}
 
 	contextInfo := &apimodels.EventContextInfo{
@@ -502,7 +502,7 @@ func (mv *MongoDBProjectMVRepo) CreateRemediation(project, stage, service string
 	existingProject, err := mv.GetProject(project)
 	if err != nil {
 		log.Errorf("Could not create remediation for service %s in stage %s in project%s. Could not load project: %s", service, stage, project, err.Error())
-		return ErrProjectNotFound
+		return common.ErrProjectNotFound
 	}
 
 	err = updateServiceInStage(existingProject, stage, service, func(service *apimodels.ExpandedService) error {
@@ -520,7 +520,7 @@ func (mv *MongoDBProjectMVRepo) CloseOpenRemediations(project, stage, service, k
 	existingProject, err := mv.GetProject(project)
 	if err != nil {
 		log.Errorf("Could not close remediation for service %s in stage %s in project %s. Could not load project: %s", service, stage, project, err.Error())
-		return ErrProjectNotFound
+		return common.ErrProjectNotFound
 	}
 	if keptnContext == "" {
 		log.Warn("No keptnContext has been set.")
@@ -539,7 +539,7 @@ func (mv *MongoDBProjectMVRepo) CloseOpenRemediations(project, stage, service, k
 		}
 
 		if !foundRemediation {
-			return ErrOpenRemediationNotFound
+			return common.ErrOpenRemediationNotFound
 		}
 		service.OpenRemediations = updatedRemediations
 		return nil

--- a/shipyard-controller/db/mongodb_project_repo.go
+++ b/shipyard-controller/db/mongodb_project_repo.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	apimodels "github.com/keptn/go-utils/pkg/api/models"
+	"github.com/keptn/keptn/shipyard-controller/common"
 	"github.com/mitchellh/copystructure"
 	log "github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/bson"
@@ -64,7 +65,7 @@ func (mdbrepo *MongoDBProjectsRepo) GetProject(projectName string) (*apimodels.E
 	result := projectCollection.FindOne(ctx, bson.M{"projectName": projectName})
 	if result.Err() != nil {
 		if result.Err() == mongo.ErrNoDocuments {
-			return nil, ErrProjectNotFound
+			return nil, common.ErrProjectNotFound
 		}
 		return nil, result.Err()
 	}

--- a/shipyard-controller/db/mongodb_project_repo_test.go
+++ b/shipyard-controller/db/mongodb_project_repo_test.go
@@ -2,9 +2,11 @@ package db
 
 import (
 	"fmt"
-	apimodels "github.com/keptn/go-utils/pkg/api/models"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	apimodels "github.com/keptn/go-utils/pkg/api/models"
+	"github.com/keptn/keptn/shipyard-controller/common"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMongoDBProjectsRepo_InsertAndRetrieve(t *testing.T) {
@@ -26,7 +28,7 @@ func TestMongoDBProjectsRepo_InsertAndRetrieve(t *testing.T) {
 
 	prj, err = r.GetProject("my-project")
 
-	require.ErrorIs(t, err, ErrProjectNotFound)
+	require.ErrorIs(t, err, common.ErrProjectNotFound)
 	require.Nil(t, prj)
 }
 

--- a/shipyard-controller/db/mongodb_sequence_execution_repo.go
+++ b/shipyard-controller/db/mongodb_sequence_execution_repo.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	apimodels "github.com/keptn/go-utils/pkg/api/models"
+	"github.com/keptn/keptn/shipyard-controller/common"
 	"github.com/keptn/keptn/shipyard-controller/db/models/sequence_execution"
 	v02 "github.com/keptn/keptn/shipyard-controller/db/models/sequence_execution/v1"
 	"github.com/keptn/keptn/shipyard-controller/models"
@@ -135,7 +136,7 @@ func (mdbrepo *MongoDBSequenceExecutionRepo) Upsert(item models.SequenceExecutio
 			return fmt.Errorf("could not check for existing sequence with same triggeredID: %w", err)
 		}
 		if existingSequence != nil {
-			return ErrSequenceWithTriggeredIDAlreadyExists
+			return common.ErrSequenceWithTriggeredIDAlreadyExists
 		}
 	}
 	opts := options.Update().SetUpsert(true)

--- a/shipyard-controller/db/mongodb_sequence_execution_repo_test.go
+++ b/shipyard-controller/db/mongodb_sequence_execution_repo_test.go
@@ -6,6 +6,7 @@ import (
 	apimodels "github.com/keptn/go-utils/pkg/api/models"
 	"github.com/keptn/go-utils/pkg/common/timeutils"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
+	"github.com/keptn/keptn/shipyard-controller/common"
 	"github.com/keptn/keptn/shipyard-controller/models"
 
 	"testing"
@@ -140,7 +141,7 @@ func TestMongoDBTaskSequenceV2Repo_InsertTwice(t *testing.T) {
 	// try to insert the same sequence again, but with check for already existing triggeredID - this should return an error
 	err = mdbrepo.Upsert(sequence, &models.SequenceExecutionUpsertOptions{CheckUniqueTriggeredID: true})
 
-	require.ErrorIs(t, err, ErrSequenceWithTriggeredIDAlreadyExists)
+	require.ErrorIs(t, err, common.ErrSequenceWithTriggeredIDAlreadyExists)
 }
 
 func TestMongoDBTaskSequenceV2Repo_AppendTaskEvent(t *testing.T) {

--- a/shipyard-controller/db/repos.go
+++ b/shipyard-controller/db/repos.go
@@ -1,27 +1,12 @@
 package db
 
 import (
-	"errors"
+	"time"
+
 	apimodels "github.com/keptn/go-utils/pkg/api/models"
 	"github.com/keptn/keptn/shipyard-controller/common"
 	"github.com/keptn/keptn/shipyard-controller/models"
-	"time"
 )
-
-// ErrSequenceWithTriggeredIDAlreadyExists indicates that a sequence execution with the same triggeredID already exists
-var ErrSequenceWithTriggeredIDAlreadyExists = errors.New("sequence with the same triggeredID already exists")
-
-// ErrProjectNotFound indicates that a project has not been found
-var ErrProjectNotFound = errors.New("project not found")
-
-// ErrStageNotFound indicates that a stage has not been found
-var ErrStageNotFound = errors.New("stage not found")
-
-// ErrServiceNotFound indicates that a service has not been found
-var ErrServiceNotFound = errors.New("service not found")
-
-// ErrOpenRemediationNotFound indicates that no open remediation has been found
-var ErrOpenRemediationNotFound = errors.New("open remediation not found")
 
 //go:generate moq --skip-ensure -pkg db_mock -out ./mock/sequencestaterepo_mock.go . SequenceStateRepo
 type SequenceStateRepo interface {

--- a/shipyard-controller/handler/evaluationhandler.go
+++ b/shipyard-controller/handler/evaluationhandler.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/keptn/keptn/shipyard-controller/common"
 	"github.com/keptn/keptn/shipyard-controller/models"
 )
 
@@ -70,13 +71,13 @@ func (eh *EvaluationHandler) CreateEvaluation(c *gin.Context) {
 
 	params := &models.CreateEvaluationParams{}
 	if err := c.ShouldBindJSON(params); err != nil {
-		SetBadRequestErrorResponse(c, fmt.Sprintf(InvalidRequestFormatMsg, err.Error()))
+		SetBadRequestErrorResponse(c, fmt.Sprintf(common.InvalidRequestFormatMsg, err.Error()))
 		return
 	}
 
 	evaluationValidator := EvaluationParamsValidator{}
 	if err := evaluationValidator.Validate(params); err != nil {
-		SetBadRequestErrorResponse(c, fmt.Sprintf(InvalidRequestFormatMsg, err.Error()))
+		SetBadRequestErrorResponse(c, fmt.Sprintf(common.InvalidRequestFormatMsg, err.Error()))
 		return
 	}
 

--- a/shipyard-controller/handler/eventdispatcher.go
+++ b/shipyard-controller/handler/eventdispatcher.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	apimodels "github.com/keptn/go-utils/pkg/api/models"
 	"strings"
 	"time"
+
+	apimodels "github.com/keptn/go-utils/pkg/api/models"
 
 	"github.com/benbjohnson/clock"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -76,7 +77,7 @@ func (e *EventDispatcher) Add(event models.DispatcherEvent, skipQueue bool) erro
 		if err := e.tryToSendEvent(*eventScope, event); err != nil {
 			// if the event cannot be sent because it is blocked by other sequences,
 			// we'll add it to the queue and try to send it again later
-			if !strings.Contains(err.Error(), OtherActiveSequencesRunning) && err != ErrSequencePaused {
+			if !strings.Contains(err.Error(), common.OtherActiveSequencesRunning) && err != common.ErrSequencePaused {
 				// in all other cases, return the error
 				return err
 			}
@@ -181,7 +182,7 @@ func (e *EventDispatcher) dispatchEvents() {
 func (e *EventDispatcher) tryToSendEvent(eventScope models.EventScope, event models.DispatcherEvent) error {
 	if e.sequenceExecutionRepo.IsContextPaused(eventScope) {
 		log.Infof("sequence %s is currently paused. will not send event %s", eventScope.KeptnContext, event.Event.ID())
-		return ErrSequencePaused
+		return common.ErrSequencePaused
 	}
 	sequenceExecutions, err := e.sequenceExecutionRepo.Get(
 		models.SequenceExecutionFilter{
@@ -193,7 +194,7 @@ func (e *EventDispatcher) tryToSendEvent(eventScope models.EventScope, event mod
 		return err
 	}
 	if len(sequenceExecutions) == 0 {
-		return ErrSequenceNotFound
+		return common.ErrSequenceNotFound
 	}
 
 	filter := models.SequenceExecutionFilter{
@@ -225,7 +226,7 @@ func checkStarted(startedSequenceExecutions []models.SequenceExecution, event mo
 		for _, otherSequence := range startedSequenceExecutions {
 			if otherSequence.Status.CurrentTask.TriggeredID != event.Event.ID() {
 				if !e.isCurrentEventOverrulingOtherEvent(otherSequence, event) {
-					return errors.New(fmt.Sprint(OtherActiveSequencesRunning, otherSequence.Scope.KeptnContext))
+					return errors.New(fmt.Sprint(common.OtherActiveSequencesRunning, otherSequence.Scope.KeptnContext))
 				}
 			}
 		}

--- a/shipyard-controller/handler/eventhandler.go
+++ b/shipyard-controller/handler/eventhandler.go
@@ -48,7 +48,7 @@ func (eh *EventHandler) GetTriggeredEvents(c *gin.Context) {
 	eventType := c.Param("eventType")
 	params := &models.GetTriggeredEventsParams{}
 	if err := c.ShouldBindQuery(params); err != nil {
-		SetBadRequestErrorResponse(c, fmt.Sprintf(InvalidRequestFormatMsg, err.Error()))
+		SetBadRequestErrorResponse(c, fmt.Sprintf(common.InvalidRequestFormatMsg, err.Error()))
 	}
 
 	params.EventType = eventType
@@ -78,7 +78,7 @@ func (eh *EventHandler) GetTriggeredEvents(c *gin.Context) {
 	}
 
 	if err != nil {
-		if errors.Is(err, ErrProjectNotFound) {
+		if errors.Is(err, common.ErrProjectNotFound) {
 			SetNotFoundErrorResponse(c, err.Error())
 			return
 		}
@@ -103,16 +103,16 @@ func (eh *EventHandler) GetTriggeredEvents(c *gin.Context) {
 func (eh *EventHandler) HandleEvent(c *gin.Context) {
 	event := &apimodels.KeptnContextExtendedCE{}
 	if err := c.ShouldBindJSON(event); err != nil {
-		SetBadRequestErrorResponse(c, fmt.Sprintf(InvalidRequestFormatMsg, err.Error()))
+		SetBadRequestErrorResponse(c, fmt.Sprintf(common.InvalidRequestFormatMsg, err.Error()))
 		return
 	}
 	keptnEvent := &apimodels.KeptnContextExtendedCE{}
 	if err := keptnv2.Decode(event, keptnEvent); err != nil {
-		SetBadRequestErrorResponse(c, fmt.Sprintf(InvalidRequestFormatMsg, err.Error()))
+		SetBadRequestErrorResponse(c, fmt.Sprintf(common.InvalidRequestFormatMsg, err.Error()))
 		return
 	}
 	if err := keptnEvent.Validate(); err != nil {
-		SetBadRequestErrorResponse(c, fmt.Sprintf(InvalidRequestFormatMsg, err.Error()))
+		SetBadRequestErrorResponse(c, fmt.Sprintf(common.InvalidRequestFormatMsg, err.Error()))
 		return
 	}
 

--- a/shipyard-controller/handler/eventhandler_test.go
+++ b/shipyard-controller/handler/eventhandler_test.go
@@ -3,16 +3,17 @@ package handler_test
 import (
 	"bytes"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
 	"github.com/gin-gonic/gin"
 	apimodels "github.com/keptn/go-utils/pkg/api/models"
 	"github.com/keptn/keptn/shipyard-controller/common"
 	"github.com/keptn/keptn/shipyard-controller/handler"
 	"github.com/keptn/keptn/shipyard-controller/handler/fake"
 	"github.com/stretchr/testify/require"
-	"net/http"
-	"net/http/httptest"
-	"strings"
-	"testing"
 )
 
 func TestEventHandler_HandleEvent(t *testing.T) {
@@ -55,7 +56,7 @@ func TestEventHandler_HandleEvent(t *testing.T) {
 			fields: fields{
 				ShipyardController: &fake.IShipyardControllerMock{
 					HandleIncomingEventFunc: func(event apimodels.KeptnContextExtendedCE, waitForCompletion bool) error {
-						return handler.ErrNoMatchingEvent
+						return common.ErrNoMatchingEvent
 					},
 				},
 			},
@@ -146,7 +147,7 @@ func TestEventHandler_GetTriggeredEvents(t *testing.T) {
 			fields: fields{
 				ShipyardController: &fake.IShipyardControllerMock{
 					GetTriggeredEventsOfProjectFunc: func(project string, filter common.EventFilter) ([]apimodels.KeptnContextExtendedCE, error) {
-						return nil, handler.ErrProjectNotFound
+						return nil, common.ErrProjectNotFound
 					},
 				},
 			},

--- a/shipyard-controller/handler/loghandler.go
+++ b/shipyard-controller/handler/loghandler.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/keptn/keptn/shipyard-controller/common"
 	"github.com/keptn/keptn/shipyard-controller/models"
 )
 
@@ -69,13 +70,13 @@ func (lh *LogHandler) CreateLogEntries(context *gin.Context) {
 func (lh *LogHandler) GetLogEntries(context *gin.Context) {
 	params := &models.GetLogParams{}
 	if err := context.ShouldBindQuery(params); err != nil {
-		SetBadRequestErrorResponse(context, fmt.Sprintf(InvalidRequestFormatMsg, err.Error()))
+		SetBadRequestErrorResponse(context, fmt.Sprintf(common.InvalidRequestFormatMsg, err.Error()))
 		return
 	}
 
 	logs, err := lh.logManager.GetLogEntries(*params)
 	if err != nil {
-		SetNotFoundErrorResponse(context, fmt.Sprintf(UnableRetrieveLogsMsg, err.Error()))
+		SetNotFoundErrorResponse(context, fmt.Sprintf(common.UnableRetrieveLogsMsg, err.Error()))
 		return
 	}
 	context.JSON(http.StatusOK, logs)
@@ -100,12 +101,12 @@ func (lh *LogHandler) GetLogEntries(context *gin.Context) {
 func (lh *LogHandler) DeleteLogEntries(context *gin.Context) {
 	params := &models.DeleteLogParams{}
 	if err := context.ShouldBindQuery(params); err != nil {
-		SetBadRequestErrorResponse(context, fmt.Sprintf(InvalidRequestFormatMsg, err.Error()))
+		SetBadRequestErrorResponse(context, fmt.Sprintf(common.InvalidRequestFormatMsg, err.Error()))
 		return
 	}
 
 	if err := lh.logManager.DeleteLogEntries(*params); err != nil {
-		SetInternalServerErrorResponse(context, fmt.Sprintf(UnableRetrieveLogsMsg, err.Error()))
+		SetInternalServerErrorResponse(context, fmt.Sprintf(common.UnableRetrieveLogsMsg, err.Error()))
 		return
 	}
 	context.JSON(http.StatusOK, models.DeleteLogParams{})

--- a/shipyard-controller/handler/projecthandler.go
+++ b/shipyard-controller/handler/projecthandler.go
@@ -197,7 +197,7 @@ func NewProjectHandler(projectManager IProjectManager, eventSender common.EventS
 func (ph *ProjectHandler) GetAllProjects(c *gin.Context) {
 	params := &models.GetProjectParams{}
 	if err := c.ShouldBindQuery(params); err != nil {
-		SetBadRequestErrorResponse(c, fmt.Sprintf(InvalidRequestFormatMsg, err.Error()))
+		SetBadRequestErrorResponse(c, fmt.Sprintf(common.InvalidRequestFormatMsg, err.Error()))
 		return
 	}
 
@@ -247,8 +247,8 @@ func (ph *ProjectHandler) GetProjectByName(c *gin.Context) {
 
 	project, err := ph.ProjectManager.GetByName(projectName)
 	if err != nil {
-		if project == nil && errors.Is(err, ErrProjectNotFound) {
-			SetNotFoundErrorResponse(c, fmt.Sprintf(ProjectNotFoundMsg, projectName))
+		if project == nil && errors.Is(err, common.ErrProjectNotFound) {
+			SetNotFoundErrorResponse(c, fmt.Sprintf(common.ProjectNotFoundMsg, projectName))
 			return
 		}
 
@@ -280,7 +280,7 @@ func (ph *ProjectHandler) CreateProject(c *gin.Context) {
 
 	params := &models.CreateProjectParams{}
 	if err := c.ShouldBindJSON(params); err != nil {
-		SetBadRequestErrorResponse(c, fmt.Sprintf(InvalidRequestFormatMsg, err.Error()))
+		SetBadRequestErrorResponse(c, fmt.Sprintf(common.InvalidRequestFormatMsg, err.Error()))
 		return
 	}
 
@@ -289,7 +289,7 @@ func (ph *ProjectHandler) CreateProject(c *gin.Context) {
 		provisioningData, err := ph.RepositoryProvisioner.ProvideRepository(*params.Name, common.GetKeptnNamespace())
 		if err != nil {
 			log.Errorf(err.Error())
-			SetFailedDependencyErrorResponse(c, UnableProvisionInstanceGeneric)
+			SetFailedDependencyErrorResponse(c, common.UnableProvisionInstanceGeneric)
 			return
 		}
 
@@ -307,7 +307,7 @@ func (ph *ProjectHandler) CreateProject(c *gin.Context) {
 
 	projectValidator := ProjectValidator{ProjectNameMaxSize: ph.Env.ProjectNameMaxSize}
 	if err := projectValidator.Validate(params); err != nil {
-		SetBadRequestErrorResponse(c, fmt.Sprintf(InvalidPayloadMsg, err.Error()))
+		SetBadRequestErrorResponse(c, fmt.Sprintf(common.InvalidPayloadMsg, err.Error()))
 		return
 	}
 
@@ -325,7 +325,7 @@ func (ph *ProjectHandler) CreateProject(c *gin.Context) {
 		}
 
 		rollback()
-		if errors.Is(err, ErrProjectAlreadyExists) {
+		if errors.Is(err, common.ErrProjectAlreadyExists) {
 			SetConflictErrorResponse(c, err.Error())
 			return
 		}
@@ -363,12 +363,12 @@ func (ph *ProjectHandler) UpdateProject(c *gin.Context) {
 	// validate the input
 	params := &models.UpdateProjectParams{}
 	if err := c.ShouldBindJSON(params); err != nil {
-		SetBadRequestErrorResponse(c, fmt.Sprintf(InvalidRequestFormatMsg, err.Error()))
+		SetBadRequestErrorResponse(c, fmt.Sprintf(common.InvalidRequestFormatMsg, err.Error()))
 		return
 	}
 	projectValidator := ProjectValidator{ProjectNameMaxSize: ph.Env.ProjectNameMaxSize}
 	if err := projectValidator.Validate(params); err != nil {
-		SetBadRequestErrorResponse(c, fmt.Sprintf(InvalidPayloadMsg, err.Error()))
+		SetBadRequestErrorResponse(c, fmt.Sprintf(common.InvalidPayloadMsg, err.Error()))
 		return
 	}
 
@@ -386,15 +386,15 @@ func (ph *ProjectHandler) UpdateProject(c *gin.Context) {
 			SetNotFoundErrorResponse(c, err.Error())
 			return
 		}
-		if errors.Is(err, ErrProjectNotFound) {
+		if errors.Is(err, common.ErrProjectNotFound) {
 			SetNotFoundErrorResponse(c, err.Error())
 			return
 		}
-		if errors.Is(err, ErrInvalidStageChange) {
+		if errors.Is(err, common.ErrInvalidStageChange) {
 			SetBadRequestErrorResponse(c, err.Error())
 			return
 		}
-		SetInternalServerErrorResponse(c, ErrInternalError.Error())
+		SetInternalServerErrorResponse(c, common.ErrInternalError.Error())
 		return
 	}
 	c.Status(http.StatusCreated)

--- a/shipyard-controller/handler/projecthandler_test.go
+++ b/shipyard-controller/handler/projecthandler_test.go
@@ -5,11 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/keptn/keptn/shipyard-controller/config"
 
@@ -192,7 +193,7 @@ func TestGetProjectByName(t *testing.T) {
 			fields: fields{
 				ProjectManager: &fake.IProjectManagerMock{
 					GetByNameFunc: func(projectName string) (*apimodels.ExpandedProject, error) {
-						return nil, ErrProjectNotFound
+						return nil, common.ErrProjectNotFound
 					},
 				},
 				EventSender:           &fake.IEventSenderMock{},
@@ -276,7 +277,7 @@ func TestCreateProject(t *testing.T) {
 			fields: fields{
 				ProjectManager: &fake.IProjectManagerMock{
 					CreateFunc: func(params *models.CreateProjectParams) (error, common.RollbackFunc) {
-						return ErrProjectAlreadyExists, func() error {
+						return common.ErrProjectAlreadyExists, func() error {
 
 							return nil
 						}
@@ -304,7 +305,7 @@ func TestCreateProject(t *testing.T) {
 			fields: fields{
 				ProjectManager: &fake.IProjectManagerMock{
 					CreateFunc: func(params *models.CreateProjectParams) (error, common.RollbackFunc) {
-						return ErrProjectAlreadyExists, func() error { return nil }
+						return common.ErrProjectAlreadyExists, func() error { return nil }
 					},
 				},
 				EventSender: &fake.IEventSenderMock{
@@ -524,7 +525,7 @@ func TestUpdateProject(t *testing.T) {
 			fields: fields{
 				ProjectManager: &fake.IProjectManagerMock{
 					UpdateFunc: func(params *models.UpdateProjectParams) (error, common.RollbackFunc) {
-						return ErrProjectNotFound, func() error { return nil }
+						return common.ErrProjectNotFound, func() error { return nil }
 					},
 				},
 				EventSender: &fake.IEventSenderMock{
@@ -600,7 +601,7 @@ func TestUpdateProject(t *testing.T) {
 			fields: fields{
 				ProjectManager: &fake.IProjectManagerMock{
 					UpdateFunc: func(params *models.UpdateProjectParams) (error, common.RollbackFunc) {
-						return ErrInvalidStageChange, func() error { return nil }
+						return common.ErrInvalidStageChange, func() error { return nil }
 					},
 				},
 				EventSender: &fake.IEventSenderMock{

--- a/shipyard-controller/handler/projectmanager_test.go
+++ b/shipyard-controller/handler/projectmanager_test.go
@@ -97,6 +97,27 @@ func TestGetByNameErr(t *testing.T) {
 	assert.Equal(t, "my-project", projectMVRepo.GetProjectCalls()[0].ProjectName)
 }
 
+func TestGetByNameErrNotFound(t *testing.T) {
+	secretStore := &common_mock.SecretStoreMock{}
+	projectMVRepo := &db_mock.ProjectMVRepoMock{}
+	eventRepo := &db_mock.EventRepoMock{}
+	configStore := &common_mock.ConfigurationStoreMock{}
+	sequenceQueueRepo := &db_mock.SequenceQueueRepoMock{}
+	eventQueueRepo := &db_mock.EventQueueRepoMock{}
+	sequenceExecutionRepo := &db_mock.SequenceExecutionRepoMock{}
+
+	projectMVRepo.GetProjectFunc = func(projectName string) (*apimodels.ExpandedProject, error) {
+		return nil, common.ErrProjectNotFound
+	}
+
+	instance := NewProjectManager(configStore, secretStore, projectMVRepo, sequenceExecutionRepo, eventRepo, sequenceQueueRepo, eventQueueRepo)
+	project, err := instance.GetByName("my-project")
+	assert.NotNil(t, err)
+	assert.Equal(t, common.ErrProjectNotFound, err)
+	assert.Nil(t, project)
+	assert.Equal(t, "my-project", projectMVRepo.GetProjectCalls()[0].ProjectName)
+}
+
 func TestGetByNameNotFound(t *testing.T) {
 	secretStore := &common_mock.SecretStoreMock{}
 	projectMVRepo := &db_mock.ProjectMVRepoMock{}
@@ -111,7 +132,7 @@ func TestGetByNameNotFound(t *testing.T) {
 	instance := NewProjectManager(configStore, secretStore, projectMVRepo, sequenceExecutionRepo, eventRepo, sequenceQueueRepo, eventQueueRepo)
 	project, err := instance.GetByName("my-project")
 	assert.NotNil(t, err)
-	assert.Equal(t, ErrProjectNotFound, err)
+	assert.Equal(t, common.ErrProjectNotFound, err)
 	assert.Nil(t, project)
 	assert.Equal(t, "my-project", projectMVRepo.GetProjectCalls()[0].ProjectName)
 }
@@ -626,7 +647,7 @@ func TestUpdate_OldProjectNotAvailable(t *testing.T) {
 	}
 	err, rollback := instance.Update(params)
 	assert.NotNil(t, err)
-	assert.Equal(t, ErrProjectNotFound, err)
+	assert.Equal(t, common.ErrProjectNotFound, err)
 	rollback()
 
 }

--- a/shipyard-controller/handler/repository_provisioner.go
+++ b/shipyard-controller/handler/repository_provisioner.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	oauthutils "github.com/keptn/go-utils/pkg/common/oauth2"
+	"github.com/keptn/keptn/shipyard-controller/common"
 	"github.com/keptn/keptn/shipyard-controller/models"
 
 	log "github.com/sirupsen/logrus"
@@ -36,34 +37,34 @@ func (rp *RepositoryProvisioner) ProvideRepository(projectName, namespace string
 	jsonRequestData, err := json.Marshal(values)
 	log.Infof("Creating project %s with provisioned gitRemoteURL", projectName)
 	if err != nil {
-		return nil, fmt.Errorf(UnableMarshallProvisioningData, err.Error())
+		return nil, fmt.Errorf(common.UnableMarshallProvisioningData, err.Error())
 	}
 
 	req, err := http.NewRequest(http.MethodPost, rp.provisioningURL+"/repository", bytes.NewBuffer(jsonRequestData))
 	req.Header.Set("Content-type", "application/json")
 	req.Header.Set("Accept", "application/json")
 	if err != nil {
-		return nil, fmt.Errorf(UnableProvisionPostReq, err.Error())
+		return nil, fmt.Errorf(common.UnableProvisionPostReq, err.Error())
 	}
 
 	resp, err := rp.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf(UnableProvisionInstance, err.Error())
+		return nil, fmt.Errorf(common.UnableProvisionInstance, err.Error())
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusConflict {
-		return nil, fmt.Errorf(UnableProvisionInstance, http.StatusText(http.StatusConflict))
+		return nil, fmt.Errorf(common.UnableProvisionInstance, http.StatusText(http.StatusConflict))
 	}
 
 	jsonProvisioningData, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf(UnableReadProvisioningData, err.Error())
+		return nil, fmt.Errorf(common.UnableReadProvisioningData, err.Error())
 	}
 
 	provisioningData := models.ProvisioningData{}
 	if err := json.Unmarshal(jsonProvisioningData, &provisioningData); err != nil {
-		return nil, fmt.Errorf(UnableUnMarshallProvisioningData, err.Error())
+		return nil, fmt.Errorf(common.UnableUnMarshallProvisioningData, err.Error())
 	}
 
 	return &provisioningData, nil
@@ -75,24 +76,24 @@ func (rp *RepositoryProvisioner) DeleteRepository(projectName string, namespace 
 	log.Infof("Deleting project %s with provisioned gitRemoteURL", projectName)
 
 	if err != nil {
-		return fmt.Errorf(UnableMarshallProvisioningData, err.Error())
+		return fmt.Errorf(common.UnableMarshallProvisioningData, err.Error())
 	}
 
 	req, err := http.NewRequest(http.MethodDelete, rp.provisioningURL+"/repository", bytes.NewBuffer(jsonRequestData))
 	req.Header.Set("Content-type", "application/json")
 	req.Header.Set("Accept", "application/json")
 	if err != nil {
-		return fmt.Errorf(UnableProvisionDeleteReq, err.Error())
+		return fmt.Errorf(common.UnableProvisionDeleteReq, err.Error())
 	}
 
 	resp, err := rp.client.Do(req)
 	if err != nil {
-		return fmt.Errorf(UnableProvisionDelete, err.Error())
+		return fmt.Errorf(common.UnableProvisionDelete, err.Error())
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotFound {
-		return fmt.Errorf(UnableProvisionDelete, http.StatusText(http.StatusNotFound))
+		return fmt.Errorf(common.UnableProvisionDelete, http.StatusText(http.StatusNotFound))
 	}
 
 	return nil

--- a/shipyard-controller/handler/repository_provisioner_test.go
+++ b/shipyard-controller/handler/repository_provisioner_test.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -11,7 +10,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/keptn/go-utils/pkg/common/testutils"
+	"github.com/keptn/keptn/shipyard-controller/common"
 	"github.com/keptn/keptn/shipyard-controller/models"
 	"github.com/stretchr/testify/assert"
 )
@@ -58,7 +60,7 @@ func TestProvideRepository(t *testing.T) {
 			Body:       "",
 			StatusCode: http.StatusConflict,
 			expResult:  nil,
-			expErr:     fmt.Errorf(UnableProvisionInstance, http.StatusText(http.StatusConflict)),
+			expErr:     fmt.Errorf(common.UnableProvisionInstance, http.StatusText(http.StatusConflict)),
 		},
 		{
 			args: args{
@@ -68,7 +70,7 @@ func TestProvideRepository(t *testing.T) {
 			Body:       `invalid body`,
 			StatusCode: http.StatusCreated,
 			expResult:  nil,
-			expErr:     fmt.Errorf(UnableUnMarshallProvisioningData, "invalid character 'i' looking for beginning of value"),
+			expErr:     fmt.Errorf(common.UnableUnMarshallProvisioningData, "invalid character 'i' looking for beginning of value"),
 		},
 	}
 
@@ -116,7 +118,7 @@ func TestDeleteRepository(t *testing.T) {
 		}, {
 			Body:       "",
 			StatusCode: http.StatusNotFound,
-			expErr:     fmt.Errorf(UnableProvisionDelete, http.StatusText(http.StatusNotFound)),
+			expErr:     fmt.Errorf(common.UnableProvisionDelete, http.StatusText(http.StatusNotFound)),
 		},
 	}
 

--- a/shipyard-controller/handler/servicehandler.go
+++ b/shipyard-controller/handler/servicehandler.go
@@ -85,13 +85,13 @@ func (sh *ServiceHandler) CreateService(c *gin.Context) {
 	keptnContext := uuid.New().String()
 	projectName := c.Param("project")
 	if projectName == "" {
-		SetBadRequestErrorResponse(c, NoProjectNameMsg)
+		SetBadRequestErrorResponse(c, common.NoProjectNameMsg)
 		return
 	}
 	// validate the input
 	params := &models.CreateServiceParams{}
 	if err := c.ShouldBindJSON(params); err != nil {
-		SetBadRequestErrorResponse(c, fmt.Sprintf(InvalidRequestFormatMsg, err.Error()))
+		SetBadRequestErrorResponse(c, fmt.Sprintf(common.InvalidRequestFormatMsg, err.Error()))
 		return
 	}
 	serviceValidator := ServiceParamsValidator{
@@ -114,7 +114,7 @@ func (sh *ServiceHandler) CreateService(c *gin.Context) {
 			log.Errorf("could not send service.create.finished event: %s", err2.Error())
 		}
 
-		if errors.Is(err, ErrServiceAlreadyExists) {
+		if errors.Is(err, common.ErrServiceAlreadyExists) {
 			SetConflictErrorResponse(c, err.Error())
 			return
 		}
@@ -148,11 +148,11 @@ func (sh *ServiceHandler) DeleteService(c *gin.Context) {
 	projectName := c.Param("project")
 	serviceName := c.Param("service")
 	if projectName == "" {
-		SetBadRequestErrorResponse(c, NoProjectNameMsg)
+		SetBadRequestErrorResponse(c, common.NoProjectNameMsg)
 		return
 	}
 	if serviceName == "" {
-		SetBadRequestErrorResponse(c, NoServiceNameMsg)
+		SetBadRequestErrorResponse(c, common.NoServiceNameMsg)
 	}
 
 	common.LockProject(projectName)
@@ -200,7 +200,7 @@ func (sh *ServiceHandler) GetService(c *gin.Context) {
 
 	service, err := sh.serviceManager.GetService(projectName, stageName, serviceName)
 	if err != nil {
-		if errors.Is(err, ErrProjectNotFound) || errors.Is(err, ErrStageNotFound) || errors.Is(err, ErrServiceNotFound) {
+		if errors.Is(err, common.ErrProjectNotFound) || errors.Is(err, common.ErrStageNotFound) || errors.Is(err, common.ErrServiceNotFound) {
 			SetNotFoundErrorResponse(c, err.Error())
 			return
 		}
@@ -234,13 +234,13 @@ func (sh *ServiceHandler) GetServices(c *gin.Context) {
 
 	params := &models.GetServiceParams{}
 	if err := c.ShouldBindQuery(params); err != nil {
-		SetBadRequestErrorResponse(c, fmt.Sprintf(InvalidRequestFormatMsg, err.Error()))
+		SetBadRequestErrorResponse(c, fmt.Sprintf(common.InvalidRequestFormatMsg, err.Error()))
 		return
 	}
 
 	services, err := sh.serviceManager.GetAllServices(projectName, stageName)
 	if err != nil {
-		if errors.Is(err, ErrProjectNotFound) || errors.Is(err, ErrStageNotFound) {
+		if errors.Is(err, common.ErrProjectNotFound) || errors.Is(err, common.ErrStageNotFound) {
 			SetNotFoundErrorResponse(c, err.Error())
 			return
 		}

--- a/shipyard-controller/handler/servicehandler_test.go
+++ b/shipyard-controller/handler/servicehandler_test.go
@@ -5,6 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
 	"github.com/cloudevents/sdk-go/v2/event"
 	"github.com/gin-gonic/gin"
 	apimodels "github.com/keptn/go-utils/pkg/api/models"
@@ -13,10 +18,6 @@ import (
 	"github.com/keptn/keptn/shipyard-controller/handler/fake"
 	"github.com/keptn/keptn/shipyard-controller/models"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
-	"net/http"
-	"net/http/httptest"
-	"testing"
 )
 
 func TestServiceHandler_CreateService(t *testing.T) {
@@ -65,7 +66,7 @@ func TestServiceHandler_CreateService(t *testing.T) {
 			fields: fields{
 				serviceManager: &fake.IServiceManagerMock{
 					CreateServiceFunc: func(projectName string, params *models.CreateServiceParams) error {
-						return ErrServiceAlreadyExists
+						return common.ErrServiceAlreadyExists
 					},
 				},
 				EventSender: &fake.IEventSenderMock{
@@ -84,7 +85,7 @@ func TestServiceHandler_CreateService(t *testing.T) {
 			expectJSONResponse: &models.CreateServiceResponse{},
 			expectJSONError: &models.Error{
 				Code:    http.StatusConflict,
-				Message: stringp(ErrServiceAlreadyExists.Error()),
+				Message: stringp(common.ErrServiceAlreadyExists.Error()),
 			},
 		},
 		{
@@ -375,7 +376,7 @@ func TestServiceHandler_GetService(t *testing.T) {
 			fields: fields{
 				serviceManager: &fake.IServiceManagerMock{
 					GetServiceFunc: func(projectName string, stageName string, serviceName string) (*apimodels.ExpandedService, error) {
-						return nil, ErrServiceNotFound
+						return nil, common.ErrServiceNotFound
 					},
 				},
 				EventSender: &fake.IEventSenderMock{},
@@ -385,7 +386,7 @@ func TestServiceHandler_GetService(t *testing.T) {
 			expectJSONResponse:         nil,
 			expectJSONError: &models.Error{
 				Code:    http.StatusNotFound,
-				Message: stringp(ErrServiceNotFound.Error()),
+				Message: stringp(common.ErrServiceNotFound.Error()),
 			},
 		},
 		{
@@ -393,7 +394,7 @@ func TestServiceHandler_GetService(t *testing.T) {
 			fields: fields{
 				serviceManager: &fake.IServiceManagerMock{
 					GetServiceFunc: func(projectName string, stageName string, serviceName string) (*apimodels.ExpandedService, error) {
-						return nil, ErrStageNotFound
+						return nil, common.ErrStageNotFound
 					},
 				},
 				EventSender: &fake.IEventSenderMock{},
@@ -403,7 +404,7 @@ func TestServiceHandler_GetService(t *testing.T) {
 			expectJSONResponse:         nil,
 			expectJSONError: &models.Error{
 				Code:    http.StatusNotFound,
-				Message: stringp(ErrStageNotFound.Error()),
+				Message: stringp(common.ErrStageNotFound.Error()),
 			},
 		},
 		{
@@ -411,7 +412,7 @@ func TestServiceHandler_GetService(t *testing.T) {
 			fields: fields{
 				serviceManager: &fake.IServiceManagerMock{
 					GetServiceFunc: func(projectName string, stageName string, serviceName string) (*apimodels.ExpandedService, error) {
-						return nil, ErrProjectNotFound
+						return nil, common.ErrProjectNotFound
 					},
 				},
 				EventSender: &fake.IEventSenderMock{},
@@ -421,7 +422,7 @@ func TestServiceHandler_GetService(t *testing.T) {
 			expectJSONResponse:         nil,
 			expectJSONError: &models.Error{
 				Code:    http.StatusNotFound,
-				Message: stringp(ErrProjectNotFound.Error()),
+				Message: stringp(common.ErrProjectNotFound.Error()),
 			},
 		},
 		{
@@ -537,7 +538,7 @@ func TestServiceHandler_GetServices(t *testing.T) {
 			fields: fields{
 				serviceManager: &fake.IServiceManagerMock{
 					GetAllServicesFunc: func(projectName string, stageName string) ([]*apimodels.ExpandedService, error) {
-						return nil, ErrStageNotFound
+						return nil, common.ErrStageNotFound
 					},
 				},
 				EventSender: &fake.IEventSenderMock{},
@@ -547,7 +548,7 @@ func TestServiceHandler_GetServices(t *testing.T) {
 			expectJSONResponse:         nil,
 			expectJSONError: &models.Error{
 				Code:    http.StatusNotFound,
-				Message: stringp(ErrStageNotFound.Error()),
+				Message: stringp(common.ErrStageNotFound.Error()),
 			},
 		},
 		{
@@ -555,7 +556,7 @@ func TestServiceHandler_GetServices(t *testing.T) {
 			fields: fields{
 				serviceManager: &fake.IServiceManagerMock{
 					GetAllServicesFunc: func(projectName string, stageName string) ([]*apimodels.ExpandedService, error) {
-						return nil, ErrProjectNotFound
+						return nil, common.ErrProjectNotFound
 					},
 				},
 				EventSender: &fake.IEventSenderMock{},
@@ -565,7 +566,7 @@ func TestServiceHandler_GetServices(t *testing.T) {
 			expectJSONResponse:         nil,
 			expectJSONError: &models.Error{
 				Code:    http.StatusNotFound,
-				Message: stringp(ErrProjectNotFound.Error()),
+				Message: stringp(common.ErrProjectNotFound.Error()),
 			},
 		},
 		{

--- a/shipyard-controller/handler/servicemanager.go
+++ b/shipyard-controller/handler/servicemanager.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"errors"
 	"fmt"
+
 	apimodels "github.com/keptn/go-utils/pkg/api/models"
 	"github.com/keptn/keptn/shipyard-controller/common"
 	"github.com/keptn/keptn/shipyard-controller/db"
@@ -42,7 +43,7 @@ func (sm *serviceManager) GetAllStages(projectName string) ([]*apimodels.Expande
 		return nil, err
 	}
 	if project == nil {
-		return nil, ErrProjectNotFound
+		return nil, common.ErrProjectNotFound
 	}
 
 	return project.Stages, nil
@@ -55,7 +56,7 @@ func (sm *serviceManager) GetService(projectName, stageName, serviceName string)
 		return nil, err
 	}
 	if project == nil {
-		return nil, ErrProjectNotFound
+		return nil, common.ErrProjectNotFound
 	}
 
 	for _, stg := range project.Stages {
@@ -65,10 +66,10 @@ func (sm *serviceManager) GetService(projectName, stageName, serviceName string)
 					return svc, nil
 				}
 			}
-			return nil, ErrServiceNotFound
+			return nil, common.ErrServiceNotFound
 		}
 	}
-	return nil, ErrStageNotFound
+	return nil, common.ErrStageNotFound
 }
 
 func (sm *serviceManager) GetAllServices(projectName, stageName string) ([]*apimodels.ExpandedService, error) {
@@ -77,7 +78,7 @@ func (sm *serviceManager) GetAllServices(projectName, stageName string) ([]*apim
 		return nil, err
 	}
 	if project == nil {
-		return nil, ErrProjectNotFound
+		return nil, common.ErrProjectNotFound
 	}
 
 	for _, stg := range project.Stages {
@@ -85,7 +86,7 @@ func (sm *serviceManager) GetAllServices(projectName, stageName string) ([]*apim
 			return stg.Services, nil
 		}
 	}
-	return nil, ErrStageNotFound
+	return nil, common.ErrStageNotFound
 }
 
 func (sm *serviceManager) CreateService(projectName string, params *models.CreateServiceParams) error {
@@ -102,7 +103,7 @@ func (sm *serviceManager) CreateService(projectName string, params *models.Creat
 		service, _ := sm.GetService(projectName, stage.StageName, *params.ServiceName)
 		if service != nil {
 			log.Infof("Service %s already exists in project %s", *params.ServiceName, projectName)
-			return ErrServiceAlreadyExists
+			return common.ErrServiceAlreadyExists
 		}
 
 		log.Infof("Creating service %s in project %s", *params.ServiceName, projectName)

--- a/shipyard-controller/handler/shipyardcontroller.go
+++ b/shipyard-controller/handler/shipyardcontroller.go
@@ -171,7 +171,7 @@ func (sc *shipyardController) HandleIncomingEvent(event apimodels.KeptnContextEx
 		go func() {
 			err := sc.handleTaskEvent(event)
 			if err != nil {
-				if errors.Is(err, ErrSequenceNotFound) || errors.Is(err, models.ErrInvalidEventScope) {
+				if errors.Is(err, common.ErrSequenceNotFound) || errors.Is(err, models.ErrInvalidEventScope) {
 					log.Infof("Unable to handle task event: %v", err)
 				} else {
 					log.Errorf("Unable to handle task event: %v", err)
@@ -273,7 +273,7 @@ func (sc *shipyardController) handleSequenceTriggered(event apimodels.KeptnConte
 		EventID:   eventScope.WrappedEvent.ID,
 		Timestamp: eventScope.WrappedEvent.Time,
 	})
-	if errors.Is(err, ErrSequenceBlockedWaiting) {
+	if errors.Is(err, common.ErrSequenceBlockedWaiting) {
 		sc.onSequenceWaiting(eventScope.WrappedEvent)
 		return nil
 	}
@@ -311,7 +311,7 @@ func (sc *shipyardController) handleTaskEvent(event apimodels.KeptnContextExtend
 	if sequenceExecution == nil {
 		log.Infof("The received %s event with keptn context %s is not accociated with a task that was previously triggered",
 			eventScope.EventType, eventScope.KeptnContext)
-		return ErrSequenceNotFound
+		return common.ErrSequenceNotFound
 	}
 
 	if keptnv2.IsStartedEventType(*event.Type) {
@@ -675,7 +675,7 @@ func (sc *shipyardController) GetTriggeredEventsOfProject(projectName string, fi
 	if err != nil {
 		return nil, err
 	} else if project == nil {
-		return nil, ErrProjectNotFound
+		return nil, common.ErrProjectNotFound
 	}
 	events, err := sc.eventRepo.GetEvents(projectName, filter, common.TriggeredEvent)
 	if err != nil && err != db.ErrNoEventFound {

--- a/shipyard-controller/handler/shipyardcontroller_component_test.go
+++ b/shipyard-controller/handler/shipyardcontroller_component_test.go
@@ -738,7 +738,7 @@ func Test_shipyardController_Scenario6(t *testing.T) {
 	// send dev.artifact-delivery.triggered event
 	err := sc.HandleIncomingEvent(getTestTaskFinishedEvent("dev", "unknown-triggered-id"), true)
 	require.NotNil(t, err)
-	require.ErrorIs(t, err, ErrSequenceNotFound)
+	require.ErrorIs(t, err, common.ErrSequenceNotFound)
 
 	require.Empty(t, mockDispatcher.AddCalls())
 }

--- a/shipyard-controller/handler/stagehandler.go
+++ b/shipyard-controller/handler/stagehandler.go
@@ -49,7 +49,7 @@ func (sh *StageHandler) GetAllStages(c *gin.Context) {
 
 	params := &models.GetStagesParams{}
 	if err := c.ShouldBindQuery(params); err != nil {
-		SetBadRequestErrorResponse(c, fmt.Sprintf(InvalidRequestFormatMsg, err.Error()))
+		SetBadRequestErrorResponse(c, fmt.Sprintf(common.InvalidRequestFormatMsg, err.Error()))
 		return
 	}
 
@@ -57,7 +57,7 @@ func (sh *StageHandler) GetAllStages(c *gin.Context) {
 
 	allStages, err := sh.StageManager.GetAllStages(params.ProjectName)
 	if err != nil {
-		if errors.Is(err, ErrProjectNotFound) {
+		if errors.Is(err, common.ErrProjectNotFound) {
 			SetNotFoundErrorResponse(c, err.Error())
 			return
 		}
@@ -107,11 +107,11 @@ func (sh *StageHandler) GetStage(c *gin.Context) {
 
 	stage, err := sh.StageManager.GetStage(projectName, stageName)
 	if err != nil {
-		if errors.Is(err, ErrProjectNotFound) {
+		if errors.Is(err, common.ErrProjectNotFound) {
 			SetNotFoundErrorResponse(c, err.Error())
 			return
 		}
-		if errors.Is(err, ErrStageNotFound) {
+		if errors.Is(err, common.ErrStageNotFound) {
 			SetNotFoundErrorResponse(c, err.Error())
 		}
 

--- a/shipyard-controller/handler/stagehandler_test.go
+++ b/shipyard-controller/handler/stagehandler_test.go
@@ -4,14 +4,16 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"github.com/gin-gonic/gin"
-	apimodels "github.com/keptn/go-utils/pkg/api/models"
-	"github.com/keptn/keptn/shipyard-controller/handler/fake"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/gin-gonic/gin"
+	apimodels "github.com/keptn/go-utils/pkg/api/models"
+	"github.com/keptn/keptn/shipyard-controller/common"
+	"github.com/keptn/keptn/shipyard-controller/handler/fake"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetStage(t *testing.T) {
@@ -30,7 +32,7 @@ func TestGetStage(t *testing.T) {
 			fields: fields{
 				StageManager: &fake.IStageManagerMock{
 					GetStageFunc: func(projectName string, stageName string) (*apimodels.ExpandedStage, error) {
-						return nil, ErrProjectNotFound
+						return nil, common.ErrProjectNotFound
 					},
 				},
 			},
@@ -41,7 +43,7 @@ func TestGetStage(t *testing.T) {
 			fields: fields{
 				StageManager: &fake.IStageManagerMock{
 					GetStageFunc: func(projectName string, stageName string) (*apimodels.ExpandedStage, error) {
-						return nil, ErrStageNotFound
+						return nil, common.ErrStageNotFound
 					},
 				},
 			},
@@ -106,7 +108,7 @@ func TestGetStages(t *testing.T) {
 			fields: fields{
 				StageManager: &fake.IStageManagerMock{
 					GetAllStagesFunc: func(projectName string) ([]*apimodels.ExpandedStage, error) {
-						return nil, ErrProjectNotFound
+						return nil, common.ErrProjectNotFound
 					},
 				},
 			},

--- a/shipyard-controller/handler/stagemanager.go
+++ b/shipyard-controller/handler/stagemanager.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	apimodels "github.com/keptn/go-utils/pkg/api/models"
+	"github.com/keptn/keptn/shipyard-controller/common"
 	"github.com/keptn/keptn/shipyard-controller/db"
 )
 
@@ -27,7 +28,7 @@ func (sm *StageManager) GetAllStages(projectName string) ([]*apimodels.ExpandedS
 		return nil, err
 	}
 	if project == nil {
-		return nil, ErrProjectNotFound
+		return nil, common.ErrProjectNotFound
 	}
 
 	return project.Stages, nil
@@ -39,7 +40,7 @@ func (sm *StageManager) GetStage(projectName, stageName string) (*apimodels.Expa
 		return nil, err
 	}
 	if project == nil {
-		return nil, ErrProjectNotFound
+		return nil, common.ErrProjectNotFound
 	}
 
 	for _, stg := range project.Stages {
@@ -47,6 +48,6 @@ func (sm *StageManager) GetStage(projectName, stageName string) (*apimodels.Expa
 			return stg, nil
 		}
 	}
-	return nil, ErrStageNotFound
+	return nil, common.ErrStageNotFound
 
 }

--- a/shipyard-controller/handler/stagemanager_test.go
+++ b/shipyard-controller/handler/stagemanager_test.go
@@ -2,10 +2,12 @@ package handler
 
 import (
 	"errors"
+	"testing"
+
 	apimodels "github.com/keptn/go-utils/pkg/api/models"
+	"github.com/keptn/keptn/shipyard-controller/common"
 	db_mock "github.com/keptn/keptn/shipyard-controller/db/mock"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestGetAllStages_GettingProjectFromDBFails(t *testing.T) {
@@ -32,7 +34,7 @@ func TestGetAllStages_ProjectNotFound(t *testing.T) {
 
 	stage, err := instance.GetAllStages("my-project")
 	assert.Nil(t, stage)
-	assert.Equal(t, ErrProjectNotFound, err)
+	assert.Equal(t, common.ErrProjectNotFound, err)
 
 }
 
@@ -84,7 +86,7 @@ func TestGetStage_ProjectNotFound(t *testing.T) {
 
 	stage, err := instance.GetStage("my-project", "the-stage")
 	assert.Nil(t, stage)
-	assert.Equal(t, ErrProjectNotFound, err)
+	assert.Equal(t, common.ErrProjectNotFound, err)
 
 }
 
@@ -108,5 +110,5 @@ func TestGetStage_StageNotFound(t *testing.T) {
 	}
 	stage, err := instance.GetStage("my-project", "unknown-stage")
 	assert.Nil(t, stage)
-	assert.Equal(t, ErrStageNotFound, err)
+	assert.Equal(t, common.ErrStageNotFound, err)
 }

--- a/shipyard-controller/handler/statehandler.go
+++ b/shipyard-controller/handler/statehandler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	apimodels "github.com/keptn/go-utils/pkg/api/models"
+	"github.com/keptn/keptn/shipyard-controller/common"
 	"github.com/keptn/keptn/shipyard-controller/db"
 	_ "github.com/keptn/keptn/shipyard-controller/models"
 )
@@ -52,7 +53,7 @@ func (sh *StateHandler) GetSequenceState(c *gin.Context) {
 	projectName := c.Param("project")
 	params := &apimodels.GetSequenceStateParams{}
 	if err := c.ShouldBindQuery(params); err != nil {
-		SetBadRequestErrorResponse(c, fmt.Sprintf(InvalidRequestFormatMsg, err.Error()))
+		SetBadRequestErrorResponse(c, fmt.Sprintf(common.InvalidRequestFormatMsg, err.Error()))
 		return
 	}
 	params.Project = projectName
@@ -61,7 +62,7 @@ func (sh *StateHandler) GetSequenceState(c *gin.Context) {
 		GetSequenceStateParams: *params,
 	})
 	if err != nil {
-		SetInternalServerErrorResponse(c, fmt.Sprintf(UnableQueryStateMsg, err.Error()))
+		SetInternalServerErrorResponse(c, fmt.Sprintf(common.UnableQueryStateMsg, err.Error()))
 		return
 	}
 
@@ -90,7 +91,7 @@ func (sh *StateHandler) ControlSequenceState(c *gin.Context) {
 
 	params := &apimodels.SequenceControlCommand{}
 	if err := c.ShouldBindJSON(params); err != nil {
-		SetBadRequestErrorResponse(c, fmt.Sprintf(InvalidRequestFormatMsg, err.Error()))
+		SetBadRequestErrorResponse(c, fmt.Sprintf(common.InvalidRequestFormatMsg, err.Error()))
 		return
 	}
 
@@ -101,10 +102,10 @@ func (sh *StateHandler) ControlSequenceState(c *gin.Context) {
 		Project:      project,
 	})
 	if err != nil {
-		if errors.Is(err, ErrSequenceNotFound) {
-			SetNotFoundErrorResponse(c, fmt.Sprintf(UnableFindSequenceMsg, err.Error()))
+		if errors.Is(err, common.ErrSequenceNotFound) {
+			SetNotFoundErrorResponse(c, fmt.Sprintf(common.UnableFindSequenceMsg, err.Error()))
 		}
-		SetInternalServerErrorResponse(c, fmt.Sprintf(UnableControleSequenceMsg, err.Error()))
+		SetInternalServerErrorResponse(c, fmt.Sprintf(common.UnableControleSequenceMsg, err.Error()))
 		return
 	}
 

--- a/shipyard-controller/handler/uniformintegrationhandler.go
+++ b/shipyard-controller/handler/uniformintegrationhandler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	apimodels "github.com/keptn/go-utils/pkg/api/models"
+	"github.com/keptn/keptn/shipyard-controller/common"
 	"github.com/keptn/keptn/shipyard-controller/db"
 	"github.com/keptn/keptn/shipyard-controller/models"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -253,12 +254,12 @@ func (rh *UniformIntegrationHandler) Unregister(c *gin.Context) {
 func (rh *UniformIntegrationHandler) GetRegistrations(c *gin.Context) {
 	params := &models.GetUniformIntegrationsParams{}
 	if err := c.ShouldBindQuery(params); err != nil {
-		SetBadRequestErrorResponse(c, fmt.Sprintf(InvalidRequestFormatMsg, err.Error()))
+		SetBadRequestErrorResponse(c, fmt.Sprintf(common.InvalidRequestFormatMsg, err.Error()))
 		return
 	}
 	uniformIntegrations, err := rh.uniformRepo.GetUniformIntegrations(*params)
 	if err != nil {
-		SetInternalServerErrorResponse(c, fmt.Sprintf(UnableQueryIntegrationsMsg, err.Error()))
+		SetInternalServerErrorResponse(c, fmt.Sprintf(common.UnableQueryIntegrationsMsg, err.Error()))
 		return
 	}
 


### PR DESCRIPTION
Signed-off-by: odubajDT <ondrej.dubaj@dynatrace.com>

### Integration tests
https://github.com/keptn/keptn/actions/runs/2705450339

### Description of the problem
Refactoring error messages and getting rid of duplicates from `db/` is necessary for a proper working of a system. A nice example when declaration and usage of duplicates can lead to bug is here https://github.com/keptn/keptn/pull/8480/files#diff-6d643b14d1fbb5301d0aed6dd99b501b9e249daa4dceb265749974aeb853dd24R251 where the handler tests if the manager returns `handler.ErrProjectNotFound`, but the manager receives a `db.ErrProjectNotFound` which is a slightly different object with the same meaning, but the condition fails and handler returns code 500 instead of 404


