### PR TITLE
ci: Set kubeconfig permissions in GCP setup step

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -260,6 +260,7 @@ jobs:
           location: "europe-west2"
 
       - name: Set permissions on Kubeconfig
+        if: env.CLOUD_PROVIDER == 'GKE'
         run: |
           chmod 600 "$KUBECONFIG"
 

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -207,6 +207,7 @@ jobs:
           location: "europe-west2"
 
       - name: Set permissions on Kubeconfig
+        if: env.CLOUD_PROVIDER == 'GKE'
         run: |
           chmod 600 "$KUBECONFIG"
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -90,3 +90,4 @@ For a realtime overview of current contributors to the Keptn project, we refer t
 * [Sarah Huber](https://github.com/sarahhuber001)
 * [Salvador Cavadini](https://github.com/chavacava)
 * [Nitin Mewar](https://github.com/nitinmewar)
+* [Philipp Hinteregger](https://github.com/philipp-hinteregger)


### PR DESCRIPTION
### This PR

- executes the set permissions step for kubeconfig in integration/zdt pipeline just for GKE cluster


