### PR TITLE
ci: Add pipeline to check helm docs against master

### DIFF
--- a/.github/workflows/validate-helm-docs.yml
+++ b/.github/workflows/validate-helm-docs.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Execute diff
         working-directory: current
         run: |
+          # TODO change path back to ../master/installer/manifests/keptn/README.md
           cp ../master/installer/README.md ./installer/manifests/keptn/README-old.md
           cd ./installer/manifests/keptn
           readme-generator --values=./values.yaml --readme=./README.md

--- a/.github/workflows/validate-helm-docs.yml
+++ b/.github/workflows/validate-helm-docs.yml
@@ -40,8 +40,7 @@ jobs:
       - name: Execute diff
         working-directory: current
         run: |
-          # TODO change path back to ../master/installer/manifests/keptn/README.md
-          cp ../master/installer/README.md ./installer/manifests/keptn/README-old.md
+          cp ../master/installer/manifests/keptn/README.md ./installer/manifests/keptn/README-old.md
           cd ./installer/manifests/keptn
           readme-generator --values=./values.yaml --readme=./README.md
           if ! cmp --quiet ./README-old.md ./README.md; then

--- a/.github/workflows/validate-helm-docs.yml
+++ b/.github/workflows/validate-helm-docs.yml
@@ -1,0 +1,49 @@
+name: Validate Helm Docs
+on:
+  pull_request:
+    branches:
+      - 'master'
+      - '[0-9]+.[1-9][0-9]*.x'
+defaults:
+  run:
+    shell: bash
+jobs:
+  check-helm-docs:
+    name: Check helm documentation values
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          path: 'current'
+
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          ref: 'master'
+          path: 'master'
+
+      - name: Set up Node
+        uses: actions/setup-node@v3.4.1
+        with:
+          node-version: 16
+
+      - name: Install readme generator
+        working-directory: current
+        run: |
+          git clone https://github.com/bitnami-labs/readme-generator-for-helm.git
+          cd ./readme-generator-for-helm
+          npm ci
+          npm install --location=global ./
+          cd ..
+
+      - name: Execute diff
+        working-directory: current
+        run: |
+          cp ../master/installer/README.md ./installer/manifests/keptn/README-old.md
+          cd ./installer/manifests/keptn
+          readme-generator --values=./values.yaml --readme=./README.md
+          if ! cmp --quiet ./README-old.md ./README.md; then
+            echo "The Helm values have changes that are not reflected in the readme. Please use ./gh-actions-scripts/generate-helm-docs.sh to re-generate the docs."
+            exit 1
+          fi

--- a/gh-actions-scripts/generate-helm-docs.sh
+++ b/gh-actions-scripts/generate-helm-docs.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Readme generator for Keptn Helm Chart
+#
+# This script will install the readme generator if it's not installed already
+# and then it will generate the readme from the local helm values
+#
+# Dependencies:
+# Node >=16
+
+echo "Checking if readme generator is installed already..."
+if [[ $(npm list -g | grep -c 'readme-generator-for-helm') -eq 0 ]]; then
+  echo "Readme Generator not installed, installing now..."
+  git clone https://github.com/bitnami-labs/readme-generator-for-helm.git
+  npm install -g ./readme-generator-for-helm
+else
+  echo "Readme Generator is already installed, continuing..."
+fi
+
+echo "Generating readme now..."
+readme-generator --values=./installer/manifests/keptn/values.yaml --readme=./installer/manifests/keptn/README.md
+
+# Please be aware, the readme file needs to exist and needs to have a Parameters section, as only this section will be re-generated

--- a/installer/README.md
+++ b/installer/README.md
@@ -1,12 +1,3 @@
 # Keptn Installer
 
-This repository contains **scripts** and **manifest files** that are needed to install Keptn on a Kubernetes cluster. The scripts help to install the manifests in correct order and to manipulate them for Cloud platform specific requirements.  
-
-The scripts and manifests are finally put into a container, which starts the initial script `installKeptn.sh`. Depending on the platform parameter that is handed over to the `installKeptn.sh`, the script then runs the installation process for one of the following Kubernetes platforms:
-* AKS
-* EKS
-* OpenShift
-* GKE
-* PKS
-* Kubernetes
-* Minikube 1.2
+This folder contains different Helm charts that are maintained by the Keptn team and are needed to install Keptn.

--- a/installer/manifests/keptn/README.md
+++ b/installer/manifests/keptn/README.md
@@ -5,9 +5,349 @@ Cloud-native application life-cycle orchestration. Keptn automates your SLO-driv
 
 ### Global values
 
