### PR TITLE
chore: github handle in MAINTAINERS

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -22,7 +22,7 @@ Ermin Muratovic, @ermin-muratovic, Dynatrace
 Florian Bacher, @bacherfl, Dynatrace
 Giovanni Liva, @thisthat, Dynatrace
 Johannes Bräuer, @johannes-b, Dynatrace
-Jürgen Etzlstorfer, @jetzlstorer, Microsoft
+Jürgen Etzlstorfer, @jetzlstorfer, Microsoft
 Klaus Strießnig, @kirdock, Dynatrace
 Moritz Wiesinger, @mowies, Dynatrace
 Anna Reale, @RealAnna, Dynatrace


### PR DESCRIPTION
Signed-off-by: Jürgen Etzlstorfer <juergen.etzlstorfer@gmail.com>

my github handle was wrong due to a typo. now fixed to @jetzlstorfer 
