### PR TITLE
fix(bridge): Fix inconsistent sequence filter

### DIFF
--- a/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.spec.ts
+++ b/bridge/client/app/_views/ktb-sequence-view/ktb-sequence-view.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { KtbSequenceViewComponent } from './ktb-sequence-view.component';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ActivatedRoute, convertToParamMap } from '@angular/router';
-import { BehaviorSubject, firstValueFrom, of, Subject } from 'rxjs';
+import { BehaviorSubject, firstValueFrom, Observable, of, Subject } from 'rxjs';
 import { POLLING_INTERVAL_MILLIS } from '../../_utils/app.utils';
 import { ApiService } from '../../_services/api.service';
 import { ApiServiceMock } from '../../_services/api.service.mock';
@@ -14,6 +14,15 @@ import { KtbSequenceViewModule } from './ktb-sequence-view.module';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { DataService } from '../../_services/data.service';
+
+// debounceTime seems untestable. No matter if fakeAsync and tick is used, it never happens to go inside the subscribe function
+jest.mock('rxjs/operators', () => ({
+  ...jest.requireActual('rxjs/operators'),
+  debounceTime:
+    () =>
+    <T>(source: Observable<T>): Observable<T> =>
+      source,
+}));
 
 describe('KtbSequenceViewComponent', () => {
   let component: KtbSequenceViewComponent;

--- a/bridge/cypress/integration/sequences.spec.ts
+++ b/bridge/cypress/integration/sequences.spec.ts
@@ -1,6 +1,7 @@
 import { SequencesPage } from '../support/pageobjects/SequencesPage';
 import EnvironmentPage from '../support/pageobjects/EnvironmentPage';
 import { interceptSequenceExecution } from '../support/intercept';
+import BasePage from '../support/pageobjects/BasePage';
 
 describe('Sequences', () => {
   const sequencePage = new SequencesPage();
@@ -351,6 +352,27 @@ describe('Sequences', () => {
         .assertFilterIsChecked('Status', 'Succeeded', false)
         .assertSequenceCount(2)
         .assertStatusOfSequences('started');
+    });
+
+    it('should navigate to other project and load filter correctly', () => {
+      const basePage = new BasePage();
+      const secondProject = 'my-error-project';
+      const project = 'sockshop';
+
+      sequencePage.interceptEmpty(secondProject);
+      sequencePage.visit(project, {
+        Service: 'carts',
+      });
+      cy.wait(`@Sequences`);
+      cy.wait(500);
+
+      basePage.selectProjectThroughHeader(secondProject);
+
+      sequencePage.waitForInitialRequests(secondProject).assertRootDeepLink(secondProject).assertQueryParams('');
+
+      basePage.selectProjectThroughHeader(project);
+
+      sequencePage.assertQueryParams('?Service=carts').assertFilterIsChecked('Service', 'carts', true);
     });
 
     it('should apply filters also when loading more sequences', () => {

--- a/bridge/cypress/support/commands.ts
+++ b/bridge/cypress/support/commands.ts
@@ -110,7 +110,7 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add('clearDtFilter', { prevSubject: 'element' }, (subject: JQuery) => {
-  subject.find('.dt-filter-field-clear-all-button').trigger('click');
+  cy.wrap(subject).find('.dt-filter-field-clear-all-button').click();
   cy.wrap(subject).find('.dt-filter-field-input').trigger('click').type('{esc}');
 });
 

--- a/bridge/cypress/support/intercept.ts
+++ b/bridge/cypress/support/intercept.ts
@@ -150,6 +150,21 @@ export function interceptServicesPageWithRemediation(): void {
   }).as('ServiceDeployment');
 }
 
+export function interceptSequencesPageEmpty(project: string): void {
+  cy.intercept(`/api/controlPlane/v1/sequence/${project}?pageSize=25`, { body: { states: [] } }).as(
+    `Sequences_${project}`
+  );
+  cy.intercept(`/api/controlPlane/v1/sequence/${project}?pageSize=25&fromTime=*`, {
+    body: {
+      states: [],
+    },
+  }).as(`SequencesUpdate_${project}`);
+
+  cy.intercept(`/api/project/${project}/sequences/filter`, { fixture: 'sequence.filter.mock' }).as(
+    `SequencesMetadata_${project}`
+  );
+}
+
 export function interceptSequencesPage(): void {
   interceptProjectBoard();
   cy.intercept('/api/controlPlane/v1/sequence/sockshop?pageSize=25', { fixture: 'sequences.sockshop' }).as('Sequences');

--- a/bridge/cypress/support/pageobjects/SequencesPage.ts
+++ b/bridge/cypress/support/pageobjects/SequencesPage.ts
@@ -3,6 +3,7 @@ import {
   interceptEvaluationOfApproval,
   interceptMain,
   interceptSequencesPage,
+  interceptSequencesPageEmpty,
   interceptSequencesPageWithSequenceThatIsNotLoaded,
 } from '../intercept';
 import { EvaluationBadgeVariant } from '../../../client/app/_components/ktb-evaluation-badge/ktb-evaluation-badge.utils';
@@ -14,6 +15,11 @@ export class SequencesPage {
 
   public intercept(): this {
     interceptSequencesPage();
+    return this;
+  }
+
+  public interceptEmpty(project: string): this {
+    interceptSequencesPageEmpty(project);
     return this;
   }
 
@@ -70,6 +76,14 @@ export class SequencesPage {
 
   public visitByEventType(keptnContext: string, eventType: EventTypes | string): this {
     cy.visit(`/trace/${keptnContext}/${eventType}`).wait('@metadata');
+    return this;
+  }
+
+  public waitForInitialRequests(project?: string): this {
+    const projectSuffix = project ? `_${project}` : '';
+    cy.wait(`@Sequences${projectSuffix}`);
+    cy.wait(`@SequencesMetadata${projectSuffix}`);
+
     return this;
   }
 


### PR DESCRIPTION
Fixes #9136 

## Additional changes
- Sequence polling for unfinished sequences is now cleared when switching the project

Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>