### PR TITLE
feat(cli): Introduce `--data` option for `trigger sequence` command

### DIFF
--- a/cli/cmd/trigger_sequence.go
+++ b/cli/cmd/trigger_sequence.go
@@ -119,32 +119,18 @@ func doTriggerSequence(sequenceInputData sequenceStruct, sequenceName string) er
 	}
 
 	// set event data
-	var eventData map[string]interface{}
+	eventData := make(map[string]interface{})
 	if len(*sequence.Data) > 0 {
 		customData, err := internal.UnfoldMap(*sequence.Data)
 		if err != nil {
 			return fmt.Errorf("Unable to process custom event data: %w", err)
 		}
-
-		// check if mandatory fields were given
-		if _, ok := customData["project"]; !ok {
-			return fmt.Errorf("unable to process custom event data: project missing")
-		}
-		if _, ok := customData["service"]; !ok {
-			return fmt.Errorf("unable to process custom event data: service missing")
-		}
-		if _, ok := customData["stage"]; !ok {
-			return fmt.Errorf("unable to process custom event data: stage missing")
-		}
 		eventData = customData
-	} else {
-		eventData = map[string]interface{}{
-			"project": *sequenceInputData.Project,
-			"stage":   *sequenceInputData.Stage,
-			"service": *sequenceInputData.Service,
-			"labels":  *sequenceInputData.Labels,
-		}
 	}
+	eventData["project"] = *sequence.Project
+	eventData["stage"] = *sequence.Stage
+	eventData["service"] = *sequence.Service
+	eventData["labels"] = *sequence.Labels
 
 	sdkEvent := cloudevents.NewEvent()
 	sdkEvent.SetID(uuid.New().String())

--- a/cli/cmd/trigger_sequence.go
+++ b/cli/cmd/trigger_sequence.go
@@ -18,11 +18,12 @@ import (
 )
 
 type sequenceStruct struct {
-	Project *string            `json:"project"`
-	Service *string            `json:"service"`
-	Stage   *string            `json:"stage"`
-	Labels  *map[string]string `json:"labels"`
-	Data    *map[string]string `json:"data"`
+	Project  *string            `json:"project"`
+	Service  *string            `json:"service"`
+	Stage    *string            `json:"stage"`
+	Labels   *map[string]string `json:"labels"`
+	Data     *map[string]string `json:"data"`
+	DataFrom *string            `json:"data-from"`
 }
 
 var sequence = sequenceStruct{}
