### PR TITLE
fix(bridge): Fix navigation to blocking sequence

### DIFF
--- a/bridge/client/app/_services/_mockData/sequence-filter.mock.ts
+++ b/bridge/client/app/_services/_mockData/sequence-filter.mock.ts
@@ -1,5 +1,5 @@
 const sequenceFilter = {
-  stages: ['dev', 'production', 'staging'],
+  stages: ['dev', 'staging', 'production'],
   services: ['carts-db', 'carts'],
 };
 

--- a/bridge/client/app/_services/_mockData/sequences.mock.ts
+++ b/bridge/client/app/_services/_mockData/sequences.mock.ts
@@ -1,6 +1,7 @@
 import { SequenceState } from '../../_models/sequenceState';
 import { ISequenceState, SequenceStatus } from '../../../../shared/interfaces/sequence';
 import { ResultTypes } from '../../../../shared/models/result-types';
+import { Trace } from '../../_models/trace';
 
 const deliveryWithDevAndStaging = {
   name: 'delivery',
@@ -1108,8 +1109,97 @@ const sequencesData = [
     ],
   },
 ] as ISequenceState[];
+
+const sequenceWithStartedSequenceMock = SequenceState.fromJSON({
+  name: 'evaluation',
+  service: 'carts',
+  project: 'sockshop',
+  time: '2021-07-05T13:35:36.482Z',
+  shkeptncontext: '7a5127e2-8dc0-4d85-9046-450ef054484b',
+  state: SequenceStatus.WAITING,
+  stages: [],
+});
+sequenceWithStartedSequenceMock.traces = [
+  Trace.fromJSON({
+    data: {
+      project: 'hipstershop',
+      service: 'frontend',
+      stage: 'production',
+    },
+    id: '3cc20fb1-02d4-410f-a60b-8b216d432759',
+    shkeptncontext: '7a5127e2-8dc0-4d85-9046-450ef054484b',
+    time: '2022-11-29T08:30:03.322814139Z',
+    type: 'sh.keptn.event.staging.delivery.triggered',
+  }),
+];
+
+const sequenceWithStagesAndStartedSequenceMock = SequenceState.fromJSON({
+  name: 'evaluation',
+  service: 'carts',
+  project: 'sockshop',
+  time: '2021-07-05T13:35:36.482Z',
+  shkeptncontext: '7a5127e2-8dc0-4d85-9046-450ef054484b',
+  state: SequenceStatus.WAITING,
+  stages: [
+    {
+      name: 'dev',
+    },
+  ],
+});
+sequenceWithStagesAndStartedSequenceMock.traces = [
+  Trace.fromJSON({
+    data: {
+      project: 'hipstershop',
+      service: 'frontend',
+      stage: 'staging',
+    },
+    id: '3cc20fb1-02d4-410f-a60b-8b216d432759',
+    shkeptncontext: '7a5127e2-8dc0-4d85-9046-450ef054484b',
+    time: '2022-11-29T08:30:03.322814139Z',
+    type: 'sh.keptn.event.staging.delivery.triggered',
+  }),
+];
+
+const sequenceWithoutStagesAndEvents = SequenceState.fromJSON({
+  name: 'evaluation',
+  service: 'carts',
+  project: 'sockshop',
+  time: '2021-07-05T13:35:36.482Z',
+  shkeptncontext: '7a5127e2-8dc0-4d85-9046-450ef054484b',
+  state: SequenceStatus.WAITING,
+  stages: [],
+});
+
+const sequenceWithUnknownEventStage = SequenceState.fromJSON({
+  name: 'evaluation',
+  service: 'carts',
+  project: 'sockshop',
+  time: '2021-07-05T13:35:36.482Z',
+  shkeptncontext: '7a5127e2-8dc0-4d85-9046-450ef054484b',
+  state: SequenceStatus.WAITING,
+  stages: [],
+});
+
+sequenceWithUnknownEventStage.traces = [
+  Trace.fromJSON({
+    data: {
+      project: 'hipstershop',
+      service: 'frontend',
+      stage: 'stageNotFound',
+    },
+    id: '3cc20fb1-02d4-410f-a60b-8b216d432759',
+    shkeptncontext: '7a5127e2-8dc0-4d85-9046-450ef054484b',
+    time: '2022-11-29T08:30:03.322814139Z',
+    type: 'sh.keptn.event.staging.delivery.triggered',
+  }),
+];
+
 const data = sequencesData.map((sequence) => SequenceState.fromJSON(sequence));
 export { data as SequencesMock };
 export { sequencesData as SequenceResponseMock };
 export { deliveryWithDevAndStaging as SequenceResponseWithDevAndStagingMock };
 export { evaluationSequence as SequenceResponseWithoutFailing };
