### PR TITLE
fix: log.Fatal will call os.Exit, use log.Println instead

### DIFF
--- a/helm-service/main.go
+++ b/helm-service/main.go
@@ -3,22 +3,20 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
+	"net/url"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
 
 	"github.com/keptn/keptn/helm-service/controller"
 	"github.com/keptn/keptn/helm-service/pkg/common"
 	"github.com/keptn/keptn/helm-service/pkg/configurationchanger"
 	"github.com/keptn/keptn/helm-service/pkg/helm"
 
-	"net/url"
-	"os/signal"
-	"sync"
-	"syscall"
-
 	logger "github.com/sirupsen/logrus"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"log"
-	"os"
 
 	"github.com/keptn/go-utils/pkg/common/kubeutils"
 
@@ -231,7 +229,7 @@ func getGracefulContext() context.Context {
 	ctx, cancel := context.WithCancel(cloudevents.WithEncodingStructured(context.WithValue(context.Background(), controller.GracefulShutdownKey, wg)))
 	go func() {
 		<-ch
-		log.Fatal("Container termination triggered, starting graceful shutdown")
+		log.Println("Container termination triggered, starting graceful shutdown")
 		wg.Wait()
 		cancel()
 	}()


### PR DESCRIPTION
Signed-off-by: Abirdcfly <fp544037857@gmail.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- use `log.Println` instead of `log.Fatal` to avoid immediate exit.
 

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #

### Notes
<!-- any additional notes for this PR -->
`log.Fatal` source code see https://cs.opensource.google/go/go/+/refs/tags/go1.18.4:src/log/log.go;l=364-366;drc=2580d0e08d5e9f979b943758d3c49877fb2324cb

[Description](https://pkg.go.dev/log#Fatal) of `log.Fatal`: Fatal is equivalent to Print() followed by a call to os.Exit(1).
### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

