### PR TITLE
ci: fix docker build caching

### DIFF
--- a/.github/workflows/test-and-build-docker-images.yml
+++ b/.github/workflows/test-and-build-docker-images.yml
@@ -216,8 +216,8 @@ jobs:
         push: ${{ inputs.should-push-image == 'true' }}
         pull: true
         builder: ${{ steps.buildx.outputs.name }}
-        cache-from: type=gha, scope=${{ github.workflow }}
-        cache-to: type=gha, scope=${{ github.workflow }}
+        cache-from: type=gha,scope=${{ github.ref_name }}-${{ inputs.artifact }}
+        cache-to: type=gha,scope=${{ github.ref_name }}-${{ inputs.artifact }}
 
     - name: Write docker image digest to file
       if: inputs.should-push-image == 'true'

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -25,12 +25,12 @@ ARG debugBuild
 # set buildflags for debug build
 RUN if [ ! -z "$debugBuild" ]; then export BUILDFLAGS='-gcflags "all=-N -l"'; fi
 
-ARG version=develop
-RUN sed -i "s/version: develop/version: ${version}/g" /go/src/github.com/keptn/keptn/api/swagger.yaml
-
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
 RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v cmd/api-server/main.go
+
+ARG version=develop
+RUN sed -i "s/version: develop/version: ${version}/g" /go/src/github.com/keptn/keptn/api/swagger.yaml
 
 
 FROM alpine:3.17 as production

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -2,9 +2,6 @@
 # This is based on Debian and sets the GOPATH to /go.
 FROM golang:1.19.4-alpine3.16 as builder
 
-ARG version=develop
-ARG debugBuild
-
 WORKDIR /go/src/github.com/keptn/keptn/api
 
 # Force the go compiler to use modules
@@ -24,9 +21,11 @@ RUN go mod download
 # Copy local code to the container image.
 COPY . .
 
+ARG debugBuild
 # set buildflags for debug build
 RUN if [ ! -z "$debugBuild" ]; then export BUILDFLAGS='-gcflags "all=-N -l"'; fi
 
+ARG version=develop
 RUN sed -i "s/version: develop/version: ${version}/g" /go/src/github.com/keptn/keptn/api/swagger.yaml
 
 # Build the command inside the container.

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -34,14 +34,12 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v cmd/api-ser
 
 
 FROM alpine:3.17 as production
-ARG version=develop
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.url="https://keptn.sh" \
     org.opencontainers.image.title="Keptn API" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \
-    org.opencontainers.image.licenses="Apache-2.0" \
-    org.opencontainers.image.version="${version}"
+    org.opencontainers.image.licenses="Apache-2.0"
 
 # we need to install ca-certificates and libc6-compat for go programs to work properly
 RUN apk add --no-cache ca-certificates libc6-compat
@@ -60,6 +58,9 @@ ENV GOTRACEBACK=all
 
 RUN adduser -D nonroot -u 65532
 USER nonroot
+
+ARG version=develop
+LABEL org.opencontainers.image.version="${version}"
 
 # Run the web service on container startup.
 CMD ["/api", "--host=0.0.0.0", "--port=8080"]

--- a/approval-service/Dockerfile
+++ b/approval-service/Dockerfile
@@ -2,9 +2,6 @@
 # This is based on Debian and sets the GOPATH to /go.
 FROM golang:1.19.4-alpine3.16 as builder
 
-ARG version=develop
-ARG debugBuild
-
 WORKDIR /go/src/github.com/keptn/keptn/approval-service
 
 # Force the go compiler to use modules
@@ -24,6 +21,7 @@ RUN go mod download
 # Copy local code to the container image.
 COPY . .
 
+ARG debugBuild
 # set buildflags for debug build
 RUN if [ ! -z "$debugBuild" ]; then export BUILDFLAGS='-gcflags "all=-N -l"'; fi
 

--- a/approval-service/Dockerfile
+++ b/approval-service/Dockerfile
@@ -30,14 +30,12 @@ RUN if [ ! -z "$debugBuild" ]; then export BUILDFLAGS='-gcflags "all=-N -l"'; fi
 RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o approval-service
 
 FROM alpine:3.17 as production
