### PR TITLE
ci: Add back helm repo add commands in pipelines

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -364,7 +364,7 @@ jobs:
 
   helm_charts_upload:
     name: Publish helm charts to dev repo
-    needs: [prepare_ci_run, helm_charts_build]
+    needs: [prepare_ci_run, helm_charts_build, docker_build]
     if: ((needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (needs.prepare_ci_run.outputs.BUILD_INSTALLER == 'true')) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository))
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -28,6 +28,8 @@ jobs:
         run: |
           VERSION=$(cat './VERSION.txt')
           cd ./installer/manifests/keptn
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add nats https://nats-io.github.io/k8s/helm/charts/
           helm dependency build ./
           # replace "appVersion: latest" with "appVersion: $VERSION" in all Chart.yaml files
           find . -name Chart.yaml -exec sed -i -- "s/appVersion: latest/appVersion: ${VERSION}/g" {} \;

--- a/gh-actions-scripts/build-helm-charts.sh
+++ b/gh-actions-scripts/build-helm-charts.sh
@@ -36,6 +36,9 @@ find . -name values.yaml -exec sed -i -- "s/docker.io\/keptn\//docker.io\/${DOCK
 
 mkdir keptn-charts/
 
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo add nats https://nats-io.github.io/k8s/helm/charts/
+
 # ####################
 # COMMON HELM CHART
 # ####################

--- a/gh-actions-scripts/build-helm-charts.sh
+++ b/gh-actions-scripts/build-helm-charts.sh
@@ -67,7 +67,9 @@ do
   BASE_NAME=$i
   BASE_PATH=${charts[$i]}
 
+  echo "::group::Helm dependency build"
   helm dependency build ${BASE_PATH}
+  echo "::endgroup::"
 
   helm package ${BASE_PATH} --app-version "$IMAGE_TAG" --version "$VERSION"
   if [ $? -ne 0 ]; then

--- a/gh-actions-scripts/build-helm-charts.sh
+++ b/gh-actions-scripts/build-helm-charts.sh
@@ -63,6 +63,7 @@ charts[jmeter-service]=jmeter-service/chart
 
 for i in "${!charts[@]}"
 do
+  echo "=== Building $i ==="
   BASE_NAME=$i
   BASE_PATH=${charts[$i]}
 

--- a/installer/manifests/keptn/templates/_helpers.tpl
+++ b/installer/manifests/keptn/templates/_helpers.tpl
@@ -15,6 +15,7 @@ If release name contains chart name it will be used as a full name.
 {{- include "keptn.common.names.fullname" . -}}
 {{- end }}
 
+
 {{/*
 Create chart name and version as used by the chart label.
 */}}

--- a/installer/manifests/keptn/templates/_helpers.tpl
+++ b/installer/manifests/keptn/templates/_helpers.tpl
@@ -15,7 +15,6 @@ If release name contains chart name it will be used as a full name.
 {{- include "keptn.common.names.fullname" . -}}
 {{- end }}
 
-
 {{/*
 Create chart name and version as used by the chart label.
 */}}


### PR DESCRIPTION
### This PR
- adds back some `helm repo add` commands to make helm happy in all our builds
- adds some better logging in the build helm charts script for better readability
- adds a depenedncy in the CI build between docker build and helm chart upload so that only when there is a docker build, the helm chart will be uploaded