### PR TITLE
ci: add concurrency group to release pipeline to avoid race conditions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,8 @@ defaults:
 jobs:
   release-please:
     runs-on: ubuntu-22.04
+    group: release
+    concurrency: 1
     outputs:
       tag_name: ${{ steps.release.outputs.tag_name }}
       releases_created: ${{ steps.release.outputs.releases_created }}
@@ -100,6 +102,8 @@ jobs:
   prepare:
     name: Prepare release run
     runs-on: ubuntu-20.04
+    group: release
+    concurrency: 1
     needs: release-please
     if: needs.release-please.outputs.releases_created == 'true'
     outputs:


### PR DESCRIPTION
Signed-off-by: afzal442 <afzal442@gmail.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->
The release job is in the "release" group and will run on the latest version of Ubuntu, and the concurrency option is set to 1, so only 1 release job will run at a time, just to avoid race condition. 

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

