### PR TITLE
fix: Add `CD` optional to bridge installation type via helm

### DIFF
--- a/installer/manifests/keptn/templates/core.yaml
+++ b/installer/manifests/keptn/templates/core.yaml
@@ -115,7 +115,7 @@ spec:
             - name: SHOW_API_TOKEN
               value: "{{ .Values.bridge.showApiToken.enabled }}"
             - name: KEPTN_INSTALLATION_TYPE
-              value: "{{ .Values.bridge.installationType |default (print "QUALITY_GATES,CONTINUOUS_OPERATIONS") }}"
+              value: "{{ .Values.bridge.installationType |default (print "QUALITY_GATES,CONTINUOUS_OPERATIONS,CONTINUOUS_DELIVERY") }}"
             - name: LOOK_AND_FEEL_URL
               value: "{{ .Values.bridge.lookAndFeelUrl |default (print "") }}"
             - name: PREFIX_PATH


### PR DESCRIPTION
Signed-off-by: afzal442 <afzal442@gmail.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->
adds `CONTINUOUS DELIVERY` optional to bridge installiation type via helm

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #8801 

### Notes
<!-- any additional notes for this PR -->
Docs contains the `helm` installation type [here](https://keptn.sh/docs/quickstart/#helm)
### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

