### PR TITLE
feat(bridge): Read secrets from volume mount instead from env var

### DIFF
--- a/bridge/README.md
+++ b/bridge/README.md
@@ -117,7 +117,7 @@ If no `LOOK_AND_FEEL_URL` was provided, the Bridge will use the default `logo.pn
    ```console
    set API_URL=http://keptn.127.0.0.1.nip.io/api
    ```
-4. Put your API token into a file called `keptn-api-token` and move it to the folder `bridge/config/basic/`.
+4. Put your API token into a file called `keptn-api-token` and move it to the folder `bridge/config/api-token/`.
 5. Run `yarn start:dev` from bridge root level to start the express server on port 3001 and the Angular app on port 3000.
 6. Access the web through the url shown on the console (e.g., http://localhost:3000/ ).
 

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -16,45 +16,20 @@ The Keptn Bridge is installed as a part of [Keptn](https://keptn.sh). To get sta
 
 ### Setting up Basic Authentication
 
-Keptn Bridge can use [basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication), the following two environment variables define the values:
+Keptn Bridge can use [basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication), the following two files (or volume mounts) define the values:
 
+Folder: `/config/basic`
 - `BASIC_AUTH_USERNAME` - username
 - `BASIC_AUTH_PASSWORD` - password
 
-To enable it within your Kubernetes cluster, we recommend creating a secret that holds the two variables and then applying this secret within the Kubernetes deployment for Keptn Bridge.
-1. Create the secret using
+To enable it within your Kubernetes cluster, we recommend creating a secret that holds the two variables and then applying this secret within the Kubernetes deployment for Keptn Bridge. 
+#### Create the secret using
 
    ```console
    kubectl -n keptn create secret generic bridge-credentials --from-literal="BASIC_AUTH_USERNAME=<USERNAME>" --from-literal="BASIC_AUTH_PASSWORD=<PASSWORD>"
    ```
 
    _Note: Replace `<USERNAME>` and `<PASSWORD>` with the desired credentials._
-
-2. In case you are using Keptn 0.6.1 or older, edit the deployment using
-
-   ```console
-   kubectl -n keptn edit deployment bridge
-   ```
-
-   and add the secret to the `bridge` container, such that the container spec looks like this:
-
-   ```yaml
-       ...
-       spec:
-         containers:
-         - name: bridge
-           image: keptn/bridge2:0.6.1
-           imagePullPolicy: Always
-           # EDIT STARTS HERE
-           envFrom:
-             - secretRef:
-                 name: bridge-credentials
-                 optional: true
-           # EDIT ENDS HERE
-           ports:
-           - containerPort: 3000
-           ...
-   ```
 
 **Note 1**: To disable authentication, just delete the secret using `kubectl -n keptn delete secret bridge-credentials`.
 
@@ -133,19 +108,18 @@ If no `LOOK_AND_FEEL_URL` was provided, the Bridge will use the default `logo.pn
 
 1. Run `yarn install` from the bridge root level.
 2. Run `yarn install` from the server folder.
-3. Set `API_URL` and `API_TOKEN` environment variables, depending on your Keptn installation and operating system:
+3. Set the `API_URL` environment variable, depending on your Keptn installation and operating system:
    **Linux/MacOS**
    ```console
    export API_URL=http://keptn.127.0.0.1.nip.io/api
-   export API_TOKEN=1234-exam-ple
    ```
    **Windows**
    ```console
    set API_URL=http://keptn.127.0.0.1.nip.io/api
-   set API_TOKEN=1234-exam-ple
    ```
