### PR TITLE
ci: Make helm build dependent on container build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -321,7 +321,7 @@ jobs:
   ############################################################################
   helm_charts_build:
     name: Build Helm Charts
-    needs: prepare_ci_run
+    needs: [prepare_ci_run, unit-tests-and-build]
     if: (needs.prepare_ci_run.outputs.BUILD_EVERYTHING == 'true') || (needs.prepare_ci_run.outputs.BUILD_INSTALLER == 'true')
     uses: ./.github/workflows/build-helm-charts.yml
     secrets: inherit


### PR DESCRIPTION
### This PR
- makes the helm chart build dependent on the docker image builds.
- This will ensure that the image timestamps used in the helm chart are equals to the ones that are pushed in the docker build step before.