### PR TITLE
ci: Add license ignores to snyk config

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -2,16 +2,77 @@
 version: v1.25.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
-  'snyk:lic:golang:symbol:MPL-2.0':
+  'snyk:lic:golang:github.com:hashicorp:golang-lru:MPL-2.0':
     - '*':
         reason: this license is fine for keptn
         created: 2022-07-12T09:35:29.655Z
+  'snyk:lic:golang:github.com:hashicorp:hcl:MPL-2.0':
+    - '*':
+        reason: this license is fine for keptn
+        created: 2022-07-12T09:35:29.655Z
+  'snyk:lic:golang:github.com:hashicorp:consul:api:MPL-2.0':
+    - '*':
+        reason: this license is fine for keptn
+        created: 2022-07-21T07:14:53.099Z
+  'snyk:lic:golang:github.com:hashicorp:consul:sdk:MPL-2.0':
+    - '*':
+        reason: this license is fine for keptn
+        created: 2022-07-21T07:14:53.099Z
+  'snyk:lic:golang:github.com:hashicorp:errwrap:MPL-2.0':
+    - '*':
+        reason: this license is fine for keptn
+        created: 2022-07-21T07:14:53.099Z
+  'snyk:lic:golang:github.com:hashicorp:go-cleanhttp:MPL-2.0':
+    - '*':
+        reason: this license is fine for keptn
+        created: 2022-07-21T07:14:53.099Z
+  'snyk:lic:golang:github.com:hashicorp:go-immutable-radix:MPL-2.0':
+    - '*':
+        reason: this license is fine for keptn
+        created: 2022-07-21T07:14:53.099Z
+  'snyk:lic:golang:github.com:hashicorp:go-version:MPL-2.0':
+    - '*':
+        reason: this license is fine for keptn
+        created: 2022-07-21T07:14:53.099Z
+  'snyk:lic:golang:github.com:hashicorp:go-multierror:MPL-2.0':
+    - '*':
+        reason: this license is fine for keptn
+        created: 2022-07-21T07:14:53.099Z
+  'snyk:lic:golang:github.com:hashicorp:go-retryablehttp:MPL-2.0':
+    - '*':
+        reason: this license is fine for keptn
+        created: 2022-07-21T07:14:53.099Z
+  'snyk:lic:golang:github.com:hashicorp:go-rootcerts:MPL-2.0':
+    - '*':
+        reason: this license is fine for keptn
+        created: 2022-07-21T07:14:53.099Z
+  'snyk:lic:golang:github.com:hashicorp:go-sockaddr:MPL-2.0':
+    - '*':
+        reason: this license is fine for keptn
+        created: 2022-07-21T07:14:53.099Z
+  'snyk:lic:golang:github.com:hashicorp:go-uuid:MPL-2.0':
+    - '*':
+        reason: this license is fine for keptn
+        created: 2022-07-21T07:14:53.099Z
+  'snyk:lic:golang:github.com:hashicorp:logutils:MPL-2.0':
+    - '*':
+        reason: this license is fine for keptn
+        created: 2022-07-21T07:14:53.099Z
+  'snyk:lic:golang:github.com:hashicorp:memberlist:MPL-2.0':
+    - '*':
+        reason: this license is fine for keptn
+        created: 2022-07-21T07:14:53.099Z
+  'snyk:lic:golang:github.com:hashicorp:serf:MPL-2.0':
+    - '*':
+        reason: this license is fine for keptn
+        created: 2022-07-21T07:14:53.099Z
+  'snyk:lic:golang:github.com:mitchellh:cli:MPL-2.0':
+    - '*':
+        reason: this license is fine for keptn
+        created: 2022-07-21T07:14:53.099Z
 patch: {}
 exclude:
   global:
     - '**/*.spec.ts'
-      # reason: typescript test files
     - '**/*_test.go'
-      # reason: go test files
-    - 'test/**'
-      # reason: zero downtime and integration tests
+    - test/**

--- a/.snyk
+++ b/.snyk
@@ -75,4 +75,4 @@ exclude:
   global:
     - '**/*.spec.ts'
     - '**/*_test.go'
-    - test/**
+    - 'test/**'


### PR DESCRIPTION
### This PR
- adds lots of license ignore rules to the snyk config file. They are all for MPL-2.0 licensed dependencies