-4. Run `yarn start:dev` from bridge root level to start the express server on port 3001 and the Angular app on port 3000.
-5. Access the web through the url shown on the console (e.g., http://localhost:3000/ ).
+4. Put your API token into a file called `keptn-api-token` and move it to the folder `bridge/config/basic/`.
+5. Run `yarn start:dev` from bridge root level to start the express server on port 3001 and the Angular app on port 3000.
+6. Access the web through the url shown on the console (e.g., http://localhost:3000/ ).
 
 ### UI testing with [Cypress](https://docs.cypress.io/api/table-of-contents)
 

--- a/bridge/server/interfaces/configuration.ts
+++ b/bridge/server/interfaces/configuration.ts
@@ -6,6 +6,17 @@ export interface OAuthSecrets {
   clientSecret?: string;
 }
 
+export interface MongoDBSecrets {
+  user: string;
+  password: string;
+}
+
+export interface BasicSecrets {
+  user: string;
+  password: string;
+  apiToken: string;
+}
+
 type RecursivePartial<T> = {
   [P in keyof T]?: RecursivePartial<T[P]>;
 };
@@ -121,10 +132,7 @@ export enum EnvVar {
   LOG_LEVEL = 'LOG_LEVEL',
   SHOW_API_TOKEN = 'SHOW_API_TOKEN',
   API_URL = 'API_URL',
-  API_TOKEN = 'API_TOKEN',
   AUTH_MSG = 'AUTH_MSG',
-  BASIC_AUTH_USERNAME = 'BASIC_AUTH_USERNAME',
-  BASIC_AUTH_PASSWORD = 'BASIC_AUTH_PASSWORD',
   REQUEST_TIME_LIMIT = 'REQUEST_TIME_LIMIT',
   REQUESTS_WITHIN_TIME = 'REQUESTS_WITHIN_TIME',
   CLEAN_BUCKET_INTERVAL = 'CLEAN_BUCKET_INTERVAL',
@@ -150,8 +158,6 @@ export enum EnvVar {
   ENABLE_VERSION_CHECK = 'ENABLE_VERSION_CHECK',
   MONGODB_DATABASE = 'MONGODB_DATABASE',
   MONGODB_HOST = 'MONGODB_HOST',
-  MONGODB_PASSWORD = 'MONGODB_PASSWORD',
-  MONGODB_USER = 'MONGODB_USER',
   NODE_ENV = 'NODE_ENV',
   VERSION = 'VERSION',
 }

--- a/bridge/server/test/bridge-info.spec.ts
+++ b/bridge/server/test/bridge-info.spec.ts
@@ -1,18 +1,51 @@
 import request from 'supertest';
-import { getBaseOptions, setupServer } from '../.jest/setupServer';
 import { Express } from 'express';
-import { getConfiguration } from '../utils/configuration';
 import MockAdapter from 'axios-mock-adapter';
 import { IMetadata } from '../../shared/interfaces/metadata';
 import { BridgeInfo } from '../../shared/interfaces/bridge-info';
 import { KeptnVersions } from '../../shared/interfaces/keptn-versions';
 import { KeptnInfoResult } from '../../shared/interfaces/keptn-info-result';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { jest } from '@jest/globals';
+
+const apiToken = 'abcdefg';
+const getOAuthSecretsSpy = jest.fn();
+const getBasicSecretsSpy = jest.fn();
+const getMongoDbSecretsSpy = jest.fn();
+getOAuthSecretsSpy.mockReturnValue({
+  sessionSecret: 'session_secret',
+  databaseEncryptSecret: 'database_secret_'.repeat(2),
+  clientSecret: '',
+});
+getBasicSecretsSpy.mockReturnValue({
+  apiToken: apiToken,
+  user: '',
+  password: '',
+});
+getMongoDbSecretsSpy.mockReturnValue({
+  user: 'user',
+  password: 'pwd',
+});
+
+jest.unstable_mockModule('../user/secrets', () => {
+  return {
+    getOAuthSecrets: getOAuthSecretsSpy,
+    getBasicSecrets: getBasicSecretsSpy,
+    getMongoDbSecrets: getMongoDbSecretsSpy,
+    getOAuthMongoExternalConnectionString: (): string => '',
+    getMongodbFolder: (): string => '',
+    mongodbPasswordFileName: 'pwdName',
+    mongodbUserFileName: 'userName',
+  };
+});
+
+const { getConfiguration } = await import('../utils/configuration');
+const { getBaseOptions, setupServer } = await import('../.jest/setupServer');
 
 describe('Test /bridgeInfo', () => {
   let app: Express;
 
   const apiUrl = 'http://localhost/api/';
-  const apiToken = 'abcdefg';
   const provMsg = '  message   ';
   const authMsg = 'a string';
   const version = 'testVersion';

--- a/bridge/server/test/oauth.spec.ts
+++ b/bridge/server/test/oauth.spec.ts
@@ -8,12 +8,28 @@ import { jest } from '@jest/globals';
 
 let store: CachedStore = {};
 const fakeGetOAuthSecrets = jest.fn();
+const getBasicSecretsSpy = jest.fn();
+const getMongoDbSecretsSpy = jest.fn();
+getBasicSecretsSpy.mockReturnValue({
+  apiToken: 'api token',
+  user: '',
+  password: '',
+});
+getMongoDbSecretsSpy.mockReturnValue({
+  user: 'user',
+  password: 'pwd',
+});
 jest.unstable_mockModule('../user/secrets', () => {
   return {
     getOAuthSecrets: fakeGetOAuthSecrets,
     getOAuthMongoExternalConnectionString(): string {
       return '';
     },
+    getBasicSecrets: getBasicSecretsSpy,
+    getMongoDbSecrets: getMongoDbSecretsSpy,
+    getMongodbFolder: (): string => '',
+    mongodbPasswordFileName: 'pwdName',
+    mongodbUserFileName: 'userName',
   };
 });
 // has to be imported after secrets mock due to mock limitations of jest

--- a/bridge/server/user/secrets.spec.ts
+++ b/bridge/server/user/secrets.spec.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { jest } from '@jest/globals';
 import { join } from 'path';
+import { BasicSecrets, MongoDBSecrets } from '../interfaces/configuration';
 
 const readFileSyncSpy = jest.fn();
 const existsSyncSpy = jest.fn();
@@ -12,7 +13,9 @@ jest.unstable_mockModule('fs', () => {
   };
 });
 
-const { getOAuthMongoExternalConnectionString, getOAuthSecrets } = await import('./secrets');
+const { getOAuthMongoExternalConnectionString, getOAuthSecrets, getBasicSecrets, getMongoDbSecrets } = await import(
+  './secrets'
+);
 
 describe('Test fetching secrets from the file system', () => {
   const options = { encoding: 'utf8', flag: 'r' };
@@ -72,5 +75,38 @@ describe('Test fetching secrets from the file system', () => {
       clientSecret: '',
     });
     expect(readFileSyncSpy).not.toHaveBeenCalled();
+  });
+
+  it('should return mongodb secrets', () => {
+    existsSyncSpy.mockReturnValue(true);
+    readFileSyncSpy.mockReturnValueOnce('secret1');
+    readFileSyncSpy.mockReturnValueOnce('secret2');
+
+    const mongoSecrets = getMongoDbSecrets('config');
+
+    expect(mongoSecrets).toEqual<MongoDBSecrets>({
+      user: 'secret1',
+      password: 'secret2',
+    });
+    expect(readFileSyncSpy).toHaveBeenCalledWith(join('config', 'oauth_mongodb', 'mongodb-user'), options);
+    expect(readFileSyncSpy).toHaveBeenCalledWith(join('config', 'oauth_mongodb', 'mongodb-passwords'), options);
+  });
+
+  it('should return basic secrets', () => {
+    existsSyncSpy.mockReturnValue(true);
+    readFileSyncSpy.mockReturnValueOnce('secret1');
+    readFileSyncSpy.mockReturnValueOnce('secret2');
+    readFileSyncSpy.mockReturnValueOnce('secret3');
+
+    const mongoSecrets = getBasicSecrets('config');
+
+    expect(mongoSecrets).toEqual<BasicSecrets>({
+      apiToken: 'secret1',
+      user: 'secret2',
+      password: 'secret3',
+    });
+    expect(readFileSyncSpy).toHaveBeenCalledWith(join('config', 'basic', 'keptn-api-token'), options);
+    expect(readFileSyncSpy).toHaveBeenCalledWith(join('config', 'basic', 'BASIC_AUTH_USERNAME'), options);
+    expect(readFileSyncSpy).toHaveBeenCalledWith(join('config', 'basic', 'BASIC_AUTH_PASSWORD'), options);
   });
 });

--- a/bridge/server/user/secrets.spec.ts
+++ b/bridge/server/user/secrets.spec.ts
@@ -54,7 +54,7 @@ describe('Test fetching secrets from the file system', () => {
 
     expect(secret).toBe('secretMongo');
     expect(readFileSyncSpy).toHaveBeenCalledWith(
-      join('config', 'oauth_mongodb', 'external_connection_string'),
+      join('config', 'oauth_mongodb_connection_string', 'external_connection_string'),
       options
     );
   });
@@ -105,7 +105,7 @@ describe('Test fetching secrets from the file system', () => {
       user: 'secret2',
       password: 'secret3',
     });
-    expect(readFileSyncSpy).toHaveBeenCalledWith(join('config', 'basic', 'keptn-api-token'), options);
+    expect(readFileSyncSpy).toHaveBeenCalledWith(join('config', 'api-token', 'keptn-api-token'), options);
     expect(readFileSyncSpy).toHaveBeenCalledWith(join('config', 'basic', 'BASIC_AUTH_USERNAME'), options);
     expect(readFileSyncSpy).toHaveBeenCalledWith(join('config', 'basic', 'BASIC_AUTH_PASSWORD'), options);
   });

