### PR TITLE
fix(resource-service): override insecureSkipTLS only if proxy is set to nil

### DIFF
--- a/resource-service/common/git.go
+++ b/resource-service/common/git.go
@@ -477,7 +477,9 @@ func (g *Git) getCurrentRemoteRevision(gitContext common_models.GitContext) (str
 
 func retrieveInsecureSkipTLS(credentials *common_models.GitCredentials) bool {
 	if credentials != nil && credentials.HttpsAuth != nil {
-		return credentials.HttpsAuth.InsecureSkipTLS
+		if credentials.HttpsAuth.Proxy == nil {
+			return credentials.HttpsAuth.InsecureSkipTLS
+		}
 	}
 	return false
 }

--- a/resource-service/common/git.go
+++ b/resource-service/common/git.go
@@ -477,6 +477,9 @@ func (g *Git) getCurrentRemoteRevision(gitContext common_models.GitContext) (str
 
 func retrieveInsecureSkipTLS(credentials *common_models.GitCredentials) bool {
 	if credentials != nil && credentials.HttpsAuth != nil {
+		// only return the HttpsAuth.InsecureSkipTLS value if no proxy has been set.
+		// otherwise, the proxy settings will be discarded by go-git.
+		// see https://github.com/go-git/go-git/issues/590
 		if credentials.HttpsAuth.Proxy == nil {
 			return credentials.HttpsAuth.InsecureSkipTLS
 		}

--- a/resource-service/common/gitsuite_test.go
+++ b/resource-service/common/gitsuite_test.go
@@ -1335,6 +1335,18 @@ func TestRetrieveInsecureFlag(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "true, but proxy is set",
+			credentials: &common_models.GitCredentials{
+				HttpsAuth: &apimodels.HttpsGitAuth{
+					InsecureSkipTLS: true,
+					Proxy: &apimodels.ProxyGitAuth{
+						URL: "http://localhost:1080",
+					},
+				},
+			},
+			want: false,
+		},
+		{
 			name: "not set",
 			credentials: &common_models.GitCredentials{
 				HttpsAuth: &apimodels.HttpsGitAuth{},


### PR DESCRIPTION
This PR fixes an issue caused by the go-git library (https://github.com/go-git/go-git/issues/590), where the library creates a new http client on its own when using the insecureSkipTLS parameter, rather than using the http client with the proxy options being set.