### PR TITLE
ci: Fix integration tests auth against GCP

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -259,6 +259,7 @@ jobs:
       - name: Install Gcloud auth plugin
         if: env.CLOUD_PROVIDER == 'GKE'
         run: |
+          sudo apt-get update
           sudo apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
 
       - name: Get Kubeconfig

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -268,8 +268,8 @@ jobs:
       - name: Run test command
         run: |
           gcloud version
-#          gke-gcloud-auth-plugin --version
           kubectl get ns
+#          gke-gcloud-auth-plugin --version
 
       - name: Push images to airgapped registry
         if: env.RUN_AIRGAPPED_TEST == 'true'

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -259,7 +259,7 @@ jobs:
       - name: Install Gcloud auth plugin
         if: env.CLOUD_PROVIDER == 'GKE'
         run: |
-          gcloud components install gke-gcloud-auth-plugin
+          apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
 
       - name: Get Kubeconfig
         if: env.CLOUD_PROVIDER == 'GKE'

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -244,12 +244,6 @@ jobs:
           k3d cluster create mykeptn --k3s-arg "--no-deploy=traefik@server:*" --agents 1 --k3s-arg "--no-deploy=servicelb@server:*" --k3s-arg "--kube-proxy-arg=conntrack-max-per-core=0@server:*" --registry-use "$AIRGAPPED_REGISTRY_URL"
           kubectl config use-context k3d-mykeptn
 
-#      - name: Install Gcloud auth plugin
-#        if: env.CLOUD_PROVIDER == 'GKE'
-#        run: |
-#          sudo apt-get update
-#          sudo apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
-
       - name: Authenticate to Google Cloud
         if: env.CLOUD_PROVIDER == 'GKE'
         uses: google-github-actions/auth@v1.0.0
@@ -265,11 +259,9 @@ jobs:
           cluster_name: ${{ matrix.CLUSTER_NAME }}
           location: "europe-west2"
 
-      - name: Run test command
+      - name: Set permissions on Kubeconfig
         run: |
-          gcloud version
-          kubectl get ns
-#          gke-gcloud-auth-plugin --version
+          chmod 600 "$KUBECONFIG"
 
       - name: Push images to airgapped registry
         if: env.RUN_AIRGAPPED_TEST == 'true'

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -244,11 +244,11 @@ jobs:
           k3d cluster create mykeptn --k3s-arg "--no-deploy=traefik@server:*" --agents 1 --k3s-arg "--no-deploy=servicelb@server:*" --k3s-arg "--kube-proxy-arg=conntrack-max-per-core=0@server:*" --registry-use "$AIRGAPPED_REGISTRY_URL"
           kubectl config use-context k3d-mykeptn
 
-      - name: Install Gcloud auth plugin
-        if: env.CLOUD_PROVIDER == 'GKE'
-        run: |
-          sudo apt-get update
-          sudo apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
+#      - name: Install Gcloud auth plugin
+#        if: env.CLOUD_PROVIDER == 'GKE'
+#        run: |
+#          sudo apt-get update
+#          sudo apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
 
       - name: Authenticate to Google Cloud
         if: env.CLOUD_PROVIDER == 'GKE'
@@ -264,7 +264,6 @@ jobs:
         with:
           cluster_name: ${{ matrix.CLUSTER_NAME }}
           location: "europe-west2"
-          use_auth_provider: true
 
       - name: Run test command
         run: |

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -268,7 +268,7 @@ jobs:
       - name: Run test command
         run: |
           gcloud version
-          gke-gcloud-auth-plugin --version
+#          gke-gcloud-auth-plugin --version
           kubectl get ns
 
       - name: Push images to airgapped registry

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -244,14 +244,6 @@ jobs:
           k3d cluster create mykeptn --k3s-arg "--no-deploy=traefik@server:*" --agents 1 --k3s-arg "--no-deploy=servicelb@server:*" --k3s-arg "--kube-proxy-arg=conntrack-max-per-core=0@server:*" --registry-use "$AIRGAPPED_REGISTRY_URL"
           kubectl config use-context k3d-mykeptn
 
-      - name: Authenticate to Google Cloud
-        if: env.CLOUD_PROVIDER == 'GKE'
-        uses: google-github-actions/auth@v1.0.0
-        with:
-          credentials_json: ${{ secrets.GCLOUD_RESTRICTED_SERVICE_KEY }}
-          access_token_lifetime: "7200s"
-          token_format: "access_token"
-
       - name: Set up Google Cloud SDK
         if: env.CLOUD_PROVIDER == 'GKE'
         uses: google-github-actions/setup-gcloud@v1.0.1
@@ -259,8 +251,15 @@ jobs:
       - name: Install Gcloud auth plugin
         if: env.CLOUD_PROVIDER == 'GKE'
         run: |
