### PR TITLE
test(bridge): Fix ignored UI tests in trigger-sequence.spec

### DIFF
--- a/bridge/client/app/_services/data.service.spec.ts
+++ b/bridge/client/app/_services/data.service.spec.ts
@@ -149,27 +149,6 @@ describe('DataService', () => {
     expect(loadLogSpy).not.toHaveBeenCalled();
   });
 
-  it('should correctly set isTriggerSequenceOpen', async () => {
-    // given, when
-    let value = await firstValueFrom(dataService.isTriggerSequenceOpen);
-    // then
-    expect(value).toBe(false);
-
-    // when
-    dataService.setIsTriggerSequenceOpen(true);
-
-    // then
-    value = await firstValueFrom(dataService.isTriggerSequenceOpen);
-    expect(value).toBe(true);
-
-    // when
-    dataService.setIsTriggerSequenceOpen(false);
-    value = await firstValueFrom(dataService.isTriggerSequenceOpen);
-
-    // then
-    expect(value).toBe(false);
-  });
-
   function setGetTracesResponse(traces: Trace[]): void {
     const response = new HttpResponse({ body: { events: traces, totalCount: 0, pageSize: 1, nextPageKey: 1 } });
     jest.spyOn(apiService, 'getTraces').mockReturnValue(of(response));

--- a/bridge/client/app/_services/data.service.ts
+++ b/bridge/client/app/_services/data.service.ts
@@ -57,7 +57,7 @@ export class DataService {
   private readonly DEFAULT_NEXT_SEQUENCE_PAGE_SIZE = 10;
   private _isQualityGatesOnly = new BehaviorSubject<boolean>(false);
   private _evaluationResults = new Subject<EvaluationHistory>();
-  private _isTriggerSequenceOpen = new BehaviorSubject<boolean>(false);
+  public isTriggerSequenceOpen = false;
 
   constructor(private apiService: ApiService) {}
 
@@ -83,14 +83,6 @@ export class DataService {
 
   get isQualityGatesOnly(): Observable<boolean> {
     return this._isQualityGatesOnly.asObservable();
-  }
-
-  get isTriggerSequenceOpen(): Observable<boolean> {
-    return this._isTriggerSequenceOpen.asObservable();
-  }
-
-  public setIsTriggerSequenceOpen(status: boolean): void {
-    this._isTriggerSequenceOpen.next(status);
   }
 
   get projectName(): Observable<string> {

--- a/bridge/client/app/_views/ktb-environment-view/ktb-environment-view.component.html
+++ b/bridge/client/app/_views/ktb-environment-view/ktb-environment-view.component.html
@@ -6,7 +6,7 @@
       [selectedStageInfo]="selectedStageInfo"
       (selectedStageInfoChange)="setSelectedStageInfo(project.projectName, $event)"
       (filteredServicesChange)="stageDetails.filteredServices = $event"
-      [isTriggerSequenceOpen]="!!(isTriggerSequenceOpen$ | async)"
+      [isTriggerSequenceOpen]="isTriggerSequenceOpen"
     ></ktb-stage-overview>
     <ktb-stage-details
       fxFlex="30"

--- a/bridge/client/app/_views/ktb-environment-view/ktb-environment-view.component.ts
+++ b/bridge/client/app/_views/ktb-environment-view/ktb-environment-view.component.ts
@@ -26,7 +26,7 @@ export class KtbEnvironmentViewComponent implements OnDestroy {
   private readonly unsubscribe$ = new Subject<void>();
   public selectedStageInfo?: ISelectedStageInfo;
   public isQualityGatesOnly$: Observable<boolean>;
-  public isTriggerSequenceOpen$: Observable<boolean>;
+  public isTriggerSequenceOpen: boolean;
 
   constructor(
     private dataService: DataService,
@@ -36,8 +36,8 @@ export class KtbEnvironmentViewComponent implements OnDestroy {
     @Inject(POLLING_INTERVAL_MILLIS) private initialDelayMillis: number
   ) {
     this.isQualityGatesOnly$ = this.dataService.isQualityGatesOnly;
-    this.isTriggerSequenceOpen$ = this.dataService.isTriggerSequenceOpen;
-    this.dataService.setIsTriggerSequenceOpen(false);
+    this.isTriggerSequenceOpen = this.dataService.isTriggerSequenceOpen;
+    this.dataService.isTriggerSequenceOpen = false;
     const selectedStageName$ = this.route.paramMap.pipe(
       map((params) => params.get('stageName')),
       takeUntil(this.unsubscribe$)

--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.ts
@@ -402,7 +402,7 @@ export class KtbSequenceViewComponent implements OnDestroy {
   }
 
   public navigateToTriggerSequence(projectName: string): void {
-    this.dataService.setIsTriggerSequenceOpen(true);
+    this.dataService.isTriggerSequenceOpen = true;
     this.router.navigate(['/project/' + projectName]);
   }
 

--- a/bridge/cypress.config.ts
+++ b/bridge/cypress.config.ts
@@ -13,6 +13,12 @@ export default defineConfig({
   viewportHeight: 1080,
   viewportWidth: 1920,
   chromeWebSecurity: false,
+  retries: {
+    // Configure retry attempts for `cypress run`
+    runMode: 2,
+    // Configure retry attempts for `cypress open`
+    openMode: 0,
+  },
   e2e: {
     baseUrl: 'http://localhost:5000', // workaround until https://github.com/cypress-io/cypress/issues/21555 is fixed
     specPattern: 'cypress/integration/**.spec.{js,jsx,ts,tsx}',

--- a/bridge/cypress/integration/trigger-sequence.spec.ts
+++ b/bridge/cypress/integration/trigger-sequence.spec.ts
@@ -273,6 +273,63 @@ describe('Trigger an evaluation sequence', () => {
       .assertTriggerSequenceEnabled(false);
   });
 
+  it('should have correct enabled status for calendar submit button', () => {
+    const variations = [
+      {
+        hours: '10',
+        minutes: '10',
+        seconds: '10',
+        expected: true,
+      },
+      {
+        hours: '10',
+        minutes: '10',
+        expected: false,
+      },
+      {
+        hours: '10',
+        seconds: '10',
+        expected: false,
+      },
+      {
+        minutes: '10',
+        seconds: '10',
+        expected: false,
+      },
+      {
+        minutes: '10',
+        expected: false,
+      },
+      {
+        seconds: '10',
+        expected: false,
+      },
+      {
+        hours: '10',
+        expected: false,
+      },
+      {
+        expected: true,
+      },
+    ];
+    triggerSequencePage.selectEvaluationEndDate().clickStartTime().assertIsCalenderSubmitButtonEnabled(true);
+    for (const variation of variations) {
+      if (variation.hours) {
+        triggerSequencePage.typeCalendarHours(variation.hours).assertIsCalenderSubmitButtonEnabled(false);
+      }
+      if (variation.minutes) {
+        triggerSequencePage.typeCalendarMinutes(variation.minutes).assertIsCalenderSubmitButtonEnabled(false);
+      }
+      if (variation.seconds) {
+        triggerSequencePage
+          .typeCalendarSeconds(variation.seconds)
+          .assertIsCalenderSubmitButtonEnabled(variation.expected);
+      }
+
+      triggerSequencePage.clearCalendarHours().clearCalendarMinutes().clearCalendarSeconds();
+    }
+  });
+
   it('should not show date error if invalid end date is changed to valid end date', () => {
     const currentDate = new Date();
     const currentMonthFormatted = (currentDate.getMonth() + 1).toString().padStart(2, '0');
@@ -351,7 +408,7 @@ describe('Trigger an evaluation sequence', () => {
       .assertTriggerSequenceEnabled(false);
   });
 
-  it.only('should preselect date if date was already selected before', () => {
+  it('should preselect date if date was already selected before', () => {
     const currentDate = new Date();
     const currentMonthFormatted = (currentDate.getMonth() + 1).toString().padStart(2, '0');
 

--- a/bridge/cypress/support/pageobjects/TriggerSequenceSubPage.ts
+++ b/bridge/cypress/support/pageobjects/TriggerSequenceSubPage.ts
@@ -96,13 +96,48 @@ export class TriggerSequenceSubPage {
       cy.get('.dt-calendar-header-button-prev-month').click();
     }
     cy.get('.dt-calendar-table-cell').eq(calElement).click();
-    cy.byTestId('keptn-datetime-picker-submit').should('be.enabled');
+    this.clearCalendarHours()
+      .clearCalendarMinutes()
+      .clearCalendarSeconds()
+      .typeCalendarHours(hours)
+      .typeCalendarMinutes(minutes)
+      .typeCalendarSeconds(seconds);
+    cy.byTestId('keptn-datetime-picker-submit').click();
+    return this;
+  }
+
+  public assertIsCalenderSubmitButtonEnabled(status: boolean): this {
+    cy.byTestId('keptn-datetime-picker-submit').should(status ? 'be.enabled' : 'be.disabled');
+    return this;
+  }
+
+  public typeCalendarHours(hours: string): this {
     cy.byTestId('keptn-datetime-picker-time').byTestId('keptn-time-input-hours').type(hours);
-    cy.byTestId('keptn-datetime-picker-submit').should('be.disabled');
+    return this;
+  }
+
+  public typeCalendarMinutes(minutes: string): this {
     cy.byTestId('keptn-datetime-picker-time').byTestId('keptn-time-input-minutes').type(minutes);
-    cy.byTestId('keptn-datetime-picker-submit').should('be.disabled');
+    return this;
+  }
+
+  public typeCalendarSeconds(seconds: string): this {
     cy.byTestId('keptn-datetime-picker-time').byTestId('keptn-time-input-seconds').type(seconds);
-    cy.byTestId('keptn-datetime-picker-submit').should('be.enabled').click();
+    return this;
+  }
+
+  public clearCalendarHours(): this {
+    cy.byTestId('keptn-datetime-picker-time').byTestId('keptn-time-input-hours').clear();
+    return this;
+  }
+
+  public clearCalendarMinutes(): this {
+    cy.byTestId('keptn-datetime-picker-time').byTestId('keptn-time-input-minutes').clear();
+    return this;
+  }
+
+  public clearCalendarSeconds(): this {
+    cy.byTestId('keptn-datetime-picker-time').byTestId('keptn-time-input-seconds').clear();
     return this;
   }
 
@@ -131,7 +166,7 @@ export class TriggerSequenceSubPage {
     return this;
   }
 
-  private clickStartTime(): this {
+  public clickStartTime(): this {
     cy.byTestId('keptn-trigger-button-starttime').click();
     return this;
   }


### PR DESCRIPTION
Only one test in `trigger-sequence.spec.ts` was executed because of `it.only`.
Removed the `only`, fixed two UI tests and fixed a bug in the environment screen regarding automatically opening the trigger-sequence form.

## Additional changes:
- Added a retry strategy for UI tests. A failed test will now run up to 2 additional times if it fails.

Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>