### PR TITLE
feat(installer): Use scarf registry as default

### DIFF
--- a/installer/manifests/keptn/README.md
+++ b/installer/manifests/keptn/README.md
@@ -5,12 +5,12 @@ Cloud-native application life-cycle orchestration. Keptn automates your SLO-driv
 
 ### Global values
 
-| Name                          | Description                                                   | Value             |
-| ----------------------------- | ------------------------------------------------------------- | ----------------- |
-| `global.keptn.registry`       | Global Docker image registry                                  | `docker.io/keptn` |
-| `global.keptn.tag`            | The tag of Keptn that should be used for all images           | `""`              |
-| `global.initContainers.image` | Init container image to enable staggered rollout of Keptn     | `curlimages/curl` |
-| `global.initContainers.tag`   | Init container image tag to enable staggered rollout of Keptn | `7.85.0`          |
+| Name                          | Description                                                   | Value                   |
+| ----------------------------- | ------------------------------------------------------------- | ----------------------- |
+| `global.keptn.registry`       | Global Docker image registry                                  | `docker.keptn.sh/keptn` |
+| `global.keptn.tag`            | The tag of Keptn that should be used for all images           | `""`                    |
+| `global.initContainers.image` | Init container image to enable staggered rollout of Keptn     | `curlimages/curl`       |
+| `global.initContainers.tag`   | Init container image tag to enable staggered rollout of Keptn | `7.85.0`                |
 
 
 ### MongoDB

--- a/installer/manifests/keptn/values.yaml
+++ b/installer/manifests/keptn/values.yaml
@@ -2,7 +2,7 @@
 global:
   keptn:
     ## @param global.keptn.registry Global Docker image registry
-    registry: docker.io/keptn
+    registry: docker.keptn.sh/keptn
     ## @param global.keptn.tag The tag of Keptn that should be used for all images
     tag: ""
   initContainers:


### PR DESCRIPTION
### This PR
- changes the default registry for the installer to docker.keptn.sh which is connected to scarf to do some usage monitoring
- this is done to get information on which we can decide to extend LTS support for Keptn