### PR TITLE
docs(cli): Fix typo in create secret command

### DIFF
--- a/cli/cmd/create_secret.go
+++ b/cli/cmd/create_secret.go
@@ -19,7 +19,7 @@ var createSecretParams *createSecretCmdParams
 var createSecretCommand = &cobra.Command{
 	Use:          `secret SECRET_NAME --from-literal="key1=value1"" --from-literal="key2=value2" --scope=my-scope`,
 	Short:        "Creates a new secret",
-	Example:      `keptn create secret SECRET_NAME --from-literal="key1=value1"" --from-literal="key2=value2" --scope=my-scope`,
+	Example:      `keptn create secret SECRET_NAME --from-literal="key1=value1" --from-literal="key2=value2" --scope=my-scope`,
 	SilenceUsage: true,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {


### PR DESCRIPTION
* Fixes typo error in create_secret file

Signed-off-by: vanshaj <vanshajdhar@gmail.com>