### PR TITLE
fix(cli): Support `--labels` option in `trigger sequence` command

### DIFF
--- a/cli/cmd/trigger_delivery.go
+++ b/cli/cmd/trigger_delivery.go
@@ -49,7 +49,7 @@ Note: The value provided in the --image flag has to contain the full qualified i
 The only exception is "docker.io", as this is the default in Kubernetes.
 For pulling an image from a private registry, we would like to refer to the Kubernetes documentation (https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
 `,
-	Example:      `keptn trigger delivery --project=<project> --service=<service> --image=<image[:tag]> [--sequence=<sequence>]`,
+	Example:      `keptn trigger delivery --project=<project> --service=<service> --image=<image[:tag]> [--sequence=<sequence>] [--labels=test-id=1234,test-name=performance-test]`,
 	SilenceUsage: true,
 	Args:         cobra.NoArgs,
 	PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/cmd/trigger_evaluation.go
+++ b/cli/cmd/trigger_evaluation.go
@@ -59,7 +59,7 @@ flag is set to --timeframe=5m, the evaluation is conducted for the last 5 minute
 * To use a certain state of the git repository, please specify --git-commit-id with the appropiate commit ID
 `,
 	Example: `keptn trigger evaluation --project=sockshop --stage=hardening --service=carts --timeframe=5m --start=2019-10-31T11:59:59 --git-commit-id=<git-commit-id>
-keptn trigger evaluation --project=sockshop --stage=hardening --service=carts --start=2019-10-31T11:59:59 --end=2019-10-31T12:04:59 --labels=test-id=1234,test-name=performance-test [--git-commit-id=<git-commit-id>]
+keptn trigger evaluation --project=sockshop --stage=hardening --service=carts --start=2019-10-31T11:59:59 --end=2019-10-31T12:04:59 [--labels=test-id=1234,test-name=performance-test] [--git-commit-id=<git-commit-id>]
 `,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/cmd/trigger_sequence.go
+++ b/cli/cmd/trigger_sequence.go
@@ -19,9 +19,10 @@ import (
 )
 
 type sequenceStruct struct {
-	Project *string `json:"project"`
-	Service *string `json:"service"`
-	Stage   *string `json:"stage"`
+	Project *string            `json:"project"`
+	Service *string            `json:"service"`
+	Stage   *string            `json:"stage"`
+	Labels  *map[string]string `json:"labels"`
 }
 
 var sequence = sequenceStruct{}
@@ -60,7 +61,7 @@ var triggerSequenceCmd = &cobra.Command{
 	Long: `Triggers the execution of any sequence in a project with an arbitrary name.
 The name of the sequence has to be provided as an argument to the command. The sequence name is used to identify the sequence to be triggered.
 `,
-	Example:      `keptn trigger sequence <sequence-name> --project=<project> --service=<service> --stage=<stage>`,
+	Example:      `keptn trigger sequence <sequence-name> --project=<project> --service=<service> --stage=<stage> [--labels=test-id=1234,test-name=performance-test]`,
 	SilenceUsage: true,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 1 {
@@ -109,6 +110,7 @@ func doTriggerSequence(sequenceInputData sequenceStruct, sequenceName string) er
 			Project: *sequenceInputData.Project,
 			Stage:   *sequenceInputData.Stage,
 			Service: *sequenceInputData.Service,
+			Labels:  *sequenceInputData.Labels,
 		},
 	}
 
@@ -155,5 +157,7 @@ func init() {
 	sequence.Stage = triggerSequenceCmd.Flags().StringP("stage", "", "",
 		"The stage in which the new artifact will be triggered")
 	triggerSequenceCmd.MarkFlagRequired("stage")
+
+	sequence.Labels = triggerSequenceCmd.Flags().StringToStringP("labels", "l", nil, "Additional labels to be included in the event")
 
 }

--- a/cli/cmd/trigger_sequence_test.go
+++ b/cli/cmd/trigger_sequence_test.go
@@ -105,7 +105,7 @@ func TestTriggerSequence(t *testing.T) {
 
 	t.Setenv("MOCK_SERVER", ts.URL)
 
-	cmd := fmt.Sprintf("trigger sequence %s --project=%s --service=%s --stage=%s --mock", "hello", "hello-world", "demo", "dev")
+	cmd := fmt.Sprintf("trigger sequence %s --project=%s --service=%s --stage=%s --labels=key1=value1,key2=value2 --mock", "hello", "hello-world", "demo", "dev")
 	_, err := executeActionCommandC(cmd)
 
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: odubajDT <ondrej.dubaj@dynatrace.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- supports --labels options in triggers sequence command

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #8803 

