### PR TITLE
feat(bridge): Add `user` obj to webhook integration

### DIFF
--- a/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.html
+++ b/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.html
@@ -56,6 +56,46 @@
     </dt-form-field>
   </div>
   <div class="settings-section">
+    <p>Custom user</p>
+  </div>
+  <dt-form-field class="mr-2" uitestid="edit-webhook-field-userName">
+    <dt-label class="required">Key</dt-label>
+    <input formControlName="key" type="text" dtInput placeholder="e.g. xaror79553@lodores.co" autocomplete="false" />
+    <dt-error>Must not be empty</dt-error>
+  </dt-form-field>
+  <dt-form-field class="mr-2" uitestid="edit-webhook-field-userValue">
+    <dt-label class="required">Value</dt-label>
+    <input
+      #userInput
+      formControlName="value"
+      type="text"
+      dtInput
+      placeholder="e.g. hhjiieAfrzquLxkpKgcU58F7"
+      autocomplete="false"
+    />
+    <dt-error>Must not be empty</dt-error>
+    <div dtSuffix uitestid="event-user">
+      <ng-container
+        [ngTemplateOutlet]="payloadButton"
+        [ngTemplateOutletContext]="{
+          $implicit: undefined,
+          controlName: 'user',
+          selectionStart: userInput.selectionStart
+        }"
+      ></ng-container>
+    </div>
+    <div dtSuffix uitestid="secret-user">
+      <ng-container
+        [ngTemplateOutlet]="secretButton"
+        [ngTemplateOutletContext]="{
+          $implicit: '',
+          controlName: 'user',
+          selectionStart: userInput.selectionStart
+        }"
+      ></ng-container>
+    </div>
+  </dt-form-field>
+  <div class="settings-section">
     <p>Custom headers</p>
     <button
       type="button"