--- a/bridge/server/user/secrets.ts
+++ b/bridge/server/user/secrets.ts
@@ -1,6 +1,9 @@
 import { join } from 'path';
 import { existsSync, readFileSync } from 'fs';
-import { OAuthSecrets } from '../interfaces/configuration';
+import { BasicSecrets, MongoDBSecrets, OAuthSecrets } from '../interfaces/configuration';
+
+export const mongodbUserFileName = 'mongodb-user';
+export const mongodbPasswordFileName = 'mongodb-passwords';
 
 function getOAuthSecrets(configFolder: string): OAuthSecrets {
   const oauthFolder = join(configFolder, 'oauth');
@@ -16,9 +19,36 @@ function getOAuthSecrets(configFolder: string): OAuthSecrets {
 }
 
 function getOAuthMongoExternalConnectionString(configFolder: string): string {
-  const mongodbFolder = join(configFolder, 'oauth_mongodb');
+  const mongodbFolder = getMongodbFolder(configFolder);
   const mongoSecretPath = join(mongodbFolder, 'external_connection_string');
   return readSecret(mongoSecretPath);
+}
+
+function getMongoDbSecrets(configFolder: string): MongoDBSecrets {
+  const mongodbFolder = getMongodbFolder(configFolder);
+  const userPath = join(mongodbFolder, mongodbUserFileName);
+  const passwordPath = join(mongodbFolder, mongodbPasswordFileName);
+
+  return {
+    user: readSecret(userPath),
+    password: readSecret(passwordPath),
+  };
+}
+
+function getMongodbFolder(configFolder: string): string {
+  return join(configFolder, 'oauth_mongodb');
+}
+
+function getBasicSecrets(configFolder: string): BasicSecrets {
+  const basicCredentialFolder = join(configFolder, 'basic');
+  const apiTokenPath = join(basicCredentialFolder, 'keptn-api-token');
+  const basicUser = join(basicCredentialFolder, 'BASIC_AUTH_USERNAME');
+  const basicPassword = join(basicCredentialFolder, 'BASIC_AUTH_PASSWORD');
+  return {
+    apiToken: readSecret(apiTokenPath),
+    user: readSecret(basicUser),
+    password: readSecret(basicPassword),
+  };
 }
 
 function readSecret(path: string): string {
@@ -28,4 +58,4 @@ function readSecret(path: string): string {
   return '';
 }
 
-export { getOAuthSecrets, getOAuthMongoExternalConnectionString };
+export { getOAuthSecrets, getOAuthMongoExternalConnectionString, getMongoDbSecrets, getBasicSecrets, getMongodbFolder };

--- a/bridge/server/user/secrets.ts
+++ b/bridge/server/user/secrets.ts
@@ -19,7 +19,7 @@ function getOAuthSecrets(configFolder: string): OAuthSecrets {
 }
 
 function getOAuthMongoExternalConnectionString(configFolder: string): string {
-  const mongodbFolder = getMongodbFolder(configFolder);
+  const mongodbFolder = join(configFolder, 'oauth_mongodb_connection_string');
   const mongoSecretPath = join(mongodbFolder, 'external_connection_string');
   return readSecret(mongoSecretPath);
 }
@@ -41,7 +41,8 @@ function getMongodbFolder(configFolder: string): string {
 
 function getBasicSecrets(configFolder: string): BasicSecrets {
   const basicCredentialFolder = join(configFolder, 'basic');
-  const apiTokenPath = join(basicCredentialFolder, 'keptn-api-token');
+  const apiFolder = join(configFolder, 'api-token');
+  const apiTokenPath = join(apiFolder, 'keptn-api-token');
   const basicUser = join(basicCredentialFolder, 'BASIC_AUTH_USERNAME');
   const basicPassword = join(basicCredentialFolder, 'BASIC_AUTH_PASSWORD');
   return {

--- a/installer/manifests/keptn/templates/core.yaml
+++ b/installer/manifests/keptn/templates/core.yaml
@@ -109,11 +109,6 @@ spec:
           env:
             - name: API_URL
               value: "http://api-gateway-nginx{{ .Values.prefixPath }}/api"
-            - name: API_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ default "keptn-api-token" .Values.apiService.tokenSecretName }}
-                  key: keptn-api-token
             - name: CLI_DOWNLOAD_LINK
               value: "{{ .Values.bridge.cliDownloadLink | default (print "https://github.com/keptn/keptn/releases/tag/" .Chart.AppVersion) }}"
             - name: ENABLE_VERSION_CHECK
@@ -157,16 +152,6 @@ spec:
               value: "{{ .Values.bridge.oauth.trustProxy }}"
             - name: MONGODB_HOST
               value: '{{ .Release.Name }}-{{ .Values.mongo.service.nameOverride }}:{{ .Values.mongo.service.ports.mongodb }}'
-            - name: MONGODB_USER
-              valueFrom:
-                secretKeyRef:
-                  name: mongodb-credentials
-                  key: mongodb-user
-            - name: MONGODB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: mongodb-credentials
-                  key: mongodb-passwords
             - name: MONGODB_DATABASE
               value: {{ .Values.mongo.auth.bridgeAuthDatabase | default "openid" }}
             - name: CONFIG_DIR
@@ -179,10 +164,6 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
-          envFrom:
-            - secretRef:
-                name: bridge-credentials
-                optional: true
           ports:
             - containerPort: 3000
           resources:
@@ -193,8 +174,18 @@ spec:
             - name: bridge-oauth
               mountPath: /config/oauth
               readOnly: true
+            - name: bridge-api-token
+              mountPath: /config/basic
+              readOnly: true
+            - name: bridge-basic-auth
+              mountPath: /config/basic
+              readOnly: true
             - name: bridge-oauth-mongodb-credentials
               mountPath: /config/oauth_mongodb
+              readOnly: true
+            - name: bridge-mongodb-credentials
+              mountPath: /config/oauth_mongodb
+              readOnly: true
             {{- if .Values.bridge.extraVolumeMounts }}
             {{- include "keptn.common.tplvalues.render" ( dict "value" .Values.bridge.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
@@ -210,10 +201,28 @@ spec:
           secret:
             secretName: bridge-oauth
             defaultMode: 0400
+        - name: bridge-api-token
+          secret:
+            secretName: {{ default "keptn-api-token" .Values.apiService.tokenSecretName }}
+            defaultMode: 0400
+        - name: bridge-basic-auth
+          secret:
+            secretName: bridge-credentials
+            defaultMode: 0400
+            optional: true
         - name: bridge-oauth-mongodb-credentials
           secret:
             secretName: bridge-oauth-mongodb-credentials
             defaultMode: 0400
+        - name: bridge-mongodb-credentials
+          secret:
+            secretName: mongodb-credentials
+            defaultMode: 0400
+            items:
+              - key: mongodb-user
+                path: mongodb-user
+              - key: mongodb-passwords
+                path: mongodb-passwords
         {{- if .Values.bridge.extraVolumes }}
         {{- include "keptn.common.tplvalues.render" ( dict "value" .Values.bridge.extraVolumes "context" $) | nindent 8 }}
         {{- end }}

--- a/installer/manifests/keptn/templates/core.yaml
+++ b/installer/manifests/keptn/templates/core.yaml
@@ -175,13 +175,13 @@ spec:
               mountPath: /config/oauth
               readOnly: true
             - name: bridge-api-token
-              mountPath: /config/basic
+              mountPath: /config/api-token
               readOnly: true
             - name: bridge-basic-auth
               mountPath: /config/basic
               readOnly: true
             - name: bridge-oauth-mongodb-credentials
-              mountPath: /config/oauth_mongodb
+              mountPath: /config/oauth_mongodb_connection_string
               readOnly: true
             - name: bridge-mongodb-credentials
               mountPath: /config/oauth_mongodb


### PR DESCRIPTION
The following secrets are now read from the volume mount instead from environment variables
- mongodb user and password
- Basic user and password
- API token

Part of: #9331 

Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>