### PR TITLE
ci: Only report security scan result on scheduled runs

### DIFF
--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -153,7 +153,7 @@ jobs:
     name: Create GitHub Issue
     runs-on: ubuntu-22.04
     needs: [ security-scans, govulncheck ]
-    if: failure()
+    if: failure() && github.event_name == 'schedule'
     steps:
     - name: Formulate bug issue
       id: formulate_bug_issue


### PR DESCRIPTION
### This PR
- changes github issue reporting for the security scan pipeline so that it only reports outcomes on scheduled runs and not on manually triggered runs