@@ -70,7 +71,13 @@ The name of the sequence has to be provided as an argument to the command. The s
 		return nil
 	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		if len(*sequence.Data) == 0 && (sequence.Project == nil || sequence.Stage == nil || sequence.Service == nil) {
+		// when user gives all event data from a file, then
+		// we do not validate any options
+		if sequence.DataFrom != nil {
+			return nil
+		}
+		// else we enfource --project/--stage/--service
+		if sequence.Project == nil || sequence.Stage == nil || sequence.Service == nil {
 			return fmt.Errorf("--project, --stage or --service option missing")
 		}
 		return nil

--- a/cli/cmd/trigger_sequence.go
+++ b/cli/cmd/trigger_sequence.go
@@ -169,6 +169,6 @@ func init() {
 	triggerSequenceCmd.MarkFlagRequired("stage")
 
 	sequence.Labels = triggerSequenceCmd.Flags().StringToStringP("labels", "l", nil, "Additional labels to be included in the event")
-	sequence.Data = triggerSequenceCmd.Flags().StringToStringP("data", "d", nil, "Comma sparated list of additional fields to be merged into the data block of the cloud event, e.g. --data test.strategy=direct,lorem.ipsum=yes")
+	sequence.Data = triggerSequenceCmd.Flags().StringToStringP("data", "d", nil, "Comma separated list of additional fields to be merged into the data block of the cloud event, e.g. --data test.strategy=direct,lorem.ipsum=yes")
 
 }

--- a/cli/cmd/trigger_sequence.go
+++ b/cli/cmd/trigger_sequence.go
@@ -18,12 +18,11 @@ import (
 )
 
 type sequenceStruct struct {
-	Project  *string            `json:"project"`
-	Service  *string            `json:"service"`
-	Stage    *string            `json:"stage"`
-	Labels   *map[string]string `json:"labels"`
-	Data     *map[string]string `json:"data"`
-	DataFrom *string            `json:"data-from"`
+	Project *string            `json:"project"`
+	Service *string            `json:"service"`
+	Stage   *string            `json:"stage"`
+	Labels  *map[string]string `json:"labels"`
+	Data    *map[string]string `json:"data"`
 }
 
 var sequence = sequenceStruct{}

--- a/cli/cmd/trigger_sequence.go
+++ b/cli/cmd/trigger_sequence.go
@@ -169,6 +169,6 @@ func init() {
 	triggerSequenceCmd.MarkFlagRequired("stage")
 
 	sequence.Labels = triggerSequenceCmd.Flags().StringToStringP("labels", "l", nil, "Additional labels to be included in the event")
-	sequence.Data = triggerSequenceCmd.Flags().StringToStringP("data", "d", nil, "Additional field data to be merged into da data block of the cloud event")
+	sequence.Data = triggerSequenceCmd.Flags().StringToStringP("data", "d", nil, "Comma sparated list of additional fields to be merged into the data block of the cloud event, e.g. --data test.strategy=direct,lorem.ipsum=yes")
 
 }

--- a/cli/cmd/trigger_sequence_test.go
+++ b/cli/cmd/trigger_sequence_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -115,6 +116,87 @@ func TestTriggerSequence(t *testing.T) {
 	select {
 	case <-receivedEvent:
 		t.Log("event has been sent successfully")
+		break
+	case <-time.After(5 * time.Second):
+		t.Error("event was not sent")
+	}
+}
+
+func TestTriggerSequenceWithCustomData(t *testing.T) {
+	credentialmanager.MockAuthCreds = true
+
+	receivedEvent := make(chan apimodels.KeptnContextExtendedCE)
+	ts := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(200)
+			if strings.Contains(r.RequestURI, "v1/event") {
+				defer r.Body.Close()
+				bytes, err := ioutil.ReadAll(r.Body)
+				if err != nil {
+					t.Errorf("could not read received event payload: %s", err.Error())
+				}
+				event := &apimodels.KeptnContextExtendedCE{}
+				if err := json.Unmarshal(bytes, event); err != nil {
+					t.Errorf("could not decode received event: %s", err.Error())
+				}
+				if *event.Type != keptnv2.GetTriggeredEventType("dev.hello") {
+					t.Errorf("did not receive correct event: %s", err.Error())
+				}
+				go func() {
+					receivedEvent <- *event
+				}()
+			} else if strings.Contains(r.RequestURI, "/v1/metadata") {
+				defer r.Body.Close()
+				w.Write([]byte(metadataMockResponse))
+				return
+			} else if strings.Contains(r.RequestURI, "service") {
+				res := fmt.Sprintf(getSvcMockResponseSequence, "demo")
+				w.Write([]byte(res))
+				return
+			} else if strings.Contains(r.RequestURI, "/controlPlane/v1/project/") {
+				res := fmt.Sprintf(getProjectMockResponseSequence, "hello-world", "demo", "dev")
+				w.Write([]byte(res))
+				return
+			}
+		}),
+	)
+	defer ts.Close()
+	t.Setenv("MOCK_SERVER", ts.URL)
+	cmd := fmt.Sprintf("trigger sequence %s --project=%s --service=%s --stage=%s --labels=key1=value1,key2=value2 --data=a.b=value,a.c=value2 --mock", "hello", "hello-world", "demo", "dev")
+	_, err := executeActionCommandC(cmd)
+
+	if err != nil {
+		t.Errorf(unexpectedErrMsg, err)
+	}
+
+	select {
+	case e := <-receivedEvent:
+		t.Log("event has been sent successfully")
+
+		type A struct {
+			B string `json:"b"`
+			C string `json:"c"`
+		}
+		type data struct {
+			Project string            `json:"project"`
+			Stage   string            `json:"stage"`
+			Service string            `json:"service"`
+			A       A                 `json:"a"`
+			Labels  map[string]string `json:"labels"`
+		}
+
+		var eventData data
+		m, _ := json.Marshal(e.Data)
+		json.Unmarshal(m, &eventData)
+		assert.Equal(t, "hello-world", eventData.Project)
+		assert.Equal(t, "dev", eventData.Stage)
+		assert.Equal(t, "demo", eventData.Service)
+		assert.Equal(t, "value", eventData.A.B)
+		assert.Equal(t, "value2", eventData.A.C)
+		assert.Equal(t, "value1", eventData.Labels["key1"])
+		assert.Equal(t, "value2", eventData.Labels["key2"])
+
 		break
 	case <-time.After(5 * time.Second):
 		t.Error("event was not sent")

--- a/cli/internal/textutils.go
+++ b/cli/internal/textutils.go
@@ -79,14 +79,17 @@ func JSONPathToJSONObj(input []string) (string, error) {
 				currentNode.AddChild(pathParts[i], child)
 				currentNode = child
 			} else {
-				currentNode = node.(*innerNode)
+				if cn, ok := node.(*innerNode); ok {
+					currentNode = cn
+				} else {
+					return "", fmt.Errorf("unable to map path part %s as the value is already bound to %s", pathParts[i], node.(*leafnode).value)
+				}
 			}
 		}
 		leaf := newLeafNode()
 		leaf.value = pathValuePair[1]
 		currentNode.AddChild(pathParts[len(pathParts)-1], leaf)
 	}
