### PR TITLE
fix(shipyard-controller): Clean up event queue when cancelling a sequence

### DIFF
--- a/shipyard-controller/main.go
+++ b/shipyard-controller/main.go
@@ -212,6 +212,8 @@ func _main(env config.EnvConfig, kubeAPI kubernetes.Interface) {
 	shipyardController.AddSequenceFinishedHook(sequenceStateMaterializedView)
 	shipyardController.AddSequenceTimeoutHook(sequenceStateMaterializedView)
 	shipyardController.AddSequenceAbortedHook(sequenceStateMaterializedView)
+	shipyardController.AddSequenceFinishedHook(eventDispatcher)
+	shipyardController.AddSequenceAbortedHook(eventDispatcher)
 	shipyardController.AddSequenceTimeoutHook(eventDispatcher)
 	shipyardController.AddSequencePausedHook(sequenceStateMaterializedView)
 	shipyardController.AddSequenceResumedHook(sequenceStateMaterializedView)


### PR DESCRIPTION
Closes #8570
Backport of #8583