-ARG version=develop
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.url="https://keptn.sh" \
     org.opencontainers.image.title="Keptn Approval Service" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \
-    org.opencontainers.image.licenses="Apache-2.0" \
-    org.opencontainers.image.version="${version}"
+    org.opencontainers.image.licenses="Apache-2.0"
 
 # we need to install ca-certificates and libc6-compat for go programs to work properly
 RUN apk add --no-cache ca-certificates libc6-compat
@@ -52,6 +50,9 @@ ENV GOTRACEBACK=all
 
 RUN adduser -D nonroot -u 65532
 USER nonroot
+
+ARG version=develop
+LABEL org.opencontainers.image.version="${version}"
 
 # Run the web service on container startup.
 CMD ["/approval-service"]

--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -1,8 +1,5 @@
 FROM node:14-alpine3.15 as bridge-builder
 
-ARG version=develop
-ENV VERSION="${version}"
-
 # Prepare app directory
 WORKDIR /usr/src/app
 
@@ -14,9 +11,6 @@ COPY . /usr/src/app
 RUN yarn build
 
 FROM node:14-alpine3.15 as bridge-server-builder
-
-ARG version=develop
-ENV VERSION="${version}"
 
 # Prepare app directory
 WORKDIR /usr/src/app/server

--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -27,14 +27,12 @@ RUN yarn build && \
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM node:14-alpine3.15 as production
-ARG version=develop
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.url="https://keptn.sh" \
     org.opencontainers.image.title="Keptn Bridge" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \
-    org.opencontainers.image.licenses="Apache-2.0" \
-    org.opencontainers.image.version="${version}"
+    org.opencontainers.image.licenses="Apache-2.0"
 
 ENV VERSION="${version}"
 ENV NODE_ENV "production"
@@ -53,6 +51,9 @@ RUN addgroup mygroup --gid 65532 && adduser -D -G mygroup myuser --uid 65532 && 
 
 # Set user
 USER myuser
+
+ARG version=develop
+LABEL org.opencontainers.image.version="${version}"
 
 EXPOSE 3000
 CMD ["npm", "start", "--prefix", "./server"]

--- a/distributor/Dockerfile
+++ b/distributor/Dockerfile
@@ -30,15 +30,12 @@ ARG gitSha=unknown
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-linkmode=external -X main.gitCommit=$gitSha -X main.buildTime=$buildTime" $BUILDFLAGS -v -o distributor ./cmd/
 
 FROM alpine:3.17 as production
-ARG version=develop
-
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.url="https://keptn.sh" \
     org.opencontainers.image.title="Keptn Distributor" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \
-    org.opencontainers.image.licenses="Apache-2.0" \
-    org.opencontainers.image.version="${version}"
+    org.opencontainers.image.licenses="Apache-2.0"
 
 RUN apk add --no-cache ca-certificates libc6-compat
 
@@ -50,6 +47,9 @@ ENV GOTRACEBACK=all
 
 RUN adduser -D nonroot -u 65532
 USER nonroot
+
+ARG version=develop
+LABEL org.opencontainers.image.version="${version}"
 
 # Run the web service on container startup.
 CMD ["/distributor"]

--- a/distributor/Dockerfile
+++ b/distributor/Dockerfile
@@ -2,10 +2,6 @@
 # This is based on Debian and sets the GOPATH to /go.
 FROM golang:1.19.4-alpine3.16 as builder
 
-ARG debugBuild
-ARG buildTime=unknown
-ARG gitSha=unknown
-
 WORKDIR /go/src/github.com/keptn/keptn/distributor
 
 # Force the go compiler to use modules
@@ -22,8 +18,12 @@ RUN go mod download
 # Copy local code to the container image.
 COPY . .
 
+ARG debugBuild
 # set buildflags for debug build
 RUN if [ ! -z "$debugBuild" ]; then export BUILDFLAGS='-gcflags "all=-N -l"'; fi
+
+ARG buildTime=unknown
+ARG gitSha=unknown
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)

--- a/lighthouse-service/Dockerfile
+++ b/lighthouse-service/Dockerfile
@@ -32,14 +32,12 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.17 as production
-ARG version=develop
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.url="https://keptn.sh" \
     org.opencontainers.image.title="Keptn Lighthouse Service" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \
