### PR TITLE
chore: Add heinzburgstaller as Bridge codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -25,7 +25,7 @@ CODEOWNERS @AloisReitbauer @johannes-b @jetzlstorfer @warber
 ADOPTERS.md @AloisReitbauer @grabnerandi @jetzlstorfer
 
 # UI / Keptn Bridge
-bridge/ @ermin-muratovic @laneli @Kirdock
+bridge/ @ermin-muratovic @laneli @Kirdock @heinzburgstaller
 
 # Release Notes
 releasenotes/ @johannes-b @warber


### PR DESCRIPTION
Adding @heinzburgstaller as Bridge code-owner since he showed good understanding of the project and has driven many 
PR review improving the overall code quality 