### PR TITLE
docs: hyperlink to `contributing.md` fixed

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -91,3 +91,4 @@ For a realtime overview of current contributors to the Keptn project, we refer t
 * [Salvador Cavadini](https://github.com/chavacava)
 * [Nitin Mewar](https://github.com/nitinmewar)
 * [Philipp Hinteregger](https://github.com/philipp-hinteregger)
+* [Sudipto Baral](https://github.com/sudiptob2)

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -2,7 +2,7 @@
 
 This folder contains docs for developers. If you are looking for the usage documentation of Keptn, or the `keptn` CLI,
 please take a look at the [keptn.sh](https://keptn.sh/docs/) website.
-We recommend to read our [CONTRIBUTING](../CONTRIBUTING.md) guidelines before reading this document.
+We recommend to read our [CONTRIBUTING](../../CONTRIBUTING.md) guidelines before reading this document.
 
 <details>
 <summary>Table of Contents</summary>


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- Fixes documentation

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #9482