-    org.opencontainers.image.licenses="Apache-2.0" \
-    org.opencontainers.image.version="${version}"
+    org.opencontainers.image.licenses="Apache-2.0"
 
 # we need to install ca-certificates and libc6-compat for go programs to work properly
 RUN apk add --no-cache ca-certificates libc6-compat
@@ -54,6 +52,9 @@ ENV GOTRACEBACK=all
 
 RUN adduser -D nonroot -u 65532
 USER nonroot
+
+ARG version=develop
+LABEL org.opencontainers.image.version="${version}"
 
 # Run the web service on container startup.
 CMD ["/lighthouse-service"]

--- a/lighthouse-service/Dockerfile
+++ b/lighthouse-service/Dockerfile
@@ -3,9 +3,6 @@
 # https://hub.docker.com/_/golang
 FROM golang:1.19.4-alpine3.16 as builder
 
-# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
-ARG SKAFFOLD_GO_GCFLAGS
-
 # Copy local code to the container image.
 WORKDIR /go/src/github.com/keptn/keptn/lighthouse-service
 
@@ -24,6 +21,9 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
+
+# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
+ARG SKAFFOLD_GO_GCFLAGS
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)

--- a/mongodb-datastore/Dockerfile
+++ b/mongodb-datastore/Dockerfile
@@ -33,14 +33,12 @@ RUN sed -i "s/version: develop/version: ${version}/g" /go/src/github.com/keptn/k
 RUN cd cmd/mongodb-datastore-server && GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o mongodb-datastore
 
 FROM alpine:3.17 as production
-ARG version=develop
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.url="https://keptn.sh" \
     org.opencontainers.image.title="Keptn MongoDB Datastore" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \
-    org.opencontainers.image.licenses="Apache-2.0" \
-    org.opencontainers.image.version="${version}"
+    org.opencontainers.image.licenses="Apache-2.0"
 
 # we need to install ca-certificates and libc6-compat for go programs to work properly
 RUN apk add --no-cache ca-certificates libc6-compat
@@ -62,6 +60,9 @@ ENV GOTRACEBACK=all
 
 RUN adduser -D nonroot -u 65532
 USER nonroot
+
+ARG version=develop
+LABEL org.opencontainers.image.version="${version}"
 
 # Run the web service on container startup.
 CMD ["/mongodb-datastore", "--port=8080", "--host=0.0.0.0"]

--- a/mongodb-datastore/Dockerfile
+++ b/mongodb-datastore/Dockerfile
@@ -2,9 +2,6 @@
 # This is based on Debian and sets the GOPATH to /go.
 FROM golang:1.19.4 as builder
 
-ARG version=develop
-ARG debugBuild
-
 WORKDIR /go/src/github.com/keptn/keptn/mongodb-datastore
 
 # Force the go compiler to use modules
@@ -24,9 +21,11 @@ RUN go mod download
 # Copy local code to the container image.
 COPY . .
 
+ARG debugBuild
 # set buildflags for debug build
 RUN if [ ! -z "$debugBuild" ]; then export BUILDFLAGS='-gcflags "all=-N -l"'; fi
 
+ARG version=develop
 RUN sed -i "s/version: develop/version: ${version}/g" /go/src/github.com/keptn/keptn/mongodb-datastore/swagger.yaml
 
 # Build the command inside the container.

--- a/mongodb-datastore/Dockerfile
+++ b/mongodb-datastore/Dockerfile
@@ -25,12 +25,12 @@ ARG debugBuild
 # set buildflags for debug build
 RUN if [ ! -z "$debugBuild" ]; then export BUILDFLAGS='-gcflags "all=-N -l"'; fi
 
-ARG version=develop
-RUN sed -i "s/version: develop/version: ${version}/g" /go/src/github.com/keptn/keptn/mongodb-datastore/swagger.yaml
-
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
 RUN cd cmd/mongodb-datastore-server && GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o mongodb-datastore
+
+ARG version=develop
+RUN sed -i "s/version: develop/version: ${version}/g" /go/src/github.com/keptn/keptn/mongodb-datastore/swagger.yaml
 
 FROM alpine:3.17 as production
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \

