### PR TITLE
feat(cli): Use sh.keptn.event.configure-monitoring.triggered instead of sh.keptn.event.monitoring.configure for keptn configure monitoring CLI command

### DIFF
--- a/cli/cmd/configure_monitoring.go
+++ b/cli/cmd/configure_monitoring.go
@@ -81,7 +81,7 @@ keptn configure monitoring datadog --project=PROJECTNAME --service=SERVICENAME
 
 		sdkEvent := cloudevents.NewEvent()
 		sdkEvent.SetID(uuid.New().String())
-		sdkEvent.SetType(keptn.ConfigureMonitoringEventType)
+		sdkEvent.SetType(keptnv2.GetTriggeredEventType("configure-monitoring"))
 		sdkEvent.SetSource(source.String())
 		sdkEvent.SetDataContentType(cloudevents.ApplicationJSON)
 		sdkEvent.SetData(cloudevents.ApplicationJSON, configureMonitoringEventData)


### PR DESCRIPTION
This breaking change also affects
* prometheus-service
* dynatrace-service
* datadog-service
* sumologic-service

Fixes #8718