-| Name                    | Description                                               | Value             |
-| ----------------------- | --------------------------------------------------------- | ----------------- |
-| `global.keptn.registry` | Global Docker image registry                              | `docker.io/keptn` |
-| `global.keptn.tag`      | The tag of Keptn that should be used for all images       | `""`              |
-| `logLevel`              | Log level that should be used for all Keptn microservices | `info`            |
+| Name                    | Description                                         | Value             |
+| ----------------------- | --------------------------------------------------- | ----------------- |
+| `global.keptn.registry` | Global Docker image registry                        | `docker.io/keptn` |
+| `global.keptn.tag`      | The tag of Keptn that should be used for all images | `""`              |
+
+
+### MongoDB
+
+| Name                                                | Description                                                         | Value                 |
+| --------------------------------------------------- | ------------------------------------------------------------------- | --------------------- |
+| `mongo.enabled`                                     |                                                                     | `true`                |
+| `mongo.host`                                        |                                                                     | `mongodb:27017`       |
+| `mongo.architecture`                                |                                                                     | `standalone`          |
+| `mongo.service.nameOverride`                        |                                                                     | `mongo`               |
+| `mongo.service.port`                                |                                                                     | `27017`               |
+| `mongo.auth.enabled`                                |                                                                     | `true`                |
+| `mongo.auth.databases`                              |                                                                     | `["keptn"]`           |
+| `mongo.auth.existingSecret`                         |                                                                     | `mongodb-credentials` |
+| `mongo.auth.usernames`                              |                                                                     | `["keptn"]`           |
+| `mongo.auth.password`                               |                                                                     | `nil`                 |
+| `mongo.auth.rootUser`                               |                                                                     | `admin`               |
+| `mongo.auth.rootPassword`                           |                                                                     | `nil`                 |
+| `mongo.auth.bridgeAuthDatabase`                     |                                                                     | `keptn`               |
+| `mongo.external.connectionString`                   |                                                                     | `nil`                 |
+| `mongo.containerSecurityContext`                    | Container Security Context that should be used for all MongoDB pods |                       |
+| `mongo.serviceAccount.automountServiceAccountToken` |                                                                     | `false`               |
+| `mongo.resources`                                   | Define resources for MongoDB                                        |                       |
+
+
+### Keptn Features
+
+| Name                                        | Description            | Value    |
+| ------------------------------------------- | ---------------------- | -------- |
+| `features.automaticProvisioning.serviceURL` |                        | `""`     |
+| `features.automaticProvisioning.message`    |                        | `""`     |
+| `features.swagger.hideDeprecated`           |                        | `false`  |
+| `features.oauth.enabled`                    | Enable OAuth for Keptn | `false`  |
+| `features.oauth.prefix`                     |                        | `keptn:` |
+| `features.git.remoteURLDenyList`            |                        | `""`     |
+
+
+### NATS
+
+| Name                                               | Description                                                                | Value        |
+| -------------------------------------------------- | -------------------------------------------------------------------------- | ------------ |
+| `nats.nameOverride`                                |                                                                            | `keptn-nats` |
+| `nats.fullnameOverride`                            |                                                                            | `keptn-nats` |
+| `nats.cluster.enabled`                             | Enable NATS clustering                                                     | `false`      |
+| `nats.cluster.replicas`                            | Define the NATS cluster size                                               | `3`          |
+| `nats.cluster.name`                                | Define the NATS cluster name                                               | `nats`       |
+| `nats.securityContext`                             | Define security context settings for NATS                                  |              |
+| `nats.nats.automountServiceAccountToken`           |                                                                            | `false`      |
+| `nats.nats.resources`                              | Define resources for NATS                                                  |              |
+| `nats.nats.healthcheck.startup.enabled`            | Enable NATS startup probe                                                  | `false`      |
+| `nats.nats.jetstream.enabled`                      |                                                                            | `true`       |
+| `nats.nats.jetstream.memStorage.enabled`           | Enable memory storage for NATS Jetstream                                   | `true`       |
+| `nats.nats.jetstream.memStorage.size`              | Define the memory storage size for NATS Jetstream                          | `500Mi`      |
+| `nats.nats.jetstream.fileStorage.enabled`          |                                                                            | `true`       |
+| `nats.nats.jetstream.fileStorage.size`             |                                                                            | `5Gi`        |
+| `nats.nats.jetstream.fileStorage.storageDirectory` |                                                                            | `/data/`     |
+| `nats.nats.jetstream.fileStorage.storageClassName` |                                                                            | `""`         |
+| `nats.nats.securityContext`                        | Define the container security context for NATS                             |              |
+| `nats.natsbox.enabled`                             | Enable NATS Box utility container                                          | `false`      |
+| `nats.reloader.enabled`                            | Enable NATS Config Reloader sidecar to reload configuration during runtime | `false`      |
+| `nats.exporter.enabled`                            | Enable NATS Prometheus Exporter sidecar to emit prometheus metrics         | `false`      |
+
+
+### API Gateway NginX
+
+| Name                                                       | Description                                             | Value                |
+| ---------------------------------------------------------- | ------------------------------------------------------- | -------------------- |
+| `apiGatewayNginx.type`                                     |                                                         | `ClusterIP`          |
+| `apiGatewayNginx.port`                                     |                                                         | `80`                 |
+| `apiGatewayNginx.targetPort`                               |                                                         | `8080`               |
+| `apiGatewayNginx.nodePort`                                 |                                                         | `31090`              |
+| `apiGatewayNginx.podSecurityContext.enabled`               | Enable the pod security context for the API Gateway     | `true`               |
+| `apiGatewayNginx.podSecurityContext.defaultSeccompProfile` | Use the default seccomp profile for the API Gateway     | `true`               |
+| `apiGatewayNginx.podSecurityContext.fsGroup`               | Filesystem group to be used by the API Gateway          | `101`                |
+| `apiGatewayNginx.containerSecurityContext`                 | Define a container security context for the API Gateway |                      |
+| `apiGatewayNginx.image.registry`                           | API Gateway image registry                              | `docker.io/nginxinc` |
+| `apiGatewayNginx.image.repository`                         | API Gateway image repository                            | `nginx-unprivileged` |
+| `apiGatewayNginx.image.tag`                                | API Gateway image tag                                   | `1.22.0-alpine`      |
+| `apiGatewayNginx.nodeSelector`                             | API Gateway node labels for pod assignment              | `{}`                 |
+| `apiGatewayNginx.gracePeriod`                              | API Gateway termination grace period                    | `60`                 |
+| `apiGatewayNginx.preStopHookTime`                          | API Gateway pre stop timeout                            | `20`                 |
+| `apiGatewayNginx.clientMaxBodySize`                        |                                                         | `5m`                 |
+| `apiGatewayNginx.sidecars`                                 | Add additional sidecar containers to the API Gateway    | `[]`                 |
+| `apiGatewayNginx.extraVolumeMounts`                        | Add additional volume mounts to the API Gateway         | `[]`                 |
+| `apiGatewayNginx.extraVolumes`                             | Add additional volumes to the API Gateway               | `[]`                 |
+| `apiGatewayNginx.resources`                                | Define resources for the API Gateway                    |                      |
+
+
+### Remediation Service
+
+| Name                                   | Description                                                  | Value                 |
+| -------------------------------------- | ------------------------------------------------------------ | --------------------- |
+| `remediationService.enabled`           | Enable Remediation Service                                   | `true`                |
+| `remediationService.image.registry`    | Remediation Service image registry                           | `""`                  |
+| `remediationService.image.repository`  | Remediation Service image repository                         | `remediation-service` |
+| `remediationService.image.tag`         | Remediation Service image tag                                | `""`                  |
+| `remediationService.nodeSelector`      | Remediation Service node labels for pod assignment           | `{}`                  |
+| `remediationService.gracePeriod`       | Remediation Service termination grace period                 | `60`                  |
+| `remediationService.preStopHookTime`   | Remediation Service pre stop timeout                         | `5`                   |
+| `remediationService.sidecars`          | Add additional sidecar containers to the Remediation Service | `[]`                  |
+| `remediationService.extraVolumeMounts` | Add additional volume mounts to the Remediation Service      | `[]`                  |
+| `remediationService.extraVolumes`      | Add additional volumes to the Remediation Service            | `[]`                  |
+| `remediationService.resources`         | Define resources for the Remediation Service                 |                       |
+
+
+### API Service
+
+| Name                                   | Description                                           | Value  |
+| -------------------------------------- | ----------------------------------------------------- | ------ |
+| `apiService.tokenSecretName`           | K8s secret to be used as API token in the API Service | `nil`  |
+| `apiService.image.registry`            | API Service image registry                            | `""`   |
+| `apiService.image.repository`          | API Service image repository                          | `api`  |
+| `apiService.image.tag`                 | API Service image tag                                 | `""`   |
+| `apiService.maxAuth.enabled`           | Enable API authentication rate limiting               | `true` |
+| `apiService.maxAuth.requestsPerSecond` | API authentication rate limiting requests per second  | `1.0`  |
+| `apiService.maxAuth.requestBurst`      | API authentication rate limiting requests burst       | `2`    |
+| `apiService.nodeSelector`              | API Service node labels for pod assignment            | `{}`   |
+| `apiService.gracePeriod`               | API Service termination grace period                  | `60`   |
+| `apiService.preStopHookTime`           | API Service pre stop timeout                          | `5`    |
+| `apiService.sidecars`                  | Add additional sidecar containers to the API Service  | `[]`   |
+| `apiService.extraVolumeMounts`         | Add additional volume mounts to the API Service       | `[]`   |
+| `apiService.extraVolumes`              | Add additional volumes to the API Service             | `[]`   |
+| `apiService.resources`                 | Define resources for the API Service                  |        |
+
+
+### Bridge
+
+| Name                              | Description                                                                                                                                                                                                                                                                    | Value     |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------- |
+| `bridge.image.registry`           | Bridge image registry                                                                                                                                                                                                                                                          | `""`      |
+| `bridge.image.repository`         | Bridge image repository                                                                                                                                                                                                                                                        | `bridge2` |
+| `bridge.image.tag`                | Bridge image tag                                                                                                                                                                                                                                                               | `""`      |
+| `bridge.cliDownloadLink`          | Define an alternative download URL for the Keptn CLI                                                                                                                                                                                                                           | `nil`     |
+| `bridge.secret.enabled`           | Enable bridge credentials for HTTP Basic Auth                                                                                                                                                                                                                                  | `true`    |
+| `bridge.versionCheck.enabled`     | Enable check for updated versions of Keptn                                                                                                                                                                                                                                     | `true`    |
+| `bridge.showApiToken.enabled`     | If disabled, the API token will not be shown in the Bridge info                                                                                                                                                                                                                | `true`    |
+| `bridge.installationType`         | Can take the values: `QUALITY_GATES`, `CONTINUOUS_OPERATIONS`, `CONTINUOUS_DELIVERY` and determines the mode in which the Bridge will be started. If only `QUALITY_GATES` is set, only functionalities and data specific for the Quality Gates Only use case will be displayed | `nil`     |
+| `bridge.lookAndFeelUrl`           | Define a different styling for the Bridge by providing a URL to a ZIP archive containing style files. This archive will be downloaded and used upon Bridge startup                                                                                                             | `nil`     |
+| `bridge.podSecurityContext`       | Define a pod security context for the Bridge                                                                                                                                                                                                                                   |           |
+| `bridge.containerSecurityContext` | Define a container security context for the Bridge                                                                                                                                                                                                                             |           |
+| `bridge.oauth`                    | Configure OAuth settings for the Bridge                                                                                                                                                                                                                                        |           |
+| `bridge.authMsg`                  |                                                                                                                                                                                                                                                                                | `""`      |
+| `bridge.d3.enabled`               | Enable D3 basic heatmaps in the Bridge                                                                                                                                                                                                                                         | `true`    |
+| `bridge.nodeSelector`             | Bridge node labels for pod assignment                                                                                                                                                                                                                                          | `{}`      |
+| `bridge.sidecars`                 | Add additional sidecar containers to the Bridge                                                                                                                                                                                                                                | `[]`      |
+| `bridge.extraVolumeMounts`        | Add additional volume mounts to the Bridge                                                                                                                                                                                                                                     | `[]`      |
+| `bridge.extraVolumes`             | Add additional volumes to the Bridge                                                                                                                                                                                                                                           | `[]`      |
+| `bridge.resources`                | Define resources for the Bridge                                                                                                                                                                                                                                                |           |
+
+
+### Distributor
+
+| Name                                         | Description                          | Value         |
+| -------------------------------------------- | ------------------------------------ | ------------- |
+| `distributor.metadata.hostname`              |                                      | `nil`         |
+| `distributor.metadata.namespace`             |                                      | `nil`         |
+| `distributor.image.registry`                 | Distributor image registry           | `""`          |
+| `distributor.image.repository`               | Distributor image repository         | `distributor` |
+| `distributor.image.tag`                      | Distributor image tag                | `""`          |
+| `distributor.config.proxy.httpTimeout`       |                                      | `30`          |
+| `distributor.config.proxy.maxPayloadBytesKB` |                                      | `64`          |
+| `distributor.config.queueGroup.enabled`      | Enable queue groups for distibutor   | `true`        |
+| `distributor.config.oauth.clientID`          |                                      | `""`          |
+| `distributor.config.oauth.clientSecret`      |                                      | `""`          |
+| `distributor.config.oauth.discovery`         |                                      | `""`          |
+| `distributor.config.oauth.tokenURL`          |                                      | `""`          |
+| `distributor.config.oauth.scopes`            |                                      | `""`          |
+| `distributor.resources`                      | Define resources for the Distributor |               |
+
+
+### Shipyard Controller
+
+| Name                                                      | Description                                                                      | Value                 |
+| --------------------------------------------------------- | -------------------------------------------------------------------------------- | --------------------- |
+| `shipyardController.image.registry`                       | Shipyard Controller image registry                                               | `""`                  |
+| `shipyardController.image.repository`                     | Shipyard Controller image repository                                             | `shipyard-controller` |
+| `shipyardController.image.tag`                            | Shipyard Controller image tag                                                    | `""`                  |
+| `shipyardController.config.taskStartedWaitDuration`       |                                                                                  | `10m`                 |
+| `shipyardController.config.uniformIntegrationTTL`         |                                                                                  | `48h`                 |
+| `shipyardController.config.leaderElection.enabled`        | Enable leader election when multiple replicas of Shipyard Controller are running | `false`               |
+| `shipyardController.config.replicas`                      | Number of replicas of Shipyard Controller                                        | `1`                   |
+| `shipyardController.config.validation.projectNameMaxSize` | Maximum number of characters that a Keptn project name can have                  | `200`                 |
+| `shipyardController.config.validation.serviceNameMaxSize` | Maximum number of characters that a service name can have                        | `43`                  |
+| `shipyardController.nodeSelector`                         | Shipyard Controller node labels for pod assignment                               | `{}`                  |
+| `shipyardController.gracePeriod`                          | Shipyard Controller termination grace period                                     | `60`                  |
+| `shipyardController.preStopHookTime`                      | Shipyard Controller pre stop timeout                                             | `15`                  |
+| `shipyardController.sidecars`                             | Add additional sidecar containers to Shipyard Controller                         | `[]`                  |
+| `shipyardController.extraVolumeMounts`                    | Add additional volume mounts to Shipyard Controller                              | `[]`                  |
+| `shipyardController.extraVolumes`                         | Add additional volumes to Shipyard Controller                                    | `[]`                  |
+| `shipyardController.resources`                            | Define resources for Shipyard Controller                                         |                       |
+
+
+### Secret Service
+
+| Name                              | Description                                             | Value            |
+| --------------------------------- | ------------------------------------------------------- | ---------------- |
+| `secretService.image.registry`    | Secret Service image registry                           | `""`             |
+| `secretService.image.repository`  | Secret Service image repository                         | `secret-service` |
+| `secretService.image.tag`         | Secret Service image tag                                | `""`             |
+| `secretService.nodeSelector`      | Secret Service node labels for pod assignment           | `{}`             |
+| `secretService.gracePeriod`       | Secret Service termination grace period                 | `60`             |
+| `secretService.preStopHookTime`   | Secret Service pre stop timeout                         | `20`             |
+| `secretService.sidecars`          | Add additional sidecar containers to the Secret Service | `[]`             |
+| `secretService.extraVolumeMounts` | Add additional volume mounts to the Secret Service      | `[]`             |
+| `secretService.extraVolumes`      | Add additional volumes to the Secret Service            | `[]`             |
+| `secretService.resources`         | Define resources for the Secret Service                 |                  |
+
+
+### Resource Service
+
+| Name                                            | Description                                                                | Value              |
+| ----------------------------------------------- | -------------------------------------------------------------------------- | ------------------ |
+| `resourceService.replicas`                      | Number of replicas of Resource Service                                     | `1`                |
+| `resourceService.image.registry`                | Resource Service image registry                                            | `""`               |
+| `resourceService.image.repository`              | Resource Service image repository                                          | `resource-service` |
+| `resourceService.image.tag`                     | Resource Service image tag                                                 | `""`               |
+| `resourceService.env.GIT_KEPTN_USER`            | Default git username for the Keptn configuration git repository            | `keptn`            |
+| `resourceService.env.GIT_KEPTN_EMAIL`           | Default git email address for the Keptn configuration git repository       | `keptn@keptn.sh`   |
+| `resourceService.env.DIRECTORY_STAGE_STRUCTURE` | Enable directory based structure in the Keptn configuration git repository | `false`            |
+| `resourceService.nodeSelector`                  | Resource Service node labels for pod assignment                            | `{}`               |
+| `resourceService.gracePeriod`                   | Resource Service termination grace period                                  | `60`               |
+| `resourceService.fsGroup`                       | Configure file system group ID to be used in Resource Service              | `1001`             |
+| `resourceService.preStopHookTime`               | Resource Service pre stop timeout                                          | `20`               |
+| `resourceService.sidecars`                      | Add additional sidecar containers to the Resource Service                  | `[]`               |
+| `resourceService.extraVolumeMounts`             | Add additional volume mounts to the Resource Service                       | `[]`               |
+| `resourceService.extraVolumes`                  | Add additional volumes to the Resource Service                             | `[]`               |
+| `resourceService.resources`                     | Define resources for the Resource Service                                  |                    |
+
+
+### MongoDB Datastore
+
+| Name                                 | Description                                                | Value               |
+| ------------------------------------ | ---------------------------------------------------------- | ------------------- |
+| `mongodbDatastore.image.registry`    | MongoDB Datastore image registry                           | `""`                |
+| `mongodbDatastore.image.repository`  | MongoDB Datastore image repository                         | `mongodb-datastore` |
+| `mongodbDatastore.image.tag`         | MongoDB Datastore image tag                                | `""`                |
+| `mongodbDatastore.nodeSelector`      | MongoDB Datastore node labels for pod assignment           | `{}`                |
+| `mongodbDatastore.gracePeriod`       | MongoDB Datastore termination grace period                 | `60`                |
+| `mongodbDatastore.preStopHookTime`   | MongoDB Datastore pre stop timeout                         | `20`                |
+| `mongodbDatastore.sidecars`          | Add additional sidecar containers to the MongoDB Datastore | `[]`                |
+| `mongodbDatastore.extraVolumeMounts` | Add additional volume mounts to the MongoDB Datastore      | `[]`                |
+| `mongodbDatastore.extraVolumes`      | Add additional volumes to the MongoDB Datastore            | `[]`                |
+| `mongodbDatastore.resources`         | Define resources for the MongoDB Datastore                 |                     |
+
+
+### Lighthouse Service
+
+| Name                                  | Description                                                 | Value                |
+| ------------------------------------- | ----------------------------------------------------------- | -------------------- |
+| `lighthouseService.enabled`           | Enable Lighthouse Service                                   | `true`               |
+| `lighthouseService.image.registry`    | Lighthouse Service image registry                           | `""`                 |
+| `lighthouseService.image.repository`  | Lighthouse Service image repository                         | `lighthouse-service` |
+| `lighthouseService.image.tag`         | Lighthouse Service image tag                                | `""`                 |
+| `lighthouseService.nodeSelector`      | Lighthouse Service node labels for pod assignment           | `{}`                 |
+| `lighthouseService.gracePeriod`       | Lighthouse Service termination grace period                 | `60`                 |
+| `lighthouseService.preStopHookTime`   | Lighthouse Service pre stop timeout                         | `20`                 |
+| `lighthouseService.sidecars`          | Add additional sidecar containers to the Lighthouse Service | `[]`                 |
+| `lighthouseService.extraVolumeMounts` | Add additional volume mounts to the Lighthouse Service      | `[]`                 |
+| `lighthouseService.extraVolumes`      | Add additional volumes to the Lighthouse Service            | `[]`                 |
+| `lighthouseService.resources`         | Define resources for the Lighthouse Service                 |                      |
+
+
+### Statistics Service
+
+| Name                                  | Description                                                 | Value                |
+| ------------------------------------- | ----------------------------------------------------------- | -------------------- |
+| `statisticsService.enabled`           | Enable Statistics Service                                   | `true`               |
+| `statisticsService.image.registry`    | Statistics Service image registry                           | `""`                 |
+| `statisticsService.image.repository`  | Statistics Service image repository                         | `statistics-service` |
+| `statisticsService.image.tag`         | Statistics Service image tag                                | `""`                 |
+| `statisticsService.nodeSelector`      | Statistics Service node labels for pod assignment           | `{}`                 |
+| `statisticsService.gracePeriod`       | Statistics Service termination grace period                 | `60`                 |
+| `statisticsService.preStopHookTime`   | Statistics Service pre stop timeout                         | `20`                 |
+| `statisticsService.sidecars`          | Add additional sidecar containers to the Statistics Service | `[]`                 |
+| `statisticsService.extraVolumeMounts` | Add additional volume mounts to the Statistics Service      | `[]`                 |
+| `statisticsService.extraVolumes`      | Add additional volumes to the Statistics Service            | `[]`                 |
+| `statisticsService.resources`         | Define resources for the Statistics Service                 |                      |
+
+
+### Approval Service
+
+| Name                                | Description                                               | Value              |
+| ----------------------------------- | --------------------------------------------------------- | ------------------ |
+| `approvalService.enabled`           | Enable Approval Service                                   | `true`             |
+| `approvalService.image.registry`    | Approval Service image registry                           | `""`               |
+| `approvalService.image.repository`  | Approval Service image repository                         | `approval-service` |
+| `approvalService.image.tag`         | Approval Service image tag                                | `""`               |
+| `approvalService.nodeSelector`      | Approval Service node labels for pod assignment           | `{}`               |
+| `approvalService.gracePeriod`       | Approval Service termination grace period                 | `60`               |
+| `approvalService.preStopHookTime`   | Approval Service pre stop timeout                         | `5`                |
+| `approvalService.sidecars`          | Add additional sidecar containers to the Approval Service | `[]`               |
+| `approvalService.extraVolumeMounts` | Add additional volume mounts to the Approval Service      | `[]`               |
+| `approvalService.extraVolumes`      | Add additional volumes to the Approval Service            | `[]`               |
+| `approvalService.resources`         | Define resources for the Approval Service                 |                    |
+
+
+### Webhook Service
+
+| Name                               | Description                                              | Value             |
+| ---------------------------------- | -------------------------------------------------------- | ----------------- |
+| `webhookService.enabled`           | Enable Webhook Service                                   | `true`            |
+| `webhookService.image.registry`    | Webhook Service image registry                           | `""`              |
+| `webhookService.image.repository`  | Webhook Service image repository                         | `webhook-service` |
+| `webhookService.image.tag`         | Webhook Service image tag                                | `""`              |
+| `webhookService.nodeSelector`      | Webhook Service node labels for pod assignment           | `{}`              |
+| `webhookService.gracePeriod`       | Webhook Service termination grace period                 | `60`              |
+| `webhookService.preStopHookTime`   | Webhook Service pre stop timeout                         | `20`              |
+| `webhookService.sidecars`          | Add additional sidecar containers to the Webhook Service | `[]`              |
+| `webhookService.extraVolumeMounts` | Add additional volume mounts to the Webhook Service      | `[]`              |
+| `webhookService.extraVolumes`      | Add additional volumes to the Webhook Service            | `[]`              |
+| `webhookService.resources`         | Define resources for the Webhook Service                 |                   |
+
+
+### Ingress
+
+| Name                  | Description                            | Value    |
+| --------------------- | -------------------------------------- | -------- |
+| `ingress.enabled`     | Enable ingress configuration for Keptn | `false`  |
+| `ingress.annotations` | Keptn Ingress annotations              | `{}`     |
+| `ingress.host`        | Keptn Ingress host URL                 | `{}`     |
+| `ingress.path`        | Keptn Ingress host path                | `/`      |
+| `ingress.pathType`    | Keptn Ingress path type                | `Prefix` |
+| `ingress.className`   | Keptn Ingress class name               | `""`     |
+| `ingress.tls`         | Keptn Ingress TLS configuration        | `[]`     |
+
+
+### Common settings
+
+| Name                                    | Description                                                            | Value           |
+| --------------------------------------- | ---------------------------------------------------------------------- | --------------- |
+| `logLevel`                              | Global log level for all Keptn services                                | `info`          |
+| `prefixPath`                            | URL prefix for all Keptn URLs                                          | `""`            |
+| `keptnSpecVersion`                      | Version of the Keptn Spec definitions to be used                       | `latest`        |
+| `strategy.type`                         | Strategy to use to replace existing Keptn pods                         | `RollingUpdate` |
+| `strategy.rollingUpdate.maxSurge`       | Maximum number of additional pods to be spun up during rolling updates | `1`             |
+| `strategy.rollingUpdate.maxUnavailable` | Maximum number of unavailable pods during rolling updates              | `0`             |
+| `podSecurityContext`                    | Set the default pod security context for all pods                      |                 |
+| `podSecurityContext.enabled`            | Enable the default pod security context for all pods                   | `true`          |
+| `containerSecurityContext`              | Set the default container security context for all containers          |                 |
+| `containerSecurityContext.enabled`      | Enable the default container security context for all containers       | `true`          |
+| `nodeSelector`                          | Default node labels for pod assignment                                 | `{}`            |
 

