### PR TITLE
fix(bridge): Show correct border color for task items in sequence view

### DIFF
--- a/bridge/client/app/_components/ktb-expandable-tile/ktb-expandable-tile.component.scss
+++ b/bridge/client/app/_components/ktb-expandable-tile/ktb-expandable-tile.component.scss
@@ -62,19 +62,19 @@
     background-color: $gray-100;
   }
 
-  &.ktb-tile-error .ktb-expandable-tile-container {
+  &.ktb-tile-error > .ktb-expandable-tile-container {
     border-color: $error-color;
   }
 
-  &.ktb-tile-warning .ktb-expandable-tile-container {
+  &.ktb-tile-warning > .ktb-expandable-tile-container {
     border-color: $warning-color;
   }
 
-  &.ktb-tile-success .ktb-expandable-tile-container {
+  &.ktb-tile-success > .ktb-expandable-tile-container {
     border-color: $cta-color;
   }
 
-  &.ktb-tile-highlight .ktb-expandable-tile-container {
+  &.ktb-tile-highlight > .ktb-expandable-tile-container {
     border-color: $approval-color;
   }
 }

--- a/bridge/cypress/fixtures/sequence.traces.mock.json
+++ b/bridge/cypress/fixtures/sequence.traces.mock.json
@@ -369,6 +369,37 @@
       "type": "sh.keptn.event.get-sli.finished"
     },
     {
+      "type": "sh.keptn.event.webhook.finished",
+      "data": {
+        "project": "sockshop",
+        "service": "carts",
+        "stage": "staging",
+        "result": "pass"
+      },
+      "id": "bf4ea320-7694-48b4-952d-31acad20f172",
+      "shkeptncontext": "62cca6f3-dc54-4df6-a04c-6ffc894a4b5e",
+      "shkeptnspecversion": "0.2.3",
+      "source": "webhook-service",
+      "specversion": "1.0",
+      "time": "2022-01-17T11:43:18.510Z",
+      "triggeredid": "bb573001-20f0-4e40-805e-aaed5e890fb2"
+    },
+    {
+      "type": "sh.keptn.event.webhook.started",
+      "data": {
+        "project": "sockshop",
+        "service": "carts",
+        "stage": "staging"
+      },
+      "id": "bf4ea320-7694-48b4-952d-31acad20f172",
+      "shkeptncontext": "62cca6f3-dc54-4df6-a04c-6ffc894a4b5e",
+      "shkeptnspecversion": "0.2.3",
+      "source": "webhook-service",
+      "specversion": "1.0",
+      "time": "2022-01-17T11:43:18.000Z",
+      "triggeredid": "bb573001-20f0-4e40-805e-aaed5e890fb2"
+    },
+    {
       "data": {
         "deployment": "canary",
         "get-sli": {

--- a/bridge/cypress/integration/sequences.spec.ts
+++ b/bridge/cypress/integration/sequences.spec.ts
@@ -445,5 +445,16 @@ describe('Sequences', () => {
         .selectSequence(keptnContext)
         .assertSequenceDeepLink(project, keptnContext, 'production');
     });
+
+    it('should still show green border around task item if sequence passed even if a subtasked failed', () => {
+      const project = 'sockshop';
+      const keptnContext = '62cca6f3-dc54-4df6-a04c-6ffc894a4b5e';
+
+      sequencePage.visit(project).selectSequence(keptnContext, 'staging');
+      cy.wait('@sequenceTraces');
+
+      sequencePage.assertExpandableTileColor('get-sli', 'error');
+      sequencePage.assertExpandableTileColor('delivery', 'success');
+    });
   });
 });

--- a/bridge/cypress/support/pageobjects/SequencesPage.ts
+++ b/bridge/cypress/support/pageobjects/SequencesPage.ts
@@ -413,4 +413,13 @@ export class SequencesPage {
     }
     return this;
   }
+
+  public assertExpandableTileColor(tileName: string, state: string): this {
+    cy.get('ktb-task-item')
+      .contains(tileName)
+      .parentsUntil('ktb-task-item')
+      .last()
+      .should('have.class', `ktb-tile-${state}`);
+    return this;
+  }
 }

--- a/bridge/shared/models/trace.ts
+++ b/bridge/shared/models/trace.ts
@@ -227,10 +227,8 @@ export class Trace {
 
   public isFaulty(stageName?: string): boolean {
     let result = false;
-    if (this.data) {
-      if (this.isFailed()) {
-        result = stageName ? this.data.stage === stageName : true;
-      }
+    if (this.data && this.isFailed()) {
+      result = stageName ? this.data.stage === stageName : true;
     }
     return result;
   }

--- a/bridge/shared/models/trace.ts
+++ b/bridge/shared/models/trace.ts
@@ -254,7 +254,7 @@ export class Trace {
   }
 
   public getFinishedEvent<T extends Trace>(this: T): T | undefined {
-    return (this.isFinishedEvent() ? this : this.traces.find((t) => t.isFinishedEvent())) as T;
+    return (this.isFinishedEvent() ? this : this.traces.find((t) => t.isFinishedEvent(this.getShortType()))) as T;
   }
 
   private isDeclined(): boolean {
@@ -328,8 +328,8 @@ export class Trace {
     return this.type.endsWith('.changed');
   }
 
-  public isFinishedEvent(): boolean {
-    return this.type.endsWith('.finished');
+  public isFinishedEvent(shortType?: string): boolean {
+    return this.type.endsWith(`${shortType ?? ''}.finished`);
   }
 
   public isStartedEvent(): boolean {

--- a/bridge/shared/models/trace.ts
+++ b/bridge/shared/models/trace.ts
@@ -228,7 +228,7 @@ export class Trace {
   public isFaulty(stageName?: string): boolean {
     let result = false;
     if (this.data) {
-      if (this.isFailed() || this.traces.some((t) => t.isFaulty())) {
+      if (this.isFailed()) {
         result = stageName ? this.data.stage === stageName : true;
       }
     }


### PR DESCRIPTION
## This PR

- Fixes problem with incorrect color being displayed if one subtask fails, but the task passes.

### Related Issues

Resolves #9054 

## Notes

![Screenshot from 2022-11-02 14-46-47](https://user-images.githubusercontent.com/36239763/199505903-c56a3226-affc-40aa-af36-c0003eebc8e4.png)

Signed-off-by: gilbert.tanner <gilbert.tanner@dynatrace.com>
