### PR TITLE
ci: Move to new way of setting env var in workflows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -147,7 +147,7 @@ jobs:
         id: build_everything
         run: |
           BUILD_EVERYTHING=true
-          echo "##[set-output name=BUILD_EVERYTHING;]$(echo ${BUILD_EVERYTHING})"
+          echo "BUILD_EVERYTHING=$(echo ${BUILD_EVERYTHING})" >> $GITHUB_ENV
 
       - name: Prepare artifacts with changes
         id: check_modified_files
@@ -196,21 +196,21 @@ jobs:
           echo "VERSION=${VERSION}"
           echo "KEPTN_SPEC_VERSION=${KEPTN_SPEC_VERSION}"
 
-          echo "::set-output name=VERSION::${VERSION}"
-          echo "::set-output name=KEPTN_SPEC_VERSION::${KEPTN_SPEC_VERSION}"
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "KEPTN_SPEC_VERSION=${KEPTN_SPEC_VERSION}" >> $GITHUB_ENV
       - name: Get current date and time
         id: get_datetime
         env:
           GO_VERSION: ${{ env.GO_VERSION }}
         run: |
-          echo "::set-output name=DATE::$(date +'%Y%m%d')"
-          echo "::set-output name=TIME::$(date +'%H%M')"
-          echo "::set-output name=DATETIME::$(date +'%Y%m%d')$(date +'%H%M')"
+          echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
+          echo "TIME=$(date +'%H%M')" >> $GITHUB_ENV
+          echo "DATETIME=$(date +'%Y%m%d')$(date +'%H%M')" >> $GITHUB_ENV
 
       - name: Get GO-Version
         id: get_go_version
         run: |
-          echo "::set-output name=GO_VERSION::$GO_VERSION"
+          echo "GO_VERSION=$GO_VERSION" >> $GITHUB_ENV
 
   store-output-in-build-config:
     name: "Store output of last step in build-config.env"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -149,7 +149,7 @@ jobs:
             fi
           fi
 
-          echo "##[set-output name=BRANCH;]$(echo ${BRANCH})"
+          echo "BRANCH=$(echo ${BRANCH})" >> $GITHUB_ENV
 
       - name: Find latest successful run ID
         id: last_run_id
@@ -167,7 +167,7 @@ jobs:
               (.head_commit != null) and (.head_commit.author.name | endswith("[bot]") | not ) and ( .conclusion == "success" ) 
             )][0] | .id')
           echo "Run ID that will be used to download artifacts from: $RUN_ID"
-          echo "::set-output name=RUN_ID::$RUN_ID"
+          echo "RUN_ID=$RUN_ID" >> $GITHUB_ENV
 
       # download artifacts from the specified branch with event type push (e.g., push to master/release branch)
       - name: Download all artifacts from last successful build of specified branch
