### PR TITLE
fix(shipyard-controller): Adapt mongodb query to be compatible with DocumentDB

### DIFF
--- a/shipyard-controller/internal/db/models/projects_mv/projects_mv.go
+++ b/shipyard-controller/internal/db/models/projects_mv/projects_mv.go
@@ -46,7 +46,7 @@ func (s *ServiceUpdate) GetBSONUpdate() (bson.D, error) {
 	changeSet := bson.M{}
 
 	if s.deployedImage != "" {
-		changeSet["stages.$.services.$[service].deployedImage"] = s.DeployedImage()
+		changeSet["stages.$[stage].services.$[service].deployedImage"] = s.DeployedImage()
 	}
 
 	if s.eventTypeUpdate != nil {
@@ -58,7 +58,7 @@ func (s *ServiceUpdate) GetBSONUpdate() (bson.D, error) {
 		if strings.Contains(s.eventTypeUpdate.EventType, ".") {
 			encodedEventType = dbcommon.EncodeKey(s.eventTypeUpdate.EventType)
 		}
-		changeSet["stages.$.services.$[service].lastEventTypes."+encodedEventType] = encodedEventInfo
+		changeSet["stages.$[stage].services.$[service].lastEventTypes."+encodedEventType] = encodedEventInfo
 	}
 
 	update := bson.D{

--- a/shipyard-controller/internal/db/models/projects_mv/projects_mv_test.go
+++ b/shipyard-controller/internal/db/models/projects_mv/projects_mv_test.go
@@ -25,8 +25,8 @@ func TestServiceUpdate_GetBSONUpdate(t *testing.T) {
 
 	expectedUpdate := bson.D{
 		{"$set", bson.M{
-			"stages.$.services.$[service].deployedImage": "my-image",
-			"stages.$.services.$[service].lastEventTypes.my~pevent~ptype": map[string]interface{}{
+			"stages.$[stage].services.$[service].deployedImage": "my-image",
+			"stages.$[stage].services.$[service].lastEventTypes.my~pevent~ptype": map[string]interface{}{
 				"eventId":      "my-event-id",
 				"keptnContext": "my-context-id",
 			},
@@ -47,7 +47,7 @@ func TestServiceUpdate_GetBSONOnlyDeployedImage(t *testing.T) {
 
 	expectedUpdate := bson.D{
 		{"$set", bson.M{
-			"stages.$.services.$[service].deployedImage": "my-image",
+			"stages.$[stage].services.$[service].deployedImage": "my-image",
 		}},
 	}
 
@@ -71,7 +71,7 @@ func TestServiceUpdate_GetBSONUpdateOnlyEventUpdate(t *testing.T) {
 
 	expectedUpdate := bson.D{
 		{"$set", bson.M{
-			"stages.$.services.$[service].lastEventTypes.my~pevent~ptype": map[string]interface{}{
+			"stages.$[stage].services.$[service].lastEventTypes.my~pevent~ptype": map[string]interface{}{
 				"eventId":      "my-event-id",
 				"keptnContext": "my-context-id",
 			},

--- a/shipyard-controller/internal/db/mongodb_project_repo.go
+++ b/shipyard-controller/internal/db/mongodb_project_repo.go
@@ -130,7 +130,6 @@ func (m *MongoDBProjectsRepo) UpdateProjectService(projectName, stageName, servi
 
 	filter := bson.D{
 		{"projectName", projectName},
-		//{"stages.stageName", stageName},
 	}
 
 	arrayFilter := options.FindOneAndUpdate().SetArrayFilters(options.ArrayFilters{

--- a/shipyard-controller/internal/db/mongodb_project_repo.go
+++ b/shipyard-controller/internal/db/mongodb_project_repo.go
@@ -130,12 +130,13 @@ func (m *MongoDBProjectsRepo) UpdateProjectService(projectName, stageName, servi
 
 	filter := bson.D{
 		{"projectName", projectName},
-		{"stages.stageName", stageName},
+		//{"stages.stageName", stageName},
 	}
 
 	arrayFilter := options.FindOneAndUpdate().SetArrayFilters(options.ArrayFilters{
 		Filters: []interface{}{
 			bson.M{"service.serviceName": serviceName},
+			bson.M{"stage.stageName": stageName},
 		},
 	})
 

--- a/shipyard-controller/internal/db/mongodb_project_repo_test.go
+++ b/shipyard-controller/internal/db/mongodb_project_repo_test.go
@@ -153,6 +153,9 @@ func TestMongoDBProjectsRepo_UpdateProjectService(t *testing.T) {
 
 	require.Empty(t, projectInfo.Stages[0].Services[1].DeployedImage)
 	require.Empty(t, projectInfo.Stages[0].Services[1].LastEventTypes)
+
+	require.Empty(t, projectInfo.Stages[1].Services[0].DeployedImage)
+	require.Empty(t, projectInfo.Stages[1].Services[0].LastEventTypes)
 }
 
 func TestMongoDBKeyEncodingProjectsRepo_UpdateProjectService(t *testing.T) {


### PR DESCRIPTION
In DocumentDB, queries containing both `$`  and `$[<identifier>]` selectors are not supported. This PR changes the query to update a service within a project accordingly