### PR TITLE
ci: Fix error when unreleased commits are on master

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -165,7 +165,7 @@ jobs:
           --dry-run=true > release-please-output
           
           GIT_NEXT_TAG=""
-          if [ cat release-please-output | grep -q 'title: build(release):' ]; then
+          if [[ cat release-please-output | grep -q -e 'title: build(release):' ]]; then
             GIT_NEXT_TAG="next"
           else
             GIT_NEXT_TAG=$(cat release-please-output | grep 'title: build(release):' | cut -d ' ' -f3)

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -164,12 +164,18 @@ jobs:
           --repo-url=keptn/keptn \
           --dry-run=true > release-please-output
           
+          echo "done with RP"
+          
           GIT_NEXT_TAG=""
-          if grep -q "title: build(release):" 'release-please-output'; then
-            GIT_NEXT_TAG="next"
+          if grep -q 'title: build(release):' 'release-please-output'; then
+            echo "didnt find version"
+            GIT_NEXT_TAG='next'
           else
+            echo "found version"
             GIT_NEXT_TAG=$(cat release-please-output | grep 'title: build(release):' | cut -d ' ' -f3)
           fi
+          
+          echo "done with if"
           
           echo "GIT_NEXT_TAG=${GIT_NEXT_TAG}"
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -165,7 +165,7 @@ jobs:
           --dry-run=true > release-please-output
           
           GIT_NEXT_TAG=""
-          if [[ $(cat release-please-output | grep -q -e 'title: build(release):') ]]; then
+          if grep -q "title: build(release):" 'release-please-output'; then
             GIT_NEXT_TAG="next"
           else
             GIT_NEXT_TAG=$(cat release-please-output | grep 'title: build(release):' | cut -d ' ' -f3)

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -163,8 +163,13 @@ jobs:
           --token="$GH_TOKEN" \
           --repo-url=keptn/keptn \
           --dry-run=true > release-please-output
-
-          GIT_NEXT_TAG=$(cat release-please-output | grep 'title: build(release):' | cut -d ' ' -f3)
+          
+          GIT_NEXT_TAG=""
+          if [ cat release-please-output | grep -q 'title: build(release):' ]; then
+            GIT_NEXT_TAG="next"
+          else
+            GIT_NEXT_TAG=$(cat release-please-output | grep 'title: build(release):' | cut -d ' ' -f3)
+          fi
           
           echo "GIT_NEXT_TAG=${GIT_NEXT_TAG}"
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -165,7 +165,7 @@ jobs:
           --dry-run=true > release-please-output
           
           GIT_NEXT_TAG=""
-          if [[ cat release-please-output | grep -q -e 'title: build(release):' ]]; then
+          if [[ $(cat release-please-output | grep -q -e 'title: build(release):') ]]; then
             GIT_NEXT_TAG="next"
           else
             GIT_NEXT_TAG=$(cat release-please-output | grep 'title: build(release):' | cut -d ' ' -f3)

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -168,11 +168,11 @@ jobs:
           
           GIT_NEXT_TAG=""
           if grep -q 'title: build(release):' 'release-please-output'; then
-            echo "didnt find version"
-            GIT_NEXT_TAG='next'
-          else
             echo "found version"
             GIT_NEXT_TAG=$(cat release-please-output | grep 'title: build(release):' | cut -d ' ' -f3)
+          else
+            echo "didnt find version"
+            GIT_NEXT_TAG='next'
           fi
           
           echo "done with if"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -164,18 +164,12 @@ jobs:
           --repo-url=keptn/keptn \
           --dry-run=true > release-please-output
           
-          echo "done with RP"
-          
           GIT_NEXT_TAG=""
           if grep -q 'title: build(release):' 'release-please-output'; then
-            echo "found version"
             GIT_NEXT_TAG=$(cat release-please-output | grep 'title: build(release):' | cut -d ' ' -f3)
           else
-            echo "didnt find version"
             GIT_NEXT_TAG='next'
           fi
-          
-          echo "done with if"
           
           echo "GIT_NEXT_TAG=${GIT_NEXT_TAG}"
 


### PR DESCRIPTION
### This PR
- fixes a bug in the CI pipeline when no new commits are there to release but we still try to calculate a new release version in the pipeline