--- a/installer/manifests/keptn/README.md
+++ b/installer/manifests/keptn/README.md
@@ -1,0 +1,13 @@
+## Keptn Installer
+Cloud-native application life-cycle orchestration. Keptn automates your SLO-driven multi-stage delivery and operations & remediation of your applications.
+
+## Parameters
+
+### Global values
+
+| Name                    | Description                                               | Value             |
+| ----------------------- | --------------------------------------------------------- | ----------------- |
+| `global.keptn.registry` | Global Docker image registry                              | `docker.io/keptn` |
+| `global.keptn.tag`      | The tag of Keptn that should be used for all images       | `""`              |
+| `logLevel`              | Log level that should be used for all Keptn microservices | `info`            |
+

--- a/installer/manifests/keptn/values.yaml
+++ b/installer/manifests/keptn/values.yaml
@@ -246,9 +246,9 @@ apiGatewayNginx:
 remediationService:
   enabled: true
   image:
-    registry: ""                             # Container Registry
-    repository: "remediation-service"        # Container Image Name
-    tag: ""                                  # Container Tag
+    registry: ""
+    repository: "remediation-service"
+    tag: ""
   nodeSelector: {}
   gracePeriod: 60
   preStopHookTime: 5
@@ -266,9 +266,9 @@ remediationService:
 apiService:
   tokenSecretName:
   image:
-    registry: ""                             # Container Registry
-    repository: "api"                        # Container Image Name
-    tag: ""                                  # Container Tag
+    registry: ""
+    repository: "api"    
+    tag: ""
   maxAuth:
     enabled: true
     requestsPerSecond: "1.0"
@@ -289,9 +289,9 @@ apiService:
 
 bridge:
   image:
-    registry: ""                             # Container Registry
-    repository: "bridge2"                    # Container Image Name
-    tag: ""                                  # Container Tag
+    registry: ""
+    repository: "bridge2"
+    tag: ""
   cliDownloadLink: null
   secret:
     enabled: true
@@ -348,9 +348,9 @@ distributor:
     hostname:
     namespace:
   image:
-    registry: ""                             # Container Registry
-    repository: "distributor"                # Container Image Name
-    tag: ""                                  # Container Tag
+    registry: ""
+    repository: "distributor"
+    tag: ""
   config:
     proxy:
       httpTimeout: "30"
@@ -373,9 +373,9 @@ distributor:
 
 shipyardController:
   image:
-    registry: ""                             # Container Registry
-    repository: "shipyard-controller"        # Container Image Name
-    tag: ""                                  # Container Tag
+    registry: ""
+    repository: "shipyard-controller"
+    tag: ""
   config:
     taskStartedWaitDuration: "10m"
     uniformIntegrationTTL: "48h"
@@ -409,9 +409,9 @@ shipyardController:
 
 secretService:
   image:
-    registry: ""                             # Container Registry
-    repository: "secret-service"             # Container Image Name
-    tag: ""                                  # Container Tag
+    registry: ""
+    repository: "secret-service"     
+    tag: ""
   nodeSelector: {}
   gracePeriod: 60
   preStopHookTime: 20
@@ -429,9 +429,9 @@ secretService:
 resourceService:
   replicas: 1
   image:
-    registry: ""                             # Container Registry
-    repository: "resource-service"           # Container Image Name
-    tag: ""                                  # Container Tag
+    registry: ""
+    repository: "resource-service"   
+    tag: ""
   env:
     GIT_KEPTN_USER: "keptn"
     GIT_KEPTN_EMAIL: "keptn@keptn.sh"
@@ -453,9 +453,9 @@ resourceService:
 
 mongodbDatastore:
   image:
-    registry: ""                             # Container Registry
-    repository: "mongodb-datastore"          # Container Image Name
-    tag: ""                                  # Container Tag
+    registry: ""
+    repository: "mongodb-datastore"  
+    tag: ""
   nodeSelector: {}
   gracePeriod: 60
   preStopHookTime: 20
@@ -473,9 +473,9 @@ mongodbDatastore:
 lighthouseService:
   enabled: true
   image:
-    registry: ""                             # Container Registry
-    repository: "lighthouse-service"         # Container Image Name
-    tag: ""                                  # Container Tag
+    registry: ""
+    repository: "lighthouse-service" 
+    tag: ""
   nodeSelector: {}
   gracePeriod: 60
   preStopHookTime: 20
@@ -493,9 +493,9 @@ lighthouseService:
 statisticsService:
   enabled: true
   image:
-    registry: ""                             # Container Registry
-    repository: "statistics-service"         # Container Image Name
-    tag: ""                                  # Container Tag
+    registry: ""
+    repository: "statistics-service" 
+    tag: ""
   nodeSelector: {}
   gracePeriod: 60
   preStopHookTime: 20
@@ -513,9 +513,9 @@ statisticsService:
 approvalService:
   enabled: true
   image:
-    registry: ""                             # Container Registry
-    repository: "approval-service"           # Container Image Name
-    tag: ""                                  # Container Tag
+    registry: ""
+    repository: "approval-service"   
+    tag: ""
   nodeSelector: {}
   gracePeriod: 60
   preStopHookTime: 5
@@ -533,9 +533,9 @@ approvalService:
 webhookService:
   enabled: true
   image:
-    registry: ""                             # Container Registry
-    repository: "webhook-service"            # Container Image Name
-    tag: ""                                  # Container Tag
+    registry: ""
+    repository: "webhook-service"    
+    tag: ""
   nodeSelector: {}
   gracePeriod: 60
   preStopHookTime: 20

--- a/installer/manifests/keptn/values.yaml
+++ b/installer/manifests/keptn/values.yaml
@@ -794,7 +794,7 @@ strategy:
     ## @param strategy.rollingUpdate.maxUnavailable Maximum number of unavailable pods during rolling updates
     maxUnavailable: 0
 
-## @extra Set the default pod security context for all pods
+## @extra podSecurityContext Set the default pod security context for all pods
 podSecurityContext:
   ## @param podSecurityContext.enabled Enable the default pod security context for all pods
   enabled: true
@@ -803,7 +803,7 @@ podSecurityContext:
   ## @skip podSecurityContext.fsGroup
   fsGroup: 65532
 
-## @extra Set the default container security context for all containers
+## @extra containerSecurityContext Set the default container security context for all containers
 containerSecurityContext:
   ## @param containerSecurityContext.enabled Enable the default container security context for all containers
   enabled: true

--- a/installer/manifests/keptn/values.yaml
+++ b/installer/manifests/keptn/values.yaml
@@ -41,7 +41,7 @@ mongo:
   external:
     ## @param mongo.external.connectionString
     connectionString:
-  ## @param mongo.containerSecurityContext Container Security Context that should be used for all MongoDB pods
+  ## @extra mongo.containerSecurityContext Container Security Context that should be used for all MongoDB pods
   ## @skip mongo.containerSecurityContext.allowPrivilegeEscalation
   ## @skip mongo.containerSecurityContext.capabilities
   ## @skip mongo.containerSecurityContext.capabilities.drop
@@ -53,11 +53,9 @@ mongo:
   serviceAccount:
     ## @param mongo.serviceAccount.automountServiceAccountToken
     automountServiceAccountToken: false
-  ## @param resources Define resources for MongoDB
-  ## @skip mongo.resources.requests.cpu
-  ## @skip mongo.resources.requests.memory
-  ## @skip mongo.resources.limits.cpu
-  ## @skip mongo.resources.limits.memory
+  ## @extra mongo.resources Define resources for MongoDB
+  ## @skip mongo.resources.requests
+  ## @skip mongo.resources.limits
   resources:
     requests:
       cpu: 200m
@@ -66,8 +64,10 @@ mongo:
       cpu: 1000m
       memory: 500Mi
 
+## @param prefixPath
 prefixPath: ""
 
+## @param keptnSpecVersion
 keptnSpecVersion: latest
 
 ## @section Keptn Features
@@ -102,7 +102,7 @@ nats:
     replicas: 3
     ## @param nats.cluster.name Define the NATS cluster name
     name: nats
-  ## @param nats.securityContext Define security context settings for NATS
+  ## @extra nats.securityContext Define security context settings for NATS
   ## @skip nats.securityContext.runAsNonRoot
   ## @skip nats.securityContext.runAsUser
   ## @skip nats.securityContext.fsGroup
@@ -113,11 +113,9 @@ nats:
   nats:
     ## @param nats.nats.automountServiceAccountToken
     automountServiceAccountToken: false
-    ## @param nats.nats.resources Define resources for NATS
-    ## @skip nats.nats.resources.requests.cpu
-    ## @skip nats.nats.resources.requests.memory
-    ## @skip nats.nats.resources.limits.cpu
-    ## @skip nats.nats.resources.limits.memory
+    ## @extra nats.nats.resources Define resources for NATS
+    ## @skip nats.nats.resources.requests
+    ## @skip nats.nats.resources.limits
     resources:
       requests:
         cpu: 200m
@@ -149,7 +147,7 @@ nats:
         size: 5Gi
         storageDirectory: /data/
         storageClassName: ""
-    ## @param nats.nats.securityContext Define the container security context for NATS
+    ## @extra nats.nats.securityContext Define the container security context for NATS
     ## @skip nats.nats.securityContext.readOnlyRootFilesystem
     ## @skip nats.nats.securityContext.allowPrivilegeEscalation
     ## @skip nats.nats.securityContext.privileged
@@ -170,7 +168,6 @@ nats:
   natsbox:
     ## @param nats.natsbox.enabled Enable NATS Box utility container
     enabled: false
-  ## @param reloader
   reloader:
     ## @param nats.reloader.enabled Enable NATS Config Reloader sidecar to reload configuration during runtime
     enabled: false
@@ -188,15 +185,14 @@ apiGatewayNginx:
   targetPort: 8080
   ## @param apiGatewayNginx.nodePort
   nodePort: 31090
-  ## @param podSecurityContext Define a pod security context for the API Gateway
-  ## @skip apiGatewayNginx.podSecurityContext.enabled
-  ## @skip apiGatewayNginx.podSecurityContext.defaultSeccompProfile
-  ## @skip apiGatewayNginx.podSecurityContext.fsGroup
   podSecurityContext:
+    ## @param apiGatewayNginx.podSecurityContext.enabled Enable the pod security context for the API Gateway
     enabled: true
+    ## @param apiGatewayNginx.podSecurityContext.defaultSeccompProfile Use the default seccomp profile for the API Gateway
     defaultSeccompProfile: true
+    ## @param apiGatewayNginx.podSecurityContext.fsGroup Filesystem group to be used by the API Gateway
     fsGroup: 101
-  ## @param containerSecurityContext Define a container security context for the API Gateway
+  ## @extra apiGatewayNginx.containerSecurityContext Define a container security context for the API Gateway
   ## @skip apiGatewayNginx.containerSecurityContext.enabled
   ## @skip apiGatewayNginx.containerSecurityContext.runAsNonRoot
   ## @skip apiGatewayNginx.containerSecurityContext.runAsUser
@@ -236,11 +232,9 @@ apiGatewayNginx:
   extraVolumeMounts: []
   ## @param apiGatewayNginx.extraVolumes Add additional volumes to the API Gateway
   extraVolumes: []
-  ## @param resources Define resources for the API Gateway
-  ## @skip apiGatewayNginx.resources.requests.cpu
-  ## @skip apiGatewayNginx.resources.requests.memory
-  ## @skip apiGatewayNginx.resources.limits.cpu
-  ## @skip apiGatewayNginx.resources.limits.memory
+  ## @extra apiGatewayNginx.resources Define resources for the API Gateway
+  ## @skip apiGatewayNginx.resources.requests
+  ## @skip apiGatewayNginx.resources.limits
   resources:
     requests:
       memory: "64Mi"

--- a/installer/manifests/keptn/values.yaml
+++ b/installer/manifests/keptn/values.yaml
@@ -1,35 +1,63 @@
+## @section Global values
 global:
   keptn:
+    ## @param global.keptn.registry Global Docker image registry
     registry: docker.io/keptn
+    ## @param global.keptn.tag The tag of Keptn that should be used for all images
     tag: ""
 
+## @section MongoDB
 mongo:
+  ## @param mongo.enabled
   enabled: true
+  ## @param mongo.host
   host: mongodb:27017
+  ## @param mongo.architecture
   architecture: standalone
   service:
+    ## @param mongo.service.nameOverride
     nameOverride: 'mongo'
+    ## @param mongo.service.port
     port: 27017
   auth:
+    ## @param mongo.auth.enabled
     enabled: true
+    ## @param mongo.auth.databases
     databases:
       - 'keptn'
+    ## @param mongo.auth.existingSecret
     existingSecret: 'mongodb-credentials' # If the password and rootPassword values below are used, remove this field.
+    ## @param mongo.auth.usernames
     usernames:
       - 'keptn'
+    ## @param mongo.auth.password
     password: null
+    ## @param mongo.auth.rootUser
     rootUser: 'admin'
+    ## @param mongo.auth.rootPassword
     rootPassword: null
+    ## @param mongo.auth.bridgeAuthDatabase
     bridgeAuthDatabase: 'keptn'
   external:
+    ## @param mongo.external.connectionString
     connectionString:
+  ## @param mongo.containerSecurityContext Container Security Context that should be used for all MongoDB pods
+  ## @skip mongo.containerSecurityContext.allowPrivilegeEscalation
+  ## @skip mongo.containerSecurityContext.capabilities
+  ## @skip mongo.containerSecurityContext.capabilities.drop
   containerSecurityContext:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
         - ALL
   serviceAccount:
+    ## @param mongo.serviceAccount.automountServiceAccountToken
     automountServiceAccountToken: false
+  ## @param resources Define resources for MongoDB
+  ## @skip mongo.resources.requests.cpu
+  ## @skip mongo.resources.requests.memory
+  ## @skip mongo.resources.limits.cpu
+  ## @skip mongo.resources.limits.memory
   resources:
     requests:
       cpu: 200m
@@ -42,31 +70,54 @@ prefixPath: ""
 
 keptnSpecVersion: latest
 
+## @section Keptn Features
 features:
   automaticProvisioning:
+    ## @param features.automaticProvisioning.serviceURL
     serviceURL: ""
+    ## @param features.automaticProvisioning.message
     message: ""
   swagger:
+    ## @param features.swagger.hideDeprecated
     hideDeprecated: false
   oauth:
+    ## @param features.oauth.enabled Enable OAuth for Keptn
     enabled: false
+    ## @param features.oauth.prefix
     prefix: "keptn:"
   git:
+    ## @param features.git.remoteURLDenyList
     remoteURLDenyList: ""
 
+## @section NATS
 nats:
+  ## @param nats.nameOverride
   nameOverride: keptn-nats
+  ## @param nats.fullnameOverride
   fullnameOverride: keptn-nats
   cluster:
+    ## @param nats.cluster.enabled Enable NATS clustering
     enabled: false
+    ## @param nats.cluster.replicas Define the NATS cluster size
     replicas: 3
+    ## @param nats.cluster.name Define the NATS cluster name
     name: nats
+  ## @param nats.securityContext Define security context settings for NATS
+  ## @skip nats.securityContext.runAsNonRoot
+  ## @skip nats.securityContext.runAsUser
+  ## @skip nats.securityContext.fsGroup
   securityContext:
     runAsNonRoot: true
     runAsUser: 10001
     fsGroup: 10001
   nats:
+    ## @param nats.nats.automountServiceAccountToken
     automountServiceAccountToken: false
+    ## @param nats.nats.resources Define resources for NATS
+    ## @skip nats.nats.resources.requests.cpu
+    ## @skip nats.nats.resources.requests.memory
+    ## @skip nats.nats.resources.limits.cpu
+    ## @skip nats.nats.resources.limits.memory
     resources:
       requests:
         cpu: 200m
@@ -76,19 +127,36 @@ nats:
         memory: 1Gi
     healthcheck:
       startup:
+        ## @param nats.nats.healthcheck.startup.enabled Enable NATS startup probe
+        ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes
         enabled: false
     jetstream:
+      ## @param nats.nats.jetstream.enabled
       enabled: true
 
+      ## @param nats.nats.jetstream.memStorage.enabled Enable memory storage for NATS Jetstream
+      ## @param nats.nats.jetstream.memStorage.size Define the memory storage size for NATS Jetstream
       memStorage:
         enabled: true
         size: 500Mi
 
+      ## @param nats.nats.jetstream.fileStorage.enabled
+      ## @param nats.nats.jetstream.fileStorage.size
+      ## @param nats.nats.jetstream.fileStorage.storageDirectory
+      ## @param nats.nats.jetstream.fileStorage.storageClassName
       fileStorage:
         enabled: true
         size: 5Gi
         storageDirectory: /data/
         storageClassName: ""
+    ## @param nats.nats.securityContext Define the container security context for NATS
+    ## @skip nats.nats.securityContext.readOnlyRootFilesystem
+    ## @skip nats.nats.securityContext.allowPrivilegeEscalation
+    ## @skip nats.nats.securityContext.privileged
+    ## @skip nats.nats.securityContext.runAsNonRoot
+    ## @skip nats.nats.securityContext.runAsUser
+    ## @skip nats.nats.securityContext.capabilities
+    ## @skip nats.nats.securityContext.capabilities.drop
     securityContext:
       readOnlyRootFilesystem: true
       allowPrivilegeEscalation: false
@@ -100,21 +168,43 @@ nats:
           - ALL
 
   natsbox:
+    ## @param nats.natsbox.enabled Enable NATS Box utility container
     enabled: false
+  ## @param reloader
   reloader:
+    ## @param nats.reloader.enabled Enable NATS Config Reloader sidecar to reload configuration during runtime
     enabled: false
   exporter:
+    ## @param nats.exporter.enabled Enable NATS Prometheus Exporter sidecar to emit prometheus metrics
     enabled: false
 
+## @section API Gateway NginX
 apiGatewayNginx:
+  ## @param apiGatewayNginx.type
   type: ClusterIP
+  ## @param apiGatewayNginx.port
   port: 80
+  ## @param apiGatewayNginx.targetPort
   targetPort: 8080
+  ## @param apiGatewayNginx.nodePort
   nodePort: 31090
+  ## @param podSecurityContext Define a pod security context for the API Gateway
+  ## @skip apiGatewayNginx.podSecurityContext.enabled
+  ## @skip apiGatewayNginx.podSecurityContext.defaultSeccompProfile
+  ## @skip apiGatewayNginx.podSecurityContext.fsGroup
   podSecurityContext:
     enabled: true
     defaultSeccompProfile: true
     fsGroup: 101
+  ## @param containerSecurityContext Define a container security context for the API Gateway
+  ## @skip apiGatewayNginx.containerSecurityContext.enabled
+  ## @skip apiGatewayNginx.containerSecurityContext.runAsNonRoot
+  ## @skip apiGatewayNginx.containerSecurityContext.runAsUser
+  ## @skip apiGatewayNginx.containerSecurityContext.readOnlyRootFilesystem
+  ## @skip apiGatewayNginx.containerSecurityContext.allowPrivilegeEscalation
+  ## @skip apiGatewayNginx.containerSecurityContext.privileged
+  ## @skip apiGatewayNginx.containerSecurityContext.capabilities
+  ## @skip apiGatewayNginx.containerSecurityContext.capabilities.drop
   containerSecurityContext:
     enabled: true
     runAsNonRoot: true
@@ -126,16 +216,31 @@ apiGatewayNginx:
       drop:
         - ALL
   image:
-    registry: "docker.io/nginxinc"           # Container Registry
-    repository: "nginx-unprivileged"         # Container Image Name
-    tag: "1.22.0-alpine"                     # Container Tag
+    ## @param apiGatewayNginx.image.registry API Gateway image registry
+    registry: "docker.io/nginxinc"
+    ## @param apiGatewayNginx.image.repository API Gateway image repository
+    repository: "nginx-unprivileged"
+    ## @param apiGatewayNginx.image.tag API Gateway image tag
+    tag: "1.22.0-alpine"
+  ## @param apiGatewayNginx.nodeSelector
   nodeSelector: {}
+  ## @param apiGatewayNginx.gracePeriod
   gracePeriod: 60
+  ## @param apiGatewayNginx.preStopHookTime
   preStopHookTime: 20
+  ## @param apiGatewayNginx.clientMaxBodySize
   clientMaxBodySize: "5m"
+  ## @param apiGatewayNginx.sidecars Add additional sidecar containers to the API Gateway
   sidecars: []
+  ## @param apiGatewayNginx.extraVolumeMounts Add additional volume mounts to the API Gateway
   extraVolumeMounts: []
+  ## @param apiGatewayNginx.extraVolumes Add additional volumes to the API Gateway
   extraVolumes: []
+  ## @param resources Define resources for the API Gateway
+  ## @skip apiGatewayNginx.resources.requests.cpu
+  ## @skip apiGatewayNginx.resources.requests.memory
+  ## @skip apiGatewayNginx.resources.limits.cpu
+  ## @skip apiGatewayNginx.resources.limits.memory
   resources:
     requests:
       memory: "64Mi"

--- a/installer/manifests/keptn/values.yaml
+++ b/installer/manifests/keptn/values.yaml
@@ -169,7 +169,7 @@ nats:
     ## @param nats.exporter.enabled Enable NATS Prometheus Exporter sidecar to emit prometheus metrics
     enabled: false
 
-## @section API Gateway NginX
+## @section API Gateway Nginx
 apiGatewayNginx:
   ## @param apiGatewayNginx.type
   type: ClusterIP
@@ -433,7 +433,7 @@ distributor:
       ## @param distributor.config.proxy.maxPayloadBytesKB
       maxPayloadBytesKB: "64"
     queueGroup:
-      ## @param distributor.config.queueGroup.enabled Enable queue groups for distibutor
+      ## @param distributor.config.queueGroup.enabled Enable queue groups for distributor
       enabled: true
     oauth:
       ## @param distributor.config.oauth.clientID

--- a/installer/manifests/keptn/values.yaml
+++ b/installer/manifests/keptn/values.yaml
@@ -237,6 +237,7 @@ apiGatewayNginx:
       memory: "128Mi"
       cpu: "100m"
 
+## @section Remediation Service
 remediationService:
   ## @param remediationService.enabled Enable Remediation Service
   enabled: true
@@ -270,7 +271,9 @@ remediationService:
       memory: "1Gi"
       cpu: "200m"
 
+## @section API Service
 apiService:
+  ## @param apiService.tokenSecretName K8s secret to be used as API token in the API Service
   tokenSecretName:
   image:
     ## @param apiService.image.registry API Service image registry
@@ -280,8 +283,11 @@ apiService:
     ## @param apiService.image.tag API Service image tag
     tag: ""
   maxAuth:
+    ## @param apiService.maxAuth.enabled Enable API authentication rate limiting
     enabled: true
+    ## @param apiService.maxAuth.requestsPerSecond API authentication rate limiting requests per second
     requestsPerSecond: "1.0"
+    ## @param apiService.maxAuth.requestBurst API authentication rate limiting requests burst
     requestBurst: "2"
   ## @param apiService.nodeSelector API Service node labels for pod assignment
   nodeSelector: {}
@@ -306,6 +312,7 @@ apiService:
       memory: "64Mi"
       cpu: "100m"
 
+## @section Bridge
 bridge:
   image:
     ## @param bridge.image.registry Bridge image registry
@@ -314,19 +321,37 @@ bridge:
     repository: "bridge2"
     ## @param bridge.image.tag Bridge image tag
     tag: ""
+  ## @param bridge.cliDownloadLink Define an alternative download URL for the Keptn CLI
   cliDownloadLink: null
   secret:
+    ## @param bridge.secret.enabled Enable bridge credentials for HTTP Basic Auth
     enabled: true
   versionCheck:
+    ## @param bridge.versionCheck.enabled Enable check for updated versions of Keptn
     enabled: true
   showApiToken:
+    ## @param bridge.showApiToken.enabled If disabled, the API token will not be shown in the Bridge info
     enabled: true
+  ## @param bridge.installationType Can take the values: `QUALITY_GATES`, `CONTINUOUS_OPERATIONS`, `CONTINUOUS_DELIVERY` and determines the mode in which the Bridge will be started. If only `QUALITY_GATES` is set, only functionalities and data specific for the Quality Gates Only use case will be displayed
   installationType: null