--- a/remediation-service/Dockerfile
+++ b/remediation-service/Dockerfile
@@ -31,14 +31,12 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.17 as production
-ARG version=develop
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.url="https://keptn.sh" \
     org.opencontainers.image.title="Keptn Remediation Service" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \
-    org.opencontainers.image.licenses="Apache-2.0" \
-    org.opencontainers.image.version="${version}"
+    org.opencontainers.image.licenses="Apache-2.0"
 
 # we need to install ca-certificates and libc6-compat for go programs to work properly
 RUN apk add --no-cache ca-certificates libc6-compat
@@ -53,6 +51,9 @@ ENV GOTRACEBACK=all
 
 RUN adduser -D nonroot -u 65532
 USER nonroot
+
+ARG version=develop
+LABEL org.opencontainers.image.version="${version}"
 
 # Run the web service on container startup.
 CMD ["/remediation-service"]

--- a/remediation-service/Dockerfile
+++ b/remediation-service/Dockerfile
@@ -3,9 +3,6 @@
 # https://hub.docker.com/_/golang
 FROM golang:1.19.4-alpine3.16 as builder
 
-# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
-ARG SKAFFOLD_GO_GCFLAGS
-
 WORKDIR /go/src/github.com/keptn/keptn/remediation-service
 
 # Force the go compiler to use modules
@@ -25,6 +22,8 @@ RUN go mod download
 # Copy local code to the container image.
 COPY . .
 
+# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
+ARG SKAFFOLD_GO_GCFLAGS
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
 RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v -o remediation-service

--- a/resource-service/Dockerfile
+++ b/resource-service/Dockerfile
@@ -3,10 +3,9 @@
 FROM golang:1.19.4-alpine3.17 as builder
 
 # install additional dependencies
-RUN apk update
-RUN apk upgrade
-RUN apk add --no-cache gcc libc-dev git cmake make openssl
-RUN apk add --no-cache libgit2-dev=1.5.0-r2
+RUN apk update && \
+    apk upgrade && \
+    apk add --no-cache gcc libc-dev git cmake make openssl libgit2-dev=1.5.0-r2
 
 # Force the go compiler to use modules
 ENV GO111MODULE=on
@@ -26,7 +25,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 # Copy local code to the container image.
-COPY . .
+COPY ./ ./
 
 # generate swagger docs
 RUN GOOS=linux swag init
@@ -48,14 +47,12 @@ RUN GOOS=linux LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib/ go build -ldfl
 
 # Use a Docker multi-stage build to create a lean production image.
 FROM alpine:3.17 as production
-ARG version=develop
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.url="https://keptn.sh" \
     org.opencontainers.image.title="Keptn Resource Service" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \
-    org.opencontainers.image.licenses="Apache-2.0" \
-    org.opencontainers.image.version="${version}"
+    org.opencontainers.image.licenses="Apache-2.0"
 
 ENV env=production
 
@@ -63,10 +60,7 @@ ENV env=production
 RUN apk add --no-cache ca-certificates libc6-compat cmake make openssl
 
 # Install git
-#RUN apk update
-#RUN apk upgrade
-RUN apk add --no-cache build-base git pkgconf
-RUN apk add --no-cache libgit2-dev=1.5.0-r2
+RUN apk add --no-cache build-base git pkgconf libgit2-dev=1.5.0-r2
 
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /go/src/github.com/keptn/keptn/resource-service/main /resource-service
@@ -83,6 +77,9 @@ ENV GOTRACEBACK=all
 
 RUN adduser -D nonroot -u 65532
 USER nonroot
+
+ARG version=develop
+LABEL org.opencontainers.image.version="${version}"
 
 # Run the web service on container startup.
 ENV GIN_MODE=release

--- a/resource-service/Dockerfile
+++ b/resource-service/Dockerfile
@@ -33,10 +33,6 @@ RUN GOOS=linux swag init
 # replace github.com/alecthomas/template; with text/template in docs/docs.go
 RUN sed -i "s|github.com/alecthomas/template|text/template|g" docs/docs.go
 
-ARG version=develop
-# replace version "develop" with actual version
-RUN sed -i "s/version: develop/version: ${version}/g" docs/swagger.yaml
-
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
 
