### PR TITLE
fix(shipyard-controller): Return 4xx error responses for upstream repository problems

### DIFF
--- a/shipyard-controller/internal/common/error.go
+++ b/shipyard-controller/internal/common/error.go
@@ -23,6 +23,8 @@ var ErrProjectNotFound = errors.New("project not found")
 
 var ErrInvalidStageChange = errors.New("stage name cannot be changed or removed")
 
+var ErrAlreadyInitializedRepository = errors.New("upstream repository already initialized")
+
 var ErrStageNotFound = errors.New("stage not found")
 
 var ErrChangesRollback = errors.New("failed to rollback changes")
@@ -88,3 +90,5 @@ var UnableProvisionDeleteReq = "Error creating delete provision request: %s"
 var UnableProvisionPostReq = "Error creating post provision request: %s"
 
 var OtherActiveSequencesRunning = "Other sequences are currently running in the same stage for the same service with context id: "
+
+var AlreadyInitializedRepositoryMsg = "Project already exists with an already initialized GIT repository"

--- a/shipyard-controller/internal/common/error.go
+++ b/shipyard-controller/internal/common/error.go
@@ -23,7 +23,7 @@ var ErrProjectNotFound = errors.New("project not found")
 
 var ErrInvalidStageChange = errors.New("stage name cannot be changed or removed")
 
-var ErrAlreadyInitializedRepository = errors.New("upstream repository already initialized")
+var ErrAlreadyInitializedRepository = errors.New("project already exists with an already initialized GIT repository")
 
 var ErrStageNotFound = errors.New("stage not found")
 
@@ -90,5 +90,3 @@ var UnableProvisionDeleteReq = "Error creating delete provision request: %s"
 var UnableProvisionPostReq = "Error creating post provision request: %s"
 
 var OtherActiveSequencesRunning = "Other sequences are currently running in the same stage for the same service with context id: "
-
-var AlreadyInitializedRepositoryMsg = "Project already exists with an already initialized GIT repository"

--- a/shipyard-controller/internal/common/error.go
+++ b/shipyard-controller/internal/common/error.go
@@ -23,8 +23,6 @@ var ErrProjectNotFound = errors.New("project not found")
 
 var ErrInvalidStageChange = errors.New("stage name cannot be changed or removed")
 
-var ErrAlreadyInitializedRepository = errors.New("project already exists with an already initialized GIT repository")
-
 var ErrStageNotFound = errors.New("stage not found")
 
 var ErrChangesRollback = errors.New("failed to rollback changes")
@@ -90,3 +88,5 @@ var UnableProvisionDeleteReq = "Error creating delete provision request: %s"
 var UnableProvisionPostReq = "Error creating post provision request: %s"
 
 var OtherActiveSequencesRunning = "Other sequences are currently running in the same stage for the same service with context id: "
+
+var AlreadyInitializedRepositoryMsg = "Project already exists with an already initialized GIT repository"

--- a/shipyard-controller/internal/handler/common.go
+++ b/shipyard-controller/internal/handler/common.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/gin-gonic/gin"
+	"github.com/keptn/keptn/shipyard-controller/internal/common"
 	"github.com/keptn/keptn/shipyard-controller/models"
 )
 
@@ -79,4 +81,33 @@ func DecodeInputData(body io.ReadCloser, params any) error {
 		return err
 	}
 	return nil
+}
+
+func mapError(c *gin.Context, err error) {
+	if errors.Is(err, common.ErrProjectAlreadyExists) {
+		SetConflictErrorResponse(c, err.Error())
+		return
+	}
+	if err.Error() == common.AlreadyInitializedRepositoryMsg {
+		SetConflictErrorResponse(c, err.Error())
+		return
+	}
+	if errors.Is(err, common.ErrConfigStoreUpstreamNotFound) {
+		SetNotFoundErrorResponse(c, err.Error())
+		return
+	}
+	if errors.Is(err, common.ErrConfigStoreInvalidToken) {
+		SetFailedDependencyErrorResponse(c, err.Error())
+		return
+	}
+	if errors.Is(err, common.ErrProjectNotFound) {
+		SetNotFoundErrorResponse(c, err.Error())
+		return
+	}
+	if errors.Is(err, common.ErrInvalidStageChange) {
+		SetBadRequestErrorResponse(c, err.Error())
+		return
+	}
+	SetInternalServerErrorResponse(c, err.Error())
+	return
 }

