### PR TITLE
feat(bridge): Better visualization of failed Key SLIs

### DIFF
--- a/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.html
+++ b/bridge/client/app/_components/ktb-evaluation-details/ktb-evaluation-details.component.html
@@ -276,21 +276,24 @@
                 [textContent]="_selectedEvaluationData.data.result"
               ></span>
             </span>
-            <ng-container
-              *ngIf="
-                _selectedEvaluationData.data.evaluation.indicatorResults &&
-                getSliInfo(_selectedEvaluationData.data.evaluation.indicatorResults) as sliInfo
-              "
-            >
-              <span class="small" *ngIf="sliInfo.keySliCount > 0" uitestid="keptn-evaluation-details-keySliInfo">
-                <span class="ml-2">Key SLI<span *ngIf="sliInfo.keySliCount > 1">s</span>: </span>
-                <span *ngIf="sliInfo.keySliFailedCount > 0" class="error">failed</span>
-                <span *ngIf="sliInfo.keySliFailedCount === 0" class="success">passed</span>
-              </span>
-            </ng-container>
           </p>
         </dt-consumption-count>
         <dt-consumption-label>
+          <p
+            class="m-0"
+            *ngIf="
+              _selectedEvaluationData.data.evaluation.indicatorResults &&
+              getSliInfo(_selectedEvaluationData.data.evaluation.indicatorResults) as sliInfo
+            "
+          >
+            <span class="small" *ngIf="sliInfo.keySliCount > 0" uitestid="keptn-evaluation-details-keySliInfo">
+              <span *ngIf="sliInfo.keySliFailedCount > 0">
+                <span [textContent]="sliInfo.keySliFailedCount"></span>
+                Key SLI<span *ngIf="sliInfo.keySliFailedCount > 1">s</span> failed</span
+              >
+              <span *ngIf="sliInfo.keySliFailedCount === 0">All Key SLIs passed</span>
+            </span>
+          </p>
           <p class="m-0 small">
             <span class="bold">Evaluation timeframe: </span
             ><span [textContent]="evaluation.timeStart | amDateFormat: 'YYYY-MM-DD HH:mm'"></span> -