-          sudo apt-get update
-          sudo apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
+          gcloud components install gke-gcloud-auth-plugin
+
+      - name: Authenticate to Google Cloud
+        if: env.CLOUD_PROVIDER == 'GKE'
+        uses: google-github-actions/auth@v1.0.0
+        with:
+          credentials_json: ${{ secrets.GCLOUD_RESTRICTED_SERVICE_KEY }}
+          access_token_lifetime: "7200s"
+          token_format: "access_token"
 
       - name: Get Kubeconfig
         if: env.CLOUD_PROVIDER == 'GKE'
@@ -273,6 +272,7 @@ jobs:
       - name: Run test command
         run: |
           gcloud version
+          gke-gcloud-auth-plugin --version
           kubectl get ns
 
       - name: Push images to airgapped registry

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -247,7 +247,8 @@ jobs:
       - name: Install Gcloud auth plugin
         if: env.CLOUD_PROVIDER == 'GKE'
         run: |
-          gcloud components install gke-gcloud-auth-plugin
+          sudo apt-get update
+          sudo apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
 
       - name: Authenticate to Google Cloud
         if: env.CLOUD_PROVIDER == 'GKE'

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -269,6 +269,11 @@ jobs:
           location: "europe-west2"
           use_auth_provider: true
 
+      - name: Run test command
+        run: |
+          gcloud version
+          kubectl get ns
+
       - name: Push images to airgapped registry
         if: env.RUN_AIRGAPPED_TEST == 'true'
         timeout-minutes: 15

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -244,6 +244,11 @@ jobs:
           k3d cluster create mykeptn --k3s-arg "--no-deploy=traefik@server:*" --agents 1 --k3s-arg "--no-deploy=servicelb@server:*" --k3s-arg "--kube-proxy-arg=conntrack-max-per-core=0@server:*" --registry-use "$AIRGAPPED_REGISTRY_URL"
           kubectl config use-context k3d-mykeptn
 
+      - name: Install Gcloud auth plugin
+        if: env.CLOUD_PROVIDER == 'GKE'
+        run: |
+          gcloud components install gke-gcloud-auth-plugin
+
       - name: Authenticate to Google Cloud
         if: env.CLOUD_PROVIDER == 'GKE'
         uses: google-github-actions/auth@v1.0.0

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -244,10 +244,6 @@ jobs:
           k3d cluster create mykeptn --k3s-arg "--no-deploy=traefik@server:*" --agents 1 --k3s-arg "--no-deploy=servicelb@server:*" --k3s-arg "--kube-proxy-arg=conntrack-max-per-core=0@server:*" --registry-use "$AIRGAPPED_REGISTRY_URL"
           kubectl config use-context k3d-mykeptn
 
-      - name: Set up Google Cloud SDK
-        if: env.CLOUD_PROVIDER == 'GKE'
-        uses: google-github-actions/setup-gcloud@v1.0.1
-
       - name: Install Gcloud auth plugin
         if: env.CLOUD_PROVIDER == 'GKE'
         run: |

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -244,11 +244,6 @@ jobs:
           k3d cluster create mykeptn --k3s-arg "--no-deploy=traefik@server:*" --agents 1 --k3s-arg "--no-deploy=servicelb@server:*" --k3s-arg "--kube-proxy-arg=conntrack-max-per-core=0@server:*" --registry-use "$AIRGAPPED_REGISTRY_URL"
           kubectl config use-context k3d-mykeptn
 
-      - name: Install Gcloud auth plugin
-        if: env.CLOUD_PROVIDER == 'GKE'
-        run: |
-          gcloud components install gke-gcloud-auth-plugin
-
       - name: Authenticate to Google Cloud
         if: env.CLOUD_PROVIDER == 'GKE'
         uses: google-github-actions/auth@v1.0.0
@@ -256,6 +251,15 @@ jobs:
           credentials_json: ${{ secrets.GCLOUD_RESTRICTED_SERVICE_KEY }}
           access_token_lifetime: "7200s"
           token_format: "access_token"
+
+      - name: Set up Google Cloud SDK
+        if: env.CLOUD_PROVIDER == 'GKE'
+        uses: google-github-actions/setup-gcloud@v1.0.1
+
+      - name: Install Gcloud auth plugin
+        if: env.CLOUD_PROVIDER == 'GKE'
+        run: |
+          gcloud components install gke-gcloud-auth-plugin
 
       - name: Get Kubeconfig
         if: env.CLOUD_PROVIDER == 'GKE'

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -259,7 +259,7 @@ jobs:
       - name: Install Gcloud auth plugin
         if: env.CLOUD_PROVIDER == 'GKE'
         run: |
-          apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
+          sudo apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
 
       - name: Get Kubeconfig
         if: env.CLOUD_PROVIDER == 'GKE'

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -191,17 +191,13 @@ jobs:
           echo "Downloaded files:"
           ls -la ./keptn*.tgz
 
