### PR TITLE
fix(lighthouse-service): Include SLO Display Name also when there is no SLI value available

### DIFF
--- a/lighthouse-service/event_handler/evaluate_sli_handler.go
+++ b/lighthouse-service/event_handler/evaluate_sli_handler.go
@@ -228,6 +228,9 @@ func evaluateObjectives(e *keptnv2.GetSLIFinishedEventData, sloConfig *keptn.Ser
 			}
 			sliEvaluationResult.Status = "fail"
 			sliEvaluationResult.Score = 0
+			sliEvaluationResult.DisplayName = objective.DisplayName
+			sliEvaluationResult.PassTargets = getEmptyTargets(objective.Pass)
+			sliEvaluationResult.WarningTargets = getEmptyTargets(objective.Warning)
 			sliEvaluationResults = append(sliEvaluationResults, sliEvaluationResult)
 			continue
 		}
@@ -291,6 +294,21 @@ func evaluateObjectives(e *keptnv2.GetSLIFinishedEventData, sloConfig *keptn.Ser
 	evaluationResult.Evaluation.IndicatorResults = sliEvaluationResults
 
 	return evaluationResult, maximumAchievableScore, keySLIFailed
+}
+
+func getEmptyTargets(targets []*keptn.SLOCriteria) []*keptnv2.SLITarget {
+	res := []*keptnv2.SLITarget{}
+
+	for _, obj := range targets {
+		for _, crit := range obj.Criteria {
+			res = append(res, &keptnv2.SLITarget{
+				Criteria: crit,
+				Violated: true,
+			})
+		}
+	}
+
+	return res
 }
 
 func checkLeftoverSLI(results []*keptnv2.SLIResult, evaluationResult *keptnv2.EvaluationFinishedEventData) {
@@ -466,9 +484,9 @@ func evaluateComparison(sliResult *keptnv2.SLIResult, co *criteriaObject, previo
 	return evaluateValue(sliResult.Value, targetValue, co.Operator)
 }
 
-//aggregateValues combines the previous values into a single one, based on the aggregation function
-//it returns the aggregated value and a boolean telling if the rest of the evaluation should be skipped
-//(no previous results or no successful previous results)
+// aggregateValues combines the previous values into a single one, based on the aggregation function
+// it returns the aggregated value and a boolean telling if the rest of the evaluation should be skipped
+// (no previous results or no successful previous results)
 func aggregateValues(previousResults []*keptnv2.SLIEvaluationResult, comparison *keptn.SLOComparison) (float64, bool) {
 
 	if len(previousResults) == 0 {

--- a/lighthouse-service/event_handler/evaluate_sli_handler_test.go
+++ b/lighthouse-service/event_handler/evaluate_sli_handler_test.go
@@ -2438,10 +2438,32 @@ func TestEvaluateObjectives(t *testing.T) {
 								Success: false,
 								Message: "no value received from SLI provider",
 							},
-							PassTargets:    nil,
-							WarningTargets: nil,
-							KeySLI:         false,
-							Status:         "fail",
+							PassTargets: []*keptnv2.SLITarget{
+								{
+									Criteria:    "<=15.0",
+									TargetValue: 0,
+									Violated:    true,
+								},
+								{
+									Criteria:    "<=+10%",
+									TargetValue: 0,
+									Violated:    true,
+								},
+							},
+							WarningTargets: []*keptnv2.SLITarget{
+								{
+									Criteria:    "<=20.0",
+									TargetValue: 0,
+									Violated:    true,
+								},
+								{
+									Criteria:    "<=+15%",
+									TargetValue: 0,
+									Violated:    true,
+								},
+							},
+							KeySLI: false,
+							Status: "fail",
 						},
 					},
 				},

--- a/lighthouse-service/event_handler/evaluate_sli_handler_test.go
+++ b/lighthouse-service/event_handler/evaluate_sli_handler_test.go
@@ -2413,6 +2413,56 @@ func TestEvaluateObjectives(t *testing.T) {
 								KeySLI:         false,
 								Status:         "pass",
 							},
+							{
+								Score: 2,
+								Value: &keptnv2.SLIResult{
+									Metric:  "a_different_metric",
+									Value:   5.0,
+									Success: true,
+									Message: "",
+								},
+								PassTargets:    nil,
+								WarningTargets: nil,
+								KeySLI:         false,
+								Status:         "pass",
+							},
+						},
+					},
+					EventData: keptnv2.EventData{
+						Result:  "pass",
+						Project: "sockshop",
+						Service: "carts",
+						Stage:   "dev",
+					},
+				},
+				{
+					Evaluation: keptnv2.EvaluationDetails{
+						TimeStart: "",
+						TimeEnd:   "",
+						Result:    "pass",
+						Score:     2,
+						IndicatorResults: []*keptnv2.SLIEvaluationResult{
+							{
+								Score: 2,
+								Value: &keptnv2.SLIResult{
+									Metric:  "my-test-metric-1",
+									Value:   10.0,
+									Success: true,
+									Message: "",
+								},
+								PassTargets:    nil,
+								WarningTargets: nil,
+								KeySLI:         false,
+								Status:         "pass",
+							},
+							{
+								Score:          2,
+								Value:          nil,
+								PassTargets:    nil,
+								WarningTargets: nil,
+								KeySLI:         false,
+								Status:         "pass",
+							},
 						},
 					},
 					EventData: keptnv2.EventData{
@@ -2441,24 +2491,24 @@ func TestEvaluateObjectives(t *testing.T) {
 							PassTargets: []*keptnv2.SLITarget{
 								{
 									Criteria:    "<=15.0",
-									TargetValue: 0,
+									TargetValue: 15,
 									Violated:    true,
 								},
 								{
 									Criteria:    "<=+10%",
-									TargetValue: 0,
+									TargetValue: 5,
 									Violated:    true,
 								},
 							},
 							WarningTargets: []*keptnv2.SLITarget{
 								{
 									Criteria:    "<=20.0",
-									TargetValue: 0,
+									TargetValue: 20,
 									Violated:    true,
 								},
 								{
 									Criteria:    "<=+15%",
-									TargetValue: 0,
+									TargetValue: 5,
 									Violated:    true,
 								},
 							},


### PR DESCRIPTION
Closes #9196 
This PR fixes a problem where the SLO display names and pass/warning propertties are not set if the corresponding SLI value is not available