--- a/bridge/cypress/fixtures/get.sockshop.service.carts.evaluations.keysli.mock.json
+++ b/bridge/cypress/fixtures/get.sockshop.service.carts.evaluations.keysli.mock.json
@@ -56,6 +56,116 @@
                 {
                   "criteria": "<=90",
                   "targetValue": 90,
+                  "violated": true
+                }
+              ],
+              "score": 0,
+              "status": "fail",
+              "value": {
+                "metric": "go_routines",
+                "success": true,
+                "value": 253
+              },
+              "warningTargets": null
+            },
+            {
+              "displayName": "Failing Requests",
+              "keySli": true,
+              "passTargets": [
+                {
+                  "criteria": "< 10",
+                  "targetValue": 10,
+                  "violated": true
+                }
+              ],
+              "score": 0,
+              "status": "fail",
+              "value": {
+                "metric": "failing_request",
+                "success": true,
+                "value": 11
+              },
+              "warningTargets": null
+            }
+          ],
+          "result": "fail",
+          "score": 25,
+          "sloFileContent": "LS0tDQpzcGVjX3ZlcnNpb246ICcwLjEuMCcNCmNvbXBhcmlzb246DQogIGNvbXBhcmVfd2l0aDogInNpbmdsZV9yZXN1bHQiDQogIGluY2x1ZGVfcmVzdWx0X3dpdGhfc2NvcmU6ICJwYXNzIg0KICBhZ2dyZWdhdGVfZnVuY3Rpb246IGF2Zw0Kb2JqZWN0aXZlczoNCiAgLSBzbGk6IGh0dHBfcmVzcG9uc2VfdGltZV9zZWNvbmRzX21haW5fcGFnZV9zdW0NCiAgICBwYXNzOg0KICAgICAgLSBjcml0ZXJpYToNCiAgICAgICAgICAtICI8PTEiDQogICAgd2FybmluZzoNCiAgICAgIC0gY3JpdGVyaWE6DQogICAgICAgICAgLSAiPD0wLjUiDQogIC0gc2xpOiByZXF1ZXN0X3Rocm91Z2hwdXQNCiAgICBwYXNzOg0KICAgICAgLSBjcml0ZXJpYToNCiAgICAgICAgICAtICI8PSsxMDAlIg0KICAgICAgICAgIC0gIj49LTgwJSINCiAgLSBzbGk6IGdvX3JvdXRpbmVzDQogICAgcGFzczoNCiAgICAgIC0gY3JpdGVyaWE6DQogICAgICAgICAgLSAiPD0xMDAiDQp0b3RhbF9zY29yZToNCiAgcGFzczogIjkwJSINCiAgd2FybmluZzogIjc1JSI=",
+          "timeEnd": "2022-02-09T09:29:47.625Z",
+          "timeStart": "2022-02-09T09:28:55.866Z"
+        },
+        "message": "Evaluation failed since the calculated score of 75 is below the target value of 90",
+        "project": "sockshop",
+        "result": "fail",
+        "service": "carts",
+        "stage": "staging",
+        "status": "succeeded"
+      },
+      "id": "1500b971-bfc3-4e20-8dc1-a624e0faf963",
+      "source": "lighthouse-service",
+      "specversion": "1.0",
+      "time": "2022-02-09T09:31:07.865Z",
+      "type": "sh.keptn.event.evaluation.finished",
+      "shkeptncontext": "da740469-9920-4e0c-b304-0fd4b18d17c2",
+      "shkeptnspecversion": "0.2.3",
+      "triggeredid": "09f53f15-c89d-4a4a-82cc-138985696172"
+    },
+    {
+      "data": {
+        "evaluation": {
+          "comparedEvents": ["182d10b8-b68d-49d4-86cd-5521352d7a42"],
+          "indicatorResults": [
+            {
+              "displayName": "HTTP Respone Time",
+              "keySli": false,
+              "passTargets": [
+                {
+                  "criteria": "<=0.4",
+                  "targetValue": 0.4,
+                  "violated": true
+                }
+              ],
+              "score": 0,
+              "status": "fail",
+              "value": {
+                "metric": "http_response_time_seconds_main_page_sum",
+                "success": true,
+                "value": 0.40115315268094103
+              },
+              "warningTargets": [
+                {
+                  "criteria": "<=0.1",
+                  "targetValue": 0.1,
+                  "violated": true
+                }
+              ]
+            },
+            {
+              "displayName": "Request Throughput",
+              "keySli": false,
+              "passTargets": [
+                {
+                  "criteria": ">=-80%",
+                  "targetValue": 0,
+                  "violated": false
+                }
+              ],
+              "score": 1,
+              "status": "pass",
+              "value": {
+                "metric": "request_throughput",
+                "success": true,
+                "value": 169.23333333333332
+              },
+              "warningTargets": null
+            },
+            {
+              "displayName": "Go Routines",
+              "keySli": true,
+              "passTargets": [
+                {
+                  "criteria": "<=90",
+                  "targetValue": 90,
                   "violated": false
                 }
               ],
@@ -101,12 +211,12 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "1500b971-bfc3-4e20-8dc1-a624e0faf963",
+      "id": "1500b971-bfc3-4e20-8dc1-a624e0faf961",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-09T09:30:07.865Z",
       "type": "sh.keptn.event.evaluation.finished",
-      "shkeptncontext": "da740469-9920-4e0c-b304-0fd4b18d17c2",
+      "shkeptncontext": "da740469-9920-4e0c-b304-0fd4b18d17c1",
       "shkeptnspecversion": "0.2.3",
       "triggeredid": "09f53f15-c89d-4a4a-82cc-138985696172"
     },

--- a/bridge/cypress/integration/evaluations.spec.ts
+++ b/bridge/cypress/integration/evaluations.spec.ts
@@ -26,14 +26,23 @@ describe('evaluations with key sli', () => {
     heatmap.interceptWithKeySli();
   });
 
-  it('should show key sli info', () => {
+  it('should show key sli info result failed 2 key slis', () => {
     heatmap.visitPageWithHeatmapComponent();
-    evaluationBoard.assertScoreInfo(50, '<', 75).assertResultInfo(ResultTypes.FAILED).assertKeySliInfo('passed');
+    evaluationBoard.assertScoreInfo(25, '<', 75).assertResultInfo(ResultTypes.FAILED).assertKeySliInfo(2);
+  });
 
-    heatmap.clickScore('52b4b2c7-fa49-41f3-9b5c-b9aea2370bb4');
-    evaluationBoard.assertScoreInfo(75, '>=', 75).assertResultInfo(ResultTypes.FAILED).assertKeySliInfo('failed');
+  it('should show key sli info result failed 0 key slis', () => {
+    heatmap.visitPageWithHeatmapComponent().clickScore('1500b971-bfc3-4e20-8dc1-a624e0faf961');
+    evaluationBoard.assertScoreInfo(50, '<', 75).assertResultInfo(ResultTypes.FAILED).assertKeySliInfo(0);
+  });
 
-    heatmap.clickScore('182d10b8-b68d-49d4-86cd-5521352d7a42');
-    evaluationBoard.assertScoreInfo(100, '>=', 90).assertResultInfo(ResultTypes.PASSED).assertKeySliInfo('passed');
+  it('should show key sli info result failed 1 key sli', () => {
+    heatmap.visitPageWithHeatmapComponent().clickScore('52b4b2c7-fa49-41f3-9b5c-b9aea2370bb4');
+    evaluationBoard.assertScoreInfo(75, '>=', 75).assertResultInfo(ResultTypes.FAILED).assertKeySliInfo(1);
+  });
+
+  it('should show key sli info result passed 0 key sli', () => {
+    heatmap.visitPageWithHeatmapComponent().clickScore('182d10b8-b68d-49d4-86cd-5521352d7a42');
+    evaluationBoard.assertScoreInfo(100, '>=', 90).assertResultInfo(ResultTypes.PASSED).assertKeySliInfo(0);
   });
 });

--- a/bridge/cypress/support/pageobjects/EvaluationBoardPage.ts
+++ b/bridge/cypress/support/pageobjects/EvaluationBoardPage.ts
@@ -71,8 +71,14 @@ export class EvaluationBoardPage {
     cy.byTestId('keptn-evaluation-details-resultInfo').should('have.text', `Result: ${type}`);
     return this;
   }
-  public assertKeySliInfo(type: 'passed' | 'failed'): this {
-    cy.byTestId('keptn-evaluation-details-keySliInfo').should('have.text', `Key SLI: ${type}`);
+  public assertKeySliInfo(failedKeySlis: number): this {
+    if (failedKeySlis > 1) {
+      cy.byTestId('keptn-evaluation-details-keySliInfo').should('have.text', `${failedKeySlis} Key SLIs failed`);
+    } else if (failedKeySlis > 0) {
+      cy.byTestId('keptn-evaluation-details-keySliInfo').should('have.text', `1 Key SLI failed`);
+    } else {
+      cy.byTestId('keptn-evaluation-details-keySliInfo').should('have.text', `All Key SLIs passed`);
+    }
     return this;
   }
 }


### PR DESCRIPTION
## This PR
- shows more details about failed Key SLIs
- shows failed SLIs in breakdown more prominent

### Related Issues
Fixes #6639 

Failed score, 2 Key SLIs failed:
![image](https://user-images.githubusercontent.com/6098219/181732818-2fd0d17b-3599-4ec5-bef6-d14a7fbee385.png)

Failed score, no Key SLIs failed:
![image](https://user-images.githubusercontent.com/6098219/181732934-26f8c77e-aed7-46e7-8612-2e662878149e.png)

Acceptable score, 1 Key SLI failed:
![image](https://user-images.githubusercontent.com/6098219/181733006-5509667d-8c51-405f-9e92-54180bca54e3.png)

Good score, no Key SLIs failed:
![image](https://user-images.githubusercontent.com/6098219/181733066-535da90c-d8b5-407a-abf8-b9bfc374a468.png)
