### PR TITLE
chore: add bradmccoydev as maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -29,6 +29,7 @@ Anna Reale, @RealAnna, Dynatrace
 Ondrej Dubaj, @odubajDT, Dynatrace
 Oleg Nenashev, @oleg-nenashev, Dynatrace/CDF/Jenkins
 Thomas Schuetz, @thschue, Dynatrace
+Brad McCoy, @bradmccoydev, Basiq/CDF
 
 # Approvers
 
@@ -52,5 +53,4 @@ Suraj Banakar, @vadasambar, No Affiliation
 Sarah Huber, @sarahhuber001, Dynatrace
 Adam Gardner, @agardnerIT, Dynatrace
 Philipp Hinteregger, @philipp-hinteregger, Dynatrace
-Brad McCoy, @bradmccoydev, Basiq/CDF
 David Hirsch, @DavidPHirsch, Dynatrace


### PR DESCRIPTION
Add @bradmccoydev as maintainer as per issue: https://github.com/keptn/community/issues/175

Signed-off-by: Brad McCoy <bradmccoydev@gmail.com>