@@ -44,6 +40,10 @@ ARG SKAFFOLD_GO_GCFLAGS
 # (You may fetch or manage dependencies here, 
 # either manually or with a tool like "godep".)
 RUN GOOS=linux LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib/ go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v main.go
+
+ARG version=develop
+# replace version "develop" with actual version
+RUN sed -i "s/version: develop/version: ${version}/g" docs/swagger.yaml
 
 # Use a Docker multi-stage build to create a lean production image.
 FROM alpine:3.17 as production

--- a/resource-service/Dockerfile
+++ b/resource-service/Dockerfile
@@ -2,10 +2,6 @@
 # This is based on Debian and sets the GOPATH to /go.
 FROM golang:1.19.4-alpine3.17 as builder
 
-ARG version=develop
-# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
-ARG SKAFFOLD_GO_GCFLAGS
-
 # install additional dependencies
 RUN apk update
 RUN apk upgrade
@@ -37,8 +33,13 @@ RUN GOOS=linux swag init
 
 # replace github.com/alecthomas/template; with text/template in docs/docs.go
 RUN sed -i "s|github.com/alecthomas/template|text/template|g" docs/docs.go
+
+ARG version=develop
 # replace version "develop" with actual version
 RUN sed -i "s/version: develop/version: ${version}/g" docs/swagger.yaml
+
+# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
+ARG SKAFFOLD_GO_GCFLAGS
 
 # Build the command inside the container. 
 # (You may fetch or manage dependencies here, 

--- a/secret-service/Dockerfile
+++ b/secret-service/Dockerfile
@@ -45,14 +45,12 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 
 # Use a Docker multi-stage build to create a lean production image.
 FROM alpine:3.17 as production
-ARG version=develop
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.url="https://keptn.sh" \
     org.opencontainers.image.title="Keptn Secret Service" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \
-    org.opencontainers.image.licenses="Apache-2.0" \
-    org.opencontainers.image.version="${version}"
+    org.opencontainers.image.licenses="Apache-2.0"
 
 
 ENV env=production
@@ -77,5 +75,8 @@ ENV GOTRACEBACK=all
 ENV GIN_MODE=release
 
 ADD scopes.yaml /data/scopes.yaml
+
+ARG version=develop
+LABEL org.opencontainers.image.version="${version}"
 
 CMD ["/secret-service"]

--- a/secret-service/Dockerfile
+++ b/secret-service/Dockerfile
@@ -2,10 +2,6 @@
 # This is based on Debian and sets the GOPATH to /go.
 FROM golang:1.19.4-alpine3.16 as builder
 
-ARG version=develop
-# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
-ARG SKAFFOLD_GO_GCFLAGS
-
 # install additional dependencies
 RUN apk add --no-cache gcc libc-dev git
 
@@ -34,8 +30,13 @@ RUN GOOS=linux swag init --parseDependency
 
 # replace github.com/alecthomas/template; with text/template in docs/docs.go
 RUN sed -i "s|github.com/alecthomas/template|text/template|g" docs/docs.go
+
+ARG version=develop
 # replace version "develop" with actual version
 RUN sed -i "s/version: develop/version: ${version}/g" docs/swagger.yaml
+
+# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
+ARG SKAFFOLD_GO_GCFLAGS
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here,

--- a/secret-service/Dockerfile
+++ b/secret-service/Dockerfile
@@ -31,10 +31,6 @@ RUN GOOS=linux swag init --parseDependency
 # replace github.com/alecthomas/template; with text/template in docs/docs.go
 RUN sed -i "s|github.com/alecthomas/template|text/template|g" docs/docs.go
 
-ARG version=develop
-# replace version "develop" with actual version
-RUN sed -i "s/version: develop/version: ${version}/g" docs/swagger.yaml
-
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
 
@@ -42,6 +38,10 @@ ARG SKAFFOLD_GO_GCFLAGS
 # (You may fetch or manage dependencies here,
 # either manually or with a tool like "godep".)
 RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v main.go
+
+ARG version=develop
+# replace version "develop" with actual version
+RUN sed -i "s/version: develop/version: ${version}/g" docs/swagger.yaml
 
 # Use a Docker multi-stage build to create a lean production image.
 FROM alpine:3.17 as production

