### PR TITLE
feat(cli): Add `sumologic` flag to keptn configure monitoring

### DIFF
--- a/cli/cmd/configure_monitoring.go
+++ b/cli/cmd/configure_monitoring.go
@@ -43,7 +43,8 @@ See https://keptn.sh/docs/install/monitoring/ for more information.
 	Example: `keptn configure monitoring dynatrace --project=PROJECTNAME
 keptn configure monitoring prometheus --project=PROJECTNAME --service=SERVICENAME
 keptn configure monitoring datadog --project=PROJECTNAME --service=SERVICENAME
-**Note:** datadog support is experimental.`,
+keptn configure monitoring sumologic --project=PROJECTNAME --service=SERVICENAME
+**Note:** datadog and sumologic support is experimental.`,
 	SilenceUsage: true,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 1 {
@@ -54,7 +55,7 @@ keptn configure monitoring datadog --project=PROJECTNAME --service=SERVICENAME
 		return nil
 	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		if args[0] == "prometheus" || args[0] == "datadog" {
+		if args[0] == "prometheus" || args[0] == "datadog" || args[0] == "sumologic" {
 			if *params.Project == "" {
 				return errors.New("Please specify a project")
 			}

--- a/cli/cmd/configure_monitoring_test.go
+++ b/cli/cmd/configure_monitoring_test.go
@@ -39,6 +39,19 @@ func TestConfigureMonitoringCmdForDatadog(t *testing.T) {
 	}
 }
 
+func TestConfigureMonitoringCmdForSumologic(t *testing.T) {
+
+	credentialmanager.MockAuthCreds = true
+
+	*params.Project = ""
+	*params.Service = ""
+	cmd := fmt.Sprintf("configure monitoring sumologic --project=%s --service=%s --mock", "sockshop", "carts")
+	_, err := executeActionCommandC(cmd)
+	if err != nil {
+		t.Errorf(unexpectedErrMsg, err)
+	}
+}
+
 func TestConfigureMonitoringCmdForPrometheusWithWrongArgs(t *testing.T) {
 
 	credentialmanager.MockAuthCreds = true
@@ -79,6 +92,27 @@ func TestConfigureMonitoringCmdForDatadogWithWrongArgs(t *testing.T) {
 	*params.Project = ""
 	*params.Service = ""
 	cmd = fmt.Sprintf("configure monitoring datadog --service=%s --mock", "carts")
+	_, err = executeActionCommandC(cmd)
+	if err.Error() != "Please specify a project" {
+		t.Errorf(unexpectedErrMsg, err)
+	}
+}
+
+func TestConfigureMonitoringCmdForSumologicWithWrongArgs(t *testing.T) {
+
+	credentialmanager.MockAuthCreds = true
+
+	*params.Project = ""
+	*params.Service = ""
+	cmd := fmt.Sprintf("configure monitoring sumologic --project=%s --mock", "sockshop")
+	_, err := executeActionCommandC(cmd)
+	if err.Error() != "Please specify a service" {
+		t.Errorf(unexpectedErrMsg, err)
+	}
+
+	*params.Project = ""
+	*params.Service = ""
+	cmd = fmt.Sprintf("configure monitoring sumologic --service=%s --mock", "carts")
 	_, err = executeActionCommandC(cmd)
 	if err.Error() != "Please specify a project" {
 		t.Errorf(unexpectedErrMsg, err)


### PR DESCRIPTION
- add tests

Signed-off-by: Suraj Banakar <surajrbanakar@gmail.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
- Adds `sumologic` as a valid argument/flag to the `keptn configure monitoring` command
- This is for https://github.com/keptn/integrations/issues/20 . SumoLogic integration sits at https://github.com/keptn-sandbox/sumologic-service

### Related Issues
https://github.com/keptn/integrations/issues/20

### How to test
1. Clone https://github.com/keptn-sandbox/sumologicservice
2. Run sumologic-service using [the installation guide](https://github.com/keptn-sandbox/sumologic-service#installation) 
3. Fetch the branch for this PR and run 
```
keptn/cli $ go run main.go configure monitoring datadog --project podtatohead --service helloservice
```
