### PR TITLE
ci: Remove schedule for ZD test

### DIFF
--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -1,8 +1,8 @@
 name: ZeroDowntime Tests
 on:
-  schedule:
-    # * is a special character in YAML so you have to quote this string
-    - cron:  '0 4 * * 1-5' # run zero downtime tests at 4 AM (UTC), monday to friday (1-5)
+#  schedule:
+#    # * is a special character in YAML so you have to quote this string
+#    - cron:  '0 4 * * 1-5' # run zero downtime tests at 4 AM (UTC), monday to friday (1-5)
   workflow_dispatch: # run zero downtime tests selecting the installation branch and the upgrade chart
     inputs:
       branch:


### PR DESCRIPTION
Removing the ZD scheduled test, since we know we do have a regression due to MongoDB changes
Workflow can still be manually triggered https://github.com/keptn/keptn/actions/runs/3005279968