### PR TITLE
test: Fix timeout problem in check for sequence state

### DIFF
--- a/shipyard-controller/main_test.go
+++ b/shipyard-controller/main_test.go
@@ -830,6 +830,10 @@ func Test__main_SequenceStateParallelStages(t *testing.T) {
 		if states == nil || len(states.States) == 0 {
 			return false
 		}
+		state := states.States[0]
+		if len(state.Stages) == 0 {
+			return false
+		}
 		return true
 	}, 10*time.Second, 100*time.Millisecond)
 


### PR DESCRIPTION
This PR should fix the flakyness of the parallel stages test in the shipyard controller's component tests