### PR TITLE
fix(lighthouse-service): return a failed Evaluation Result for nil SLIs

### DIFF
--- a/lighthouse-service/event_handler/evaluate_sli_handler.go
+++ b/lighthouse-service/event_handler/evaluate_sli_handler.go
@@ -228,6 +228,7 @@ func evaluateObjectives(e *keptnv2.GetSLIFinishedEventData, sloConfig *keptn.Ser
 			}
 			sliEvaluationResult.Status = "fail"
 			sliEvaluationResult.Score = 0
+			sliEvaluationResults = append(sliEvaluationResults, sliEvaluationResult)
 			continue
 		}
 		sliEvaluationResult.Value = (*keptnv2.SLIResult)(result)

--- a/lighthouse-service/event_handler/evaluate_sli_handler_test.go
+++ b/lighthouse-service/event_handler/evaluate_sli_handler_test.go
@@ -2425,11 +2425,25 @@ func TestEvaluateObjectives(t *testing.T) {
 			},
 			ExpectedEvaluationResult: &keptnv2.EvaluationFinishedEventData{
 				Evaluation: keptnv2.EvaluationDetails{
-					TimeStart:        "2019-10-20T07:57:27.152330783Z",
-					TimeEnd:          "2019-10-22T08:57:27.152330783Z",
-					Result:           "", // not set by the tested function
-					Score:            0,  // not calculated by tested function
-					IndicatorResults: nil,
+					TimeStart: "2019-10-20T07:57:27.152330783Z",
+					TimeEnd:   "2019-10-22T08:57:27.152330783Z",
+					Result:    "", // not set by the tested function
+					Score:     0,  // not calculated by tested function
+					IndicatorResults: []*keptnv2.SLIEvaluationResult{
+						{
+							Score: 0,
+							Value: &keptnv2.SLIResult{
+								Metric:  "a_different_metric",
+								Value:   0,
+								Success: false,
+								Message: "no value received from SLI provider",
+							},
+							PassTargets:    nil,
+							WarningTargets: nil,
+							KeySLI:         false,
+							Status:         "fail",
+						},
+					},
 				},
 				EventData: keptnv2.EventData{
 					Result:  "",


### PR DESCRIPTION
Signed-off-by: RealAnna <anna.reale@dynatrace.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- when failing due to empty result we should still append the indicator result to the evaluation.finished event. 

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Part of #8602
