### PR TITLE
fix(installer): RoleBinding is not installed if not needed for shippy leader election

### DIFF
--- a/installer/manifests/keptn/templates/rbac.yaml
+++ b/installer/manifests/keptn/templates/rbac.yaml
@@ -335,6 +335,7 @@ subjects:
     name: keptn-secret-service
 
 ---
+{{- if and (ge .Capabilities.KubeVersion.Minor "14") (.Values.shipyardController.config.leaderElection.enabled) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -348,3 +349,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: keptn-shipyard-controller
+{{- end }}

--- a/installer/manifests/keptn/templates/rbac.yaml
+++ b/installer/manifests/keptn/templates/rbac.yaml
@@ -180,6 +180,7 @@ rules:
       - get
 
 ---
+{{- if and (ge .Capabilities.KubeVersion.Minor "14") (.Values.shipyardController.config.leaderElection.enabled) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -197,6 +198,7 @@ rules:
       - get
       - update
       - create
+{{- end }}
 
 ---
 {{- if .Values.lighthouseService.enabled }}

--- a/installer/manifests/keptn/templates/shipyard-controller.yaml
+++ b/installer/manifests/keptn/templates/shipyard-controller.yaml
@@ -9,7 +9,7 @@ spec:
     matchLabels: {{- include "keptn.common.labels.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/name: shipyard-controller
   {{- if and (ge .Capabilities.KubeVersion.Minor "14") (.Values.shipyardController.config.leaderElection.enabled) }}
-  replicas: {{ .Values.shipyardController.config.replicas | default 3 }}
+  replicas: {{ .Values.shipyardController.config.replicas }}
   {{- else }}
   replicas: 1
   {{- end }}

--- a/installer/manifests/keptn/templates/shipyard-controller.yaml
+++ b/installer/manifests/keptn/templates/shipyard-controller.yaml
@@ -88,10 +88,10 @@ spec:
             - name: AUTOMATIC_PROVISIONING_URL
               value: {{ ((.Values.features).automaticProvisioning).serviceURL | default "" | quote }}
             - name: DISABLE_LEADER_ELECTION
-              {{- if  lt .Capabilities.KubeVersion.Minor "14"}}
+              {{- if lt .Capabilities.KubeVersion.Minor "14" }}
               value: {{ true | quote }}
               {{ else }}
-              value: {{ .Values.shipyardController.config.leaderElection.enabled | default true | quote }}
+              value: {{ not ((.Values.shipyardController.config).leaderElection).enabled | quote }}
               {{- end }}
             - name: PROJECT_NAME_MAX_SIZE
               value: {{ .Values.shipyardController.config.validation.projectNameMaxSize | default 200 | quote }}

--- a/installer/manifests/keptn/templates/shipyard-controller.yaml
+++ b/installer/manifests/keptn/templates/shipyard-controller.yaml
@@ -11,7 +11,7 @@ spec:
   {{- if and (ge .Capabilities.KubeVersion.Minor "14") (.Values.shipyardController.config.leaderElection.enabled) }}
   replicas: {{ .Values.shipyardController.config.replicas | default 3 }}
   {{- else }}
-  replicas : 1
+  replicas: 1
   {{- end }}
   {{- include "keptn.common.update-strategy" . | nindent 2 }}
   template:
@@ -90,9 +90,9 @@ spec:
             - name: DISABLE_LEADER_ELECTION
               {{- if  lt .Capabilities.KubeVersion.Minor "14"}}
               value: {{ true | quote }}
-              {{else }}
-              value: {{ .Values.shipyardController.config.disableLeaderElection | default false | quote }}
-              {{- end}}
+              {{ else }}
+              value: {{ .Values.shipyardController.config.leaderElection.enabled | default true | quote }}
+              {{- end }}
             - name: PROJECT_NAME_MAX_SIZE
               value: {{ .Values.shipyardController.config.validation.projectNameMaxSize | default 200 | quote }}
             - name: SERVICE_NAME_MAX_SIZE

--- a/installer/manifests/keptn/templates/shipyard-controller.yaml
+++ b/installer/manifests/keptn/templates/shipyard-controller.yaml
@@ -8,10 +8,10 @@ spec:
   selector:
     matchLabels: {{- include "keptn.common.labels.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/name: shipyard-controller
-  {{- if or (lt .Capabilities.KubeVersion.Minor "14") (.Values.shipyardController.config.disableLeaderElection) }}
-  replicas : 1
-  {{- else }}
+  {{- if and (ge .Capabilities.KubeVersion.Minor "14") (.Values.shipyardController.config.leaderElection.enabled) }}
   replicas: {{ .Values.shipyardController.config.replicas | default 3 }}
+  {{- else }}
+  replicas : 1
   {{- end }}
   {{- include "keptn.common.update-strategy" . | nindent 2 }}
   template:

--- a/installer/manifests/keptn/values.yaml
+++ b/installer/manifests/keptn/values.yaml
@@ -289,7 +289,8 @@ shipyardController:
   config:
     taskStartedWaitDuration: "10m"
     uniformIntegrationTTL: "48h"
-    disableLeaderElection: true
+    leaderElection:
+      enabled: false
     replicas: 1
     validation:
       # On Database level, Keptn creates collections that are named like <PROJECTNAME>-<suffix>


### PR DESCRIPTION
### This PR
Fixes an issue, where the role binding for shippy to acquire the lease for leader election was always installed. Now, it's only installed if leader election is actually enabled.
This PR also adjusts the helm value slightly to follow our own standards for helm values. (`disableLeaderElection` -> `leaderElection.enabled`)

Fixes #8534 