+  ## @param bridge.lookAndFeelUrl Define a different styling for the Bridge by providing a URL to a ZIP archive containing style files. This archive will be downloaded and used upon Bridge startup
   lookAndFeelUrl: null
+  ## @extra bridge.podSecurityContext Define a pod security context for the Bridge
+  ## @skip bridge.podSecurityContext.enabled
+  ## @skip bridge.podSecurityContext.defaultSeccompProfile
+  ## @skip bridge.podSecurityContext.fsGroup
   podSecurityContext:
     enabled: true
     defaultSeccompProfile: true
     fsGroup: 65532
+  ## @extra bridge.containerSecurityContext Define a container security context for the Bridge
+  ## @skip bridge.containerSecurityContext.enabled
+  ## @skip bridge.containerSecurityContext.runAsNonRoot
+  ## @skip bridge.containerSecurityContext.runAsUser
+  ## @skip bridge.containerSecurityContext.readOnlyRootFilesystem
+  ## @skip bridge.containerSecurityContext.allowPrivilegeEscalation
+  ## @skip bridge.containerSecurityContext.privileged
+  ## @skip bridge.containerSecurityContext.capabilities
   containerSecurityContext:
     enabled: true
     runAsNonRoot: true
@@ -337,6 +362,19 @@ bridge:
     capabilities:
       drop:
         - ALL
+  ## @extra bridge.oauth Configure OAuth settings for the Bridge
+  ## @skip bridge.oauth.discovery
+  ## @skip bridge.oauth.secureCookie
+  ## @skip bridge.oauth.trustProxy
+  ## @skip bridge.oauth.sessionTimeoutMin
+  ## @skip bridge.oauth.sessionValidatingTimeoutMin
+  ## @skip bridge.oauth.baseUrl
+  ## @skip bridge.oauth.clientID
+  ## @skip bridge.oauth.clientSecret
+  ## @skip bridge.oauth.IDTokenAlg
+  ## @skip bridge.oauth.scope
+  ## @skip bridge.oauth.userIdentifier
+  ## @skip bridge.oauth.mongoConnectionString
   oauth:
     discovery: ""
     secureCookie: false
@@ -350,8 +388,10 @@ bridge:
     scope: ""
     userIdentifier: ""
     mongoConnectionString: ""
+  ## @param bridge.authMsg
   authMsg: ""
   d3:
+    ## @param bridge.d3.enabled Enable D3 basic heatmaps in the Bridge
     enabled: true
   ## @param bridge.nodeSelector Bridge node labels for pod assignment
   nodeSelector: {}
@@ -372,9 +412,12 @@ bridge:
       memory: "256Mi"
       cpu: "200m"
 
+## @section Distributor
 distributor:
   metadata:
+    ## @param distributor.metadata.hostname
     hostname:
+    ## @param distributor.metadata.namespace
     namespace:
   image:
     ## @param distributor.image.registry Distributor image registry
@@ -385,15 +428,23 @@ distributor:
     tag: ""
   config:
     proxy:
+      ## @param distributor.config.proxy.httpTimeout
       httpTimeout: "30"
+      ## @param distributor.config.proxy.maxPayloadBytesKB
       maxPayloadBytesKB: "64"
     queueGroup:
+      ## @param distributor.config.queueGroup.enabled Enable queue groups for distibutor
       enabled: true
     oauth:
+      ## @param distributor.config.oauth.clientID
       clientID: ""
+      ## @param distributor.config.oauth.clientSecret
       clientSecret: ""
+      ## @param distributor.config.oauth.discovery
       discovery: ""
+      ## @param distributor.config.oauth.tokenURL
       tokenURL: ""
+      ## @param distributor.config.oauth.scopes
       scopes: ""
   ## @extra distributor.resources Define resources for the Distributor
   ## @skip distributor.resources.requests
@@ -406,6 +457,7 @@ distributor:
       memory: "32Mi"
       cpu: "100m"
 
+## @section Shipyard Controller
 shipyardController:
   image:
     ## @param shipyardController.image.registry Shipyard Controller image registry
@@ -415,17 +467,25 @@ shipyardController:
     ## @param shipyardController.image.tag Shipyard Controller image tag
     tag: ""
   config:
+    ## @param shipyardController.config.taskStartedWaitDuration
     taskStartedWaitDuration: "10m"
+    ## @param shipyardController.config.uniformIntegrationTTL
     uniformIntegrationTTL: "48h"
     leaderElection:
+      ## @param shipyardController.config.leaderElection.enabled Enable leader election when multiple replicas of Shipyard Controller are running
       enabled: false
+    ## @param shipyardController.config.replicas Number of replicas of Shipyard Controller
     replicas: 1
     validation:
+      ## @param shipyardController.config.validation.projectNameMaxSize Maximum number of characters that a Keptn project name can have
+      #
       # On Database level, Keptn creates collections that are named like <PROJECTNAME>-<suffix>
       # Keep in mind that "suffix" can occupy up to 20 characters so that you will eventually
       # hit the database limit for max collection name size when your project name is too long.
       # projectNameMaxSize can be used to forbid project names longer than a certain size in Keptn
       projectNameMaxSize: 200
+      ## @param shipyardController.config.validation.serviceNameMaxSize Maximum number of characters that a service name can have
+      #
       # The limit of 43 characters for a service's name is currently imposed by the helm-service,
       # which, if being used for the CD use case with blue/green deployments generates a helm release called <serviceName>-generated,
       # and helm releases have a maximum length of 53 characters. Therefore, we use this value as a default.
@@ -454,6 +514,7 @@ shipyardController:
       memory: "128Mi"
       cpu: "100m"
 
+## @section Secret Service
 secretService:
   image:
     ## @param secretService.image.registry Secret Service image registry
@@ -485,6 +546,7 @@ secretService:
       memory: "64Mi"
       cpu: "200m"
 
+## @section Resource Service
 resourceService:
   ## @param resourceService.replicas Number of replicas of Resource Service
   replicas: 1
@@ -527,6 +589,7 @@ resourceService:
       memory: "64Mi"
       cpu: "100m"
 
+## @section MongoDB Datastore
 mongodbDatastore:
   image:
     ## @param mongodbDatastore.image.registry MongoDB Datastore image registry
@@ -558,6 +621,7 @@ mongodbDatastore:
       memory: "512Mi"
       cpu: "300m"
 
+## @section Lighthouse Service
 lighthouseService:
   ## @param lighthouseService.enabled Enable Lighthouse Service
   enabled: true
@@ -591,6 +655,7 @@ lighthouseService:
       memory: "1Gi"
       cpu: "200m"
 
+## @section Statistics Service
 statisticsService:
   ## @param statisticsService.enabled Enable Statistics Service
   enabled: true
@@ -624,6 +689,7 @@ statisticsService:
       memory: "64Mi"
       cpu: "100m"
 
+## @section Approval Service
 approvalService:
   ## @param approvalService.enabled Enable Approval Service
   enabled: true

--- a/installer/manifests/keptn/values.yaml
+++ b/installer/manifests/keptn/values.yaml
@@ -212,11 +212,11 @@ apiGatewayNginx:
     repository: "nginx-unprivileged"
     ## @param apiGatewayNginx.image.tag API Gateway image tag
     tag: "1.22.0-alpine"
-  ## @param apiGatewayNginx.nodeSelector
+  ## @param apiGatewayNginx.nodeSelector API Gateway node labels for pod assignment
   nodeSelector: {}
-  ## @param apiGatewayNginx.gracePeriod
+  ## @param apiGatewayNginx.gracePeriod API Gateway termination grace period
   gracePeriod: 60
-  ## @param apiGatewayNginx.preStopHookTime
+  ## @param apiGatewayNginx.preStopHookTime API Gateway pre stop timeout
   preStopHookTime: 20
   ## @param apiGatewayNginx.clientMaxBodySize
   clientMaxBodySize: "5m"
@@ -238,6 +238,7 @@ apiGatewayNginx:
       cpu: "100m"
 
 remediationService:
+  ## @param remediationService.enabled Enable Remediation Service
   enabled: true
   image:
     ## @param remediationService.image.registry Remediation Service image registry
@@ -246,8 +247,11 @@ remediationService:
     repository: "remediation-service"
     ## @param remediationService.image.tag Remediation Service image tag
     tag: ""
+  ## @param remediationService.nodeSelector Remediation Service node labels for pod assignment
   nodeSelector: {}
+  ## @param remediationService.gracePeriod Remediation Service termination grace period
   gracePeriod: 60
+  ## @param remediationService.preStopHookTime Remediation Service pre stop timeout
   preStopHookTime: 5
   ## @param remediationService.sidecars Add additional sidecar containers to the Remediation Service
   sidecars: []
@@ -279,8 +283,11 @@ apiService:
     enabled: true
     requestsPerSecond: "1.0"
     requestBurst: "2"
+  ## @param apiService.nodeSelector API Service node labels for pod assignment
   nodeSelector: {}
+  ## @param apiService.gracePeriod API Service termination grace period
   gracePeriod: 60
+  ## @param apiService.preStopHookTime API Service pre stop timeout
   preStopHookTime: 5
   ## @param apiService.sidecars Add additional sidecar containers to the API Service
   sidecars: []
@@ -346,6 +353,7 @@ bridge:
   authMsg: ""
   d3:
     enabled: true
+  ## @param bridge.nodeSelector Bridge node labels for pod assignment
   nodeSelector: {}
   ## @param bridge.sidecars Add additional sidecar containers to the Bridge
   sidecars: []
@@ -423,8 +431,11 @@ shipyardController:
       # and helm releases have a maximum length of 53 characters. Therefore, we use this value as a default.
       # If the helm chart generation for blue/green deployments is not needed, and this value is too small, it can be adapted here
       serviceNameMaxSize: 43
+  ## @param shipyardController.nodeSelector Shipyard Controller node labels for pod assignment
   nodeSelector: {}
+  ## @param shipyardController.gracePeriod Shipyard Controller termination grace period
   gracePeriod: 60
+  ## @param shipyardController.preStopHookTime Shipyard Controller pre stop timeout
   preStopHookTime: 15
   ## @param shipyardController.sidecars Add additional sidecar containers to Shipyard Controller
   sidecars: []
@@ -451,8 +462,11 @@ secretService:
     repository: "secret-service"     
     ## @param secretService.image.tag Secret Service image tag
     tag: ""
+  ## @param secretService.nodeSelector Secret Service node labels for pod assignment
   nodeSelector: {}
+  ## @param secretService.gracePeriod Secret Service termination grace period
   gracePeriod: 60
+  ## @param secretService.preStopHookTime Secret Service pre stop timeout
   preStopHookTime: 20
   ## @param secretService.sidecars Add additional sidecar containers to the Secret Service
   sidecars: []
@@ -472,6 +486,7 @@ secretService:
       cpu: "200m"
 
 resourceService:
+  ## @param resourceService.replicas Number of replicas of Resource Service
   replicas: 1
   image:
     ## @param resourceService.image.registry Resource Service image registry
@@ -481,12 +496,19 @@ resourceService:
     ## @param resourceService.image.tag Resource Service image tag
     tag: ""
   env:
+    ## @param resourceService.env.GIT_KEPTN_USER Default git username for the Keptn configuration git repository
     GIT_KEPTN_USER: "keptn"
+    ## @param resourceService.env.GIT_KEPTN_EMAIL Default git email address for the Keptn configuration git repository
     GIT_KEPTN_EMAIL: "keptn@keptn.sh"
+    ## @param resourceService.env.DIRECTORY_STAGE_STRUCTURE Enable directory based structure in the Keptn configuration git repository
     DIRECTORY_STAGE_STRUCTURE: "false"
+  ## @param resourceService.nodeSelector Resource Service node labels for pod assignment
   nodeSelector: {}
+  ## @param resourceService.gracePeriod Resource Service termination grace period
   gracePeriod: 60
+  ## @param resourceService.fsGroup Configure file system group ID to be used in Resource Service
   fsGroup: 1001
+  ## @param resourceService.preStopHookTime Resource Service pre stop timeout
   preStopHookTime: 20
   ## @param resourceService.sidecars Add additional sidecar containers to the Resource Service
   sidecars: []
@@ -513,8 +535,11 @@ mongodbDatastore:
     repository: "mongodb-datastore"  
     ## @param mongodbDatastore.image.tag MongoDB Datastore image tag
     tag: ""
+  ## @param mongodbDatastore.nodeSelector MongoDB Datastore node labels for pod assignment
   nodeSelector: {}
+  ## @param mongodbDatastore.gracePeriod MongoDB Datastore termination grace period
   gracePeriod: 60
+  ## @param mongodbDatastore.preStopHookTime MongoDB Datastore pre stop timeout
   preStopHookTime: 20
   ## @param mongodbDatastore.sidecars Add additional sidecar containers to the MongoDB Datastore
   sidecars: []
@@ -534,6 +559,7 @@ mongodbDatastore:
       cpu: "300m"
 
 lighthouseService:
+  ## @param lighthouseService.enabled Enable Lighthouse Service
   enabled: true
   image:
     ## @param lighthouseService.image.registry Lighthouse Service image registry
@@ -542,8 +568,11 @@ lighthouseService:
     repository: "lighthouse-service" 
     ## @param lighthouseService.image.tag Lighthouse Service image tag
     tag: ""
+  ## @param lighthouseService.nodeSelector Lighthouse Service node labels for pod assignment
   nodeSelector: {}
+  ## @param lighthouseService.gracePeriod Lighthouse Service termination grace period
   gracePeriod: 60
+  ## @param lighthouseService.preStopHookTime Lighthouse Service pre stop timeout
   preStopHookTime: 20
   ## @param lighthouseService.sidecars Add additional sidecar containers to the Lighthouse Service
   sidecars: []
@@ -563,6 +592,7 @@ lighthouseService:
       cpu: "200m"
 
 statisticsService:
+  ## @param statisticsService.enabled Enable Statistics Service
   enabled: true
   image:
     ## @param statisticsService.image.registry Statistics Service image registry
@@ -571,8 +601,11 @@ statisticsService:
     repository: "statistics-service" 
     ## @param statisticsService.image.tag Statistics Service image tag
     tag: ""
+  ## @param statisticsService.nodeSelector Statistics Service node labels for pod assignment
   nodeSelector: {}
+  ## @param statisticsService.gracePeriod Statistics Service termination grace period
   gracePeriod: 60
+  ## @param statisticsService.preStopHookTime Statistics Service pre stop timeout
   preStopHookTime: 20
   ## @param statisticsService.sidecars Add additional sidecar containers to the Statistics Service
   sidecars: []
@@ -592,6 +625,7 @@ statisticsService:
       cpu: "100m"
 
 approvalService:
+  ## @param approvalService.enabled Enable Approval Service
   enabled: true
   image:
     ## @param approvalService.image.registry Approval Service image registry
@@ -600,8 +634,11 @@ approvalService:
     repository: "approval-service"   
     ## @param approvalService.image.tag Approval Service image tag
     tag: ""
+  ## @param approvalService.nodeSelector Approval Service node labels for pod assignment
   nodeSelector: {}
+  ## @param approvalService.gracePeriod Approval Service termination grace period
   gracePeriod: 60
+  ## @param approvalService.preStopHookTime Approval Service pre stop timeout
   preStopHookTime: 5
   ## @param approvalService.sidecars Add additional sidecar containers to the Approval Service
   sidecars: []
@@ -620,7 +657,9 @@ approvalService:
       memory: "128Mi"
       cpu: "100m"
 
+## @section Webhook Service
 webhookService:
+  ## @param webhookService.enabled Enable Webhook Service
   enabled: true
   image:
     ## @param webhookService.image.registry Webhook Service image registry
@@ -629,8 +668,11 @@ webhookService:
     repository: "webhook-service"    
     ## @param webhookService.image.tag Webhook Service image tag
     tag: ""
+  ## @param webhookService.nodeSelector Webhook Service node labels for pod assignment
   nodeSelector: {}
+  ## @param webhookService.gracePeriod Webhook Service termination grace period
   gracePeriod: 60
+  ## @param webhookService.preStopHookTime Webhook Service pre stop timeout
   preStopHookTime: 20
   ## @param webhookService.sidecars Add additional sidecar containers to the Webhook Service
   sidecars: []
@@ -651,41 +693,67 @@ webhookService:
 
 ## @section Ingress
 ingress:
+  ## @param ingress.enabled Enable ingress configuration for Keptn
   enabled: false
+  ## @param ingress.annotations Keptn Ingress annotations
   annotations: {}
+  ## @param ingress.host Keptn Ingress host URL
   host: {}
+  ## @param ingress.path Keptn Ingress host path
   path: /
+  ## @param ingress.pathType Keptn Ingress path type
   pathType: Prefix
+  ## @param ingress.className Keptn Ingress class name
   className: ""
+  ## @param ingress.tls Keptn Ingress TLS configuration
   tls:
     []
 
 ## @section Common settings
+## @param logLevel Global log level for all Keptn services
 logLevel: "info"
 
-## @param prefixPath
+## @param prefixPath URL prefix for all Keptn URLs
 prefixPath: ""
 
-## @param keptnSpecVersion
+## @param keptnSpecVersion Version of the Keptn Spec definitions to be used
 keptnSpecVersion: latest
 
 strategy:
+  ## @param strategy.type Strategy to use to replace existing Keptn pods
   type: RollingUpdate
   rollingUpdate:
+    ## @param strategy.rollingUpdate.maxSurge Maximum number of additional pods to be spun up during rolling updates
     maxSurge: 1
+    ## @param strategy.rollingUpdate.maxUnavailable Maximum number of unavailable pods during rolling updates
     maxUnavailable: 0
+
+## @extra Set the default pod security context for all pods
 podSecurityContext:
+  ## @param podSecurityContext.enabled Enable the default pod security context for all pods
   enabled: true
+  ## @skip podSecurityContext.defaultSeccompProfile
   defaultSeccompProfile: true
+  ## @skip podSecurityContext.fsGroup
   fsGroup: 65532
+
+## @extra Set the default container security context for all containers
 containerSecurityContext:
+  ## @param containerSecurityContext.enabled Enable the default container security context for all containers
   enabled: true
+  ## @skip containerSecurityContext.runAsNonRoot
   runAsNonRoot: true
+  ## @skip containerSecurityContext.runAsUser
   runAsUser: 65532
+  ## @skip containerSecurityContext.readOnlyRootFilesystem
   readOnlyRootFilesystem: true
+  ## @skip containerSecurityContext.allowPrivilegeEscalation
   allowPrivilegeEscalation: false
+  ## @skip containerSecurityContext.privileged
   privileged: false
+  ## @skip containerSecurityContext.capabilities
   capabilities:
     drop:
       - ALL
+## @param nodeSelector Default node labels for pod assignment
 nodeSelector: {}

--- a/installer/manifests/keptn/values.yaml
+++ b/installer/manifests/keptn/values.yaml
@@ -64,12 +64,6 @@ mongo:
       cpu: 1000m
       memory: 500Mi
 
-## @param prefixPath
-prefixPath: ""
-
-## @param keptnSpecVersion
-keptnSpecVersion: latest
-
 ## @section Keptn Features
 features:
   automaticProvisioning:
@@ -561,6 +555,12 @@ ingress:
     []
 
 logLevel: "info"
+
+## @param prefixPath
+prefixPath: ""
+
+## @param keptnSpecVersion
+keptnSpecVersion: latest
 
 strategy:
   type: RollingUpdate

--- a/installer/manifests/keptn/values.yaml
+++ b/installer/manifests/keptn/values.yaml
@@ -240,8 +240,11 @@ apiGatewayNginx:
 remediationService:
   enabled: true
   image:
+    ## @param remediationService.image.registry Remediation Service image registry
     registry: ""
+    ## @param remediationService.image.repository Remediation Service image repository
     repository: "remediation-service"
+    ## @param remediationService.image.tag Remediation Service image tag
     tag: ""
   nodeSelector: {}
   gracePeriod: 60
@@ -266,8 +269,11 @@ remediationService:
 apiService:
   tokenSecretName:
   image:
+    ## @param apiService.image.registry API Service image registry
     registry: ""
+    ## @param apiService.image.repository API Service image repository
     repository: "api"    
+    ## @param apiService.image.tag API Service image tag
     tag: ""
   maxAuth:
     enabled: true
@@ -295,8 +301,11 @@ apiService:
 
 bridge:
   image:
+    ## @param bridge.image.registry Bridge image registry
     registry: ""
+    ## @param bridge.image.repository Bridge image repository
     repository: "bridge2"
+    ## @param bridge.image.tag Bridge image tag
     tag: ""
   cliDownloadLink: null
   secret:
@@ -360,8 +369,11 @@ distributor:
     hostname:
     namespace:
   image:
+    ## @param distributor.image.registry Distributor image registry
     registry: ""
+    ## @param distributor.image.repository Distributor image repository
     repository: "distributor"
+    ## @param distributor.image.tag Distributor image tag
     tag: ""
   config:
     proxy:
@@ -388,8 +400,11 @@ distributor:
 
 shipyardController:
   image:
+    ## @param shipyardController.image.registry Shipyard Controller image registry
     registry: ""
+    ## @param shipyardController.image.repository Shipyard Controller image repository
     repository: "shipyard-controller"
+    ## @param shipyardController.image.tag Shipyard Controller image tag
     tag: ""
   config:
     taskStartedWaitDuration: "10m"
@@ -430,8 +445,11 @@ shipyardController:
 
 secretService:
   image:
+    ## @param secretService.image.registry Secret Service image registry
     registry: ""
+    ## @param secretService.image.repository Secret Service image repository
     repository: "secret-service"     
+    ## @param secretService.image.tag Secret Service image tag
     tag: ""
   nodeSelector: {}
   gracePeriod: 60
@@ -456,8 +474,11 @@ secretService:
 resourceService:
   replicas: 1
   image:
+    ## @param resourceService.image.registry Resource Service image registry
     registry: ""
+    ## @param resourceService.image.repository Resource Service image repository
     repository: "resource-service"   