+export { sequenceWithStartedSequenceMock as SequenceWithStartedSequenceMock };
+export { sequenceWithStagesAndStartedSequenceMock as SequenceWithStagesAndStartedSequenceMock };
+export { sequenceWithoutStagesAndEvents as SequenceWithoutStagesAndEvents };
+export { sequenceWithUnknownEventStage as SequenceWithUnknownEventStage };

--- a/bridge/cypress/integration/sequences.spec.ts
+++ b/bridge/cypress/integration/sequences.spec.ts
@@ -1,6 +1,6 @@
 import { SequencesPage } from '../support/pageobjects/SequencesPage';
 import EnvironmentPage from '../support/pageobjects/EnvironmentPage';
-import { interceptSequenceExecution } from '../support/intercept';
+import { interceptBlockingSequence, interceptSequenceExecution } from '../support/intercept';
 import BasePage from '../support/pageobjects/BasePage';
 
 describe('Sequences', () => {
@@ -124,6 +124,26 @@ describe('Sequences', () => {
         events: [],
       },
     });
+    interceptSequenceExecution(project, blockingContext, 'production', 'carts-db');
+
+    sequencePage
+      .visit(project)
+      .assertIsWaitingSequence(context, true)
+      .selectSequence(context)
+      .clickBlockingSequenceNavigationButton()
+      .assertSequenceDeepLink(project, blockingContext, 'dev');
+  });
+
+  it('should navigate to blocking sequence that is not initially loaded', () => {
+    const context = 'f78c2fc7-d272-4bcd-9845-3f3041080ae1';
+    const blockingContext = '88d5f9c0-1e2c-474b-af27-13fe12e038a7';
+    const project = 'sockshop';
+    cy.intercept(`/api/mongodb-datastore/event?keptnContext=${context}&project=${project}`, {
+      body: {
+        events: [],
+      },
+    });
+    interceptBlockingSequence(project, blockingContext);
     interceptSequenceExecution(project, blockingContext, 'production', 'carts-db');
 
     sequencePage

--- a/bridge/cypress/support/intercept.ts
+++ b/bridge/cypress/support/intercept.ts
@@ -500,9 +500,62 @@ export function interceptSequenceExecution(
           scope: {
             keptnContext: returnKeptnContext,
             stage: 'dev',
+            project,
           },
         },
       ],
     },
   }).as('sequenceExecution');
+}
+
+export function interceptBlockingSequence(project: string, blockingContext: string): void {
+  // Intercept blocking sequence
+  cy.intercept(`/api/mongodb-datastore/event?keptnContext=${blockingContext}&project=${project}`, {
+    body: {
+      events: [],
+    },
+  });
+  cy.intercept(
+    `/api/controlPlane/v1/sequence/${project}?pageSize=10&fromTime=2021-07-06T09:21:43.659Z&beforeTime=2021-07-06T09:22:56.433Z`,
+    {
+      body: {
+        states: [],
+      },
+    }
+  );
+
+  // intercept sequence information retrieval of blocking sequence
+  cy.intercept(`/api/controlPlane/v1/sequence/${project}?pageSize=1&keptnContext=${blockingContext}`, {
+    body: {
+      states: [
+        {
+          name: 'evaluation',
+          service: 'carts',
+          project: 'sockshop',
+          time: '2021-07-06T09:21:43.659Z',
+          shkeptncontext: '88d5f9c0-1e2c-474b-af27-13fe12e038a7',
+          state: 'finished',
+          stages: [
+            {
+              name: 'staging',
+              latestEvaluation: {
+                result: 'fail',
+                score: 66.66666666666666,
+              },
+              latestEvent: {
+                type: 'sh.keptn.event.staging.evaluation.finished',
+                id: '16614663-aea7-4420-bafe-41f480b572d8',
+                time: '2021-07-06T09:21:53.145Z',
+              },
+              latestFailedEvent: {
+                type: 'sh.keptn.event.staging.evaluation.finished',
+                id: '16614663-aea7-4420-bafe-41f480b572d8',
+                time: '2021-07-06T09:21:53.145Z',
+              },
+            },
+          ],
+        },
+      ],
+    },
+  });
 }


### PR DESCRIPTION
Fixes #9199
Also fixes another bug that the "go to blocking sequence" button did not work immediately (two clicks needed) if the blocking sequence was not initially loaded.

Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>