### PR TITLE
feat(webhook-service): Added unmarshalling of curl responses 

### DIFF
--- a/webhook-service/deploy/service.yaml
+++ b/webhook-service/deploy/service.yaml
@@ -27,10 +27,6 @@ spec:
         helm.sh/chart: keptn-0.1.0
     spec:
       serviceAccountName: keptn-webhook-service
-      securityContext:
-        fsGroup: 65532
-        seccompProfile:
-          type: RuntimeDefault
       containers:
         - name: webhook-service
           image: 'docker.io/keptndev/webhook-service'

--- a/webhook-service/deploy/service.yaml
+++ b/webhook-service/deploy/service.yaml
@@ -26,6 +26,11 @@ spec:
         app.kubernetes.io/version: develop
         helm.sh/chart: keptn-0.1.0
     spec:
+      serviceAccountName: keptn-webhook-service
+      securityContext:
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: webhook-service
           image: 'docker.io/keptndev/webhook-service'

--- a/webhook-service/handler/handler.go
+++ b/webhook-service/handler/handler.go
@@ -68,7 +68,9 @@ func (th *TaskHandler) Execute(keptnHandler sdk.IKeptn, event sdk.KeptnEvent) (i
 		return nil, sdkError(removeSecretsFromMessage(err.Error(), secretEnvVars), err)
 	}
 	eventAdapter.Add("env", secretEnvVars)
-	responses, err := th.performWebhookRequests(*webhook, eventAdapter)
+
+	responses := []interface{}{}
+	responses, err = th.performWebhookRequests(*webhook, eventAdapter, responses)
 	if err != nil {
 		onError(err, secretEnvVars)
 		return nil, sdkError(removeSecretsFromMessage(err.Error(), secretEnvVars), err)
@@ -199,8 +201,8 @@ func (th *TaskHandler) onStartedWebhookExecution(keptnHandler sdk.IKeptn, event 
 	return nil
 }
 
-func (th *TaskHandler) performWebhookRequests(webhook lib.Webhook, eventAdapter *lib.EventDataAdapter) ([]interface{}, error) {
-	var responses []interface{}
+func (th *TaskHandler) performWebhookRequests(webhook lib.Webhook, eventAdapter *lib.EventDataAdapter, responses []interface{}) ([]interface{}, error) {
+
 	executedRequests := 0
 	logger.Infof("executing webhooks for subscriptionID %s", webhook.SubscriptionID)
 	for _, req := range webhook.Requests {

--- a/webhook-service/handler/handler.go
+++ b/webhook-service/handler/handler.go
@@ -221,28 +221,26 @@ func (th *TaskHandler) performWebhookRequests(webhook lib.Webhook, eventAdapter 
 		}
 		executedRequests = executedRequests + 1
 
-		//attempt to create a json object out of the response as requested in https://github.com/keptn/keptn/issues/8256
-
-		dat := map[string]interface{}{}
-
-		resp := []byte(response)
-		if json.Valid(resp) {
-
-			err = json.Unmarshal(resp, &dat)
-			if err == nil {
-				logger.Infof("Webhook response unmarshalled! %+v", dat)
-				responses = append(responses, dat)
-			} else {
-				logger.Infof("Webhook response cannot be unmarshalled! %s", err.Error())
-			}
-
-		} else {
-			logger.Infof("Webhook response could not be changed")
-			responses = append(responses, response)
-		}
-
+		data := UnmarshalResponse(response)
+		responses = append(responses, data)
 	}
 	return responses, nil
+}
+
+//UnmarshalResponse attempts to create a json object out of the response as requested in https://github.com/keptn/keptn/issues/8256
+func UnmarshalResponse(response string) interface{} {
+	dat := map[string]interface{}{}
+
+	resp := []byte(response)
+
+	err := json.Unmarshal(resp, &dat)
+	if err != nil {
+		logger.Debugf("Webhook response is unmarshallable : %s, appending response as string", err.Error())
+		return response
+	}
+	logger.Debugf("Webhook response unmarshalled! %+v", dat)
+	return dat
+
 }
 
 func (th *TaskHandler) gatherSecretEnvVars(webhook lib.Webhook) (map[string]string, error) {


### PR DESCRIPTION
For each response, webhook attempts to convert it into an object and appends it to the finished event
![image](https://user-images.githubusercontent.com/89971034/187646582-aba51685-92d0-4512-9226-39656ae091d1.png)

closes #8256 