### PR TITLE
feat(api): Enable import endpoint

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -24,7 +24,7 @@ kubectl delete -f deploy/service.yaml
 
 ## Updating the API specification
 After a modification to the `swagger.yaml`, the generated code can be updated using the command
-NOTE: To avoid re-generating too many files it is recommended to use swagger v0.25.0
+NOTE: To avoid re-generating too many files it is recommended to use [swagger v0.29.0](https://github.com/go-swagger/go-swagger/releases/tag/v0.29.0).
 
 ```console
 swagger generate server -A keptn -P models.Principal -f ./swagger.yaml

--- a/api/models/import_summary.go
+++ b/api/models/import_summary.go
@@ -106,6 +106,8 @@ func (m *ImportSummary) validateTasks(formats strfmt.Registry) error {
 			if err := m.Tasks[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("tasks" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("tasks" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -138,6 +140,8 @@ func (m *ImportSummary) contextValidateTasks(ctx context.Context, formats strfmt
 			if err := m.Tasks[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("tasks" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("tasks" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/api/restapi/embedded_spec.go
+++ b/api/restapi/embedded_spec.go
@@ -48,6 +48,7 @@ func init() {
     },
     "/event": {
       "post": {
+        "description": "\u003cspan class=\"oauth-scopes\"\u003eRequired OAuth scopes: ${prefix}events:write\u003c/span\u003e\n",
         "tags": [
           "Event"
         ],
@@ -79,7 +80,7 @@ func init() {
     },
     "/import": {
       "post": {
-        "description": "This API is still in alpha state and we do not recommend its usage outside of testing purposes",
+        "description": "Import a zip package to create services, secrets and webhook subscriptions, as well as add resources to Keptn",
         "consumes": [
           "multipart/form-data"
         ],
@@ -89,7 +90,7 @@ func init() {
         "tags": [
           "Import"
         ],
-        "summary": "Alpha: Import a zip package",
+        "summary": "Import a zip package",
         "operationId": "import",
         "parameters": [
           {
@@ -143,6 +144,7 @@ func init() {
     },
     "/metadata": {
       "get": {
+        "description": "\u003cspan class=\"oauth-scopes\"\u003eRequired OAuth scopes: ${prefix}metadata:read\u003c/span\u003e\n",
         "tags": [
           "Metadata"
         ],
@@ -343,6 +345,7 @@ func init() {
     },
     "/event": {
       "post": {
+        "description": "\u003cspan class=\"oauth-scopes\"\u003eRequired OAuth scopes: ${prefix}events:write\u003c/span\u003e\n",
         "tags": [
           "Event"
         ],
@@ -374,7 +377,7 @@ func init() {
     },
     "/import": {
       "post": {
-        "description": "This API is still in alpha state and we do not recommend its usage outside of testing purposes",
+        "description": "Import a zip package to create services, secrets and webhook subscriptions, as well as add resources to Keptn",
         "consumes": [
           "multipart/form-data"
         ],
@@ -384,7 +387,7 @@ func init() {
         "tags": [
           "Import"
         ],
-        "summary": "Alpha: Import a zip package",
+        "summary": "Import a zip package",
         "operationId": "import",
         "parameters": [
           {
@@ -438,6 +441,7 @@ func init() {
     },
     "/metadata": {
       "get": {
+        "description": "\u003cspan class=\"oauth-scopes\"\u003eRequired OAuth scopes: ${prefix}metadata:read\u003c/span\u003e\n",
         "tags": [
           "Metadata"
         ],

--- a/api/restapi/operations/event/post_event.go
+++ b/api/restapi/operations/event/post_event.go
@@ -35,6 +35,9 @@ func NewPostEvent(ctx *middleware.Context, handler PostEventHandler) *PostEvent 
 
 Forwards the received event
 
+<span class="oauth-scopes">Required OAuth scopes: ${prefix}events:write</span>
+
+
 */
 type PostEvent struct {
 	Context *middleware.Context

--- a/api/restapi/operations/import_operations/import.go
+++ b/api/restapi/operations/import_operations/import.go
@@ -33,9 +33,9 @@ func NewImport(ctx *middleware.Context, handler ImportHandler) *Import {
 
 /* Import swagger:route POST /import Import import
 
-Alpha: Import a zip package
+Import a zip package
 
-This API is still in alpha state and we do not recommend its usage outside of testing purposes
+Import a zip package to create services, secrets and webhook subscriptions, as well as add resources to Keptn
 
 */
 type Import struct {

--- a/api/restapi/operations/metadata/metadata.go
+++ b/api/restapi/operations/metadata/metadata.go
@@ -35,6 +35,9 @@ func NewMetadata(ctx *middleware.Context, handler MetadataHandler) *Metadata {
 
 Get keptn installation metadata
 
+<span class="oauth-scopes">Required OAuth scopes: ${prefix}metadata:read</span>
+
+
 */
 type Metadata struct {
 	Context *middleware.Context

--- a/api/restapi/server.go
+++ b/api/restapi/server.go
@@ -305,9 +305,6 @@ func (s *Server) Serve() (err error) {
 			s.Fatalf("no certificate was configured for TLS")
 		}
 
-		// must have at least one certificate or panics
-		httpsServer.TLSConfig.BuildNameToCertificate()
-
 		configureServer(httpsServer, "https", s.httpsServerL.Addr().String())
 
 		servers = append(servers, httpsServer)

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -68,8 +68,8 @@ paths:
       tags:
         - Import
       operationId: import
-      summary: "Alpha: Import a zip package"
-      description: "This API is still in alpha state and we do not recommend its usage outside of testing purposes"
+      summary: "Import a zip package"
+      description: "Import a zip package to create services, secrets and webhook subscriptions, as well as add resources to Keptn"
       parameters:         
         - in: formData
           name: configPackage


### PR DESCRIPTION
## This PR

enables the import endpoint.

I've adapted the swagger.yaml, then I ran (as it is described in the README.md) 
```bash
swagger generate server -A keptn -P models.Principal -f ./swagger.yaml
```

which lead to the changes in the .go files (and i'm not sure if all of them are expected/valid).