@@ -215,7 +215,7 @@ jobs:
           ls dist/keptn-installer/*.tgz # debug output
           HELM_CHART_NAME=$(ls dist/keptn-installer/keptn*.tgz)
 
-          echo "##[set-output name=HELM_CHART_NAME;]$(echo ${HELM_CHART_NAME})"
+          echo "HELM_CHART_NAME=$(echo ${HELM_CHART_NAME})" >> $GITHUB_ENV
 
       # setup cloud provider kubernetes instance
       - name: Install and start Minishift
@@ -424,7 +424,7 @@ jobs:
           fi
           KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n ${KEPTN_NAMESPACE} -ojsonpath={.data.keptn-api-token} | base64 --decode)
           echo "KEPTN_ENDPOINT=${KEPTN_ENDPOINT}"
-          echo "##[set-output name=KEPTN_ENDPOINT;]$(echo ${KEPTN_ENDPOINT})"
+          echo "KEPTN_ENDPOINT=$(echo ${KEPTN_ENDPOINT})" >> $GITHUB_ENV
 
       - name: Prepare test run
         id: prepare_test_run
@@ -800,7 +800,7 @@ jobs:
             echo "" >> integration-tests-failed.md
             echo "Note: This issue was auto-generated from [integration_tests.yml](.github/workflows/integration_tests.yml)" >> integration-tests-failed.md
 
-            echo "##[set-output name=INTEGRATION_TESTS_FAILED;]true"
+            echo "INTEGRATION_TESTS_FAILED=true" >> $GITHUB_ENV
           else
             echo "Integration tests passed, moving on..."
           fi

--- a/.github/workflows/mongodb-version-check.yml
+++ b/.github/workflows/mongodb-version-check.yml
@@ -25,14 +25,14 @@ jobs:
       id: get_keptn_mongodb_version
       run: |
         MONGODB_VERSION=$(cd ./installer/manifests/keptn/ && helm dependency list | grep -e "mongodb" | awk '{print $2}')
-        echo "::set-output name=MONGODB_VERSION::$MONGODB_VERSION"
+        echo "MONGODB_VERSION=$MONGODB_VERSION" >> $GITHUB_ENV
   
     - name: "Get latest Bitnami/MongoDB version"
       id: get_bitnami_mongodb_version
       run: |
         helm repo add bitnami https://charts.bitnami.com/bitnami
         MONGODB_VERSION=$(helm search repo bitnami | grep -e "mongodb " | awk '{print $2}')
-        echo "::set-output name=MONGODB_VERSION::$MONGODB_VERSION"
+        echo "MONGODB_VERSION=$MONGODB_VERSION" >> $GITHUB_ENV
 
     - name: "Compare MongoDB Chart versions"
       id: compare_mongodb_versions
@@ -44,7 +44,7 @@ jobs:
         if [[ "$KEPTN_VERSION" != "$BITNAMI_VERSION" ]]; then
           CREATE_ISSUE=true
         fi
-        echo "::set-output name=CREATE_ISSUE::$CREATE_ISSUE"
+        echo "CREATE_ISSUE=$CREATE_ISSUE" >> $GITHUB_ENV
 
   create_issue:
     name: Create GitHub Issue

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -126,9 +126,9 @@ jobs:
       - name: Get current date and time
         id: get_datetime
         run: |
-          echo "::set-output name=DATE::$(date +'%Y%m%d')"
-          echo "::set-output name=TIME::$(date +'%H%M')"
-          echo "::set-output name=DATETIME::$(date +'%Y%m%d')$(date +'%H%M')"
+          echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
+          echo "TIME=$(date +'%H%M')" >> $GITHUB_ENV
+          echo "DATETIME=$(date +'%Y%m%d')$(date +'%H%M')" >> $GITHUB_ENV
 
       - name: Find next version number
         id: version_number
@@ -151,14 +151,14 @@ jobs:
           fi
 
           NEXT_VERSION=$(cat VERSION.txt)
-          echo "::set-output name=next-version::${NEXT_VERSION}"
+          echo "next-version=${NEXT_VERSION}" >> $GITHUB_ENV
           git checkout HEAD -- VERSION.txt
 
       - name: Find current branch
         id: current_branch
         run: |
           branch=${GITHUB_REF#refs/heads/}
-          echo "::set-output name=branch::${branch}"
+          echo "branch=${branch}" >> $GITHUB_ENV
 
       - name: Get keptn spec version
         id: keptn_spec_version
@@ -166,14 +166,14 @@ jobs:
           git submodule update --init
           cd specification
           KEPTN_SPEC_VERSION=$(git describe --tags)
-          echo "::set-output name=keptn-spec-version::${KEPTN_SPEC_VERSION}"
+          echo "keptn-spec-version=${KEPTN_SPEC_VERSION}" >> $GITHUB_ENV
 
       - name: Get GO-Version
         id: get_go_version
         env:
           GO_VERSION: ${{ env.GO_VERSION }}
         run: |
-          echo "::set-output name=GO_VERSION::$GO_VERSION"
+          echo "GO_VERSION=$GO_VERSION" >> $GITHUB_ENV
 
       - name: Prepare artifact build matrix
         id: check_modified_files
@@ -328,7 +328,7 @@ jobs:
               --skip.changelog
           fi
 
-          echo "::set-output name=tag-name::$(git describe --tags --abbrev=0)"
+          echo "tag-name=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
 
           echo "⚡️ Pushing changes to remote repository..."
           git push --follow-tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,9 +126,9 @@ jobs:
       - name: Get current date and time
         id: get_datetime
         run: |
-          echo "::set-output name=DATE::$(date +'%Y%m%d')"
-          echo "::set-output name=TIME::$(date +'%H%M')"
-          echo "::set-output name=DATETIME::$(date +'%Y%m%d')$(date +'%H%M')"
+          echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
+          echo "TIME=$(date +'%H%M')" >> $GITHUB_ENV
+          echo "DATETIME=$(date +'%Y%m%d')$(date +'%H%M')" >> $GITHUB_ENV
 
       - name: Find next version number
         id: version_number
@@ -149,14 +149,14 @@ jobs:
           fi
 
           NEXT_VERSION=$(cat VERSION.txt)
-          echo "::set-output name=next-version::${NEXT_VERSION}"
+          echo "next-version=${NEXT_VERSION}" >> $GITHUB_ENV
           git checkout HEAD -- VERSION.txt
 
       - name: Find current branch
         id: current_branch
         run: |
           branch=${GITHUB_REF#refs/heads/}
-          echo "::set-output name=branch::${branch}"
+          echo "branch=${branch}" >> $GITHUB_ENV
 
       - name: Get keptn spec version
         id: keptn_spec_version
@@ -164,14 +164,14 @@ jobs:
           git submodule update --init
           cd specification
           KEPTN_SPEC_VERSION=$(git describe --tags)
-          echo "::set-output name=keptn-spec-version::${KEPTN_SPEC_VERSION}"
+          echo "keptn-spec-version=${KEPTN_SPEC_VERSION}" >> $GITHUB_ENV
 
       - name: Get GO-Version
         id: get_go_version
         env:
           GO_VERSION: ${{ env.GO_VERSION }}
         run: |
-          echo "::set-output name=GO_VERSION::$GO_VERSION"
+          echo "GO_VERSION=$GO_VERSION" >> $GITHUB_ENV
 
       - name: Prepare artifact build matrix
         id: check_modified_files
@@ -323,7 +323,7 @@ jobs:
             npx standard-version@^9.3.1
           fi
 
-          echo "::set-output name=tag-name::$(git describe --tags --abbrev=0)"
+          echo "tag-name=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
 
           echo "Fetching previously deleted old tags..."
           git fetch origin --tags -f

--- a/.github/workflows/test-and-build-docker-images.yml
+++ b/.github/workflows/test-and-build-docker-images.yml
@@ -88,7 +88,7 @@ jobs:
       id: yarn-cache-dir-path
       if: inputs.artifact == 'bridge2'
       working-directory: bridge
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_ENV
     
     - name: Setup yarn cache
       uses: actions/cache@v3

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -101,7 +101,7 @@ jobs:
             BRANCH=$(echo "${STR%.*}.x")
           fi
 
-          echo "##[set-output name=BRANCH;]$(echo ${BRANCH})"
+          echo "BRANCH=$(echo ${BRANCH})" >> $GITHUB_ENV
 
       - name: Find latest successful run ID
         id: last_run_id
@@ -119,7 +119,7 @@ jobs:
               (.head_commit != null) and (.head_commit.author.name | endswith("[bot]") | not ) and ( .conclusion == "success" )
             )][0] | .id')
           echo "Run ID that will be used to download artifacts from: $RUN_ID"
-          echo "::set-output name=RUN_ID::$RUN_ID"
+          echo "RUN_ID=$RUN_ID" >> $GITHUB_ENV
 
           
 
@@ -168,7 +168,7 @@ jobs:
         run: |
           ls dist/keptn-installer/*.tgz # debug output
           HELM_CHART_NAME=$(ls dist/keptn-installer/keptn*.tgz)
-          echo "##[set-output name=HELM_CHART_NAME;]$(echo ${HELM_CHART_NAME})"
+          echo "HELM_CHART_NAME=$(echo ${HELM_CHART_NAME})" >> $GITHUB_ENV
 
       - name: Setup upgrade charts
         id: setup_upgrade_charts
@@ -278,7 +278,7 @@ jobs:
 
           KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n ${KEPTN_NAMESPACE} -ojsonpath={.data.keptn-api-token} | base64 --decode)
           echo "KEPTN_ENDPOINT=${KEPTN_ENDPOINT}"
-          echo "##[set-output name=KEPTN_ENDPOINT;]$(echo ${KEPTN_ENDPOINT})"
+          echo "KEPTN_ENDPOINT=$(echo ${KEPTN_ENDPOINT})" >> $GITHUB_ENV
 
       - name: Set up gotestfmt
         uses: haveyoudebuggedit/gotestfmt-action@v2.0.0
@@ -366,7 +366,7 @@ jobs:
           
           FINAL=$(cat temp_res/test-summary.md) 
           echo "$FINAL" >>  $GITHUB_STEP_SUMMARY
-          echo "##[set-output name=FINAL;]$(echo ${FINAL})"
+          echo "FINAL=$(echo ${FINAL})" >> $GITHUB_ENV
 
       - name: Generate Github Summary
         if: always()


### PR DESCRIPTION
### This PR
- changes all occurrences where environment variables are set during runtime in all workflows to the new way of setting them

Closes #9008 

Reference: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/