### PR TITLE
fix(bridge): check if configurationChange has image

### DIFF
--- a/bridge/shared/models/trace.ts
+++ b/bridge/shared/models/trace.ts
@@ -64,8 +64,8 @@ export interface TraceData {
     token: string;
   };
   configurationChange?: {
-    values: {
-      image: unknown;
+    values?: {
+      image?: unknown;
     };
   };
 
@@ -128,7 +128,7 @@ export class Trace {
   }
 
   public getConfigurationChangeImage(): string | undefined {
-    return typeof this.data.configurationChange?.values.image === 'string'
+    return typeof this.data.configurationChange?.values?.image === 'string'
       ? this.data.configurationChange.values.image.split('/').pop()
       : undefined;
   }


### PR DESCRIPTION
Signed-off-by: ermin.muratovic <ermin.muratovic@dynatrace.com>

## This PR
- fixes the evaluation board if `image` is missing in `configurationChange` in payload

### Related Issues
Fixes #8506 

