### PR TITLE
test(api): Fix failing import package integration tests

### DIFF
--- a/test/assets/import/sample-package/manifest.yaml
+++ b/test/assets/import/sample-package/manifest.yaml
@@ -23,7 +23,7 @@ tasks:
 
   # create a secret which we will later use in webhook
   - name: "Create secret"
-    id: create-secret
+    id: create_secret
     type: api
     payload: "api/create-secret.json"
     action: "keptn-api-v1-uniform-create-secret"

--- a/test/go-tests/test_importer_test.go
+++ b/test/go-tests/test_importer_test.go
@@ -67,7 +67,7 @@ func Test_ImportCorrectManifestNonExistingProject(t *testing.T) {
 	projectName := "keptn-importer-test-non-existing"
 	wrongProjectName := "ketpn-importer-test-non-existing"
 	errorMessage := "project not found"
-	expectedErrorCode := 424
+	expectedErrorCode := 404
 
 	t.Logf("Creating a new project %s with Gitea Upstream", projectName)
 	shipyardFilePath, err := CreateTmpShipyardFile(importerShipyard)


### PR DESCRIPTION
## This PR
- corrects ids in the import package manifest integration tests

### Related Issues
Fixes #8642
