### PR TITLE
fix: Fixed automatic navigation to latest stage

### DIFF
--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.html
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.html
@@ -49,7 +49,7 @@
               uitestid="keptn-sequence-view-roots"
               [events]="filteredSequences"
               [selectedEvent]="currentSequence"
-              (selectedEventChange)="selectSequence($event); loadTraces($event.sequence)"
+              (selectedEventChange)="selectSequence($event); loadTraces($event.sequence, undefined, $event.stage)"
             ></ktb-root-events-list>
             <div fxLayout="row" fxLayoutAlign="center">
               <ktb-loading-distractor *ngIf="loading" uitestid="keptn-loadingOldSequences">

--- a/bridge/cypress/integration/sequences.spec.ts
+++ b/bridge/cypress/integration/sequences.spec.ts
@@ -412,5 +412,26 @@ describe('Sequences', () => {
       sequencePage.visit('sockshop');
       cy.byTestId('keptn-root-events-list-e28592c6-d857-44fe-aea6-e65de02929bf').assertDtIcon('pause');
     });
+
+    it('should select stage when clicking stage tag', () => {
+      const project = 'sockshop';
+      const stage = 'dev';
+      const keptnContext = '62cca6f3-dc54-4df6-a04c-6ffc894a4b5e';
+      sequencePage.visit(project).selectSequence(keptnContext, stage);
+
+      // Wait for loadTraces call
+      cy.wait(100);
+
+      sequencePage.assertSequenceDeepLink(project, keptnContext, stage);
+    });
+
+    it('should select last stage when clicking ktb-selectable-tile', () => {
+      const project = 'sockshop';
+      const keptnContext = '62cca6f3-dc54-4df6-a04c-6ffc894a4b5e';
+      sequencePage
+        .visit(project)
+        .selectSequence(keptnContext)
+        .assertSequenceDeepLink(project, keptnContext, 'production');
+    });
   });
 });

--- a/bridge/cypress/integration/sequences.spec.ts
+++ b/bridge/cypress/integration/sequences.spec.ts
@@ -420,7 +420,7 @@ describe('Sequences', () => {
       sequencePage.visit(project).selectSequence(keptnContext, stage);
 
       // Wait for loadTraces call
-      cy.wait(100);
+      cy.wait('@sequenceTraces');
 
       sequencePage.assertSequenceDeepLink(project, keptnContext, stage);
     });

--- a/bridge/cypress/support/intercept.ts
+++ b/bridge/cypress/support/intercept.ts
@@ -168,7 +168,7 @@ export function interceptSequencesPage(): void {
   cy.intercept('/api/project/sockshop/sequences/filter', { fixture: 'sequence.filter.mock' }).as('SequencesMetadata');
   cy.intercept('/api/mongodb-datastore/event?keptnContext=62cca6f3-dc54-4df6-a04c-6ffc894a4b5e&project=sockshop', {
     fixture: 'sequence.traces.mock.json',
-  });
+  }).as('sequenceTraces');
 
   cy.intercept('/api/mongodb-datastore/event?keptnContext=99a20ef4-d822-4185-bbee-0d7a364c213b&project=sockshop', {
     fixture: 'sequence-traces/approval.mock.json',

--- a/bridge/cypress/support/pageobjects/SequencesPage.ts
+++ b/bridge/cypress/support/pageobjects/SequencesPage.ts
@@ -107,7 +107,7 @@ export class SequencesPage {
   public selectSequence(keptnContext: string, stage?: string): this {
     const rootEvent = cy.byTestId(`keptn-root-events-list-${keptnContext}`);
     if (stage) {
-      rootEvent.find('dt-tag').contains(stage).parentsUntil('ktb-stage-badge').first().click({ force: true });
+      rootEvent.find('dt-tag').contains(stage).parents('ktb-stage-badge').click();
       return this;
     }
     rootEvent.click();

--- a/bridge/cypress/support/pageobjects/SequencesPage.ts
+++ b/bridge/cypress/support/pageobjects/SequencesPage.ts
@@ -104,8 +104,13 @@ export class SequencesPage {
     return this;
   }
 
-  public selectSequence(keptnContext: string): this {
-    cy.byTestId(`keptn-root-events-list-${keptnContext}`).click();
+  public selectSequence(keptnContext: string, stage?: string): this {
+    const rootEvent = cy.byTestId(`keptn-root-events-list-${keptnContext}`);
+    if (stage) {
+      rootEvent.find('dt-tag').contains(stage).parentsUntil('ktb-stage-badge').first().click({ force: true });
+      return this;
+    }
+    rootEvent.click();
     return this;
   }
 


### PR DESCRIPTION
## This PR

- Fixes automatic navigation to latest stage when clicking `dt-tag` from `ktb-root-events-list`.
- Added UI tests for navigation to correct stage.

### Related Issues

Fixes #8684

### Notes

https://user-images.githubusercontent.com/36239763/185873075-f3c2a07e-faaf-4ce3-888a-a977437bc329.mp4

Signed-off-by: TannerGilbert <gilberttanner.work@gmail.com>