### PR TITLE
fix(shipyard-controller): Add new stage to sequence state immediately after receiving triggered event

### DIFF
--- a/shipyard-controller/internal/controller/sequencestate.go
+++ b/shipyard-controller/internal/controller/sequencestate.go
@@ -54,8 +54,7 @@ func (smv *SequenceStateMaterializedView) OnSequenceTriggered(event apimodels.Ke
 		State:          apimodels.SequenceTriggeredState,
 		Stages: []apimodels.SequenceStateStage{
 			{
-				Name:  eventScope.Stage,
-				State: apimodels.SequenceTriggeredState,
+				Name: eventScope.Stage,
 			},
 		},
 	}

--- a/shipyard-controller/internal/controller/sequencestate_test.go
+++ b/shipyard-controller/internal/controller/sequencestate_test.go
@@ -130,6 +130,42 @@ func TestSequenceStateMaterializedView_OnSequenceWaiting(t *testing.T) {
 			},
 			expectUpdateToBeCalled: true,
 		},
+		{
+			name: "try to set finished sequence to 'waiting'",
+			fields: SequenceStateMVTestFields{
+				SequenceStateRepo: &db_mock.SequenceStateRepoMock{
+					FindSequenceStatesFunc: func(filter models.StateFilter) (*models.SequenceStates, error) {
+						return &models.SequenceStates{
+							States: []models.SequenceState{
+								{
+									Name:           "my-sequence",
+									Service:        "my-service",
+									Project:        "my-project",
+									Shkeptncontext: "my-context",
+									State:          apimodels.SequenceFinished,
+									Stages:         nil,
+								},
+							},
+						}, nil
+					},
+					UpdateSequenceStateFunc: func(state models.SequenceState) error {
+						return nil
+					},
+				},
+			},
+			args: args{
+				event: models.KeptnContextExtendedCE{
+					Data: keptnv2.EventData{
+						Project: "my-project",
+						Stage:   "my-stage",
+						Service: "my-service",
+					},
+					Shkeptncontext: "my-context",
+					Type:           common.Stringp("my-type"),
+				},
+			},
+			expectUpdateToBeCalled: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/shipyard-controller/internal/controller/sequencestate_test.go
+++ b/shipyard-controller/internal/controller/sequencestate_test.go
@@ -948,6 +948,41 @@ func TestSequenceStateMaterializedView_OnSequenceTriggered(t *testing.T) {
 			sequenceName:                "my-sequence",
 		},
 		{
+			name: "state already exists - updating fails",
+			fields: SequenceStateMVTestFields{
+				SequenceStateRepo: &db_mock.SequenceStateRepoMock{
+					CreateSequenceStateFunc: func(state models.SequenceState) error {
+						return db.ErrStateAlreadyExists
+					},
+					FindSequenceStatesFunc: func(filter apimodels.StateFilter) (*apimodels.SequenceStates, error) {
+						return &apimodels.SequenceStates{States: []apimodels.SequenceState{
+							{
+								Name:           "my-sequence",
+								Service:        "my-service",
+								Project:        "my-project",
+								Shkeptncontext: "my-context",
+								State:          "",
+								Stages: []apimodels.SequenceStateStage{
+									{
+										Name: "my-other-stage",
+									},
+								},
+							},
+						}}, nil
+					},
+					UpdateSequenceStateFunc: func(state apimodels.SequenceState) error {
+						return errors.New("oops")
+					},
+				},
+			},
+			expectCreateStateToBeCalled: true,
+			project:                     "my-project",
+			service:                     "my-service",
+			stage:                       "my-stage",
+			keptnContext:                "my-context",
+			sequenceName:                "my-sequence",
+		},
+		{
 			name: "create state returns an error",
 			fields: SequenceStateMVTestFields{
 				SequenceStateRepo: &db_mock.SequenceStateRepoMock{

--- a/shipyard-controller/main_test.go
+++ b/shipyard-controller/main_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/keptn/keptn/shipyard-controller/models"
 	"github.com/nats-io/nats-server/v2/server"
 	natsserver "github.com/nats-io/nats-server/v2/test"
+	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/require"
 	"github.com/tryvium-travels/memongo"
 	"go.mongodb.org/mongo-driver/mongo"

--- a/shipyard-controller/main_test.go
+++ b/shipyard-controller/main_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/keptn/keptn/shipyard-controller/models"
 	"github.com/nats-io/nats-server/v2/server"
 	natsserver "github.com/nats-io/nats-server/v2/test"
-	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/require"
 	"github.com/tryvium-travels/memongo"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -1027,7 +1026,7 @@ func Test__main_SequenceStateParallelStages(t *testing.T) {
 			return false
 		}
 		return true
-	}, 3*time.Second, 100*time.Millisecond)
+	}, 10*time.Second, 100*time.Millisecond)
 
 	// now finish the sequence in staging-2
 	_, err = keptn.SendTaskFinishedEvent(&keptnv2.EventData{


### PR DESCRIPTION
This will prevent sequences that have been finished in one stage from being displayed as waiting when they are actually waiting in the next stage