--- a/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.spec.ts
+++ b/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.spec.ts
@@ -175,7 +175,10 @@ describe('KtbWebhookSettingsComponent', () => {
     expect(component.getFormControl('method').value).toEqual(WebhookConfigMock.method);
     expect(component.getFormControl('payload').value).toEqual(WebhookConfigMock.payload);
     expect(component.getFormControl('proxy').value).toEqual(WebhookConfigMock.proxy);
-
+    expect(WebhookConfigMock.user).toEqual({
+      key: component.userControls.get('key')?.value,
+      value: component.userControls.get('value')?.value,
+    });
     for (let i = 0; i < component.headerControls.length; ++i) {
       expect(WebhookConfigMock.header[i]).toEqual({
         key: component.headerControls[i].get('key')?.value,
@@ -294,6 +297,8 @@ describe('KtbWebhookSettingsComponent', () => {
     component.getFormControl('method').setValue(component.webhookMethods[0]);
     component.getFormControl('url').setValue('https://example.com');
     component.addHeader();
+    component.userControls.get('key')?.setValue('email-id');
+    component.userControls.get('value')?.setValue('token-value');
     component.headerControls[0].get('key')?.setValue('x-token');
     component.headerControls[0].get('value')?.setValue('token-value');
     component.getFormControl('payload').setValue('payload');
@@ -305,6 +310,7 @@ describe('KtbWebhookSettingsComponent', () => {
     // then
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith({
+      user: { key: 'email-id', value: 'token-value' },
       header: [{ key: 'x-token', value: 'token-value' }],
       method: 'GET',
       payload: 'payload',

--- a/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.ts
+++ b/bridge/client/app/_components/ktb-webhook-settings/ktb-webhook-settings.component.ts
@@ -8,7 +8,7 @@ import { IClientSecret } from '../../../../shared/interfaces/secret';
 import { ActivatedRoute } from '@angular/router';
 import { map } from 'rxjs/operators';
 
-type ControlType = 'method' | 'url' | 'payload' | 'proxy' | 'header' | 'sendFinished' | 'sendStarted';
+type ControlType = 'method' | 'url' | 'payload' | 'proxy' | 'user' | 'header' | 'sendFinished' | 'sendStarted';
 
 @Component({
   selector: 'ktb-webhook-settings',
@@ -21,6 +21,7 @@ export class KtbWebhookSettingsComponent implements OnInit {
     method: new FormControl('', [Validators.required]),
     url: new FormControl('', [Validators.required, FormUtils.isUrlOrSecretValidator]),
     payload: new FormControl('', [FormUtils.payloadSpecialCharValidator]),
+    user: new FormControl(''),
     header: new FormArray([]),
     proxy: new FormControl('', [FormUtils.isUrlValidator]),
     sendFinished: new FormControl('true'),
@@ -53,6 +54,7 @@ export class KtbWebhookSettingsComponent implements OnInit {
       this.getFormControl('url').setValue(webhookConfig.url);
       this.getFormControl('payload').setValue(webhookConfig.payload);
       this.getFormControl('proxy').setValue(webhookConfig.proxy);
+      this.addUser(webhookConfig.user.key, webhookConfig.user.value);
       this.setSendFinishedControl();
 
       for (const header of webhookConfig.header || []) {
@@ -114,6 +116,10 @@ export class KtbWebhookSettingsComponent implements OnInit {
   @Output() webhookChange: EventEmitter<IWebhookConfigClient> = new EventEmitter<IWebhookConfigClient>();
   @Output() webhookFormDirty: EventEmitter<boolean> = new EventEmitter<boolean>();
 
+  get user(): FormControl {
+    return this.getFormControl('user') as FormControl;
+  }
+
   get header(): FormArray {
     return this.getFormControl('header') as FormArray;
   }
@@ -138,6 +144,7 @@ export class KtbWebhookSettingsComponent implements OnInit {
       url: this.getFormControl('url').value,
       payload: this.getFormControl('payload').value,
       proxy: this.getFormControl('proxy').value,
+      user: this.getFormControl('user').value,
       header: this.getFormControl('header').value,
       sendFinished: this.getFormControl('sendFinished').value === 'true',
       sendStarted: this.getFormControl('sendStarted').value === 'true',
@@ -145,6 +152,15 @@ export class KtbWebhookSettingsComponent implements OnInit {
     };
     this.webhookChange.emit(this._webhook);
     this.webhookFormDirty.emit(this.webhookConfigForm.dirty);
+  }
+
+  public addUser(name?: string, value?: string): void {
+    this.user(
+      {
+        key: new FormControl(name || '', [Validators.required]),
+        value: new FormControl(value || '', [Validators.required]),
+      }
+    );
   }
 
   public addHeader(name?: string, value?: string): void {

--- a/bridge/cypress/support/pageobjects/UniformPage.ts
+++ b/bridge/cypress/support/pageobjects/UniformPage.ts
@@ -8,6 +8,8 @@ class UniformPage {
   SUBSCRIPTION_DETAILS_LOC = 'ktb-expandable-tile dt-expandable-panel ktb-subscription-item';
   SUBSCRIPTION_EXPANDABLE_LOC = 'ktb-expandable-tile';
   EDIT_WEBHOOK_PAYLOAD_ID = 'edit-webhook-field-payload';
+  EDIT_WEBHOOK_FIELD_USER_NAME_ID = 'edit-webhook-field-userName';
+  EDIT_WEBHOOK_FIELD_USER_VALUE_ID = 'edit-webhook-field-userValue';
   EDIT_WEBHOOK_FIELD_HEADER_NAME_ID = 'edit-webhook-field-headerName';
   EDIT_WEBHOOK_FIELD_HEADER_VALUE_ID = 'edit-webhook-field-headerValue';
   UPDATE_SUBSCRIPTION_BUTTON_ID = 'updateSubscriptionButton';
@@ -19,6 +21,8 @@ class UniformPage {
   EDIT_WEBHOOK_EVENT_SELECTOR_URL = 'event-url';
   EDIT_WEBHOOK_SECRET_SELECTOR_PAYLOAD = 'secret-payload';
   EDIT_WEBHOOK_EVENT_SELECTOR_PAYLOAD = 'event-payload';
+  EDIT_WEBHOOK_EVENT_SELECTOR_USER = 'event-user';
+  EDIT_WEBHOOK_SECRET_SELECTOR_USER = 'secret-user';
   EDIT_WEBHOOK_SECRET_SELECTOR_HEADER = 'secret-header';
   EDIT_WEBHOOK_EVENT_SELECTOR_HEADER = 'event-header';
   EDIT_WEBHOOK_FILTER = 'edit-subscription-field-filterStageService';


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- adds `user` object to support webhook integration API

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

For #8552 

