### PR TITLE
feat: Add query parameters to GET secret endpoint

### DIFF
--- a/secret-service/deploy/service.yaml
+++ b/secret-service/deploy/service.yaml
@@ -43,7 +43,7 @@ spec:
                 port: 8080
               initialDelaySeconds: 10
               periodSeconds: 5
-          image: keptndev/secret-service:latest
+          image: keptndev/secret-service:0.18.1-dev
           ports:
             - containerPort: 8080
           resources:

--- a/secret-service/docs/docs.go
+++ b/secret-service/docs/docs.go
@@ -30,7 +30,7 @@ const docTemplate = `{
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Get scopes",
+                "description": "Get scopes\n\u003cspan class=\"oauth-scopes\"\u003eRequired OAuth scopes: ${prefix}secrets:read\u003c/span\u003e",
                 "tags": [
                     "Scopes"
                 ],
@@ -58,11 +58,27 @@ const docTemplate = `{
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Get secrets",
+                "description": "Get secrets\n\u003cspan class=\"oauth-scopes\"\u003eRequired OAuth scopes: ${prefix}secrets:read\u003c/span\u003e",
                 "tags": [
                     "Secrets"
                 ],
                 "summary": "Get secrets",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The name of the secret",
+                        "name": "name",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "The scope of the secret",
+                        "name": "scope",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -84,7 +100,7 @@ const docTemplate = `{
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Update an existing Secret",
+                "description": "Update an existing Secret\n\u003cspan class=\"oauth-scopes\"\u003eRequired OAuth scopes: ${prefix}secrets:write\u003c/span\u003e",
                 "consumes": [
                     "application/json"
                 ],
@@ -139,7 +155,7 @@ const docTemplate = `{
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Create a new Secret",
+                "description": "Create a new Secret\n\u003cspan class=\"oauth-scopes\"\u003eRequired OAuth scopes: ${prefix}secrets:write\u003c/span\u003e",
                 "consumes": [
                     "application/json"
                 ],
@@ -194,7 +210,7 @@ const docTemplate = `{
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Delete an existing Secret",
+                "description": "Delete an existing Secret\n\u003cspan class=\"oauth-scopes\"\u003eRequired OAuth scopes: ${prefix}secrets:delete\u003c/span\u003e",
                 "tags": [
                     "Secrets"
                 ],

--- a/secret-service/docs/docs.go
+++ b/secret-service/docs/docs.go
@@ -68,15 +68,13 @@ const docTemplate = `{
                         "type": "string",
                         "description": "The name of the secret",
                         "name": "name",
-                        "in": "query",
-                        "required": true
+                        "in": "query"
                     },
                     {
                         "type": "string",
                         "description": "The scope of the secret",
                         "name": "scope",
-                        "in": "query",
-                        "required": true
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -220,13 +218,15 @@ const docTemplate = `{
                         "type": "string",
                         "description": "The name of the secret",
                         "name": "name",
-                        "in": "query"
+                        "in": "query",
+                        "required": true
                     },
                     {
                         "type": "string",
                         "description": "The scope of the secret",
                         "name": "scope",
-                        "in": "query"
+                        "in": "query",
+                        "required": true
                     }
                 ],
                 "responses": {

--- a/secret-service/docs/docs.go
+++ b/secret-service/docs/docs.go
@@ -220,15 +220,13 @@ const docTemplate = `{
                         "type": "string",
                         "description": "The name of the secret",
                         "name": "name",
-                        "in": "query",
-                        "required": true
+                        "in": "query"
                     },
                     {
                         "type": "string",
                         "description": "The scope of the secret",
                         "name": "scope",
-                        "in": "query",
-                        "required": true
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/secret-service/docs/swagger.json
+++ b/secret-service/docs/swagger.json
@@ -212,15 +212,13 @@
                         "type": "string",
                         "description": "The name of the secret",
                         "name": "name",
-                        "in": "query",
-                        "required": true
+                        "in": "query"
                     },
                     {
                         "type": "string",
                         "description": "The scope of the secret",
                         "name": "scope",
-                        "in": "query",
-                        "required": true
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/secret-service/docs/swagger.json
+++ b/secret-service/docs/swagger.json
@@ -22,7 +22,7 @@
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Get scopes",
+                "description": "Get scopes\n\u003cspan class=\"oauth-scopes\"\u003eRequired OAuth scopes: ${prefix}secrets:read\u003c/span\u003e",
                 "tags": [
                     "Scopes"
                 ],
@@ -50,11 +50,27 @@
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Get secrets",
+                "description": "Get secrets\n\u003cspan class=\"oauth-scopes\"\u003eRequired OAuth scopes: ${prefix}secrets:read\u003c/span\u003e",
                 "tags": [
                     "Secrets"
                 ],
                 "summary": "Get secrets",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The name of the secret",
+                        "name": "name",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "The scope of the secret",
+                        "name": "scope",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -76,7 +92,7 @@
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Update an existing Secret",
+                "description": "Update an existing Secret\n\u003cspan class=\"oauth-scopes\"\u003eRequired OAuth scopes: ${prefix}secrets:write\u003c/span\u003e",
                 "consumes": [
                     "application/json"
                 ],
@@ -131,7 +147,7 @@
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Create a new Secret",
+                "description": "Create a new Secret\n\u003cspan class=\"oauth-scopes\"\u003eRequired OAuth scopes: ${prefix}secrets:write\u003c/span\u003e",
                 "consumes": [
                     "application/json"
                 ],
@@ -186,7 +202,7 @@
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Delete an existing Secret",
+                "description": "Delete an existing Secret\n\u003cspan class=\"oauth-scopes\"\u003eRequired OAuth scopes: ${prefix}secrets:delete\u003c/span\u003e",
                 "tags": [
                     "Secrets"
                 ],

--- a/secret-service/docs/swagger.json
+++ b/secret-service/docs/swagger.json
@@ -60,15 +60,13 @@
                         "type": "string",
                         "description": "The name of the secret",
                         "name": "name",
-                        "in": "query",
-                        "required": true
+                        "in": "query"
                     },
                     {
                         "type": "string",
                         "description": "The scope of the secret",
                         "name": "scope",
-                        "in": "query",
-                        "required": true
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -212,13 +210,15 @@
                         "type": "string",
                         "description": "The name of the secret",
                         "name": "name",
-                        "in": "query"
+                        "in": "query",
+                        "required": true
                     },
                     {
                         "type": "string",
                         "description": "The scope of the secret",
                         "name": "scope",
-                        "in": "query"
+                        "in": "query",
+                        "required": true
                     }
                 ],
                 "responses": {

--- a/secret-service/docs/swagger.yaml
+++ b/secret-service/docs/swagger.yaml
@@ -90,10 +90,12 @@ paths:
       - description: The name of the secret
         in: query
         name: name
+        required: true
         type: string
       - description: The scope of the secret
         in: query
         name: scope
+        required: true
         type: string
       responses:
         "200":
@@ -123,12 +125,10 @@ paths:
       - description: The name of the secret
         in: query
         name: name
-        required: true
         type: string
       - description: The scope of the secret
         in: query
         name: scope
-        required: true
         type: string
       responses:
         "200":

--- a/secret-service/docs/swagger.yaml
+++ b/secret-service/docs/swagger.yaml
@@ -64,7 +64,9 @@ info:
 paths:
   /scope:
     get:
-      description: Get scopes
+      description: |-
+        Get scopes
+        <span class="oauth-scopes">Required OAuth scopes: ${prefix}secrets:read</span>
       responses:
         "200":
           description: OK
@@ -81,7 +83,9 @@ paths:
       - Scopes
   /secret:
     delete:
-      description: Delete an existing Secret
+      description: |-
+        Delete an existing Secret
+        <span class="oauth-scopes">Required OAuth scopes: ${prefix}secrets:delete</span>
       parameters:
       - description: The name of the secret
         in: query
@@ -114,7 +118,20 @@ paths:
       tags:
       - Secrets
     get:
-      description: Get secrets
+      description: |-
+        Get secrets
+        <span class="oauth-scopes">Required OAuth scopes: ${prefix}secrets:read</span>
+      parameters:
+      - description: The name of the secret
+        in: query
+        name: name
+        required: true
+        type: string
+      - description: The scope of the secret
+        in: query
+        name: scope
+        required: true
+        type: string
       responses:
         "200":
           description: OK
@@ -132,7 +149,9 @@ paths:
     post:
       consumes:
       - application/json
-      description: Create a new Secret
+      description: |-
+        Create a new Secret
+        <span class="oauth-scopes">Required OAuth scopes: ${prefix}secrets:write</span>
       parameters:
       - description: The new secret to be created
         in: body
@@ -167,7 +186,9 @@ paths:
     put:
       consumes:
       - application/json
-      description: Update an existing Secret
+      description: |-
+        Update an existing Secret
+        <span class="oauth-scopes">Required OAuth scopes: ${prefix}secrets:write</span>
       parameters:
       - description: The updated Secret
         in: body

--- a/secret-service/docs/swagger.yaml
+++ b/secret-service/docs/swagger.yaml
@@ -90,12 +90,10 @@ paths:
       - description: The name of the secret
         in: query
         name: name
-        required: true
         type: string
       - description: The scope of the secret
         in: query
         name: scope
-        required: true
         type: string
       responses:
         "200":

--- a/secret-service/pkg/backend/fake/secretbackend_mock.go
+++ b/secret-service/pkg/backend/fake/secretbackend_mock.go
@@ -28,7 +28,7 @@ var _ backend.SecretBackend = &SecretBackendMock{}
 // 			GetScopesFunc: func() ([]string, error) {
 // 				panic("mock out the GetScopes method")
 // 			},
-// 			GetSecretsFunc: func() ([]model.GetSecretResponseItem, error) {
+// 			GetSecretsFunc: func(secret model.Secret) ([]model.GetSecretResponseItem, error) {
 // 				panic("mock out the GetSecrets method")
 // 			},
 // 			UpdateSecretFunc: func(secret model.Secret) error {
@@ -51,7 +51,7 @@ type SecretBackendMock struct {
 	GetScopesFunc func() ([]string, error)
 
 	// GetSecretsFunc mocks the GetSecrets method.
-	GetSecretsFunc func() ([]model.GetSecretResponseItem, error)
+	GetSecretsFunc func(secret model.Secret) ([]model.GetSecretResponseItem, error)
 
 	// UpdateSecretFunc mocks the UpdateSecret method.
 	UpdateSecretFunc func(secret model.Secret) error
@@ -73,6 +73,7 @@ type SecretBackendMock struct {
 		}
 		// GetSecrets holds details about calls to the GetSecrets method.
 		GetSecrets []struct {
+			Secret model.Secret
 		}
 		// UpdateSecret holds details about calls to the UpdateSecret method.
 		UpdateSecret []struct {
@@ -176,24 +177,27 @@ func (mock *SecretBackendMock) GetScopesCalls() []struct {
 }
 
 // GetSecrets calls GetSecretsFunc.
-func (mock *SecretBackendMock) GetSecrets() ([]model.GetSecretResponseItem, error) {
+func (mock *SecretBackendMock) GetSecrets(secret model.Secret) ([]model.GetSecretResponseItem, error) {
 	if mock.GetSecretsFunc == nil {
 		panic("SecretBackendMock.GetSecretsFunc: method is nil but SecretBackend.GetSecrets was just called")
 	}
 	callInfo := struct {
+		Secret model.Secret
 	}{}
 	mock.lockGetSecrets.Lock()
 	mock.calls.GetSecrets = append(mock.calls.GetSecrets, callInfo)
 	mock.lockGetSecrets.Unlock()
-	return mock.GetSecretsFunc()
+	return mock.GetSecretsFunc(secret)
 }
 
 // GetSecretsCalls gets all the calls that were made to GetSecrets.
 // Check the length with:
 //     len(mockedSecretBackend.GetSecretsCalls())
 func (mock *SecretBackendMock) GetSecretsCalls() []struct {
+	Secret model.Secret
 } {
 	var calls []struct {
+		Secret model.Secret
 	}
 	mock.lockGetSecrets.RLock()
 	calls = mock.calls.GetSecrets

--- a/secret-service/pkg/backend/secretbackend.go
+++ b/secret-service/pkg/backend/secretbackend.go
@@ -10,7 +10,7 @@ type SecretManager interface {
 	CreateSecret(model.Secret) error
 	UpdateSecret(model.Secret) error
 	DeleteSecret(model.Secret) error
-	GetSecrets() ([]model.GetSecretResponseItem, error)
+	GetSecrets(model.Secret) ([]model.GetSecretResponseItem, error)
 }
 
 type ScopeManager interface {

--- a/secret-service/pkg/backend/secretbackend_k8s_test.go
+++ b/secret-service/pkg/backend/secretbackend_k8s_test.go
@@ -190,7 +190,7 @@ func TestCreateSecret_NoMatchingScopeConfigured(t *testing.T) {
 /**
 GET SECRET TESTS
 */
-func TestGetSecret(t *testing.T) {
+func TestGetSecret_ReturnsAllSecrets(t *testing.T) {
 	kubernetes := k8sfake.NewSimpleClientset()
 	scopesRepository := &fake.ScopesRepositoryMock{}
 	scopesRepository.ReadFunc = func() (model.Scopes, error) { return createTestScopes(), nil }
@@ -205,7 +205,136 @@ func TestGetSecret(t *testing.T) {
 	err := backend.CreateSecret(secret)
 	assert.Nil(t, err)
 
-	secrets, err := backend.GetSecrets()
+	secrets, err := backend.GetSecrets(model.Secret{})
+	require.Nil(t, err)
+
+	require.Equal(t, []model.GetSecretResponseItem{
+		{
+			SecretMetadata: model.SecretMetadata{
+				Name:  "my-secret",
+				Scope: "my-scope",
+			},
+			Keys: []string{"password"},
+		},
+	}, secrets)
+}
+
+func TestGetSecret_ReturnsSecretsByScope(t *testing.T) {
+	kubernetes := k8sfake.NewSimpleClientset()
+	scopesRepository := &fake.ScopesRepositoryMock{}
+	scopesRepository.ReadFunc = func() (model.Scopes, error) { return createTestScopes(), nil }
+
+	backend := K8sSecretBackend{
+		KubeAPI:                kubernetes,
+		KeptnNamespaceProvider: FakeNamespaceProvider(),
+		ScopesRepository:       scopesRepository,
+	}
+
+	secret := createTestSecret("my-secret", "my-scope")
+	err := backend.CreateSecret(secret)
+	assert.Nil(t, err)
+
+	secret = createTestSecret("my-secret2", "my-scope")
+	err = backend.CreateSecret(secret)
+	assert.Nil(t, err)
+
+	secret = createTestSecret("my-secret3", "keptn-default")
+	err = backend.CreateSecret(secret)
+	assert.Nil(t, err)
+
+	secrets, err := backend.GetSecrets(
+		model.Secret{
+			SecretMetadata: model.SecretMetadata{
+				Name:  "",
+				Scope: "my-scope",
+			},
+		})
+	require.Nil(t, err)
+
+	require.Equal(t, []model.GetSecretResponseItem{
+		{
+			SecretMetadata: model.SecretMetadata{
+				Name:  "my-secret",
+				Scope: "my-scope",
+			},
+			Keys: []string{"password"},
+		},
+		{
+			SecretMetadata: model.SecretMetadata{
+				Name:  "my-secret2",
+				Scope: "my-scope",
+			},
+			Keys: []string{"password"},
+		},
+	}, secrets)
+
+}
+
+func TestGetSecret_ReturnsSecretsByName(t *testing.T) {
+	kubernetes := k8sfake.NewSimpleClientset()
+	scopesRepository := &fake.ScopesRepositoryMock{}
+	scopesRepository.ReadFunc = func() (model.Scopes, error) { return createTestScopes(), nil }
+
+	backend := K8sSecretBackend{
+		KubeAPI:                kubernetes,
+		KeptnNamespaceProvider: FakeNamespaceProvider(),
+		ScopesRepository:       scopesRepository,
+	}
+
+	secret := createTestSecret("my-secret", "my-scope")
+	err := backend.CreateSecret(secret)
+	assert.Nil(t, err)
+
+	secret = createTestSecret("my-secret2", "my-scope")
+	err = backend.CreateSecret(secret)
+	assert.Nil(t, err)
+
+	secrets, err := backend.GetSecrets(
+		model.Secret{
+			SecretMetadata: model.SecretMetadata{
+				Name:  "my-secret",
+				Scope: "",
+			},
+		})
+	require.Nil(t, err)
+
+	require.Equal(t, []model.GetSecretResponseItem{
+		{
+			SecretMetadata: model.SecretMetadata{
+				Name:  "my-secret",
+				Scope: "my-scope",
+			},
+			Keys: []string{"password"},
+		},
+	}, secrets)
+}
+
+func TestGetSecret_ReturnsSecretsByNameAndScope(t *testing.T) {
+	kubernetes := k8sfake.NewSimpleClientset()
+	scopesRepository := &fake.ScopesRepositoryMock{}
+	scopesRepository.ReadFunc = func() (model.Scopes, error) { return createTestScopes(), nil }
+
+	backend := K8sSecretBackend{
+		KubeAPI:                kubernetes,
+		KeptnNamespaceProvider: FakeNamespaceProvider(),
+		ScopesRepository:       scopesRepository,
+	}
+
+	secret := createTestSecret("my-secret", "my-scope")
+	err := backend.CreateSecret(secret)
+	assert.Nil(t, err)
+
+	secret = createTestSecret("my-secret3", "keptn-default")
+	err = backend.CreateSecret(secret)
+	assert.Nil(t, err)
+
+	secrets, err := backend.GetSecrets(
+		model.Secret{
+			SecretMetadata: model.SecretMetadata{
+				Name:  "my-secret",
+				Scope: "my-scope",
+			},
+		})
 	require.Nil(t, err)
 
 	require.Equal(t, []model.GetSecretResponseItem{
@@ -234,7 +363,7 @@ func TestGetSecret_Fails(t *testing.T) {
 		return true, nil, errors.New("oops")
 	})
 
-	secrets, err := backend.GetSecrets()
+	secrets, err := backend.GetSecrets(model.Secret{})
 
 	require.NotNil(t, err)
 	require.Nil(t, secrets)

--- a/secret-service/pkg/handler/secrethandler.go
+++ b/secret-service/pkg/handler/secrethandler.go
@@ -113,8 +113,8 @@ func (s SecretHandler) UpdateSecret(c *gin.Context) {
 // @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}secrets:delete</span>
 // @Tags         Secrets
 // @Security     ApiKeyAuth
-// @Param        name   query  string  true  "The name of the secret"
-// @Param        scope  query  string  true  "The scope of the secret"
+// @Param        name   query  string  false  "The name of the secret"
+// @Param        scope  query  string  false  "The scope of the secret"
 // @Success      200    "OK"
 // @Failure      400    {object}  model.Error  "Invalid payload"
 // @Failure      404    {object}  model.Error  "Not Found"

--- a/secret-service/pkg/handler/secrethandler.go
+++ b/secret-service/pkg/handler/secrethandler.go
@@ -113,8 +113,8 @@ func (s SecretHandler) UpdateSecret(c *gin.Context) {
 // @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}secrets:delete</span>
 // @Tags         Secrets
 // @Security     ApiKeyAuth
-// @Param        name   query  string  false  "The name of the secret"
-// @Param        scope  query  string  false  "The scope of the secret"
+// @Param        name   query  string  true  "The name of the secret"
+// @Param        scope  query  string  true  "The scope of the secret"
 // @Success      200    "OK"
 // @Failure      400    {object}  model.Error  "Invalid payload"
 // @Failure      404    {object}  model.Error  "Not Found"
@@ -158,8 +158,8 @@ func (s SecretHandler) DeleteSecret(c *gin.Context) {
 // @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}secrets:read</span>
 // @Tags         Secrets
 // @Security     ApiKeyAuth
-// @Param        name   query  string  true  "The name of the secret"
-// @Param        scope  query  string  true  "The scope of the secret"
+// @Param        name   query  string  false  "The name of the secret"
+// @Param        scope  query  string  false  "The scope of the secret"
 // @Success      200  {object}  model.GetSecretsResponse  "OK"
 // @Failure      500  {object}  model.Error               "Internal Server Error"
 // @Router       /secret [get]

--- a/secret-service/pkg/handler/secrethandler.go
+++ b/secret-service/pkg/handler/secrethandler.go
@@ -121,7 +121,7 @@ func (s SecretHandler) UpdateSecret(c *gin.Context) {
 // @Failure      500    {object}  model.Error  "Internal Server Error"
 // @Router       /secret [delete]
 func (s SecretHandler) DeleteSecret(c *gin.Context) {
-	params := &DeleteSecretQueryParams{}
+	params := &model.DeleteSecretQueryParams{}
 	if err := c.ShouldBindQuery(params); err != nil {
 		SetBadRequestErrorResponse(c, fmt.Sprintf(ErrInvalidRequestFormatMsg, err.Error()))
 		return
@@ -158,11 +158,25 @@ func (s SecretHandler) DeleteSecret(c *gin.Context) {
 // @Description  <span class="oauth-scopes">Required OAuth scopes: ${prefix}secrets:read</span>
 // @Tags         Secrets
 // @Security     ApiKeyAuth
+// @Param        name   query  string  true  "The name of the secret"
+// @Param        scope  query  string  true  "The scope of the secret"
 // @Success      200  {object}  model.GetSecretsResponse  "OK"
 // @Failure      500  {object}  model.Error               "Internal Server Error"
 // @Router       /secret [get]
 func (s SecretHandler) GetSecrets(c *gin.Context) {
-	secrets, err := s.SecretManager.GetSecrets()
+	params := &model.GetSecretQueryParams{}
+	if err := c.ShouldBindQuery(params); err != nil {
+		SetBadRequestErrorResponse(c, fmt.Sprintf(ErrInvalidRequestFormatMsg, err.Error()))
+		return
+	}
+	secret := model.Secret{
+		SecretMetadata: model.SecretMetadata{
+			Name:  params.Name,
+			Scope: params.Scope,
+		},
+		Data: nil,
+	}
+	secrets, err := s.SecretManager.GetSecrets(secret)
 	if err != nil {
 		SetInternalServerErrorResponse(c, fmt.Sprintf(ErrGetSecretMsg, err.Error()))
 		return
@@ -170,9 +184,4 @@ func (s SecretHandler) GetSecrets(c *gin.Context) {
 
 	c.Status(http.StatusOK)
 	c.JSON(http.StatusOK, model.GetSecretsResponse{Secrets: secrets})
-}
-
-type DeleteSecretQueryParams struct {
-	Name  string `form:"name" binding:"required"`
-	Scope string `form:"scope" binding:"required"`
 }

--- a/secret-service/pkg/handler/secrethandler_test.go
+++ b/secret-service/pkg/handler/secrethandler_test.go
@@ -339,7 +339,7 @@ func TestHandler_GetSecrets(t *testing.T) {
 			name: "GET Secret - SUCCESS",
 			fields: fields{
 				Backend: &fake.SecretBackendMock{
-					GetSecretsFunc: func() ([]model.GetSecretResponseItem, error) {
+					GetSecretsFunc: func(secret model.Secret) ([]model.GetSecretResponseItem, error) {
 						return []model.GetSecretResponseItem{}, nil
 					},
 				},
@@ -351,7 +351,7 @@ func TestHandler_GetSecrets(t *testing.T) {
 			name: "GET Secret - Backend some error",
 			fields: fields{
 				Backend: &fake.SecretBackendMock{
-					GetSecretsFunc: func() ([]model.GetSecretResponseItem, error) {
+					GetSecretsFunc: func(secret model.Secret) ([]model.GetSecretResponseItem, error) {
 						return nil, errors.New("oops")
 					},
 				},

--- a/secret-service/pkg/model/secret.go
+++ b/secret-service/pkg/model/secret.go
@@ -25,3 +25,13 @@ type GetSecretResponseItem struct {
 type GetSecretsResponse struct {
 	Secrets []GetSecretResponseItem `json:"Secrets"`
 }
+
+type GetSecretQueryParams struct {
+	Name  string `form:"name,omitempty"`
+	Scope string `form:"scope,omitempty"`
+}
+
+type DeleteSecretQueryParams struct {
+	Name  string `form:"name" binding:"required"`
+	Scope string `form:"scope" binding:"required"`
+}


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- adds name and scope as non-mandatory parameters
- if none is defined the endpoint returns all secrets as before
- unit test 

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #8474 

### Notes
<!-- any additional notes for this PR -->
no integration test was provided since it would only be a redundant test of /gin + swagger 

### How to test
<!-- if applicable, add testing instructions under this section -->
run this version of secret service and use the GET endpoint, first with no parameters than only with name or scope finally with both.
<img src="https://user-images.githubusercontent.com/89971034/186393733-a793ea35-7f61-43ba-8c3c-1605ac33bcc4.png" width="600">
<img src="https://user-images.githubusercontent.com/89971034/186396319-c5188cb4-fb0d-4cd0-a88e-1f802b1ea585.png" width="600">
<img src="https://user-images.githubusercontent.com/89971034/186396621-f93e6592-de85-485d-abfd-89397caf0866.png" width="600">
<img src="https://user-images.githubusercontent.com/89971034/186396743-d02d1c73-091c-40c9-bb3e-9c4ed09e466f.png" width="600">