-      - name: Install Gcloud auth plugin
-        if: env.CLOUD_PROVIDER == 'GKE'
-        run: |
-          sudo apt-get update
-          sudo apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
-
       - name: Authenticate to Google Cloud
         if: env.CLOUD_PROVIDER == 'GKE'
         uses: google-github-actions/auth@v1.0.0
         with:
           credentials_json: ${{ secrets.GCLOUD_RESTRICTED_SERVICE_KEY }}
+          access_token_lifetime: "7200s"
+          token_format: "access_token"
 
       - name: Get Kubeconfig
         if: env.CLOUD_PROVIDER == 'GKE'
@@ -209,6 +205,10 @@ jobs:
         with:
           cluster_name: ${{ matrix.CLUSTER_NAME }}
           location: "europe-west2"
+
+      - name: Set permissions on Kubeconfig
+        run: |
+          chmod 600 "$KUBECONFIG"
 
       - name: Install Keptn
         id: keptn_install

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -191,10 +191,6 @@ jobs:
           echo "Downloaded files:"
           ls -la ./keptn*.tgz
 
-      - name: Set up Google Cloud SDK
-        if: env.CLOUD_PROVIDER == 'GKE'
-        uses: google-github-actions/setup-gcloud@v1.0.1
-
       - name: Install Gcloud auth plugin
         if: env.CLOUD_PROVIDER == 'GKE'
         run: |

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -191,12 +191,6 @@ jobs:
           echo "Downloaded files:"
           ls -la ./keptn*.tgz
 
-      - name: Authenticate to Google Cloud
-        if: env.CLOUD_PROVIDER == 'GKE'
-        uses: google-github-actions/auth@v1.0.0
-        with:
-          credentials_json: ${{ secrets.GCLOUD_RESTRICTED_SERVICE_KEY }}
-
       - name: Set up Google Cloud SDK
         if: env.CLOUD_PROVIDER == 'GKE'
         uses: google-github-actions/setup-gcloud@v1.0.1
@@ -206,6 +200,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
+
+      - name: Authenticate to Google Cloud
+        if: env.CLOUD_PROVIDER == 'GKE'
+        uses: google-github-actions/auth@v1.0.0
+        with:
+          credentials_json: ${{ secrets.GCLOUD_RESTRICTED_SERVICE_KEY }}
 
       - name: Get Kubeconfig
         if: env.CLOUD_PROVIDER == 'GKE'

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -204,7 +204,7 @@ jobs:
       - name: Install Gcloud auth plugin
         if: env.CLOUD_PROVIDER == 'GKE'
         run: |
-          gcloud components install gke-gcloud-auth-plugin
+          apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
 
       - name: Get Kubeconfig
         if: env.CLOUD_PROVIDER == 'GKE'

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -204,7 +204,7 @@ jobs:
       - name: Install Gcloud auth plugin
         if: env.CLOUD_PROVIDER == 'GKE'
         run: |
-          apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
+          sudo apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
 
       - name: Get Kubeconfig
         if: env.CLOUD_PROVIDER == 'GKE'

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -191,6 +191,11 @@ jobs:
           echo "Downloaded files:"
           ls -la ./keptn*.tgz
 
+      - name: Install Gcloud auth plugin
+        if: env.CLOUD_PROVIDER == 'GKE'
+        run: |
+          gcloud components install gke-gcloud-auth-plugin
+
       - name: Authenticate to Google Cloud
         if: env.CLOUD_PROVIDER == 'GKE'
         uses: google-github-actions/auth@v1.0.0

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -191,11 +191,6 @@ jobs:
           echo "Downloaded files:"
           ls -la ./keptn*.tgz
 
-      - name: Install Gcloud auth plugin
-        if: env.CLOUD_PROVIDER == 'GKE'
-        run: |
-          gcloud components install gke-gcloud-auth-plugin
-
       - name: Authenticate to Google Cloud
         if: env.CLOUD_PROVIDER == 'GKE'
         uses: google-github-actions/auth@v1.0.0
@@ -205,6 +200,11 @@ jobs:
       - name: Set up Google Cloud SDK
         if: env.CLOUD_PROVIDER == 'GKE'
         uses: google-github-actions/setup-gcloud@v1.0.1
+
+      - name: Install Gcloud auth plugin
+        if: env.CLOUD_PROVIDER == 'GKE'
+        run: |
+          gcloud components install gke-gcloud-auth-plugin
 
       - name: Get Kubeconfig
         if: env.CLOUD_PROVIDER == 'GKE'

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -204,6 +204,7 @@ jobs:
       - name: Install Gcloud auth plugin
         if: env.CLOUD_PROVIDER == 'GKE'
         run: |
+          sudo apt-get update
           sudo apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
 
       - name: Get Kubeconfig


### PR DESCRIPTION
### This PR
- fixes kubectl access to the GKE clusters in the integration tests by removing the `use_auth_provider` setting for now
- changes the access pattern in the ZD tests to be the same as in the integration tests

Fixes #9328 
Integration test run where cluster access works: https://github.com/keptn/keptn/actions/runs/3730168580/jobs/6326903287