--- a/shipyard-controller/Dockerfile
+++ b/shipyard-controller/Dockerfile
@@ -46,15 +46,12 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 
 # Use a Docker multi-stage build to create a lean production image.
 FROM alpine:3.17 as production
-ARG version=develop
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.url="https://keptn.sh" \
     org.opencontainers.image.title="Keptn Shipyard Controller" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \
-    org.opencontainers.image.licenses="Apache-2.0" \
-    org.opencontainers.image.version="${version}"
-
+    org.opencontainers.image.licenses="Apache-2.0"
 
 ENV env=production
 
@@ -85,6 +82,9 @@ ENV GOTRACEBACK=all
 
 RUN adduser -D nonroot -u 65532
 USER nonroot
+
+ARG version=develop
+LABEL org.opencontainers.image.version="${version}"
 
 # Run the web service on container startup.
 ENV GIN_MODE=release

--- a/shipyard-controller/Dockerfile
+++ b/shipyard-controller/Dockerfile
@@ -2,10 +2,6 @@
 # This is based on Debian and sets the GOPATH to /go.
 FROM golang:1.19.4 as builder
 
-ARG version=develop
-# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
-ARG SKAFFOLD_GO_GCFLAGS
-
 # install additional dependencies
 RUN apt-get install -y gcc libc-dev git
 
@@ -34,8 +30,14 @@ RUN GOOS=linux swag init --parseDependency
 
 # replace github.com/alecthomas/template; with text/template in docs/docs.go
 RUN sed -i "s|github.com/alecthomas/template|text/template|g" docs/docs.go
+
+ARG version=develop
+
 # replace version "develop" with actual version
 RUN sed -i "s/version: develop/version: ${version}/g" docs/swagger.yaml
+
+# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
+ARG SKAFFOLD_GO_GCFLAGS
 
 # Build the command inside the container. 
 # (You may fetch or manage dependencies here, 

--- a/shipyard-controller/Dockerfile
+++ b/shipyard-controller/Dockerfile
@@ -23,18 +23,13 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 # Copy local code to the container image.
-COPY . .
+COPY ./ ./
 
 # generate swagger docs
 RUN GOOS=linux swag init --parseDependency
 
 # replace github.com/alecthomas/template; with text/template in docs/docs.go
 RUN sed -i "s|github.com/alecthomas/template|text/template|g" docs/docs.go
-
-ARG version=develop
-
-# replace version "develop" with actual version
-RUN sed -i "s/version: develop/version: ${version}/g" docs/swagger.yaml
 
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
@@ -43,6 +38,10 @@ ARG SKAFFOLD_GO_GCFLAGS
 # (You may fetch or manage dependencies here, 
 # either manually or with a tool like "godep".)
 RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v main.go
+
+ARG version=develop
+# replace version "develop" with actual version
+RUN sed -i "s/version: develop/version: ${version}/g" docs/swagger.yaml
 
 # Use a Docker multi-stage build to create a lean production image.
 FROM alpine:3.17 as production

--- a/statistics-service/Dockerfile
+++ b/statistics-service/Dockerfile
@@ -2,10 +2,6 @@
 # This is based on Debian and sets the GOPATH to /go.
 FROM golang:1.19.4 as builder
 
-ARG version=develop
-# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
-ARG SKAFFOLD_GO_GCFLAGS
-
 # install additional dependencies
 RUN apt-get install -y gcc libc-dev git
 
@@ -34,8 +30,13 @@ RUN GOOS=linux swag init --parseDependency
 
 # replace github.com/alecthomas/template; with text/template in docs/docs.go
 RUN sed -i "s|github.com/alecthomas/template|text/template|g" docs/docs.go
+
+ARG version=develop
 # replace version "develop" with actual version
 RUN sed -i "s/version: develop/version: ${version}/g" docs/swagger.yaml
+
+# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
+ARG SKAFFOLD_GO_GCFLAGS
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here,

