### PR TITLE
chore: add @TannerGilbert to Bridge Code Owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -25,7 +25,7 @@ CODEOWNERS @AloisReitbauer @johannes-b @jetzlstorfer @warber
 ADOPTERS.md @AloisReitbauer @grabnerandi @jetzlstorfer
 
 # UI / Keptn Bridge
-bridge/ @ermin-muratovic @laneli @Kirdock @heinzburgstaller
+bridge/ @ermin-muratovic @laneli @Kirdock @heinzburgstaller @TannerGilbert
 
 # Release Notes
 releasenotes/ @johannes-b @warber


### PR DESCRIPTION
Signed-off-by: Giovanni Liva <giovanni.liva@dynatrace.com>

@TannerGilbert [contributed](https://github.com/keptn/keptn/pulls?q=author%3ATannerGilbert+sort%3Aupdated-desc+) extensively in the Bridge service. 

