### PR TITLE
fix(installer): Disable nats cluster due to unreliable behavior

### DIFF
--- a/installer/manifests/keptn/values.yaml
+++ b/installer/manifests/keptn/values.yaml
@@ -64,8 +64,8 @@ nats:
   nameOverride: keptn-nats
   fullnameOverride: keptn-nats
   cluster:
-    enabled: true
-    replicas: 3
+    enabled: false
+    replicas: 1
     name: nats
   securityContext:
     runAsNonRoot: true

--- a/installer/manifests/keptn/values.yaml
+++ b/installer/manifests/keptn/values.yaml
@@ -65,7 +65,7 @@ nats:
   fullnameOverride: keptn-nats
   cluster:
     enabled: false
-    replicas: 1
+    replicas: 3
     name: nats
   securityContext:
     runAsNonRoot: true


### PR DESCRIPTION
Closes #8522

This PR sets the `nats.cluster.enabled` option to `false`, due to the reasons described in #8522