### PR TITLE
ci: Remove unused needs part in the CI pipeline

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -103,7 +103,6 @@ jobs:
     name: Prepare CI Run
     # Prepare CI Run looks at what has been changed in this commit/PR/... and determines which artifacts should be
     # built afterwards (in other jobs that depend on this one).
-    needs: calculate-queue-time
     runs-on: ubuntu-20.04
     outputs: # declare what this job outputs (so it can be re-used for other jobs)
       # build config


### PR DESCRIPTION
Signed-off-by: Philipp Hinteregger <philipp.hinteregger@dynatrace.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR

- removes the `needs` property of the `prepare_ci_run` stage within the CI pipeline, since it's not being used anymore.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #9140 