+    ## @param resourceService.image.tag Resource Service image tag
     tag: ""
   env:
     GIT_KEPTN_USER: "keptn"
@@ -486,8 +507,11 @@ resourceService:
 
 mongodbDatastore:
   image:
+    ## @param mongodbDatastore.image.registry MongoDB Datastore image registry
     registry: ""
+    ## @param mongodbDatastore.image.repository MongoDB Datastore image repository
     repository: "mongodb-datastore"  
+    ## @param mongodbDatastore.image.tag MongoDB Datastore image tag
     tag: ""
   nodeSelector: {}
   gracePeriod: 60
@@ -512,8 +536,11 @@ mongodbDatastore:
 lighthouseService:
   enabled: true
   image:
+    ## @param lighthouseService.image.registry Lighthouse Service image registry
     registry: ""
+    ## @param lighthouseService.image.repository Lighthouse Service image repository
     repository: "lighthouse-service" 
+    ## @param lighthouseService.image.tag Lighthouse Service image tag
     tag: ""
   nodeSelector: {}
   gracePeriod: 60
@@ -538,8 +565,11 @@ lighthouseService:
 statisticsService:
   enabled: true
   image:
+    ## @param statisticsService.image.registry Statistics Service image registry
     registry: ""
+    ## @param statisticsService.image.repository Statistics Service image repository
     repository: "statistics-service" 
+    ## @param statisticsService.image.tag Statistics Service image tag
     tag: ""
   nodeSelector: {}
   gracePeriod: 60
@@ -564,8 +594,11 @@ statisticsService:
 approvalService:
   enabled: true
   image:
+    ## @param approvalService.image.registry Approval Service image registry
     registry: ""
+    ## @param approvalService.image.repository Approval Service image repository
     repository: "approval-service"   
+    ## @param approvalService.image.tag Approval Service image tag
     tag: ""
   nodeSelector: {}
   gracePeriod: 60
@@ -590,8 +623,11 @@ approvalService:
 webhookService:
   enabled: true
   image:
+    ## @param webhookService.image.registry Webhook Service image registry
     registry: ""
+    ## @param webhookService.image.repository Webhook Service image repository
     repository: "webhook-service"    
+    ## @param webhookService.image.tag Webhook Service image tag
     tag: ""
   nodeSelector: {}
   gracePeriod: 60

--- a/installer/manifests/keptn/values.yaml
+++ b/installer/manifests/keptn/values.yaml
@@ -246,9 +246,15 @@ remediationService:
   nodeSelector: {}
   gracePeriod: 60
   preStopHookTime: 5
+  ## @param remediationService.sidecars Add additional sidecar containers to the Remediation Service
   sidecars: []
+  ## @param remediationService.extraVolumeMounts Add additional volume mounts to the Remediation Service
   extraVolumeMounts: []
+  ## @param remediationService.extraVolumes Add additional volumes to the Remediation Service
   extraVolumes: []
+  ## @extra remediationService.resources Define resources for the Remediation Service
+  ## @skip remediationService.resources.requests
+  ## @skip remediationService.resources.limits
   resources:
     requests:
       memory: "64Mi"
@@ -270,9 +276,15 @@ apiService:
   nodeSelector: {}
   gracePeriod: 60
   preStopHookTime: 5
+  ## @param apiService.sidecars Add additional sidecar containers to the API Service
   sidecars: []
+  ## @param apiService.extraVolumeMounts Add additional volume mounts to the API Service
   extraVolumeMounts: []
+  ## @param apiService.extraVolumes Add additional volumes to the API Service
   extraVolumes: []
+  ## @extra apiService.resources Define resources for the API Service
+  ## @skip apiService.resources.requests
+  ## @skip apiService.resources.limits
   resources:
     requests:
       memory: "32Mi"
@@ -326,9 +338,15 @@ bridge:
   d3:
     enabled: true
   nodeSelector: {}
+  ## @param bridge.sidecars Add additional sidecar containers to the Bridge
   sidecars: []
+  ## @param bridge.extraVolumeMounts Add additional volume mounts to the Bridge
   extraVolumeMounts: []
+  ## @param bridge.extraVolumes Add additional volumes to the Bridge
   extraVolumes: []
+  ## @extra bridge.resources Define resources for the Bridge
+  ## @skip bridge.resources.requests
+  ## @skip bridge.resources.limits
   resources:
     requests:
       memory: "64Mi"
@@ -357,6 +375,9 @@ distributor:
       discovery: ""
       tokenURL: ""
       scopes: ""
+  ## @extra distributor.resources Define resources for the Distributor
+  ## @skip distributor.resources.requests
+  ## @skip distributor.resources.limits
   resources:
     requests:
       memory: "16Mi"
@@ -390,9 +411,15 @@ shipyardController:
   nodeSelector: {}
   gracePeriod: 60
   preStopHookTime: 15
+  ## @param shipyardController.sidecars Add additional sidecar containers to Shipyard Controller
   sidecars: []
+  ## @param shipyardController.extraVolumeMounts Add additional volume mounts to Shipyard Controller
   extraVolumeMounts: []
+  ## @param shipyardController.extraVolumes Add additional volumes to Shipyard Controller
   extraVolumes: []
+  ## @extra shipyardController.resources Define resources for Shipyard Controller
+  ## @skip shipyardController.resources.requests
+  ## @skip shipyardController.resources.limits
   resources:
     requests:
       memory: "32Mi"
@@ -409,9 +436,15 @@ secretService:
   nodeSelector: {}
   gracePeriod: 60
   preStopHookTime: 20
+  ## @param secretService.sidecars Add additional sidecar containers to the Secret Service
   sidecars: []
+  ## @param secretService.extraVolumeMounts Add additional volume mounts to the Secret Service
   extraVolumeMounts: []
+  ## @param secretService.extraVolumes Add additional volumes to the Secret Service
   extraVolumes: []
+  ## @extra secretService.resources Define resources for the Secret Service
+  ## @skip secretService.resources.requests
+  ## @skip secretService.resources.limits
   resources:
     requests:
       memory: "32Mi"
@@ -434,9 +467,15 @@ resourceService:
   gracePeriod: 60
   fsGroup: 1001
   preStopHookTime: 20
+  ## @param resourceService.sidecars Add additional sidecar containers to the Resource Service
   sidecars: []
+  ## @param resourceService.extraVolumeMounts Add additional volume mounts to the Resource Service
   extraVolumeMounts: []
+  ## @param resourceService.extraVolumes Add additional volumes to the Resource Service
   extraVolumes: []
+  ## @extra resourceService.resources Define resources for the Resource Service
+  ## @skip resourceService.resources.requests
+  ## @skip resourceService.resources.limits
   resources:
     requests:
       memory: "32Mi"
@@ -453,9 +492,15 @@ mongodbDatastore:
   nodeSelector: {}
   gracePeriod: 60
   preStopHookTime: 20
+  ## @param mongodbDatastore.sidecars Add additional sidecar containers to the MongoDB Datastore
   sidecars: []
+  ## @param mongodbDatastore.extraVolumeMounts Add additional volume mounts to the MongoDB Datastore
   extraVolumeMounts: []
+  ## @param mongodbDatastore.extraVolumes Add additional volumes to the MongoDB Datastore
   extraVolumes: []
+  ## @extra mongodbDatastore.resources Define resources for the MongoDB Datastore
+  ## @skip mongodbDatastore.resources.requests
+  ## @skip mongodbDatastore.resources.limits
   resources:
     requests:
       memory: "32Mi"
@@ -473,9 +518,15 @@ lighthouseService:
   nodeSelector: {}
   gracePeriod: 60
   preStopHookTime: 20
+  ## @param lighthouseService.sidecars Add additional sidecar containers to the Lighthouse Service
   sidecars: []
+  ## @param lighthouseService.extraVolumeMounts Add additional volume mounts to the Lighthouse Service
   extraVolumeMounts: []
+  ## @param lighthouseService.extraVolumes Add additional volumes to the Lighthouse Service
   extraVolumes: []
+  ## @extra lighthouseService.resources Define resources for the Lighthouse Service
+  ## @skip lighthouseService.resources.requests
+  ## @skip lighthouseService.resources.limits
   resources:
     requests:
       memory: "128Mi"
@@ -493,9 +544,15 @@ statisticsService:
   nodeSelector: {}
   gracePeriod: 60
   preStopHookTime: 20
+  ## @param statisticsService.sidecars Add additional sidecar containers to the Statistics Service
   sidecars: []
+  ## @param statisticsService.extraVolumeMounts Add additional volume mounts to the Statistics Service
   extraVolumeMounts: []
+  ## @param statisticsService.extraVolumes Add additional volumes to the Statistics Service
   extraVolumes: []
+  ## @extra statisticsService.resources Define resources for the Statistics Service
+  ## @skip statisticsService.resources.requests
+  ## @skip statisticsService.resources.limits
   resources:
     requests:
       memory: "32Mi"
@@ -513,9 +570,15 @@ approvalService:
   nodeSelector: {}
   gracePeriod: 60
   preStopHookTime: 5
+  ## @param approvalService.sidecars Add additional sidecar containers to the Approval Service
   sidecars: []
+  ## @param approvalService.extraVolumeMounts Add additional volume mounts to the Approval Service
   extraVolumeMounts: []
+  ## @param approvalService.extraVolumes Add additional volumes to the Approval Service
   extraVolumes: []
+  ## @extra approvalService.resources Define resources for the Approval Service
+  ## @skip approvalService.resources.requests
+  ## @skip approvalService.resources.limits
   resources:
     requests:
       memory: "32Mi"
@@ -533,9 +596,15 @@ webhookService:
   nodeSelector: {}
   gracePeriod: 60
   preStopHookTime: 20
+  ## @param webhookService.sidecars Add additional sidecar containers to the Webhook Service
   sidecars: []
+  ## @param webhookService.extraVolumeMounts Add additional volume mounts to the Webhook Service
   extraVolumeMounts: []
+  ## @param webhookService.extraVolumes Add additional volumes to the Webhook Service
   extraVolumes: []
+  ## @extra webhookService.resources Define resources for the Webhook Service
+  ## @skip webhookService.resources.requests
+  ## @skip webhookService.resources.limits
   resources:
     requests:
       memory: "32Mi"
@@ -544,6 +613,7 @@ webhookService:
       memory: "64Mi"
       cpu: "100m"
 
+## @section Ingress
 ingress:
   enabled: false
   annotations: {}
@@ -554,6 +624,7 @@ ingress:
   tls:
     []
 
+## @section Common settings
 logLevel: "info"
 
 ## @param prefixPath


### PR DESCRIPTION
### This PR
- adds a pipeline that checks whether the helm values documentation is up to date with the current set of helm values in a given PR
- adds a script to generate helm values documentation
- adds lots of documentation to the `values.yaml` file
- adds the generated readme to the helm chart
- adjusts the old readme in the installer folder

### Notes
The helm docs pipeline will fail for this PR since the generated readme doesn't exist yet on master

### Follow-up tasks
https://github.com/keptn/keptn/issues/8686
https://github.com/keptn/keptn/issues/8687

Fixes #8463 
Closes #8448