### PR TITLE
feat(bridge): Improve indicator result score visualization

### DIFF
--- a/bridge/client/app/_components/ktb-sli-breakdown/ktb-sli-breakdown.component.html
+++ b/bridge/client/app/_components/ktb-sli-breakdown/ktb-sli-breakdown.component.html
@@ -142,6 +142,7 @@
           *ngIf="result.success"
           [class.error]="result.result === ResultTypes.FAILED"
           [class.warning]="result.result === ResultTypes.WARNING"
+          class="underline-info"
         >
           {{ result.score | truncateNumber: 2 }}/{{
             (maximumAvailableWeight !== 0 ? result.weight / maximumAvailableWeight : 0) * 100 | truncateNumber: 2

--- a/bridge/client/app/_components/ktb-sli-breakdown/ktb-sli-breakdown.component.html
+++ b/bridge/client/app/_components/ktb-sli-breakdown/ktb-sli-breakdown.component.html
@@ -3,7 +3,7 @@
   <ng-container dtColumnDef="details" dtColumnProportion="0.1" dtColumnMinWidth="50">
     <dt-header-cell *dtHeaderCellDef></dt-header-cell>
     <dt-cell *dtCellDef="let row">
-      <ng-container *ngIf="row | toType: SliResultClass as result">
+      <ng-container *ngIf="toSliResult(row) as result">
         <div fxFlexFill>
           <button dt-icon-button variant="nested" *ngIf="result.comparedValue !== undefined">
             <dt-icon name="dropdownclosed" [class.open]="result.expanded" class="transform-icon"></dt-icon>
@@ -16,7 +16,7 @@
   <ng-container dtColumnDef="name" dtColumnAlign="text" dtColumnProportion="5">
     <dt-header-cell dt-sort-header *dtHeaderCellDef>Name</dt-header-cell>
     <dt-cell uitestid="keptn-sli-breakdown-name-cell" *dtCellDef="let row">
-      <div fxFlexFill fxLayout="column" *ngIf="row | toType: SliResultClass as result" [class.bold]="result.keySli">
+      <div fxFlexFill fxLayout="column" *ngIf="toSliResult(row) as result" [class.bold]="result.keySli">
         <p class="truncate m-0" [title]="result.name" [textContent]="result.name"></p>
         <ng-container *ngIf="result.expanded">
           <p class="small m-0">Absolute change:</p>
@@ -30,7 +30,7 @@
   <ng-container dtColumnDef="value" dtColumnAlign="text" dtColumnProportion="2">
     <dt-header-cell *dtHeaderCellDef>Value</dt-header-cell>
     <dt-cell uitestid="keptn-sli-breakdown-value-cell" *dtCellDef="let row">
-      <div fxFlexFill fxLayout="column" *ngIf="row | toType: SliResultClass as result">
+      <div fxFlexFill fxLayout="column" *ngIf="toSliResult(row) as result">
         <p class="m-0" *ngIf="result.success">
           <span [textContent]="result.value"></span>
           <span
@@ -76,7 +76,7 @@
     <dt-header-cell dt-sort-header *dtHeaderCellDef>Weight</dt-header-cell>
     <dt-cell uitestid="keptn-sli-breakdown-weight-cell" *dtCellDef="let row">
       <div fxFlexFill>
-        <span [textContent]="(row | toType: SliResultClass).weight"></span>
+        <span [textContent]="toSliResult(row).weight"></span>
       </div>
     </dt-cell>
   </ng-container>
@@ -86,7 +86,7 @@
     <dt-cell uitestid="keptn-sli-breakdown-pass-criteria-cell" *dtCellDef="let row">
       <div fxFlexFill>
         <ktb-sli-breakdown-criteria-item
-          *ngIf="row | toType: SliResultClass as result"
+          *ngIf="toSliResult(row) as result"
           [isInformative]="!result.success"
           [targets]="result.passTargets || []"
         ></ktb-sli-breakdown-criteria-item>
@@ -99,7 +99,7 @@
     <dt-cell uitestid="keptn-sli-breakdown-warning-criteria-cell" *dtCellDef="let row">
       <div fxFlexFill>
         <ktb-sli-breakdown-criteria-item
-          *ngIf="row | toType: SliResultClass as result"
+          *ngIf="toSliResult(row) as result"
           [isInformative]="!result.success"
           [targets]="result.warningTargets || []"
         ></ktb-sli-breakdown-criteria-item>
@@ -110,7 +110,7 @@
   <ng-container dtColumnDef="targets" dtColumnAlign="number" dtColumnProportion="2">
     <dt-header-cell *dtHeaderCellDef>Criteria</dt-header-cell>
     <dt-cell uitestid="keptn-sli-breakdown-criteria-cell" *dtCellDef="let row">
-      <div fxFlexFill *ngIf="row | toType: SliResultClass as result">
+      <div fxFlexFill *ngIf="toSliResult(row) as result">
         <ktb-sli-breakdown-criteria-item
           *ngIf="result.success"
           [targets]="result.targets || []"
@@ -123,7 +123,7 @@
   <ng-container dtColumnDef="result" dtColumnAlign="number" dtColumnProportion="1">
     <dt-header-cell *dtHeaderCellDef>Result</dt-header-cell>
     <dt-cell uitestid="keptn-sli-breakdown-result-cell" *dtCellDef="let row">
-      <div fxFlexFill *ngIf="row | toType: SliResultClass as result">
+      <div fxFlexFill *ngIf="toSliResult(row) as result">
         <span *ngIf="result.success" [textContent]="evaluationState.get(result.result)"></span>
       </div>
     </dt-cell>
@@ -131,18 +131,42 @@
 
   <ng-container dtColumnDef="score" dtColumnAlign="number" dtColumnProportion="1">
     <dt-header-cell dt-sort-header *dtHeaderCellDef>Score</dt-header-cell>
-    <dt-cell uitestid="keptn-sli-breakdown-score-cell" *dtCellDef="let row" [dtOverlay]="scoreOverlay">
-      <div fxFlexFill *ngIf="row | toType: SliResultClass as result">
+    <dt-cell
+      uitestid="keptn-sli-breakdown-score-cell"
+      *dtCellDef="let row"
+      [dtOverlay]="scoreOverlay"
+      [dtOverlayConfig]="{ data: row }"
+    >
+      <div fxFlexFill *ngIf="toSliResult(row) as result">
         <span
           *ngIf="result.success"
           [class.error]="result.result === ResultTypes.FAILED"
           [class.warning]="result.result === ResultTypes.WARNING"
-          [textContent]="result.score | truncateNumber: 2"
-        ></span>
+        >
+          {{ result.score | truncateNumber: 2 }}/{{
+            (maximumAvailableWeight !== 0 ? result.weight / maximumAvailableWeight : 0) * 100 | truncateNumber: 2
+          }}
+        </span>
       </div>
     </dt-cell>
-    <ng-template #scoreOverlay>
-      The score represents the portion an SLI contributes to the overall evaluation result between 0 and 100
+    <ng-template #scoreOverlay let-data>
+      <ng-container *ngIf="toSliResult(data) as result">
+        The score represents the portion an SLI contributes to the overall evaluation result between 0 and 100
+        <p
+          *ngIf="result.result === ResultTypes.FAILED"
+          class="error m-0"
+          uitestid="ktb-sli-breakdown-score-overlay-failed"
+        >
+          The score was set to 0 because the result is <span class="bold">failed</span>
+        </p>
+        <p
+          *ngIf="result.result === ResultTypes.WARNING"
+          class="warning m-0"
+          uitestid="ktb-sli-breakdown-score-overlay-warning"
+        >
+          The score was halved because the result is <span class="bold">warning</span>
+        </p>
+      </ng-container>
     </ng-template>
   </ng-container>
 

--- a/bridge/client/app/_components/ktb-sli-breakdown/ktb-sli-breakdown.component.html
+++ b/bridge/client/app/_components/ktb-sli-breakdown/ktb-sli-breakdown.component.html
@@ -129,7 +129,7 @@
     </dt-cell>
   </ng-container>
 
-  <ng-container dtColumnDef="score" dtColumnAlign="number" dtColumnProportion="1">
+  <ng-container dtColumnDef="score" dtColumnAlign="number" dtColumnProportion="1" dtColumnMinWidth="110">
     <dt-header-cell dt-sort-header *dtHeaderCellDef>Score</dt-header-cell>
     <dt-cell
       uitestid="keptn-sli-breakdown-score-cell"

--- a/bridge/client/app/_components/ktb-sli-breakdown/ktb-sli-breakdown.component.scss
+++ b/bridge/client/app/_components/ktb-sli-breakdown/ktb-sli-breakdown.component.scss
@@ -14,3 +14,7 @@
 .open {
   transform: rotate(90deg);
 }
+
+.underline-info {
+  border-bottom: dotted 1px black;
+}

--- a/bridge/client/app/_components/ktb-sli-breakdown/ktb-sli-breakdown.component.ts
+++ b/bridge/client/app/_components/ktb-sli-breakdown/ktb-sli-breakdown.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectorRef, Component, Input, OnInit, ViewChild } from '@angular/core';
 import { DtSort, DtTableDataSource } from '@dynatrace/barista-components/table';
-import { SliResult } from '../../_models/sli-result';
+import { SliResult } from '../../_interfaces/sli-result';
 import { IndicatorResult } from '../../../../shared/interfaces/indicator-result';
 import { ResultTypes } from '../../../../shared/models/result-types';
 import { AppUtils } from '../../_utils/app.utils';
@@ -27,8 +27,9 @@ export class KtbSliBreakdownComponent implements OnInit {
   private _score = 0;
   public columnNames: string[] = [];
   public tableEntries: DtTableDataSource<SliResult> = new DtTableDataSource();
-  public readonly SliResultClass = SliResult;
   private _comparedIndicatorResults: IndicatorResult[][] = [];
+  public maximumAvailableWeight = 1;
+  public toSliResult = (row: SliResult): SliResult => row;
 
   @Input()
   get indicatorResults(): IndicatorResult[] {
@@ -83,7 +84,10 @@ export class KtbSliBreakdownComponent implements OnInit {
   }
 
   private updateDataSource(): void {
-    this.tableEntries.data = this.assembleTablesEntries(this.indicatorResults);
+    const sliResults = this.assembleTablesEntries(this.indicatorResults);
+    // max reachable weight is actually the max reachable score. max weight = 100% score
+    this.maximumAvailableWeight = sliResults.reduce((acc, result) => acc + result.weight, 0);
+    this.tableEntries.data = sliResults;
   }
 
   private assembleTablesEntries(indicatorResults: IndicatorResult[]): SliResult[] {

--- a/bridge/client/app/_interfaces/sli-result.ts
+++ b/bridge/client/app/_interfaces/sli-result.ts
@@ -1,21 +1,21 @@
 import { ResultTypes } from '../../../shared/models/result-types';
 import { Target } from '../../../shared/interfaces/indicator-result';
 
-export class SliResult {
+export interface SliResult {
   comparedValue?: number;
-  name!: string;
-  value!: string | number;
-  result!: ResultTypes;
-  score!: number;
+  name: string;
+  value: string | number;
+  result: ResultTypes;
+  score: number;
   passTargets?: Target[] | null;
   warningTargets?: Target[] | null;
   targets?: Target[];
-  keySli!: boolean;
-  success!: boolean;
-  expanded!: boolean;
+  keySli: boolean;
+  success: boolean;
+  expanded: boolean;
   calculatedChanges?: {
     absolute: number;
     relative: number;
   };
-  weight!: number;
+  weight: number;
 }

--- a/bridge/cypress/fixtures/get.sockshop.service.carts.evaluations.mock.json
+++ b/bridge/cypress/fixtures/get.sockshop.service.carts.evaluations.mock.json
@@ -406,8 +406,8 @@
                   "violated": true
                 }
               ],
-              "score": 0,
-              "status": "fail",
+              "score": 0.5,
+              "status": "warning",
               "value": {
                 "metric": "http_response_time_seconds_main_page_sum",
                 "success": true,
@@ -417,7 +417,7 @@
                 {
                   "criteria": "<=0.5",
                   "targetValue": 0.5,
-                  "violated": true
+                  "violated": false
                 }
               ]
             },

--- a/bridge/cypress/integration/sli-breakdown.spec.ts
+++ b/bridge/cypress/integration/sli-breakdown.spec.ts
@@ -1,5 +1,5 @@
 import ServicesPage from '../support/pageobjects/ServicesPage';
-import { SliResult } from '../../client/app/_models/sli-result';
+import { SliResult } from '../../client/app/_interfaces/sli-result';
 import { interceptProjectBoard } from '../support/intercept';
 
 describe('sli-breakdown', () => {

--- a/bridge/cypress/integration/sli-breakdown.spec.ts
+++ b/bridge/cypress/integration/sli-breakdown.spec.ts
@@ -1,24 +1,24 @@
 import ServicesPage from '../support/pageobjects/ServicesPage';
-import { SliResult } from '../../client/app/_interfaces/sli-result';
-import { interceptProjectBoard } from '../support/intercept';
+import { HeatmapComponentPage } from '../support/pageobjects/HeatmapComponentPage';
+import { interceptD3 } from '../support/intercept';
+import { ResultTypes } from '../../shared/models/result-types';
 
 describe('sli-breakdown', () => {
   const servicesPage = new ServicesPage();
 
   beforeEach(() => {
-    interceptProjectBoard();
+    servicesPage.interceptAll();
+    interceptD3();
+    servicesPage.visitServicePage('sockshop').selectService('carts', 'v0.1.2');
   });
 
   it('should load the heatmap with sli breakdown in service screen', () => {
     servicesPage
-      .intercept()
-      .visitServicePage('sockshop')
-      .selectService('carts', 'v0.1.2')
       .verifySliBreakdown(
         {
           name: 'go_routines',
           value: 88,
-          result: 'pass',
+          result: ResultTypes.PASSED,
           score: 33.99,
           passTargets: [
             {
@@ -37,14 +37,15 @@ describe('sli-breakdown', () => {
             absolute: 80,
             relative: 1000,
           },
-        } as SliResult,
+          availableScore: 33.33,
+        },
         false
       )
       .verifySliBreakdown(
         {
           name: 'request_throughput',
           value: 18.42,
-          result: 'fail',
+          result: ResultTypes.FAILED,
           score: 0,
           passTargets: [
             {
@@ -68,73 +69,43 @@ describe('sli-breakdown', () => {
             absolute: 18.42,
             relative: 1742,
           },
-        } as SliResult,
+          availableScore: 33.33,
+        },
         false
       );
   });
 
   it('should show more details when expanding sli breakdown in service screen', () => {
-    cy.intercept('GET', '/api/project/sockshop/serviceStates', {
-      statusCode: 200,
-      fixture: 'get.sockshop.service.states.mock.json',
-    }).as('serviceStates');
-    cy.intercept('GET', '/api/project/sockshop/deployment/da740469-9920-4e0c-b304-0fd4b18d17c2', {
-      statusCode: 200,
-      fixture: 'get.sockshop.service.carts.deployment.mock.json',
-    }).as('ServiceDeployment');
-    cy.intercept('GET', 'api/mongodb-datastore/event/type/sh.keptn.event.evaluation.finished?*', {
-      statusCode: 200,
-      fixture: 'get.sockshop.service.carts.evaluations.mock.json',
-    });
-
-    servicesPage
-      .visitServicePage('sockshop')
-      .selectService('carts', 'v0.1.2')
-      .expandSliBreakdown('go_routines')
-      .verifySliBreakdown(
-        {
-          name: 'go_routines',
-          value: 88,
-          result: 'pass',
-          score: 33.99,
-          passTargets: [
-            {
-              criteria: '<=100',
-              targetValue: 100,
-              violated: false,
-            },
-          ],
-          warningTargets: null,
-          keySli: false,
-          success: true,
-          expanded: false,
-          weight: 1,
-          comparedValue: 8,
-          calculatedChanges: {
-            absolute: 80,
-            relative: 1000,
+    servicesPage.expandSliBreakdown('go_routines').verifySliBreakdown(
+      {
+        name: 'go_routines',
+        value: 88,
+        result: ResultTypes.PASSED,
+        score: 33.99,
+        passTargets: [
+          {
+            criteria: '<=100',
+            targetValue: 100,
+            violated: false,
           },
-        } as SliResult,
-        true
-      );
+        ],
+        warningTargets: null,
+        keySli: false,
+        success: true,
+        expanded: false,
+        weight: 1,
+        comparedValue: 8,
+        calculatedChanges: {
+          absolute: 80,
+          relative: 1000,
+        },
+        availableScore: 33.33,
+      },
+      true
+    );
   });
 
   it('should sort elements correctly', () => {
-    cy.intercept('GET', '/api/project/sockshop/serviceStates', {
-      statusCode: 200,
-      fixture: 'get.sockshop.service.states.mock.json',
-    }).as('serviceStates');
-    cy.intercept('GET', '/api/project/sockshop/deployment/da740469-9920-4e0c-b304-0fd4b18d17c2', {
-      statusCode: 200,
-      fixture: 'get.sockshop.service.carts.deployment.mock.json',
-    }).as('ServiceDeployment');
-    cy.intercept('GET', 'api/mongodb-datastore/event/type/sh.keptn.event.evaluation.finished?*', {
-      statusCode: 200,
-      fixture: 'get.sockshop.service.carts.evaluations.mock.json',
-    });
-
-    servicesPage.visitServicePage('sockshop').selectService('carts', 'v0.1.2');
-
     // sort name asc
     servicesPage
       .clickSliBreakdownHeader('Name')
@@ -146,9 +117,27 @@ describe('sli-breakdown', () => {
       .verifySliBreakdownSorting(1, 'descending', 'request_throughput', 'http_response_time_seconds_main_page_sum');
 
     // sort score asc
-    servicesPage.clickSliBreakdownHeader('Score').verifySliBreakdownSorting(7, 'ascending', '0', '0');
+    servicesPage.clickSliBreakdownHeader('Score').verifySliBreakdownSorting(7, 'ascending', ' 0/33.33 ', ' 0/33.33 ');
 
     // sort score desc
-    servicesPage.clickSliBreakdownHeader('Score').verifySliBreakdownSorting(7, 'descending', '33.99', '0');
+    servicesPage
+      .clickSliBreakdownHeader('Score')
+      .verifySliBreakdownSorting(7, 'descending', ' 33.99/33.33 ', ' 0/33.33 ');
+  });
+
+  describe('score overlay', () => {
+    it('should show default score overlay', () => {
+      servicesPage.assertSliScoreOverlayDefault('go_routines');
+    });
+
+    it('should show score overlay with warning message', () => {
+      const heatmapPage = new HeatmapComponentPage();
+      heatmapPage.selectEvaluation('8a549059-8dcd-43ea-adff-b7c2ea9a0d99');
+      servicesPage.assertSliScoreOverlayWarning('http_response_time_seconds_main_page_sum');
+    });
+
+    it('should show score overlay with error message', () => {
+      servicesPage.assertSliScoreOverlayFailed('http_response_time_seconds_main_page_sum');
+    });
   });
 });

--- a/bridge/cypress/support/intercept.ts
+++ b/bridge/cypress/support/intercept.ts
@@ -408,9 +408,13 @@ export function interceptEvaluationBoardWithoutDeployment(): void {
   });
 }
 
-export function interceptHeatmapComponent(): void {
-  cy.intercept('/api/v1/metadata', { fixture: 'metadata.mock' });
+export function interceptD3(): void {
   cy.intercept('/api/bridgeInfo', { fixture: 'bridgeInfoEnableD3Heatmap.mock.json' });
+}
+
+export function interceptHeatmapComponent(): void {
+  interceptD3();
+  cy.intercept('/api/v1/metadata', { fixture: 'metadata.mock' });
   cy.intercept('/api/hasUnreadUniformRegistrationLogs', { body: false });
   cy.intercept('/api/controlPlane/v1/project?disableUpstreamSync=true&pageSize=50', { fixture: 'projects.mock' });
   cy.intercept('GET', '/api/project/sockshop/serviceStates', {

--- a/bridge/cypress/support/pageobjects/HeatmapComponentPage.ts
+++ b/bridge/cypress/support/pageobjects/HeatmapComponentPage.ts
@@ -183,6 +183,11 @@ export class HeatmapComponentPage {
     cy.get('ktb-heatmap button.show-more-button').should(visible ? 'be.visible' : 'not.be.visible');
     return this;
   }
+
+  public selectEvaluation(id: string): this {
+    cy.byTestId(`ktb-heatmap-tile-${id}`).eq(0).click();
+    return this;
+  }
 }
 
 export const range = (start: number, stop: number, step: number): number[] =>

--- a/bridge/cypress/support/pageobjects/ServicesPage.ts
+++ b/bridge/cypress/support/pageobjects/ServicesPage.ts
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-import { SliResult } from '../../../client/app/_models/sli-result';
+import { SliResult } from '../../../client/app/_interfaces/sli-result';
 import {
   interceptProjectBoard,
   interceptServicesPage,


### PR DESCRIPTION
Part of #6560 
Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>

Overlay if the result is pass:
![image](https://user-images.githubusercontent.com/11599148/182803316-887b298d-9189-4f54-bbe1-9c2e29175123.png)


Overlay if the result is failed:
![image](https://user-images.githubusercontent.com/11599148/182803276-d0223b05-278f-4e31-9eab-b009040ea145.png)


Overlay if the result is warning:
![image](https://user-images.githubusercontent.com/11599148/182803370-04c01f66-e942-4f77-86a7-1261ee2891f4.png)

## Additional Changes
Also added an underline to the score in order to make it more obvious that there is an overlay/info