### PR TITLE
fix: Merge integration subscriptions into one, apply newly supplied subscriptions if existing ones are empty

### DIFF
--- a/shipyard-controller/handler/uniformintegrationhandler.go
+++ b/shipyard-controller/handler/uniformintegrationhandler.go
@@ -209,7 +209,6 @@ func (rh *UniformIntegrationHandler) updateIntegration(c *gin.Context, existingI
 }
 
 func (rh *UniformIntegrationHandler) updateIntegrationMetadata(integration *apimodels.Integration) error {
->>>>>>> ec0036f45 (fix: Merge integration subscriptions into one, apply newly supplied subscriptions if existing ones are empty (#8573)):shipyard-controller/internal/handler/uniformintegrationhandler.go
 	var err error
 	result, err := rh.uniformRepo.GetUniformIntegrations(models.GetUniformIntegrationsParams{ID: integration.ID})
 
@@ -568,4 +567,3 @@ func getMostRecentIntegration(integrations []apimodels.Integration) (*apimodels.
 	}
 	return &targetIntegration, nil
 }
-

--- a/shipyard-controller/handler/uniformintegrationhandler_test.go
+++ b/shipyard-controller/handler/uniformintegrationhandler_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	apimodels "github.com/keptn/go-utils/pkg/api/models"

--- a/shipyard-controller/handler/uniformintegrationhandler_test.go
+++ b/shipyard-controller/handler/uniformintegrationhandler_test.go
@@ -269,6 +269,95 @@ func TestUniformIntegrationHandler_Register(t *testing.T) {
 
 }
 
+func TestUniformIntegrationHandler_RegisterMergeIntegrationInstancesNoExistingSubscriptions(t *testing.T) {
+	mockRepo := &db_mock.UniformRepoMock{
+		CreateUniformIntegrationFunc: func(integration apimodels.Integration) error { return db.ErrUniformRegistrationAlreadyExists },
+		CreateOrUpdateUniformIntegrationFunc: func(integration apimodels.Integration) error {
+			return nil
+		},
+		UpdateLastSeenFunc: func(integrationID string) (*apimodels.Integration, error) {
+			return nil, nil
+		},
+		UpdateVersionInfoFunc: func(integrationID string, integrationVersion string, distributorVersion string) (*apimodels.Integration, error) {
+			return nil, nil
+		},
+		GetUniformIntegrationsFunc: func(filter models.GetUniformIntegrationsParams) ([]apimodels.Integration, error) {
+			return []apimodels.Integration{
+				{
+					ID:   "123",
+					Name: "my-integration",
+					MetaData: apimodels.MetaData{
+						Hostname:           "my-host",
+						DistributorVersion: "0.16.0",
+						KubernetesMetaData: apimodels.KubernetesMetaData{
+							Namespace: "my-namespace",
+						},
+						LastSeen: time.Now(),
+					},
+					Subscriptions: []apimodels.EventSubscription{},
+				},
+				{
+					ID:   "456",
+					Name: "my-integration",
+					MetaData: apimodels.MetaData{
+						Hostname:           "my-host",
+						DistributorVersion: "0.17.0",
+						KubernetesMetaData: apimodels.KubernetesMetaData{
+							Namespace: "my-namespace",
+						},
+						LastSeen: time.Now().Add(10 * time.Second),
+					},
+					Subscriptions: []apimodels.EventSubscription{},
+				},
+			}, nil
+		},
+	}
+
+	h := handler.NewUniformIntegrationHandler(mockRepo)
+
+	router := gin.Default()
+	router.POST("/uniform/registration", func(c *gin.Context) {
+		h.Register(c)
+	})
+
+	myIntegration := &apimodels.Integration{
+		Name: "my-integration",
+		MetaData: apimodels.MetaData{
+			Hostname:           "my-host",
+			DistributorVersion: "0.17.0",
+			KubernetesMetaData: apimodels.KubernetesMetaData{
+				Namespace: "my-namespace",
+			},
+		},
+		Subscriptions: []apimodels.EventSubscription{
+			{
+				Event: "sh.keptn.event.test.triggered",
+			},
+		},
+	}
+	payload, _ := json.Marshal(myIntegration)
+
+	request := httptest.NewRequest("POST", "/uniform/registration", bytes.NewBuffer(payload))
+
+	resp := performRequest(router, request)
+
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	require.Len(t, mockRepo.CreateOrUpdateUniformIntegrationCalls(), 1)
+
+	// the update should have been performed for the integration which has been seen most recently
+	require.Equal(t, "456", mockRepo.CreateOrUpdateUniformIntegrationCalls()[0].Integration.ID)
+
+	require.Len(t, mockRepo.CreateOrUpdateUniformIntegrationCalls()[0].Integration.Subscriptions, 1)
+
+	// in this case we want to apply the subscriptions from the new integration, since the existing integrations did not have any subscriptions
+	require.ElementsMatch(t, mockRepo.CreateOrUpdateUniformIntegrationCalls()[0].Integration.Subscriptions, []apimodels.EventSubscription{
+		{
+			Event: "sh.keptn.event.test.triggered",
+		},
+	})
+}
+
 func TestUniformIntegrationKeepAlive(t *testing.T) {
 
 	existingIntegration := &apimodels.Integration{


### PR DESCRIPTION
Backport of #8573 