### PR TITLE
ci: Add comment on why we skip bot PR from integration tests

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -157,6 +157,8 @@ jobs:
             jq '[.workflow_runs[] | select(
               (.head_commit != null) and (.head_commit.author.name | endswith("[bot]") | not ) and ( .conclusion == "success" ) 
             )][0] | .id')
+          # here we skip BOT PRs because they don't build artifacts
+          # Secrets are not there in the builds so there is no artifact pushed and retagged
           echo "Run ID that will be used to download artifacts from: $RUN_ID"
           echo "RUN_ID=$RUN_ID" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Signed-off-by: Giovanni Liva <giovanni.liva@dynatrace.com>
Add explanation comment on why Dependency PR are not considered in the integration tests