-
 	return root.String(), nil
 }
 

--- a/cli/internal/textutils.go
+++ b/cli/internal/textutils.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -87,4 +88,28 @@ func JSONPathToJSONObj(input []string) (string, error) {
 	}
 
 	return root.String(), nil
+}
+
+// UnfoldToMap takes a map of with keys of the form "a.b.c" and a value "v" each
+// and returns an "unfold" map containing map[a[b[c]]] = v
+func UnfoldMap(inMap map[string]string) (map[string]interface{}, error) {
+	if inMap == nil {
+		return map[string]interface{}{}, nil
+	}
+	var transformed []string
+	for path, value := range inMap {
+		transformed = append(transformed, path+"="+value)
+	}
+	s, err := JSONPathToJSONObj(transformed)
+	if err != nil {
+		return map[string]interface{}{}, err
+	}
+
+	var res map[string]interface{}
+	err = json.Unmarshal([]byte(s), &res)
+	if err != nil {
+		return map[string]interface{}{}, err
+	}
+
+	return res, nil
 }

--- a/cli/internal/textutils_test.go
+++ b/cli/internal/textutils_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"fmt"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -24,6 +25,52 @@ func Test_JSONPathToJSONObj(t *testing.T) {
 			out, err := JSONPathToJSONObj(tt.in)
 			assert.Equal(t, tt.out, out)
 			assert.Equal(t, tt.err, err != nil)
+		})
+	}
+}
+
+func TestUnfoldMap(t *testing.T) {
+	type args struct {
+		toAdd map[string]string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    map[string]interface{}
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "minimal event data",
+			args: args{
+				toAdd: map[string]string{"project": "pr", "stage": "st", "service": "sv"},
+			},
+			want:    map[string]interface{}{"project": "pr", "stage": "st", "service": "sv"},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "valid additional fields",
+			args: args{
+				toAdd: map[string]string{"project": "pr", "stage": "st", "service": "sv", "a.b": "value", "b.a": "othervalue"},
+			},
+			want:    map[string]interface{}{"project": "pr", "stage": "st", "service": "sv", "a": map[string]interface{}{"b": "value"}, "b": map[string]interface{}{"a": "othervalue"}},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "receive nil argument",
+			args: args{
+				toAdd: nil,
+			},
+			want:    map[string]interface{}{},
+			wantErr: assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := UnfoldMap(tt.args.toAdd)
+			if !tt.wantErr(t, err, fmt.Sprintf("AddToData(%v)", tt.args.toAdd)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "AddToData(%v)", tt.args.toAdd)
 		})
 	}
 }

--- a/cli/internal/textutils_test.go
+++ b/cli/internal/textutils_test.go
@@ -14,6 +14,7 @@ func Test_JSONPathToJSONObj(t *testing.T) {
 		out  string
 		err  bool
 	}{
+		{"0", []string{"a.b=v1", "a.b.c=v2"}, "", true},
 		{"1", []string{""}, "", true},
 		{"2", []string{"a.b.c=v1"}, `{"a":{"b":{"c":"v1"}}}`, false},
 		{"3", []string{"a.b.c=v", "a.b.d=v2"}, `{"a":{"b":{"c":"v","d":"v2"}}}`, false},
@@ -54,6 +55,14 @@ func TestUnfoldMap(t *testing.T) {
 			},
 			want:    map[string]interface{}{"project": "pr", "stage": "st", "service": "sv", "a": map[string]interface{}{"b": "value"}, "b": map[string]interface{}{"a": "othervalue"}},
 			wantErr: assert.NoError,
+		},
+		{
+			name: "valid additional fields",
+			args: args{
+				toAdd: map[string]string{"project": "pr", "stage": "st", "service": "sv", "a.b": "value", "b.a": "othervalue", "b.a.c": "myotherCvalue"},
+			},
+			want:    map[string]interface{}{},
+			wantErr: assert.Error,
 		},
 		{
 			name: "receive nil argument",


### PR DESCRIPTION
closes #8803 

This PR introduces the `--data` option for the `trigger sequence` command in order to pass custom data fields contained in the `data` block of the cloude event emmitted by the CLI.

e.g.:
```bash
trigger sequence mysequence --project=ultimate-echo-project --stage=first-stage --service=myservice --data=test.strategy=direct,evaluation.timeframe=5m
```
![image](https://user-images.githubusercontent.com/72415058/189110258-22588381-b4d3-40f8-8e67-19a31df35305.png)

Note that you cannot "overwrite" project,service,stage or labels with this.