### PR TITLE
feat(bridge): Added autofocus to deletion dialog input field

### DIFF
--- a/bridge/client/app/_components/_dialogs/ktb-deletion-dialog/ktb-deletion-dialog.component.html
+++ b/bridge/client/app/_components/_dialogs/ktb-deletion-dialog/ktb-deletion-dialog.component.html
@@ -15,11 +15,12 @@
   <div class="mb-2" *ngIf="data.name">
     <dt-form-field>
       <input
-        autofocus
         [formControl]="deletionConfirmationControl"
         class="wide-input"
         type="text"
         dtInput
+        #formInput
+        (keyup.enter)="deleteConfirm()"
         [placeholder]="data.name"
       />
     </dt-form-field>

--- a/bridge/client/app/_components/_dialogs/ktb-deletion-dialog/ktb-deletion-dialog.component.spec.ts
+++ b/bridge/client/app/_components/_dialogs/ktb-deletion-dialog/ktb-deletion-dialog.component.spec.ts
@@ -138,6 +138,7 @@ describe('KtbDeletionDialogComponent', () => {
     // given
     eventService = TestBed.inject(EventService);
     const spy = jest.spyOn(eventService.deletionTriggeredEvent, 'next');
+    component.deletionConfirmationForm.setValue({ deletionConfirmation: 'sockshop' });
 
     // when
     component.deleteConfirm();

--- a/bridge/client/app/_components/_dialogs/ktb-deletion-dialog/ktb-deletion-dialog.component.ts
+++ b/bridge/client/app/_components/_dialogs/ktb-deletion-dialog/ktb-deletion-dialog.component.ts
@@ -1,4 +1,13 @@
-import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
+import {
+  AfterViewInit,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  Inject,
+  OnDestroy,
+  OnInit,
+  ViewChild,
+} from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { DeleteData, DeleteResult } from '../../../_interfaces/delete';
@@ -11,7 +20,7 @@ import { Subject } from 'rxjs';
   templateUrl: './ktb-deletion-dialog.component.html',
   styleUrls: [],
 })
-export class KtbDeletionDialogComponent implements OnInit, OnDestroy {
+export class KtbDeletionDialogComponent implements OnInit, OnDestroy, AfterViewInit {
   private unsubscribe$ = new Subject<void>();
   public isDeleteInProgress$ = this.eventService.deletionProgressEvent
     .asObservable()
@@ -21,11 +30,13 @@ export class KtbDeletionDialogComponent implements OnInit, OnDestroy {
   public deletionConfirmationForm = new FormGroup({
     deletionConfirmation: this.deletionConfirmationControl,
   });
+  @ViewChild('formInput') formInput: ElementRef | undefined;
 
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: DeleteData,
     public dialogRef: MatDialogRef<KtbDeletionDialogComponent>,
-    private eventService: EventService
+    private eventService: EventService,
+    private _changeDetectorRef: ChangeDetectorRef
   ) {}
 
   ngOnInit(): void {
@@ -40,12 +51,17 @@ export class KtbDeletionDialogComponent implements OnInit, OnDestroy {
     });
   }
 
+  ngAfterViewInit(): void {
+    this.formInput?.nativeElement.focus();
+    this._changeDetectorRef.detectChanges();
+  }
+
   ngOnDestroy(): void {
     this.unsubscribe$.next();
     this.unsubscribe$.complete();
   }
 
   public deleteConfirm(): void {
-    this.eventService.deletionTriggeredEvent.next(this.data);
+    if (this.deletionConfirmationForm.valid) this.eventService.deletionTriggeredEvent.next(this.data);
   }
 }

--- a/bridge/cypress/integration/project-delete.spec.ts
+++ b/bridge/cypress/integration/project-delete.spec.ts
@@ -16,4 +16,14 @@ describe('Project delete test', () => {
       .submitDelete();
     dashboardPage.assertIsValidPath();
   });
+
+  it('should be possible to delete project by pressing enter after typing project name', () => {
+    dashboardPage.intercept();
+    projectSettingsPage
+      .interceptSettings()
+      .visitSettings('sockshop')
+      .clickDeleteProjectButton()
+      .deleteByEnter('sockshop');
+    dashboardPage.assertIsValidPath();
+  });
 });

--- a/bridge/cypress/support/pageobjects/ProjectSettingsPage.ts
+++ b/bridge/cypress/support/pageobjects/ProjectSettingsPage.ts
@@ -451,6 +451,12 @@ class ProjectSettingsPage {
     cy.get('span.dt-button-label').contains('I understand the consequences, delete this project').click();
     return this;
   }
+
+  public deleteByEnter(projectName: string): this {
+    const projectInputLoc = 'input[placeholder=proj_pattern]';
+    cy.get(projectInputLoc.replace('proj_pattern', projectName)).type(`${projectName}{enter}`);
+    return this;
+  }
 }
 
 export default ProjectSettingsPage;


### PR DESCRIPTION
## This PR

- Added autofocus to deletion dialog input field
- Added onEnter delete functionality (only active if the project name was provided correctly)

### Related Issues

Resolves #7521

### Notes

https://user-images.githubusercontent.com/36239763/196683836-6f30399a-18dc-4815-b09c-f303861d760e.mp4

Signed-off-by: gilbert.tanner <gilbert.tanner@dynatrace.com>
