### PR TITLE
feat(installer): Move git remote URL deny list under features

### DIFF
--- a/installer/manifests/keptn/templates/shipyard-controller.yaml
+++ b/installer/manifests/keptn/templates/shipyard-controller.yaml
@@ -143,4 +143,4 @@ metadata:
     app.kubernetes.io/name: shipyard-controller
 data:
   git-remote-url-denylist: |-
-{{ .Values.git.remoteURLDenyList | default "" | indent 4 }}
+{{ .Values.features.git.remoteURLDenyList | default "" | indent 4 }}

--- a/installer/manifests/keptn/values.yaml
+++ b/installer/manifests/keptn/values.yaml
@@ -51,9 +51,8 @@ features:
   oauth:
     enabled: false
     prefix: "keptn:"
-
-git:
-  remoteURLDenyList: ""
+  git:
+    remoteURLDenyList: ""
 
 nats:
   nameOverride: keptn-nats


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- moves the `git.remoteURLDenyList` helm value key under the `features:` key

### Notes
This is a breaking change

