### PR TITLE
fix(shipyard-controller): Update complete sequence execution after sequence is finished

### DIFF
--- a/shipyard-controller/internal/controller/shipyardcontroller.go
+++ b/shipyard-controller/internal/controller/shipyardcontroller.go
@@ -768,7 +768,7 @@ func (sc *ShipyardController) triggerNextTaskSequences(eventScope models.EventSc
 
 func (sc *ShipyardController) completeTaskSequence(eventScope models.EventScope, sequenceExecution models.SequenceExecution, reason string) error {
 	sequenceExecution.Status.State = reason
-	_, err := sc.sequenceExecutionRepo.UpdateStatus(sequenceExecution)
+	err := sc.sequenceExecutionRepo.Upsert(sequenceExecution, nil)
 
 	if err != nil {
 		return err

--- a/shipyard-controller/internal/controller/shipyardcontroller_component_test.go
+++ b/shipyard-controller/internal/controller/shipyardcontroller_component_test.go
@@ -297,6 +297,21 @@ func Test_shipyardController_Scenario1(t *testing.T) {
 	ShouldNotContainEvent(t, finishedEvents, keptnv2.GetFinishedEventType(keptnv2.EvaluationTaskName), "dev")
 	ShouldNotContainEvent(t, finishedEvents, keptnv2.GetFinishedEventType(keptnv2.ReleaseTaskName), "dev")
 
+	sequenceExecutions, err := sc.sequenceExecutionRepo.Get(models.SequenceExecutionFilter{Scope: models.EventScope{
+		EventData: keptnv2.EventData{
+			Project: "test-project",
+			Stage:   "dev",
+		},
+	}})
+
+	require.Nil(t, err)
+	require.Len(t, sequenceExecutions, 1)
+
+	require.Equal(t, "", sequenceExecutions[0].Status.CurrentTask.Name)
+	require.Equal(t, "", sequenceExecutions[0].Status.CurrentTask.TriggeredID)
+	require.Empty(t, sequenceExecutions[0].Status.CurrentTask.Events)
+	require.Len(t, sequenceExecutions[0].Status.PreviousTasks, 4)
+
 	// STEP 9.1
 	// send deployment.started event 1 with ID 1
 	sendAndVerifyStartedEvent(t, sc, keptnv2.DeploymentTaskName, triggeredID, "hardening", "carts", "test-source-1")

--- a/shipyard-controller/main_test.go
+++ b/shipyard-controller/main_test.go
@@ -845,8 +845,14 @@ func Test__main_SequenceStateParallelStages(t *testing.T) {
 	require.Equal(t, keptnv2.GetTriggeredEventType("delivery"), stage.LatestEvent.Type)
 
 	// get delivery.triggered event
-	deliveryTriggeredEvent := natsClient.getLatestEventOfType(*keptnContext.KeptnContext, projectName, "dev", keptnv2.GetTriggeredEventType("delivery"))
-	require.NotNil(t, deliveryTriggeredEvent)
+	var deliveryTriggeredEvent *apimodels.KeptnContextExtendedCE
+	require.Eventually(t, func() bool {
+		deliveryTriggeredEvent = natsClient.getLatestEventOfType(*keptnContext.KeptnContext, projectName, "dev", keptnv2.GetTriggeredEventType("delivery"))
+		if deliveryTriggeredEvent == nil {
+			return false
+		}
+		return true
+	}, 1*time.Second, 100*time.Millisecond)
 
 	cloudEvent := keptnv2.ToCloudEvent(*deliveryTriggeredEvent)
 


### PR DESCRIPTION
This PR changes the final update of a sequence execution to update the complete item instead of just setting the `state` property to `finished`
Closes #8808