--- a/statistics-service/Dockerfile
+++ b/statistics-service/Dockerfile
@@ -23,17 +23,13 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 # Copy local code to the container image.
-COPY . .
+COPY ./ ./
 
 # generate swagger docs
 RUN GOOS=linux swag init --parseDependency
 
 # replace github.com/alecthomas/template; with text/template in docs/docs.go
 RUN sed -i "s|github.com/alecthomas/template|text/template|g" docs/docs.go
-
-ARG version=develop
-# replace version "develop" with actual version
-RUN sed -i "s/version: develop/version: ${version}/g" docs/swagger.yaml
 
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
@@ -42,6 +38,10 @@ ARG SKAFFOLD_GO_GCFLAGS
 # (You may fetch or manage dependencies here,
 # either manually or with a tool like "godep".)
 RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v main.go
+
+ARG version=develop
+# replace version "develop" with actual version
+RUN sed -i "s/version: develop/version: ${version}/g" docs/swagger.yaml
 
 # Use a Docker multi-stage build to create a lean production image.
 FROM alpine:3.17 as production

--- a/statistics-service/Dockerfile
+++ b/statistics-service/Dockerfile
@@ -45,14 +45,12 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 
 # Use a Docker multi-stage build to create a lean production image.
 FROM alpine:3.17 as production
-ARG version=develop
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.url="https://keptn.sh" \
     org.opencontainers.image.title="Keptn Statistics Service" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \
-    org.opencontainers.image.licenses="Apache-2.0" \
-    org.opencontainers.image.version="${version}"
+    org.opencontainers.image.licenses="Apache-2.0"
 
 ENV env=production
 
@@ -74,6 +72,9 @@ ENV GOTRACEBACK=all
 
 RUN adduser -D nonroot -u 65532
 USER nonroot
+
+ARG version=develop
+LABEL org.opencontainers.image.version="${version}"
 
 # Run the web service on container startup.
 ENV GIN_MODE=release

--- a/webhook-service/Dockerfile
+++ b/webhook-service/Dockerfile
@@ -3,9 +3,6 @@
 # https://hub.docker.com/_/golang
 FROM golang:1.19.4-alpine3.16 as builder
 
-# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
-ARG SKAFFOLD_GO_GCFLAGS
-
 WORKDIR /go/src/github.com/keptn/keptn/webhook-service
 
 # Force the go compiler to use modules
@@ -24,6 +21,9 @@ RUN go mod download
 
 # Copy local code to the container image.
 COPY . .
+
+# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
+ARG SKAFFOLD_GO_GCFLAGS
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)

--- a/webhook-service/Dockerfile
+++ b/webhook-service/Dockerfile
@@ -32,14 +32,12 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GC
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.17 as production
-ARG version=develop
 LABEL org.opencontainers.image.source="https://github.com/keptn/keptn" \
     org.opencontainers.image.url="https://keptn.sh" \
     org.opencontainers.image.title="Keptn Webhook Service" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.documentation="https://keptn.sh/docs/" \
-    org.opencontainers.image.licenses="Apache-2.0" \
-    org.opencontainers.image.version="${version}"
+    org.opencontainers.image.licenses="Apache-2.0"
 
 # we need to install ca-certificates and libc6-compat for go programs to work properly
 RUN apk add --no-cache ca-certificates libc6-compat curl
@@ -54,6 +52,9 @@ ENV GOTRACEBACK=all
 
 RUN adduser -D nonroot -u 65532
 USER nonroot
+
+ARG version=develop
+LABEL org.opencontainers.image.version="${version}"
 
 # Run the web service on container startup.
 CMD ["/webhook-service"]


### PR DESCRIPTION
### This PR
- fixes caching for docker builds both locally and in the pipelines, which should speed up builds a little bit
- the solution was to re-order the `ARG` steps so that they are exactly before the variables from `ARG` are used.

The caching bug occurred because all build arguments were set at the top of the dockerfile. But build arguments invalidate the cache as soon as a RUN step comes up since they are passed along to the cmd in the RUN step as env vars and docker doesn't know what happens inside the cmd, so the cache needs to be invalidated since the behaviour of the cmd could change depending on the variable value.

A better description from the docker docs can be found [here](https://docs.docker.com/engine/reference/builder/#impact-on-build-caching).
To see the docker caches in action, check the docker build steps for any container image from this PR. You should see cache hits at least until after `go mod download`