--- a/shipyard-controller/internal/handler/common.go
+++ b/shipyard-controller/internal/handler/common.go
@@ -88,7 +88,7 @@ func mapError(c *gin.Context, err error) {
 		SetConflictErrorResponse(c, err.Error())
 		return
 	}
-	if err.Error() == common.AlreadyInitializedRepositoryMsg {
+	if strings.Contains(err.Error(), common.AlreadyInitializedRepositoryMsg) {
 		SetConflictErrorResponse(c, err.Error())
 		return
 	}

--- a/shipyard-controller/internal/handler/common.go
+++ b/shipyard-controller/internal/handler/common.go
@@ -84,6 +84,9 @@ func DecodeInputData(body io.ReadCloser, params any) error {
 }
 
 func mapError(c *gin.Context, err error) {
+	if err == nil {
+		return
+	}
 	if errors.Is(err, common.ErrProjectAlreadyExists) {
 		SetConflictErrorResponse(c, err.Error())
 		return

--- a/shipyard-controller/internal/handler/projecthandler.go
+++ b/shipyard-controller/internal/handler/projecthandler.go
@@ -346,7 +346,7 @@ func (ph *ProjectHandler) CreateProject(c *gin.Context) {
 			SetConflictErrorResponse(c, err.Error())
 			return
 		}
-		if errors.Is(err, common.ErrAlreadyInitializedRepository) {
+		if err.Error() == common.AlreadyInitializedRepositoryMsg {
 			SetConflictErrorResponse(c, err.Error())
 			return
 		}
@@ -422,7 +422,7 @@ func (ph *ProjectHandler) UpdateProject(c *gin.Context) {
 			SetBadRequestErrorResponse(c, err.Error())
 			return
 		}
-		if errors.Is(err, common.ErrAlreadyInitializedRepository) {
+		if err.Error() == common.AlreadyInitializedRepositoryMsg {
 			SetConflictErrorResponse(c, err.Error())
 			return
 		}

--- a/shipyard-controller/internal/handler/projecthandler.go
+++ b/shipyard-controller/internal/handler/projecthandler.go
@@ -346,8 +346,8 @@ func (ph *ProjectHandler) CreateProject(c *gin.Context) {
 			SetConflictErrorResponse(c, err.Error())
 			return
 		}
-		if err.Error() == common.AlreadyInitializedRepositoryMsg {
-			SetConflictErrorResponse(c, common.ErrAlreadyInitializedRepository.Error())
+		if errors.Is(err, common.ErrAlreadyInitializedRepository) {
+			SetConflictErrorResponse(c, err.Error())
 			return
 		}
 		if errors.Is(err, common.ErrConfigStoreUpstreamNotFound) {
@@ -422,8 +422,8 @@ func (ph *ProjectHandler) UpdateProject(c *gin.Context) {
 			SetBadRequestErrorResponse(c, err.Error())
 			return
 		}
-		if err.Error() == common.AlreadyInitializedRepositoryMsg {
-			SetConflictErrorResponse(c, common.ErrAlreadyInitializedRepository.Error())
+		if errors.Is(err, common.ErrAlreadyInitializedRepository) {
+			SetConflictErrorResponse(c, err.Error())
 			return
 		}
 		SetInternalServerErrorResponse(c, common.ErrInternalError.Error())

--- a/shipyard-controller/internal/handler/projecthandler.go
+++ b/shipyard-controller/internal/handler/projecthandler.go
@@ -342,19 +342,7 @@ func (ph *ProjectHandler) CreateProject(c *gin.Context) {
 
 		rollback()
 		log.Debugf("rolled back %s", err.Error())
-		if errors.Is(err, common.ErrProjectAlreadyExists) {
-			SetConflictErrorResponse(c, err.Error())
-			return
-		}
-		if err.Error() == common.AlreadyInitializedRepositoryMsg {
-			SetConflictErrorResponse(c, err.Error())
-			return
-		}
-		if errors.Is(err, common.ErrConfigStoreUpstreamNotFound) {
-			SetBadRequestErrorResponse(c, err.Error())
-			return
-		}
-		SetInternalServerErrorResponse(c, err.Error())
+		mapError(c, err)
 		return
 	}
 	if err := ph.sendProjectCreateSuccessFinishedEvent(keptnContext, params); err != nil {
@@ -406,27 +394,7 @@ func (ph *ProjectHandler) UpdateProject(c *gin.Context) {
 	err, rollback := ph.ProjectManager.Update(params)
 	if err != nil {
 		rollback()
-		if errors.Is(err, common.ErrConfigStoreInvalidToken) {
-			SetFailedDependencyErrorResponse(c, err.Error())
-			return
-		}
-		if errors.Is(err, common.ErrConfigStoreUpstreamNotFound) {
-			SetNotFoundErrorResponse(c, err.Error())
-			return
-		}
-		if errors.Is(err, common.ErrProjectNotFound) {
-			SetNotFoundErrorResponse(c, err.Error())
-			return
-		}
-		if errors.Is(err, common.ErrInvalidStageChange) {
-			SetBadRequestErrorResponse(c, err.Error())
-			return
-		}
-		if err.Error() == common.AlreadyInitializedRepositoryMsg {
-			SetConflictErrorResponse(c, err.Error())
-			return
-		}
-		SetInternalServerErrorResponse(c, common.ErrInternalError.Error())
+		mapError(c, err)
 		return
 	}
 	c.Status(http.StatusCreated)

--- a/shipyard-controller/internal/handler/projecthandler.go
+++ b/shipyard-controller/internal/handler/projecthandler.go
@@ -346,6 +346,10 @@ func (ph *ProjectHandler) CreateProject(c *gin.Context) {
 			SetConflictErrorResponse(c, err.Error())
 			return
 		}
+		if err.Error() == common.AlreadyInitializedRepositoryMsg {
+			SetConflictErrorResponse(c, common.ErrAlreadyInitializedRepository.Error())
+			return
+		}
 		if errors.Is(err, common.ErrConfigStoreUpstreamNotFound) {
 			SetBadRequestErrorResponse(c, err.Error())
 			return
@@ -416,6 +420,10 @@ func (ph *ProjectHandler) UpdateProject(c *gin.Context) {
 		}
 		if errors.Is(err, common.ErrInvalidStageChange) {
 			SetBadRequestErrorResponse(c, err.Error())
+			return
+		}
+		if err.Error() == common.AlreadyInitializedRepositoryMsg {
+			SetConflictErrorResponse(c, common.ErrAlreadyInitializedRepository.Error())
 			return
 		}
 		SetInternalServerErrorResponse(c, common.ErrInternalError.Error())

--- a/shipyard-controller/internal/handler/projecthandler_test.go
+++ b/shipyard-controller/internal/handler/projecthandler_test.go
@@ -379,7 +379,7 @@ func TestCreateProject(t *testing.T) {
 				RemoteURLValidator:    remoteURLValidator,
 			},
 			jsonPayload:      examplePayload,
-			expectHttpStatus: http.StatusBadRequest,
+			expectHttpStatus: http.StatusNotFound,
 			projectNameParam: "my-project",
 		},
 		{

--- a/shipyard-controller/internal/handler/projecthandler_test.go
+++ b/shipyard-controller/internal/handler/projecthandler_test.go
@@ -387,7 +387,7 @@ func TestCreateProject(t *testing.T) {
 			fields: fields{
 				ProjectManager: &fake.IProjectManagerMock{
 					CreateFunc: func(params *models.CreateProjectParams, options models.InternalCreateProjectOptions) (error, common.RollbackFunc) {
-						return fmt.Errorf(common.AlreadyInitializedRepositoryMsg), func() error { return nil }
+						return common.ErrAlreadyInitializedRepository, func() error { return nil }
 					},
 				},
 				EventSender: &fake.IEventSenderMock{
@@ -759,7 +759,7 @@ func TestUpdateProject(t *testing.T) {
 			fields: fields{
 				ProjectManager: &fake.IProjectManagerMock{
 					UpdateFunc: func(params *models.UpdateProjectParams) (error, common.RollbackFunc) {
-						return fmt.Errorf(common.AlreadyInitializedRepositoryMsg), func() error { return nil }
+						return common.ErrAlreadyInitializedRepository, func() error { return nil }
 					},
 				},
 				EventSender: &fake.IEventSenderMock{

--- a/shipyard-controller/internal/handler/projecthandler_test.go
+++ b/shipyard-controller/internal/handler/projecthandler_test.go
@@ -383,6 +383,27 @@ func TestCreateProject(t *testing.T) {
 			projectNameParam: "my-project",
 		},
 		{
+			name: "Create project with already initialized repository",
+			fields: fields{
+				ProjectManager: &fake.IProjectManagerMock{
+					CreateFunc: func(params *models.CreateProjectParams, options models.InternalCreateProjectOptions) (error, common.RollbackFunc) {
+						return fmt.Errorf(common.AlreadyInitializedRepositoryMsg), func() error { return nil }
+					},
+				},
+				EventSender: &fake.IEventSenderMock{
+					SendEventFunc: func(eventMoqParam event.Event) error {
+						return nil
+					},
+				},
+				EnvConfig:             config.EnvConfig{ProjectNameMaxSize: 20},
+				RepositoryProvisioner: &fake2.IRepositoryProvisionerMock{},
+				RemoteURLValidator:    remoteURLValidator,
+			},
+			jsonPayload:      examplePayload,
+			expectHttpStatus: http.StatusConflict,
+			projectNameParam: "my-project",
+		},
+		{
 			name: "Create project creating project fails",
 			fields: fields{
 				ProjectManager: &fake.IProjectManagerMock{
@@ -732,6 +753,26 @@ func TestUpdateProject(t *testing.T) {
 			},
 			jsonPayload:        examplePayload,
 			expectedHTTPStatus: http.StatusNotFound,
+		},
+		{
+			name: "Update project with already initialized repository",
+			fields: fields{
+				ProjectManager: &fake.IProjectManagerMock{
+					UpdateFunc: func(params *models.UpdateProjectParams) (error, common.RollbackFunc) {
+						return fmt.Errorf(common.AlreadyInitializedRepositoryMsg), func() error { return nil }
+					},
+				},
+				EventSender: &fake.IEventSenderMock{
+					SendEventFunc: func(eventMoqParam event.Event) error {
+						return nil
+					},
+				},
+				EnvConfig:             config.EnvConfig{ProjectNameMaxSize: 200},
+				RepositoryProvisioner: &fake2.IRepositoryProvisionerMock{},
+				RemoteURLValidator:    remoteURLValidator,
+			},
+			jsonPayload:        examplePayload,
+			expectedHTTPStatus: http.StatusConflict,
 		},
 		{
 			name: "Update project",

--- a/shipyard-controller/internal/handler/projecthandler_test.go
+++ b/shipyard-controller/internal/handler/projecthandler_test.go
@@ -387,7 +387,7 @@ func TestCreateProject(t *testing.T) {
 			fields: fields{
 				ProjectManager: &fake.IProjectManagerMock{
 					CreateFunc: func(params *models.CreateProjectParams, options models.InternalCreateProjectOptions) (error, common.RollbackFunc) {
-						return common.ErrAlreadyInitializedRepository, func() error { return nil }
+						return fmt.Errorf(common.AlreadyInitializedRepositoryMsg), func() error { return nil }
 					},
 				},
 				EventSender: &fake.IEventSenderMock{
@@ -759,7 +759,7 @@ func TestUpdateProject(t *testing.T) {
 			fields: fields{
 				ProjectManager: &fake.IProjectManagerMock{
 					UpdateFunc: func(params *models.UpdateProjectParams) (error, common.RollbackFunc) {
-						return common.ErrAlreadyInitializedRepository, func() error { return nil }
+						return fmt.Errorf(common.AlreadyInitializedRepositoryMsg), func() error { return nil }
 					},
 				},
 				EventSender: &fake.IEventSenderMock{


### PR DESCRIPTION
Signed-off-by: odubajDT <ondrej.dubaj@dynatrace.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->
- unified HTTP error response to 404 when upstream repository is not found
- return 409 HTTP error response when the upstream repository is already initialized when creating or updating project

BREAKING CHANGE: Keptn returns 404 instead of 400 HTTP error code when creation of the project fails when upstream repository is not found. Also returns 409 instead of 500 HTTP error code when creation or update of project fails due to upstream repository is already initialized.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #9038 

![Screenshot from 2022-11-07 16-32-15](https://user-images.githubusercontent.com/93584209/200350619-a42b6711-5726-4c8e-86b5-8b7d00079625.png)
