### PR TITLE
fix(bridge): Fix incorrect SLI grouping in heatmap

### DIFF
--- a/bridge/client/app/_components/ktb-heatmap/ktb-heatmap-utils.spec.ts
+++ b/bridge/client/app/_components/ktb-heatmap/ktb-heatmap-utils.spec.ts
@@ -8,9 +8,12 @@ import {
   getHiddenYElements,
   getLimitedYElements,
   getXAxisReducedElements,
+  setUniqueXAxis,
+  setUniqueYAxis,
 } from './ktb-heatmap-utils';
-import { GroupedDataPoints } from '../../_interfaces/heatmap';
+import { GroupedDataPoints, IDataPoint, IHeatmapTooltipType } from '../../_interfaces/heatmap';
 import { TestUtils } from '../../_utils/test.utils';
+import { ResultTypes } from '../../../../shared/models/result-types';
 import Mock = jest.Mock;
 
 describe('KtbHeatmapUtils', () => {
@@ -34,6 +37,52 @@ describe('KtbHeatmapUtils', () => {
     });
     // verify order of keys
     expect(Object.keys(groupedDataPoints)).toEqual(['response_time_p0', 'score']);
+  });
+
+  it('should rename the xAxis if there are duplicates', () => {
+    const dataPoints = getDataPointsWithXAxisDuplicates();
+    setUniqueXAxis(dataPoints);
+
+    expect(dataPoints.map((dt) => dt.xElement)).toEqual([
+      '2022-11-10T08:17:47.152Z (1)',
+      '2022-11-10T08:17:47.152Z (1)',
+      '2022-11-10T08:17:47.152Z (2)',
+    ]);
+  });
+
+  it('should not rename xAxis elements', () => {
+    const dataPoints = mockDataPoints(2, 2);
+    setUniqueXAxis(dataPoints);
+
+    expect(dataPoints.map((dt) => dt.xElement)).toEqual([
+      'myDate0',
+      'myDate0',
+      'myDate0',
+      'myDate1',
+      'myDate1',
+      'myDate1',
+    ]);
+  });
+
+  it('should rename yAxis elements', () => {
+    const dataPoints = getDataPointsWithYAxisDuplicates();
+    setUniqueYAxis(dataPoints);
+
+    expect(dataPoints.map((dt) => dt.yElement)).toEqual(['SLI (1)', 'SLI (2)', 'SLI (1)']);
+  });
+
+  it('should not rename yAxis elements', () => {
+    const dataPoints = mockDataPoints(2, 2);
+    setUniqueXAxis(dataPoints);
+
+    expect(dataPoints.map((dt) => dt.yElement)).toEqual([
+      'response_time_p0',
+      'response_time_p1',
+      'score',
+      'response_time_p0',
+      'response_time_p1',
+      'score',
+    ]);
   });
 
   it('should correctly return axis elements without duplicates', () => {
@@ -200,5 +249,105 @@ describe('KtbHeatmapUtils', () => {
     mockIdentifiers = false
   ): GroupedDataPoints {
     return createGroupedDataPoints(mockDataPoints(counter, slis, identifierSuffix, dateSuffix, mockIdentifiers));
+  }
+
+  function getDataPointsWithXAxisDuplicates(): IDataPoint[] {
+    return [
+      {
+        identifier: '1',
+        yElement: 'SLI',
+        xElement: '2022-11-10T08:17:47.152Z',
+        comparedIdentifier: [],
+        color: ResultTypes.PASSED,
+        tooltip: {
+          type: IHeatmapTooltipType.SLI,
+          keySli: false,
+          value: 0,
+          warningTargets: [],
+          passTargets: [],
+          score: 0,
+        },
+      },
+      {
+        identifier: '1',
+        yElement: 'SLI2',
+        xElement: '2022-11-10T08:17:47.152Z',
+        comparedIdentifier: [],
+        color: ResultTypes.PASSED,
+        tooltip: {
+          type: IHeatmapTooltipType.SLI,
+          keySli: false,
+          value: 0,
+          warningTargets: [],
+          passTargets: [],
+          score: 0,
+        },
+      },
+      {
+        identifier: '2',
+        yElement: 'SLI1',
+        xElement: '2022-11-10T08:17:47.152Z',
+        comparedIdentifier: [],
+        color: ResultTypes.PASSED,
+        tooltip: {
+          type: IHeatmapTooltipType.SLI,
+          keySli: false,
+          value: 0,
+          warningTargets: [],
+          passTargets: [],
+          score: 0,
+        },
+      },
+    ];
+  }
+
+  function getDataPointsWithYAxisDuplicates(): IDataPoint[] {
+    return [
+      {
+        identifier: '1',
+        yElement: 'SLI',
+        xElement: '2022-11-10T08:17:47.152Z',
+        comparedIdentifier: [],
+        color: ResultTypes.PASSED,
+        tooltip: {
+          type: IHeatmapTooltipType.SLI,
+          keySli: false,
+          value: 0,
+          warningTargets: [],
+          passTargets: [],
+          score: 0,
+        },
+      },
+      {
+        identifier: '1',
+        yElement: 'SLI',
+        xElement: '2022-11-10T08:17:47.152Z',
+        comparedIdentifier: [],
+        color: ResultTypes.PASSED,
+        tooltip: {
+          type: IHeatmapTooltipType.SLI,
+          keySli: false,
+          value: 0,
+          warningTargets: [],
+          passTargets: [],
+          score: 0,
+        },
+      },
+      {
+        identifier: '2',
+        yElement: 'SLI',
+        xElement: '2022-11-10T08:17:47.152Z',
+        comparedIdentifier: [],
+        color: ResultTypes.PASSED,
+        tooltip: {
+          type: IHeatmapTooltipType.SLI,
+          keySli: false,
+          value: 0,
+          warningTargets: [],
+          passTargets: [],
+          score: 0,
+        },
+      },
+    ];
   }
 });

--- a/bridge/client/app/_components/ktb-heatmap/ktb-heatmap-utils.ts
+++ b/bridge/client/app/_components/ktb-heatmap/ktb-heatmap-utils.ts
@@ -29,13 +29,10 @@ export function setUniqueYAxis(dataPoints: IDataPoint[]): void {
     let displayValue = dataPoint.yElement;
     const identifier = dataPoint.identifier;
     let foundIndex;
-    if (
-      (foundIndex = dataPoints.findIndex(
-        // eslint-disable-next-line @typescript-eslint/no-loop-func
-        (dt) => dt.yElement === displayValue && dt.identifier === identifier
-      )) < index &&
-      foundIndex !== -1
-    ) {
+    const hasYElementDuplicatesWithinIdentifierBeforeChild =
+      (foundIndex = dataPoints.findIndex((dt) => dt.yElement === displayValue && dt.identifier === identifier)) <
+        index && foundIndex !== -1;
+    if (hasYElementDuplicatesWithinIdentifierBeforeChild) {
       duplicatesDict[identifier] ??= {};
       duplicatesDict[identifier][displayValue] ??= 1;
       ++duplicatesDict[identifier][displayValue];
@@ -58,26 +55,34 @@ export function setUniqueYAxis(dataPoints: IDataPoint[]): void {
 }
 
 export function setUniqueXAxis(dataPoints: IDataPoint[]): void {
-  const dataPointToIdentifierXElement = (dataPointDict: Record<string, string>, dataPoint: IDataPoint) => {
+  const dataPointToIdentifierXElement = (
+    dataPointDict: Record<string, string>,
+    dataPoint: IDataPoint
+  ): Record<string, string> => {
     dataPointDict[dataPoint.identifier] ??= dataPoint.xElement;
     return dataPointDict;
   };
-  const identifierToDuplicateDict =(identifiers: string[], identifierToXElement: Record<string, string>) => (duplicateCount: Record<string, number>, identifier:string, index: number): Record<string, number> => {
-    const previousDuplicates = identifiers.filter(
-      (nextIdentifier, nextIndex) =>
-        nextIndex < index && identifierToXElement[nextIdentifier] === identifierToXElement[identifier]
-    ).length;
-    const nextDuplicates = identifiers.filter(
-      (nextIdentifier, nextIndex) =>
-        nextIndex > index && identifierToXElement[nextIdentifier] === identifierToXElement[identifier]
-    ).length;
-    duplicateCount[identifier] = previousDuplicates + nextDuplicates === 0 ? 0 : previousDuplicates + 1;
-    return duplicateCount;
-  }
+  const identifierToDuplicateDict =
+    (identifiers: string[], identifierToXElement: Record<string, string>) =>
+    (duplicateCount: Record<string, number>, identifier: string, index: number): Record<string, number> => {
+      const previousDuplicates = identifiers.filter(
+        (nextIdentifier, nextIndex) =>
+          nextIndex < index && identifierToXElement[nextIdentifier] === identifierToXElement[identifier]
+      ).length;
+      const nextDuplicates = identifiers.filter(
+        (nextIdentifier, nextIndex) =>
+          nextIndex > index && identifierToXElement[nextIdentifier] === identifierToXElement[identifier]
+      ).length;
+      duplicateCount[identifier] = previousDuplicates + nextDuplicates === 0 ? 0 : previousDuplicates + 1;
+      return duplicateCount;
+    };
 
   const identifierToXElement = dataPoints.reduce<Record<string, string>>(dataPointToIdentifierXElement, {});
   const identifiers = Object.keys(identifierToXElement);
-  const duplicates = identifiers.reduce<Record<string, number>>(identifierToDuplicateDict(identifiers, identifierToXElement), {});
+  const duplicates = identifiers.reduce<Record<string, number>>(
+    identifierToDuplicateDict(identifiers, identifierToXElement),
+    {}
+  );
 
   dataPoints.forEach((dataPoint) => {
     if (duplicates[dataPoint.identifier]) {

--- a/bridge/client/app/_components/ktb-heatmap/ktb-heatmap-utils.ts
+++ b/bridge/client/app/_components/ktb-heatmap/ktb-heatmap-utils.ts
@@ -1,13 +1,17 @@
 import { GroupedDataPoints, IDataPoint } from '../../_interfaces/heatmap';
 
 export function createGroupedDataPoints(data: IDataPoint[]): GroupedDataPoints {
-  setUniqueHeaders(data, 'xElement', 'yElement');
-  setUniqueHeaders(data, 'yElement', 'xElement');
+  setUniqueHeaders(data);
   return data.reduce((groupedData: GroupedDataPoints, dataPoint) => {
     groupedData[dataPoint.yElement] ||= [];
     groupedData[dataPoint.yElement].push(dataPoint);
     return groupedData;
   }, {});
+}
+
+function setUniqueHeaders(data: IDataPoint[]): void {
+  setUniqueYAxis(data);
+  setUniqueXAxis(data);
 }
 
 export const getLimitedYElements = (yElements: string[], limit: number): string[] => {
@@ -17,46 +21,67 @@ export const getLimitedYElements = (yElements: string[], limit: number): string[
   return yElements.slice(yElements.length - limit, yElements.length);
 };
 
-export function setUniqueHeaders(dataPoints: IDataPoint[], key: 'xElement', compare: 'yElement'): void;
-export function setUniqueHeaders(dataPoints: IDataPoint[], key: 'yElement', compare: 'xElement'): void;
-export function setUniqueHeaders(
-  dataPoints: IDataPoint[],
-  key: 'yElement' | 'xElement',
-  compare: 'xElement' | 'yElement'
-): void {
-  const duplicatesDict: { [key: string]: { [compare: string]: number } } = {};
+export function setUniqueYAxis(dataPoints: IDataPoint[]): void {
+  // if it is the y-axis compare if there is the same SLI name with the same identifier
+  const duplicatesDict: { [identifier: string]: { [compare: string]: number } } = {};
+  const hasDuplicates: { [yElement: string]: boolean | undefined } = {};
   dataPoints.forEach((dataPoint, index) => {
-    let uniqueHeader = dataPoint[key];
-    const compareWith = dataPoint[compare];
+    let displayValue = dataPoint.yElement;
+    const identifier = dataPoint.identifier;
     let foundIndex;
-    while (
+    if (
       (foundIndex = dataPoints.findIndex(
         // eslint-disable-next-line @typescript-eslint/no-loop-func
-        (dt) => dt[key] === uniqueHeader && dt[compare] === compareWith
+        (dt) => dt.yElement === displayValue && dt.identifier === identifier
       )) < index &&
       foundIndex !== -1
     ) {
-      if (duplicatesDict[uniqueHeader] === undefined) {
-        duplicatesDict[uniqueHeader] = {};
-      }
-      if (duplicatesDict[uniqueHeader][compareWith] === undefined) {
-        duplicatesDict[uniqueHeader][compareWith] = 1;
-      }
-      ++duplicatesDict[uniqueHeader][compareWith];
+      duplicatesDict[identifier] ??= {};
+      duplicatesDict[identifier][displayValue] ??= 1;
+      ++duplicatesDict[identifier][displayValue];
+      hasDuplicates[displayValue] = true;
       // occurrence is 1 but since it is the next element after the first found duplicate it's +1
-      uniqueHeader = `${dataPoint[key]} (${duplicatesDict[uniqueHeader][compareWith]})`;
+      displayValue = `${dataPoint.yElement} (${duplicatesDict[identifier][displayValue]})`;
     }
-    dataPoint[key] = uniqueHeader;
+    dataPoint.yElement = displayValue;
   });
 
   // if there are duplicates set the first occurrence to (1)
   dataPoints.forEach((dataPoint) => {
-    const uniqueHeader = dataPoint[key];
-    const compareWith = dataPoint[compare];
+    const uniqueHeader = dataPoint.yElement;
 
     // if there are duplicates the counter is at least set to 2
-    if (duplicatesDict[uniqueHeader]?.[compareWith]) {
-      dataPoint[key] = `${dataPoint[key]} (1)`;
+    if (hasDuplicates[uniqueHeader]) {
+      dataPoint.yElement = `${dataPoint.yElement} (1)`;
+    }
+  });
+}
+
+export function setUniqueXAxis(dataPoints: IDataPoint[]): void {
+  const dataPointToIdentifierXElement = (dataPointDict: Record<string, string>, dataPoint: IDataPoint) => {
+    dataPointDict[dataPoint.identifier] ??= dataPoint.xElement;
+    return dataPointDict;
+  };
+  const identifierToDuplicateDict =(identifiers: string[], identifierToXElement: Record<string, string>) => (duplicateCount: Record<string, number>, identifier:string, index: number): Record<string, number> => {
+    const previousDuplicates = identifiers.filter(
+      (nextIdentifier, nextIndex) =>
+        nextIndex < index && identifierToXElement[nextIdentifier] === identifierToXElement[identifier]
+    ).length;
+    const nextDuplicates = identifiers.filter(
+      (nextIdentifier, nextIndex) =>
+        nextIndex > index && identifierToXElement[nextIdentifier] === identifierToXElement[identifier]
+    ).length;
+    duplicateCount[identifier] = previousDuplicates + nextDuplicates === 0 ? 0 : previousDuplicates + 1;
+    return duplicateCount;
+  }
+
+  const identifierToXElement = dataPoints.reduce<Record<string, string>>(dataPointToIdentifierXElement, {});
+  const identifiers = Object.keys(identifierToXElement);
+  const duplicates = identifiers.reduce<Record<string, number>>(identifierToDuplicateDict(identifiers, identifierToXElement), {});
+
+  dataPoints.forEach((dataPoint) => {
+    if (duplicates[dataPoint.identifier]) {
+      dataPoint.xElement = `${dataPoint.xElement} (${duplicates[dataPoint.identifier]})`;
     }
   });
 }

--- a/bridge/client/app/_components/ktb-sli-breakdown/ktb-sli-breakdown.component.spec.ts
+++ b/bridge/client/app/_components/ktb-sli-breakdown/ktb-sli-breakdown.component.spec.ts
@@ -10,6 +10,7 @@ import { KtbSliBreakdownModule } from './ktb-sli-breakdown.module';
 import { DataService } from '../../_services/data.service';
 import { of } from 'rxjs';
 import { ResultTypes } from '../../../../shared/models/result-types';
+import { SliResult } from '../../_interfaces/sli-result';
 
 describe(KtbSliBreakdownComponent.name, () => {
   let component: KtbSliBreakdownComponent;
@@ -146,6 +147,49 @@ describe(KtbSliBreakdownComponent.name, () => {
     expect(component.fallBackData.comparedIndicatorResults).toEqual([[newIndicatorResult]]);
     expect(component.tableEntries.data.length).toBe(1);
   });
+
+  it('should rename sliName if it is not unique', () => {
+    // given, when
+    const results = component.getUniqueSliResult([
+      generateSliResult('Name'),
+      generateSliResult('Name'),
+      generateSliResult('Name'),
+      generateSliResult('Name1'),
+    ]);
+
+    // then
+    expect(results.map((res) => res.name)).toEqual(['Name (1)', 'Name (2)', 'Name (3)', 'Name1']);
+  });
+
+  it('should not rename sliName if it is unique', () => {
+    // given, when
+    const results = component.getUniqueSliResult([
+      generateSliResult('Name1'),
+      generateSliResult('Name2'),
+      generateSliResult('Name3'),
+      generateSliResult('Name4'),
+    ]);
+
+    // then
+    expect(results.map((res) => res.name)).toEqual(['Name1', 'Name2', 'Name3', 'Name4']);
+  });
+
+  function generateSliResult(name: string): SliResult {
+    return {
+      keySli: false,
+      score: 2,
+      value: 0,
+      name,
+      result: ResultTypes.PASSED,
+      weight: 0,
+      expanded: true,
+      calculatedChanges: {
+        absolute: 0,
+        relative: 0,
+      },
+      success: true,
+    };
+  }
 
   function initEvaluation(selectedEvaluationIndex: number): void {
     const selectedEvaluation = EvaluationsMock.data.evaluationHistory?.[selectedEvaluationIndex] as Trace;

--- a/bridge/client/app/_components/ktb-sli-breakdown/ktb-sli-breakdown.component.ts
+++ b/bridge/client/app/_components/ktb-sli-breakdown/ktb-sli-breakdown.component.ts
@@ -166,7 +166,7 @@ export class KtbSliBreakdownComponent {
       return undefined;
     }
 
-    return indicatorResults.map((indicatorResult) => ({
+    const sliResults = indicatorResults.map<SliResult>((indicatorResult) => ({
       name: indicatorResult.displayName || indicatorResult.value.metric,
       value: indicatorResult.value.message || AppUtils.formatNumber(indicatorResult.value.value),
       result: indicatorResult.status,
@@ -180,6 +180,26 @@ export class KtbSliBreakdownComponent {
       weight: this.objectives?.find((obj) => obj.sli === indicatorResult.value.metric)?.weight ?? 1,
       ...this.getComparedValues(indicatorResult),
     }));
+
+    return this.getUniqueSliResult(sliResults);
+  }
+
+  public getUniqueSliResult(sliResults: SliResult[]): SliResult[] {
+    return sliResults.map((sliResult, index) => ({
+      ...sliResult,
+      name: this.getUniqueSliName(sliResult.name, index, sliResults),
+    }));
+  }
+
+  private getUniqueSliName(sliName: string, sliResultIndex: number, sliResults: SliResult[]): string {
+    const duplicates = sliResults.filter((result) => result.name === sliName);
+    if (duplicates.length > 1) {
+      const previousDuplicates = sliResults.filter(
+        (result, index) => index < sliResultIndex && result.name === sliName
+      ).length;
+      return `${sliName} (${previousDuplicates + 1})`;
+    }
+    return sliName;
   }
 
   private setColumnNames(indicatorResults: IndicatorResult[]): void {

--- a/bridge/cypress/fixtures/get.sockshop.service.carts.evaluations.heatmap.manyscores.mock.json
+++ b/bridge/cypress/fixtures/get.sockshop.service.carts.evaluations.heatmap.manyscores.mock.json
@@ -49,7 +49,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00a",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -78,7 +78,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00b",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -107,7 +107,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00c",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -136,7 +136,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00d",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -165,7 +165,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00e",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -194,7 +194,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00f",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -223,7 +223,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00g",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -252,7 +252,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00h",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -281,7 +281,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00i",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -310,7 +310,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00j",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -339,7 +339,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00k",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -368,7 +368,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00l",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -397,7 +397,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00m",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -426,7 +426,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00n",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -455,7 +455,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00o",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -484,7 +484,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00p",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -513,7 +513,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00q",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -542,7 +542,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00r",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -571,7 +571,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00s",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -600,7 +600,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00t",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -629,7 +629,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00u",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -658,7 +658,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00v",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -687,7 +687,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00w",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -716,7 +716,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00x",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -745,7 +745,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00y",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -774,7 +774,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00z",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -803,7 +803,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00a1",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -832,7 +832,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00a2",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -861,7 +861,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00a3",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -890,7 +890,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00a4",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -919,7 +919,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00a5",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -948,7 +948,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00a6",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -977,7 +977,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00a7",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -1006,7 +1006,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00a8",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -1035,7 +1035,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00a9",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -1064,7 +1064,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00b0",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -1093,7 +1093,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00b1",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -1122,7 +1122,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00b2",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -1151,7 +1151,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00b3",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -1180,7 +1180,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00b4",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -1209,7 +1209,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00b5",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",
@@ -1238,7 +1238,7 @@
         "stage": "staging",
         "status": "succeeded"
       },
-      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a003",
+      "id": "25ab0f26-e6d8-48d5-a08f-08c8a136a00b6",
       "source": "lighthouse-service",
       "specversion": "1.0",
       "time": "2022-02-01T02:46:35.853Z",


### PR DESCRIPTION
Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>

Fixes #9131 
Also adds numeration to duplicate SLI names to the sli-breakdown

Previous: 
![image](https://user-images.githubusercontent.com/11599148/201080098-af3469e3-ce28-4f64-941e-e3d170086f94.png)


Now: 
![image](https://user-images.githubusercontent.com/11599148/201080040-132b5497-ec89-4e62-bd10-a5301443143a.png)
