### PR TITLE
fix(shipyard-controller): Adopt previous value of IsUpstreamAutoProvisioned when migrating project with old git credentials structure

### DIFF
--- a/shipyard-controller/internal/db/migration/project_credentials_migration_test.go
+++ b/shipyard-controller/internal/db/migration/project_credentials_migration_test.go
@@ -228,12 +228,13 @@ var projectOld = &models.ExpandedProjectOld{
 			},
 		},
 	},
-	GitRemoteURI:    "http://some-url2",
-	GitUser:         "user2",
-	InsecureSkipTLS: true,
-	GitProxyURL:     "url2",
-	GitProxyScheme:  "http2",
-	GitProxyUser:    "proxy-user2",
+	GitRemoteURI:              "http://some-url2",
+	GitUser:                   "user2",
+	InsecureSkipTLS:           true,
+	GitProxyURL:               "url2",
+	GitProxyScheme:            "http2",
+	GitProxyUser:              "proxy-user2",
+	IsUpstreamAutoProvisioned: true,
 }
 
 var projectOldToNew = &apimodels.ExpandedProject{
@@ -259,6 +260,7 @@ var projectOldToNew = &apimodels.ExpandedProject{
 			},
 		},
 	},
+	IsUpstreamAutoProvisioned: true,
 }
 
 func TestProjectCredentialsMigration_TransformNewModel(t *testing.T) {

--- a/shipyard-controller/internal/db/project_credentials_repo.go
+++ b/shipyard-controller/internal/db/project_credentials_repo.go
@@ -101,6 +101,7 @@ func TransformGitCredentials(project *models.ExpandedProjectOld) *apimodels.Expa
 			RemoteURL: project.GitRemoteURI,
 			User:      project.GitUser,
 		},
+		IsUpstreamAutoProvisioned: project.IsUpstreamAutoProvisioned,
 	}
 
 	if strings.HasPrefix(project.GitRemoteURI, "http") {

--- a/shipyard-controller/models/expanded_project_old.go
+++ b/shipyard-controller/models/expanded_project_old.go
@@ -41,6 +41,9 @@ type ExpandedProjectOld struct {
 	// insecure skip tls
 	InsecureSkipTLS bool `json:"insecureSkipTLS"`
 
+	// is upstream auto provisioned
+	IsUpstreamAutoProvisioned bool `json:"isUpstreamAutoProvisioned"`
+
 	// stages
 	Stages []*apimodels.ExpandedStage `json:"stages"`
 }


### PR DESCRIPTION
This PR fixes a problem where a project with `isUpstreamAutoProvisioned` set to true loses that value when it is migrated to use the new upstream git info structure