### PR TITLE
fix(lighthouse-service): inconsistent behavior when SLI provider returns warning

### DIFF
--- a/lighthouse-service/event_handler/evaluate_sli_handler.go
+++ b/lighthouse-service/event_handler/evaluate_sli_handler.go
@@ -42,6 +42,12 @@ type criteriaObject struct {
 	CheckIncrease   bool
 }
 
+type KeySLI struct {
+	Failed  bool
+	Message string
+	Name    string
+}
+
 func (o criteriaObject) getTargetValue(sloConfig *keptn.ServiceLevelObjectives, previousResults []*keptnv2.SLIEvaluationResult) float64 {
 	if !o.IsComparison {
 		return o.Value
@@ -189,7 +195,7 @@ func (eh *EvaluateSLIHandler) processGetSliFinishedEvent(ctx context.Context, sh
 		filteredPreviousEvaluationEvents = append(filteredPreviousEvaluationEvents, val)
 	}
 
-	evaluationResult, maximumAchievableScore, keySLIFailed, err := evaluateObjectives(e, sloConfig, filteredPreviousEvaluationEvents)
+	evaluationResult, maximumAchievableScore, keySLI, err := evaluateObjectives(e, sloConfig, filteredPreviousEvaluationEvents)
 	evaluationResult.Labels = e.Labels
 	evaluationResult.Evaluation.ComparedEvents = comparisonEventIDs
 	evaluationResult.Evaluation.SLOFileContent = base64.StdEncoding.EncodeToString(sloFileContent)
@@ -204,7 +210,7 @@ func (eh *EvaluateSLIHandler) processGetSliFinishedEvent(ctx context.Context, sh
 	}
 
 	// calculate the total score
-	err = calculateScore(maximumAchievableScore, evaluationResult, sloConfig, keySLIFailed)
+	err = calculateScore(maximumAchievableScore, evaluationResult, sloConfig, keySLI)
 	if err != nil {
 		return sendErroredFinishedEventWithMessage(shkeptncontext, triggeredID, commitID, err.Error(), string(sloFileContent), eh.KeptnHandler, e)
 	}
@@ -220,7 +226,7 @@ func (eh *EvaluateSLIHandler) processGetSliFinishedEvent(ctx context.Context, sh
 	return sendEvent(shkeptncontext, triggeredID, keptnv2.GetFinishedEventType(keptnv2.EvaluationTaskName), commitID, eh.KeptnHandler, evaluationResult)
 }
 
-func evaluateObjectives(e *keptnv2.GetSLIFinishedEventData, sloConfig *keptn.ServiceLevelObjectives, previousEvaluationEvents []*keptnv2.EvaluationFinishedEventData) (*keptnv2.EvaluationFinishedEventData, float64, bool, error) {
+func evaluateObjectives(e *keptnv2.GetSLIFinishedEventData, sloConfig *keptn.ServiceLevelObjectives, previousEvaluationEvents []*keptnv2.EvaluationFinishedEventData) (*keptnv2.EvaluationFinishedEventData, float64, KeySLI, error) {
 	evaluationResult := &keptnv2.EvaluationFinishedEventData{
 		EventData: keptnv2.EventData{
 			Status:  "",
@@ -235,13 +241,15 @@ func evaluateObjectives(e *keptnv2.GetSLIFinishedEventData, sloConfig *keptn.Ser
 	}
 	var sliEvaluationResults []*keptnv2.SLIEvaluationResult
 	maximumAchievableScore := 0.0
-	keySLIFailed := false
+	keySLI := KeySLI{
+		Failed: false,
+	}
 	// no objectives provided
 	if len(sloConfig.Objectives) == 0 {
 		evaluationResult.Evaluation.Result = "fail"
 		evaluationResult.Evaluation.Score = 0
 		evaluationResult.EventData.Result = "fail"
-		return evaluationResult, 100, keySLIFailed, nil
+		return evaluationResult, 100, keySLI, nil
 	}
 	for _, objective := range sloConfig.Objectives {
 		// only consider the SLI for the total score if pass criteria have been included
@@ -280,7 +288,7 @@ func evaluateObjectives(e *keptnv2.GetSLIFinishedEventData, sloConfig *keptn.Ser
 			continue
 		}
 
-		if result == nil || !result.Success {
+		if result == nil {
 			// no result available => fail the objective
 			sliEvaluationResult.Value = &keptnv2.SLIResult{
 				Metric:  objective.SLI,
@@ -293,7 +301,27 @@ func evaluateObjectives(e *keptnv2.GetSLIFinishedEventData, sloConfig *keptn.Ser
 			sliEvaluationResult.PassTargets = getEmptyTargets(sloConfig, objective.Pass, previousSLIResults)
 			sliEvaluationResult.WarningTargets = getEmptyTargets(sloConfig, objective.Warning, previousSLIResults)
 			if objective.KeySLI {
-				keySLIFailed = true
+				keySLI = KeySLI{
+					Failed:  true,
+					Name:    objective.DisplayName,
+					Message: sliEvaluationResult.Value.Message,
+				}
+			}
+			continue
+		}
+
+		if !result.Success {
+			sliEvaluationResult.Status = "fail"
+			sliEvaluationResult.Score = 0
+			sliEvaluationResult.DisplayName = objective.DisplayName
+			sliEvaluationResult.PassTargets = getEmptyTargets(sloConfig, objective.Pass, previousSLIResults)
+			sliEvaluationResult.WarningTargets = getEmptyTargets(sloConfig, objective.Warning, previousSLIResults)
+			if objective.KeySLI {
+				keySLI = KeySLI{
+					Failed:  true,
+					Name:    objective.DisplayName,
+					Message: sliEvaluationResult.Value.Message,
+				}
 			}
 			continue
 		}
@@ -315,7 +343,7 @@ func evaluateObjectives(e *keptnv2.GetSLIFinishedEventData, sloConfig *keptn.Ser
 				} else {
 					errMsg = fmt.Errorf("error with %s: %v", objective.SLI, err)
 				}
-				return evaluationResult, 100, keySLIFailed, errMsg
+				return evaluationResult, 100, keySLI, errMsg
 			}
 			if isPassed {
 				sliEvaluationResult.Score = float64(objective.Weight)
@@ -342,7 +370,11 @@ func evaluateObjectives(e *keptnv2.GetSLIFinishedEventData, sloConfig *keptn.Ser
 
 		if !isPassed && !isWarning {
 			if objective.KeySLI {
-				keySLIFailed = true
+				keySLI = KeySLI{
+					Failed:  true,
+					Name:    objective.DisplayName,
+					Message: fmt.Sprintf("failed evaluation with score %f", sliEvaluationResult.Score),
+				}
 			}
 			sliEvaluationResult.Status = "fail"
 			sliEvaluationResult.Score = 0
@@ -353,7 +385,7 @@ func evaluateObjectives(e *keptnv2.GetSLIFinishedEventData, sloConfig *keptn.Ser
 	checkLeftoverSLI(e.GetSLI.IndicatorValues, evaluationResult)
 	evaluationResult.Evaluation.IndicatorResults = sliEvaluationResults
 
-	return evaluationResult, maximumAchievableScore, keySLIFailed, nil
+	return evaluationResult, maximumAchievableScore, keySLI, nil
 }
 
 func getEmptyTargets(sloConfig *keptn.ServiceLevelObjectives, targets []*keptn.SLOCriteria, previousResults []*keptnv2.SLIEvaluationResult) []*keptnv2.SLITarget {
@@ -395,7 +427,7 @@ func checkLeftoverSLI(results []*keptnv2.SLIResult, evaluationResult *keptnv2.Ev
 	}
 }
 
-func calculateScore(maximumAchievableScore float64, evaluationResult *keptnv2.EvaluationFinishedEventData, sloConfig *keptn.ServiceLevelObjectives, keySLIFailed bool) error {
+func calculateScore(maximumAchievableScore float64, evaluationResult *keptnv2.EvaluationFinishedEventData, sloConfig *keptn.ServiceLevelObjectives, keySLI KeySLI) error {
 	if sloConfig.TotalScore == nil || sloConfig.TotalScore.Pass == "" {
 		return errors.New("no target score defined")
 	}
@@ -424,11 +456,11 @@ func calculateScore(maximumAchievableScore float64, evaluationResult *keptnv2.Ev
 	}
 	achievedPercentage := 100.0 * (totalScore / maximumAchievableScore)
 	evaluationResult.Evaluation.Score = achievedPercentage
-	if achievedPercentage >= passTargetPercentage && !keySLIFailed {
+	if achievedPercentage >= passTargetPercentage && !keySLI.Failed {
 		evaluationResult.Evaluation.Result = "pass"
 		evaluationResult.Result = keptnv2.ResultPass
 		evaluationResult.Status = keptnv2.StatusSucceeded
-	} else if sloConfig.TotalScore.Warning != "" && !keySLIFailed {
+	} else if sloConfig.TotalScore.Warning != "" && !keySLI.Failed {
 		warnTargetPercentage, err := strconv.ParseFloat(strings.TrimSuffix(sloConfig.TotalScore.Warning, "%"), 64)
 
 		if err != nil {
@@ -445,6 +477,11 @@ func calculateScore(maximumAchievableScore float64, evaluationResult *keptnv2.Ev
 			evaluationResult.Status = keptnv2.StatusSucceeded
 			evaluationResult.Message = fmt.Sprintf("Evaluation failed since the calculated score of %v is below the warning value of %v", achievedPercentage, warnTargetPercentage)
 		}
+	} else if keySLI.Failed {
+		evaluationResult.Evaluation.Result = "fail"
+		evaluationResult.Result = keptnv2.ResultFailed
+		evaluationResult.Status = keptnv2.StatusSucceeded
+		evaluationResult.Message = fmt.Sprintf("Evaluation failed due to key_sli objective '%s': %s", keySLI.Name, keySLI.Message)
 	} else {
 		evaluationResult.Evaluation.Result = "fail"
 		evaluationResult.Result = keptnv2.ResultFailed

--- a/lighthouse-service/event_handler/evaluate_sli_handler.go
+++ b/lighthouse-service/event_handler/evaluate_sli_handler.go
@@ -292,6 +292,9 @@ func evaluateObjectives(e *keptnv2.GetSLIFinishedEventData, sloConfig *keptn.Ser
 			sliEvaluationResult.DisplayName = objective.DisplayName
 			sliEvaluationResult.PassTargets = getEmptyTargets(sloConfig, objective.Pass, previousSLIResults)
 			sliEvaluationResult.WarningTargets = getEmptyTargets(sloConfig, objective.Warning, previousSLIResults)
+			if objective.KeySLI {
+				keySLIFailed = true
+			}
 			continue
 		}
 

--- a/lighthouse-service/event_handler/evaluate_sli_handler.go
+++ b/lighthouse-service/event_handler/evaluate_sli_handler.go
@@ -253,7 +253,7 @@ func evaluateObjectives(e *keptnv2.GetSLIFinishedEventData, sloConfig *keptn.Ser
 	}
 	for _, objective := range sloConfig.Objectives {
 		// only consider the SLI for the total score if pass criteria have been included
-		if len(objective.Pass) > 0 || len(objective.Warning) > 0 {
+		if len(objective.Pass) > 0 {
 			maximumAchievableScore += float64(objective.Weight)
 		}
 
@@ -279,7 +279,7 @@ func evaluateObjectives(e *keptnv2.GetSLIFinishedEventData, sloConfig *keptn.Ser
 
 		sliEvaluationResult.Value = result
 
-		if len(objective.Pass) == 0 && len(objective.Warning) == 0 {
+		if len(objective.Pass) == 0 {
 			sliEvaluationResult.Score = 0
 			sliEvaluationResult.Status = "info"
 			sliEvaluationResult.DisplayName = objective.DisplayName
@@ -441,7 +441,7 @@ func calculateScore(maximumAchievableScore float64, evaluationResult *keptnv2.Ev
 	}
 	totalScore := 0.0
 	for _, result := range evaluationResult.Evaluation.IndicatorResults {
-		if len(result.PassTargets) > 0 || len(result.WarningTargets) > 0 {
+		if len(result.PassTargets) > 0 {
 			totalScore += result.Score
 		}
 	}

--- a/lighthouse-service/event_handler/evaluate_sli_handler.go
+++ b/lighthouse-service/event_handler/evaluate_sli_handler.go
@@ -155,13 +155,6 @@ func (eh *EvaluateSLIHandler) processGetSliFinishedEvent(ctx context.Context, sh
 		return sendEvent(shkeptncontext, triggeredID, keptnv2.GetFinishedEventType(keptnv2.EvaluationTaskName), commitID, eh.KeptnHandler, &evalResult)
 	}
 
-	if e.Result == keptnv2.ResultFailed {
-		evalResult.EventData.Result = e.Result
-		evalResult.EventData.Status = keptnv2.StatusSucceeded
-		evalResult.Message = fmt.Sprintf("lighthouse failed because SLI failed with message %s", e.Message)
-		return sendEvent(shkeptncontext, triggeredID, keptnv2.GetFinishedEventType(keptnv2.EvaluationTaskName), commitID, eh.KeptnHandler, &evalResult)
-	}
-
 	// compare the results based on the evaluation strategy
 	sloConfig, sloFileContent, err := eh.SLOFileRetriever.GetSLOs(e.Project, e.Stage, e.Service, commitID)
 
@@ -221,6 +214,9 @@ func (eh *EvaluateSLIHandler) processGetSliFinishedEvent(ctx context.Context, sh
 		e.Result = keptnv2.ResultFailed
 		evaluationResult.EventData.Result = keptnv2.ResultFailed
 		evaluationResult.Message = fmt.Sprintf("lighthouse failed because no SLO objective was provided")
+	} else if e.Result == keptnv2.ResultFailed {
+		evaluationResult.EventData.Result = keptnv2.ResultFailed
+		evaluationResult.Message = fmt.Sprintf("lighthouse failed because SLI failed with message %s", e.Message)
 	}
 
 	return sendEvent(shkeptncontext, triggeredID, keptnv2.GetFinishedEventType(keptnv2.EvaluationTaskName), commitID, eh.KeptnHandler, evaluationResult)

--- a/lighthouse-service/event_handler/evaluate_sli_handler_test.go
+++ b/lighthouse-service/event_handler/evaluate_sli_handler_test.go
@@ -1944,7 +1944,9 @@ func TestEvaluateObjectives(t *testing.T) {
 								Success: true,
 								Message: "",
 							},
-							Status: "info",
+							PassTargets:    []*keptnv2.SLITarget{},
+							WarningTargets: []*keptnv2.SLITarget{},
+							Status:         "info",
 						},
 					},
 				},
@@ -2112,7 +2114,9 @@ func TestEvaluateObjectives(t *testing.T) {
 								Success:       true,
 								Message:       "",
 							},
-							Status: "info",
+							PassTargets:    []*keptnv2.SLITarget{},
+							WarningTargets: []*keptnv2.SLITarget{},
+							Status:         "info",
 						},
 					},
 				},
@@ -2629,10 +2633,24 @@ func TestCalculateScore(t *testing.T) {
 								Success: true,
 								Message: "",
 							},
-							PassTargets:    nil,
-							WarningTargets: nil,
-							KeySLI:         false,
-							Status:         "pass",
+							PassTargets: []*keptnv2.SLITarget{
+								{
+									Criteria: "<=15.0",
+								},
+								{
+									Criteria: "<=+10%",
+								},
+							},
+							WarningTargets: []*keptnv2.SLITarget{
+								{
+									Criteria: "<=20.0",
+								},
+								{
+									Criteria: "<=+15%",
+								},
+							},
+							KeySLI: false,
+							Status: "pass",
 						},
 					},
 				},
@@ -2696,10 +2714,24 @@ func TestCalculateScore(t *testing.T) {
 								Success: true,
 								Message: "",
 							},
-							PassTargets:    nil,
-							WarningTargets: nil,
-							KeySLI:         false,
-							Status:         "pass",
+							PassTargets: []*keptnv2.SLITarget{
+								{
+									Criteria: "<=15.0",
+								},
+								{
+									Criteria: "<=+10%",
+								},
+							},
+							WarningTargets: []*keptnv2.SLITarget{
+								{
+									Criteria: "<=20.0",
+								},
+								{
+									Criteria: "<=+15%",
+								},
+							},
+							KeySLI: false,
+							Status: "pass",
 						},
 					},
 				},
@@ -2731,10 +2763,24 @@ func TestCalculateScore(t *testing.T) {
 								Success: true,
 								Message: "",
 							},
-							PassTargets:    nil,
-							WarningTargets: nil,
-							KeySLI:         false,
-							Status:         "pass",
+							PassTargets: []*keptnv2.SLITarget{
+								{
+									Criteria: "<=15.0",
+								},
+								{
+									Criteria: "<=+10%",
+								},
+							},
+							WarningTargets: []*keptnv2.SLITarget{
+								{
+									Criteria: "<=20.0",
+								},
+								{
+									Criteria: "<=+15%",
+								},
+							},
+							KeySLI: false,
+							Status: "pass",
 						},
 						{
 							Score: 0,
@@ -2744,10 +2790,24 @@ func TestCalculateScore(t *testing.T) {
 								Success: true,
 								Message: "",
 							},
-							PassTargets:    nil,
-							WarningTargets: nil,
-							KeySLI:         false,
-							Status:         "fail",
+							PassTargets: []*keptnv2.SLITarget{
+								{
+									Criteria: "<=15.0",
+								},
+								{
+									Criteria: "<=+10%",
+								},
+							},
+							WarningTargets: []*keptnv2.SLITarget{
+								{
+									Criteria: "<=20.0",
+								},
+								{
+									Criteria: "<=+15%",
+								},
+							},
+							KeySLI: false,
+							Status: "fail",
 						},
 					},
 				},
@@ -2832,10 +2892,24 @@ func TestCalculateScore(t *testing.T) {
 								Success: true,
 								Message: "",
 							},
-							PassTargets:    nil,
-							WarningTargets: nil,
-							KeySLI:         false,
-							Status:         "pass",
+							PassTargets: []*keptnv2.SLITarget{
+								{
+									Criteria: "<=15.0",
+								},
+								{
+									Criteria: "<=+10%",
+								},
+							},
+							WarningTargets: []*keptnv2.SLITarget{
+								{
+									Criteria: "<=20.0",
+								},
+								{
+									Criteria: "<=+15%",
+								},
+							},
+							KeySLI: false,
+							Status: "pass",
 						},
 						{
 							Score: 0,
@@ -2845,10 +2919,24 @@ func TestCalculateScore(t *testing.T) {
 								Success: true,
 								Message: "",
 							},
-							PassTargets:    nil,
-							WarningTargets: nil,
-							KeySLI:         false,
-							Status:         "fail",
+							PassTargets: []*keptnv2.SLITarget{
+								{
+									Criteria: "<=15.0",
+								},
+								{
+									Criteria: "<=+10%",
+								},
+							},
+							WarningTargets: []*keptnv2.SLITarget{
+								{
+									Criteria: "<=20.0",
+								},
+								{
+									Criteria: "<=+15%",
+								},
+							},
+							KeySLI: false,
+							Status: "fail",
 						},
 					},
 				},
@@ -2881,10 +2969,24 @@ func TestCalculateScore(t *testing.T) {
 								Success: true,
 								Message: "",
 							},
-							PassTargets:    nil,
-							WarningTargets: nil,
-							KeySLI:         false,
-							Status:         "pass",
+							PassTargets: []*keptnv2.SLITarget{
+								{
+									Criteria: "<=8.0",
+								},
+								{
+									Criteria: "<=+10%",
+								},
+							},
+							WarningTargets: []*keptnv2.SLITarget{
+								{
+									Criteria: "<=13.0",
+								},
+								{
+									Criteria: "<=+15%",
+								},
+							},
+							KeySLI: false,
+							Status: "pass",
 						},
 						{
 							Score: 0.506,
@@ -2894,10 +2996,24 @@ func TestCalculateScore(t *testing.T) {
 								Success: true,
 								Message: "",
 							},
-							PassTargets:    nil,
-							WarningTargets: nil,
-							KeySLI:         false,
-							Status:         "pass",
+							PassTargets: []*keptnv2.SLITarget{
+								{
+									Criteria: "<=8.0",
+								},
+								{
+									Criteria: "<=+10%",
+								},
+							},
+							WarningTargets: []*keptnv2.SLITarget{
+								{
+									Criteria: "<=12.0",
+								},
+								{
+									Criteria: "<=+15%",
+								},
+							},
+							KeySLI: false,
+							Status: "pass",
 						},
 					},
 				},
@@ -2982,10 +3098,24 @@ func TestCalculateScore(t *testing.T) {
 								Success: true,
 								Message: "",
 							},
-							PassTargets:    nil,
-							WarningTargets: nil,
-							KeySLI:         false,
-							Status:         "pass",
+							PassTargets: []*keptnv2.SLITarget{
+								{
+									Criteria: "<=8.0",
+								},
+								{
+									Criteria: "<=+10%",
+								},
+							},
+							WarningTargets: []*keptnv2.SLITarget{
+								{
+									Criteria: "<=13.0",
+								},
+								{
+									Criteria: "<=+15%",
+								},
+							},
+							KeySLI: false,
+							Status: "pass",
 						},
 						{
 							Score: 0.506,
@@ -2995,10 +3125,24 @@ func TestCalculateScore(t *testing.T) {
 								Success: true,
 								Message: "",
 							},
-							PassTargets:    nil,
-							WarningTargets: nil,
-							KeySLI:         false,
-							Status:         "pass",
+							PassTargets: []*keptnv2.SLITarget{
+								{
+									Criteria: "<=8.0",
+								},
+								{
+									Criteria: "<=+10%",
+								},
+							},
+							WarningTargets: []*keptnv2.SLITarget{
+								{
+									Criteria: "<=12.0",
+								},
+								{
+									Criteria: "<=+15%",
+								},
+							},
+							KeySLI: false,
+							Status: "pass",
 						},
 					},
 				},
@@ -3031,10 +3175,24 @@ func TestCalculateScore(t *testing.T) {
 								Success: true,
 								Message: "",
 							},
-							PassTargets:    nil,
-							WarningTargets: nil,
-							KeySLI:         false,
-							Status:         "pass",
+							PassTargets: []*keptnv2.SLITarget{
+								{
+									Criteria: "<=8.0",
+								},
+								{
+									Criteria: "<=+10%",
+								},
+							},
+							WarningTargets: []*keptnv2.SLITarget{
+								{
+									Criteria: "<=10.0",
+								},
+								{
+									Criteria: "<=+15%",
+								},
+							},
+							KeySLI: false,
+							Status: "pass",
 						},
 						{
 							Score: 0.48,
@@ -3044,10 +3202,24 @@ func TestCalculateScore(t *testing.T) {
 								Success: false,
 								Message: "",
 							},
-							PassTargets:    nil,
-							WarningTargets: nil,
-							KeySLI:         false,
-							Status:         "fail",
+							PassTargets: []*keptnv2.SLITarget{
+								{
+									Criteria: "<=8.0",
+								},
+								{
+									Criteria: "<=+10%",
+								},
+							},
+							WarningTargets: []*keptnv2.SLITarget{
+								{
+									Criteria: "<=10.0",
+								},
+								{
+									Criteria: "<=+15%",
+								},
+							},
+							KeySLI: false,
+							Status: "fail",
 						},
 					},
 				},
@@ -3132,10 +3304,24 @@ func TestCalculateScore(t *testing.T) {
 								Success: true,
 								Message: "",
 							},
-							PassTargets:    nil,
-							WarningTargets: nil,
-							KeySLI:         false,
-							Status:         "pass",
+							PassTargets: []*keptnv2.SLITarget{
+								{
+									Criteria: "<=8.0",
+								},
+								{
+									Criteria: "<=+10%",
+								},
+							},
+							WarningTargets: []*keptnv2.SLITarget{
+								{
+									Criteria: "<=10.0",
+								},
+								{
+									Criteria: "<=+15%",
+								},
+							},
+							KeySLI: false,
+							Status: "pass",
 						},
 						{
 							Score: 0.48,
@@ -3145,10 +3331,24 @@ func TestCalculateScore(t *testing.T) {
 								Success: false,
 								Message: "",
 							},
-							PassTargets:    nil,
-							WarningTargets: nil,
-							KeySLI:         false,
-							Status:         "fail",
+							PassTargets: []*keptnv2.SLITarget{
+								{
+									Criteria: "<=8.0",
+								},
+								{
+									Criteria: "<=+10%",
+								},
+							},
+							WarningTargets: []*keptnv2.SLITarget{
+								{
+									Criteria: "<=10.0",
+								},
+								{
+									Criteria: "<=+15%",
+								},
+							},
+							KeySLI: false,
+							Status: "fail",
 						},
 					},
 				},

--- a/lighthouse-service/event_handler/evaluate_sli_handler_test.go
+++ b/lighthouse-service/event_handler/evaluate_sli_handler_test.go
@@ -1500,7 +1500,7 @@ type evaluateObjectivesTestObject struct {
 	InPreviousEvaluationEvents []*keptnv2.EvaluationFinishedEventData
 	ExpectedEvaluationResult   *keptnv2.EvaluationFinishedEventData
 	ExpectedMaximumScore       float64
-	ExpectedKeySLIFailed       KeySLI
+	ExpectedKeySLIFailed       keySLI
 }
 
 func TestEvaluateObjectives(t *testing.T) {
@@ -1647,7 +1647,7 @@ func TestEvaluateObjectives(t *testing.T) {
 				},
 			},
 			ExpectedMaximumScore: 1,
-			ExpectedKeySLIFailed: KeySLI{
+			ExpectedKeySLIFailed: keySLI{
 				Failed: false,
 			},
 		},
@@ -1793,7 +1793,7 @@ func TestEvaluateObjectives(t *testing.T) {
 				},
 			},
 			ExpectedMaximumScore: 1,
-			ExpectedKeySLIFailed: KeySLI{
+			ExpectedKeySLIFailed: keySLI{
 				Failed: false,
 			},
 		},
@@ -1962,7 +1962,7 @@ func TestEvaluateObjectives(t *testing.T) {
 				},
 			},
 			ExpectedMaximumScore: 1,
-			ExpectedKeySLIFailed: KeySLI{
+			ExpectedKeySLIFailed: keySLI{
 				Failed: false,
 			},
 		},
@@ -2134,7 +2134,7 @@ func TestEvaluateObjectives(t *testing.T) {
 				},
 			},
 			ExpectedMaximumScore: 1,
-			ExpectedKeySLIFailed: KeySLI{
+			ExpectedKeySLIFailed: keySLI{
 				Failed: false,
 			},
 		},
@@ -2227,7 +2227,7 @@ func TestEvaluateObjectives(t *testing.T) {
 				},
 			},
 			ExpectedMaximumScore: 1,
-			ExpectedKeySLIFailed: KeySLI{
+			ExpectedKeySLIFailed: keySLI{
 				Failed: false,
 			},
 		},
@@ -2345,7 +2345,7 @@ func TestEvaluateObjectives(t *testing.T) {
 				},
 			},
 			ExpectedMaximumScore: 1,
-			ExpectedKeySLIFailed: KeySLI{
+			ExpectedKeySLIFailed: keySLI{
 				Failed: false,
 			},
 		},
@@ -2542,7 +2542,7 @@ func TestEvaluateObjectives(t *testing.T) {
 				},
 			},
 			ExpectedMaximumScore: 1,
-			ExpectedKeySLIFailed: KeySLI{
+			ExpectedKeySLIFailed: keySLI{
 				Failed: false,
 			},
 		},
@@ -2602,7 +2602,7 @@ func TestEvaluateObjectives(t *testing.T) {
 				},
 			},
 			ExpectedMaximumScore: 100,
-			ExpectedKeySLIFailed: KeySLI{
+			ExpectedKeySLIFailed: keySLI{
 				Failed: false,
 			},
 		},
@@ -2748,7 +2748,7 @@ func TestEvaluateObjectives(t *testing.T) {
 				},
 			},
 			ExpectedMaximumScore: 1,
-			ExpectedKeySLIFailed: KeySLI{
+			ExpectedKeySLIFailed: keySLI{
 				Failed: false,
 			},
 		},
@@ -2894,7 +2894,7 @@ func TestEvaluateObjectives(t *testing.T) {
 				},
 			},
 			ExpectedMaximumScore: 1,
-			ExpectedKeySLIFailed: KeySLI{
+			ExpectedKeySLIFailed: keySLI{
 				Failed: false,
 			},
 		},
@@ -2916,7 +2916,7 @@ type calculateScoreTestObject struct {
 	InMaximumScore           float64
 	InEvaluationResult       *keptnv2.EvaluationFinishedEventData
 	InSLOConfig              *apimodelsv2.ServiceLevelObjectives
-	InKeySLIFailed           KeySLI
+	InKeySLIFailed           keySLI
 	ExpectedEvaluationResult *keptnv2.EvaluationFinishedEventData
 	ExpectedError            error
 }
@@ -3006,7 +3006,7 @@ func TestCalculateScore(t *testing.T) {
 					Warning: "75%",
 				},
 			},
-			InKeySLIFailed: KeySLI{
+			InKeySLIFailed: keySLI{
 				Failed: false,
 			},
 			ExpectedEvaluationResult: &keptnv2.EvaluationFinishedEventData{
@@ -3186,7 +3186,7 @@ func TestCalculateScore(t *testing.T) {
 					Warning: "75%",
 				},
 			},
-			InKeySLIFailed: KeySLI{
+			InKeySLIFailed: keySLI{
 				Failed:  true,
 				Name:    "cpu time",
 				Message: "evaluation failed",
@@ -3396,7 +3396,7 @@ func TestCalculateScore(t *testing.T) {
 					Warning: "75%",
 				},
 			},
-			InKeySLIFailed: KeySLI{
+			InKeySLIFailed: keySLI{
 				Failed: false,
 			},
 			ExpectedEvaluationResult: &keptnv2.EvaluationFinishedEventData{
@@ -3604,7 +3604,7 @@ func TestCalculateScore(t *testing.T) {
 					Warning: "75%",
 				},
 			},
-			InKeySLIFailed: KeySLI{
+			InKeySLIFailed: keySLI{
 				Failed: false,
 			},
 			ExpectedEvaluationResult: &keptnv2.EvaluationFinishedEventData{
@@ -3753,7 +3753,7 @@ func TestCalculateScore(t *testing.T) {
 					Warning: "75%",
 				},
 			},
-			InKeySLIFailed: KeySLI{
+			InKeySLIFailed: keySLI{
 				Failed: false,
 			},
 			ExpectedEvaluationResult: &keptnv2.EvaluationFinishedEventData{
@@ -3905,7 +3905,7 @@ func TestCalculateScore(t *testing.T) {
 					Warning: "75%",
 				},
 			},
-			InKeySLIFailed: KeySLI{
+			InKeySLIFailed: keySLI{
 				Failed: false,
 			},
 			ExpectedEvaluationResult: &keptnv2.EvaluationFinishedEventData{

--- a/lighthouse-service/event_handler/evaluate_sli_handler_test.go
+++ b/lighthouse-service/event_handler/evaluate_sli_handler_test.go
@@ -2606,6 +2606,298 @@ func TestEvaluateObjectives(t *testing.T) {
 				Failed: false,
 			},
 		},
+		{
+			Name: "Fail with result equal to nil",
+			InGetSLIDoneEvent: &keptnv2.GetSLIFinishedEventData{
+				EventData: keptnv2.EventData{
+					Project: "sockshop",
+					Service: "carts",
+					Stage:   "dev",
+				},
+				GetSLI: keptnv2.GetSLIFinished{
+					Start:           "2019-10-20T07:57:27.152330783Z",
+					End:             "2019-10-22T08:57:27.152330783Z",
+					IndicatorValues: []*keptnv2.SLIResult{
+						// {
+						// 	Metric:  "my-test-metric-1",
+						// 	Value:   10.0,
+						// 	Success: true,
+						// 	Message: "",
+						// },
+					},
+				},
+			},
+			InSLOConfig: &apimodelsv2.ServiceLevelObjectives{
+				SpecVersion: "1.0",
+				Filter:      nil,
+				Comparison: &apimodelsv2.SLOComparison{
+					CompareWith:               "several_results",
+					IncludeResultWithScore:    "pass",
+					NumberOfComparisonResults: 2,
+					AggregateFunction:         "avg",
+				},
+				Objectives: []*apimodelsv2.SLO{
+					{
+						SLI: "my-test-metric-1",
+						Pass: []*apimodelsv2.SLOCriteria{
+							{
+								Criteria: []string{"<=15.0"},
+							},
+							{
+								Criteria: []string{"<=+10%"},
+							},
+						},
+						Warning: []*apimodelsv2.SLOCriteria{
+							{
+								Criteria: []string{"<=20.0"},
+							},
+							{
+								Criteria: []string{"<=+15%"},
+							},
+						},
+						Weight: 1,
+						KeySLI: false,
+					},
+				},
+				TotalScore: &apimodelsv2.SLOScore{
+					Pass:    "90%",
+					Warning: "75%",
+				},
+			},
+			InPreviousEvaluationEvents: []*keptnv2.EvaluationFinishedEventData{
+				{
+					Evaluation: keptnv2.EvaluationDetails{
+						TimeStart: "",
+						TimeEnd:   "",
+						Result:    "pass",
+						Score:     2,
+						IndicatorResults: []*keptnv2.SLIEvaluationResult{
+							{
+								Score: 2,
+								Value: &keptnv2.SLIResult{
+									Metric:  "my-test-metric-1",
+									Value:   10.0,
+									Success: true,
+									Message: "",
+								},
+								PassTargets:    nil,
+								WarningTargets: nil,
+								KeySLI:         false,
+								Status:         "pass",
+							},
+						},
+					},
+					EventData: keptnv2.EventData{
+						Result:  "pass",
+						Project: "sockshop",
+						Service: "carts",
+						Stage:   "dev",
+					},
+				},
+			},
+			ExpectedEvaluationResult: &keptnv2.EvaluationFinishedEventData{
+				Evaluation: keptnv2.EvaluationDetails{
+					TimeStart: "2019-10-20T07:57:27.152330783Z",
+					TimeEnd:   "2019-10-22T08:57:27.152330783Z",
+					Result:    "", // not set by the tested function
+					Score:     0,  // not calculated by tested function
+					IndicatorResults: []*keptnv2.SLIEvaluationResult{
+						{
+							Score: 0,
+							Value: &keptnv2.SLIResult{
+								Metric:        "my-test-metric-1",
+								Value:         0,
+								ComparedValue: 0,
+								Success:       false,
+								Message:       "no value received from SLI provider",
+							},
+							WarningTargets: []*keptnv2.SLITarget{
+								{
+									Criteria:    "<=20.0",
+									TargetValue: 20,
+									Violated:    true,
+								},
+								{
+									Criteria:    "<=+15%",
+									TargetValue: 10,
+									Violated:    true,
+								},
+							},
+							PassTargets: []*keptnv2.SLITarget{
+								{
+									Criteria:    "<=15.0",
+									TargetValue: 15.0,
+									Violated:    true,
+								},
+								{
+									Criteria:    "<=+10%",
+									TargetValue: 10,
+									Violated:    true,
+								},
+							},
+							KeySLI: false,
+							Status: "fail",
+						},
+					},
+				},
+				EventData: keptnv2.EventData{
+					Result:  "",
+					Project: "sockshop",
+					Service: "carts",
+					Stage:   "dev",
+				},
+			},
+			ExpectedMaximumScore: 1,
+			ExpectedKeySLIFailed: KeySLI{
+				Failed: false,
+			},
+		},
+		{
+			Name: "Fail with result success = false",
+			InGetSLIDoneEvent: &keptnv2.GetSLIFinishedEventData{
+				EventData: keptnv2.EventData{
+					Project: "sockshop",
+					Service: "carts",
+					Stage:   "dev",
+				},
+				GetSLI: keptnv2.GetSLIFinished{
+					Start: "2019-10-20T07:57:27.152330783Z",
+					End:   "2019-10-22T08:57:27.152330783Z",
+					IndicatorValues: []*keptnv2.SLIResult{
+						{
+							Metric:  "my-test-metric-1",
+							Value:   0,
+							Success: false,
+							Message: "could not get data",
+						},
+					},
+				},
+			},
+			InSLOConfig: &apimodelsv2.ServiceLevelObjectives{
+				SpecVersion: "1.0",
+				Filter:      nil,
+				Comparison: &apimodelsv2.SLOComparison{
+					CompareWith:               "several_results",
+					IncludeResultWithScore:    "pass",
+					NumberOfComparisonResults: 2,
+					AggregateFunction:         "avg",
+				},
+				Objectives: []*apimodelsv2.SLO{
+					{
+						SLI: "my-test-metric-1",
+						Pass: []*apimodelsv2.SLOCriteria{
+							{
+								Criteria: []string{"<=15.0"},
+							},
+							{
+								Criteria: []string{"<=+10%"},
+							},
+						},
+						Warning: []*apimodelsv2.SLOCriteria{
+							{
+								Criteria: []string{"<=20.0"},
+							},
+							{
+								Criteria: []string{"<=+15%"},
+							},
+						},
+						Weight: 1,
+						KeySLI: false,
+					},
+				},
+				TotalScore: &apimodelsv2.SLOScore{
+					Pass:    "90%",
+					Warning: "75%",
+				},
+			},
+			InPreviousEvaluationEvents: []*keptnv2.EvaluationFinishedEventData{
+				{
+					Evaluation: keptnv2.EvaluationDetails{
+						TimeStart: "",
+						TimeEnd:   "",
+						Result:    "pass",
+						Score:     2,
+						IndicatorResults: []*keptnv2.SLIEvaluationResult{
+							{
+								Score: 2,
+								Value: &keptnv2.SLIResult{
+									Metric:  "my-test-metric-1",
+									Value:   10.0,
+									Success: true,
+									Message: "",
+								},
+								PassTargets:    nil,
+								WarningTargets: nil,
+								KeySLI:         false,
+								Status:         "pass",
+							},
+						},
+					},
+					EventData: keptnv2.EventData{
+						Result:  "pass",
+						Project: "sockshop",
+						Service: "carts",
+						Stage:   "dev",
+					},
+				},
+			},
+			ExpectedEvaluationResult: &keptnv2.EvaluationFinishedEventData{
+				Evaluation: keptnv2.EvaluationDetails{
+					TimeStart: "2019-10-20T07:57:27.152330783Z",
+					TimeEnd:   "2019-10-22T08:57:27.152330783Z",
+					Result:    "", // not set by the tested function
+					Score:     0,  // not calculated by tested function
+					IndicatorResults: []*keptnv2.SLIEvaluationResult{
+						{
+							Score: 0,
+							Value: &keptnv2.SLIResult{
+								Metric:        "my-test-metric-1",
+								Value:         0,
+								ComparedValue: 0,
+								Success:       false,
+								Message:       "could not get data",
+							},
+							WarningTargets: []*keptnv2.SLITarget{
+								{
+									Criteria:    "<=20.0",
+									TargetValue: 20,
+									Violated:    true,
+								},
+								{
+									Criteria:    "<=+15%",
+									TargetValue: 10,
+									Violated:    true,
+								},
+							},
+							PassTargets: []*keptnv2.SLITarget{
+								{
+									Criteria:    "<=15.0",
+									TargetValue: 15.0,
+									Violated:    true,
+								},
+								{
+									Criteria:    "<=+10%",
+									TargetValue: 10,
+									Violated:    true,
+								},
+							},
+							KeySLI: false,
+							Status: "fail",
+						},
+					},
+				},
+				EventData: keptnv2.EventData{
+					Result:  "",
+					Project: "sockshop",
+					Service: "carts",
+					Stage:   "dev",
+				},
+			},
+			ExpectedMaximumScore: 1,
+			ExpectedKeySLIFailed: KeySLI{
+				Failed: false,
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/lighthouse-service/event_handler/evaluate_sli_handler_test.go
+++ b/lighthouse-service/event_handler/evaluate_sli_handler_test.go
@@ -1500,7 +1500,7 @@ type evaluateObjectivesTestObject struct {
 	InPreviousEvaluationEvents []*keptnv2.EvaluationFinishedEventData
 	ExpectedEvaluationResult   *keptnv2.EvaluationFinishedEventData
 	ExpectedMaximumScore       float64
-	ExpectedKeySLIFailed       bool
+	ExpectedKeySLIFailed       KeySLI
 }
 
 func TestEvaluateObjectives(t *testing.T) {
@@ -1647,7 +1647,9 @@ func TestEvaluateObjectives(t *testing.T) {
 				},
 			},
 			ExpectedMaximumScore: 1,
-			ExpectedKeySLIFailed: false,
+			ExpectedKeySLIFailed: KeySLI{
+				Failed: false,
+			},
 		},
 		{
 			Name: "Expect Warning",
@@ -1791,7 +1793,9 @@ func TestEvaluateObjectives(t *testing.T) {
 				},
 			},
 			ExpectedMaximumScore: 1,
-			ExpectedKeySLIFailed: false,
+			ExpectedKeySLIFailed: KeySLI{
+				Failed: false,
+			},
 		},
 		{
 			Name: "Logging SLI with no pass criteria should not affect score",
@@ -1958,7 +1962,9 @@ func TestEvaluateObjectives(t *testing.T) {
 				},
 			},
 			ExpectedMaximumScore: 1,
-			ExpectedKeySLIFailed: false,
+			ExpectedKeySLIFailed: KeySLI{
+				Failed: false,
+			},
 		},
 		{
 			Name: "Logging SLI with empty pass criteria array should not affect score and have status 'info' - BUG 2231",
@@ -2128,7 +2134,9 @@ func TestEvaluateObjectives(t *testing.T) {
 				},
 			},
 			ExpectedMaximumScore: 1,
-			ExpectedKeySLIFailed: false,
+			ExpectedKeySLIFailed: KeySLI{
+				Failed: false,
+			},
 		},
 		{
 			Name: "BUG 1125",
@@ -2219,7 +2227,9 @@ func TestEvaluateObjectives(t *testing.T) {
 				},
 			},
 			ExpectedMaximumScore: 1,
-			ExpectedKeySLIFailed: false,
+			ExpectedKeySLIFailed: KeySLI{
+				Failed: false,
+			},
 		},
 		{
 			Name: "BUG 1263",
@@ -2335,7 +2345,9 @@ func TestEvaluateObjectives(t *testing.T) {
 				},
 			},
 			ExpectedMaximumScore: 1,
-			ExpectedKeySLIFailed: false,
+			ExpectedKeySLIFailed: KeySLI{
+				Failed: false,
+			},
 		},
 		{
 			Name: "6096 if SLI does not have objective have a message",
@@ -2530,7 +2542,9 @@ func TestEvaluateObjectives(t *testing.T) {
 				},
 			},
 			ExpectedMaximumScore: 1,
-			ExpectedKeySLIFailed: false,
+			ExpectedKeySLIFailed: KeySLI{
+				Failed: false,
+			},
 		},
 		{
 			Name: "9198 SLO file does not have objectives",
@@ -2588,7 +2602,9 @@ func TestEvaluateObjectives(t *testing.T) {
 				},
 			},
 			ExpectedMaximumScore: 100,
-			ExpectedKeySLIFailed: false,
+			ExpectedKeySLIFailed: KeySLI{
+				Failed: false,
+			},
 		},
 	}
 
@@ -2608,7 +2624,7 @@ type calculateScoreTestObject struct {
 	InMaximumScore           float64
 	InEvaluationResult       *keptnv2.EvaluationFinishedEventData
 	InSLOConfig              *apimodelsv2.ServiceLevelObjectives
-	InKeySLIFailed           bool
+	InKeySLIFailed           KeySLI
 	ExpectedEvaluationResult *keptnv2.EvaluationFinishedEventData
 	ExpectedError            error
 }
@@ -2698,7 +2714,9 @@ func TestCalculateScore(t *testing.T) {
 					Warning: "75%",
 				},
 			},
-			InKeySLIFailed: false,
+			InKeySLIFailed: KeySLI{
+				Failed: false,
+			},
 			ExpectedEvaluationResult: &keptnv2.EvaluationFinishedEventData{
 				Evaluation: keptnv2.EvaluationDetails{
 					TimeStart: "2019-10-20T07:57:27.152330783Z",
@@ -2806,7 +2824,7 @@ func TestCalculateScore(t *testing.T) {
 									Criteria: "<=+15%",
 								},
 							},
-							KeySLI: false,
+							KeySLI: true,
 							Status: "fail",
 						},
 					},
@@ -2876,7 +2894,11 @@ func TestCalculateScore(t *testing.T) {
 					Warning: "75%",
 				},
 			},
-			InKeySLIFailed: true,
+			InKeySLIFailed: KeySLI{
+				Failed:  true,
+				Name:    "cpu time",
+				Message: "evaluation failed",
+			},
 			ExpectedEvaluationResult: &keptnv2.EvaluationFinishedEventData{
 				Evaluation: keptnv2.EvaluationDetails{
 					TimeStart: "2019-10-20T07:57:27.152330783Z",
@@ -2935,7 +2957,7 @@ func TestCalculateScore(t *testing.T) {
 									Criteria: "<=+15%",
 								},
 							},
-							KeySLI: false,
+							KeySLI: true,
 							Status: "fail",
 						},
 					},
@@ -2947,7 +2969,7 @@ func TestCalculateScore(t *testing.T) {
 					Project: "sockshop",
 					Service: "carts",
 					Stage:   "dev",
-					Message: "Evaluation failed since the calculated score of 50 is below the target value of 90",
+					Message: "Evaluation failed due to key_sli objective 'cpu time': evaluation failed",
 				},
 			},
 			ExpectedError: nil,
@@ -3082,7 +3104,9 @@ func TestCalculateScore(t *testing.T) {
 					Warning: "75%",
 				},
 			},
-			InKeySLIFailed: false,
+			InKeySLIFailed: KeySLI{
+				Failed: false,
+			},
 			ExpectedEvaluationResult: &keptnv2.EvaluationFinishedEventData{
 				Evaluation: keptnv2.EvaluationDetails{
 					TimeStart: "2019-10-20T07:57:27.152330783Z",
@@ -3288,7 +3312,9 @@ func TestCalculateScore(t *testing.T) {
 					Warning: "75%",
 				},
 			},
-			InKeySLIFailed: false,
+			InKeySLIFailed: KeySLI{
+				Failed: false,
+			},
 			ExpectedEvaluationResult: &keptnv2.EvaluationFinishedEventData{
 				Evaluation: keptnv2.EvaluationDetails{
 					TimeStart: "2019-10-20T07:57:27.152330783Z",
@@ -3435,7 +3461,9 @@ func TestCalculateScore(t *testing.T) {
 					Warning: "75%",
 				},
 			},
-			InKeySLIFailed: true,
+			InKeySLIFailed: KeySLI{
+				Failed: false,
+			},
 			ExpectedEvaluationResult: &keptnv2.EvaluationFinishedEventData{
 				Evaluation: keptnv2.EvaluationDetails{
 					TimeStart: "2019-10-20T07:57:27.152330783Z",

--- a/lighthouse-service/event_handler/evaluate_sli_handler_test.go
+++ b/lighthouse-service/event_handler/evaluate_sli_handler_test.go
@@ -3512,6 +3512,169 @@ func TestCalculateScore(t *testing.T) {
 			},
 			ExpectedError: nil,
 		},
+		{
+			Name:           "Info objectives should not be part of score",
+			InMaximumScore: 1,
+			InEvaluationResult: &keptnv2.EvaluationFinishedEventData{
+				Evaluation: keptnv2.EvaluationDetails{
+					TimeStart: "2019-10-20T07:57:27.152330783Z",
+					TimeEnd:   "2019-10-22T08:57:27.152330783Z",
+					Result:    "", // to be calculated
+					Score:     0,  // to be calculated
+					IndicatorResults: []*keptnv2.SLIEvaluationResult{
+						{
+							Score: 1,
+							Value: &keptnv2.SLIResult{
+								Metric:  "my-test-metric-1",
+								Value:   10.0,
+								Success: true,
+								Message: "",
+							},
+							PassTargets: []*keptnv2.SLITarget{
+								{
+									Criteria: "<=15.0",
+								},
+								{
+									Criteria: "<=+10%",
+								},
+							},
+							WarningTargets: []*keptnv2.SLITarget{
+								{
+									Criteria: "<=20.0",
+								},
+								{
+									Criteria: "<=+15%",
+								},
+							},
+							KeySLI: false,
+							Status: "pass",
+						},
+						{
+							Score: 1,
+							Value: &keptnv2.SLIResult{
+								Metric:  "my-info-metric-1",
+								Value:   10.0,
+								Success: true,
+								Message: "",
+							},
+							PassTargets:    nil,
+							WarningTargets: nil,
+							KeySLI:         false,
+							Status:         "pass",
+						},
+					},
+				},
+				EventData: keptnv2.EventData{
+					Result:  "",
+					Project: "sockshop",
+					Service: "carts",
+					Stage:   "dev",
+				},
+			},
+			InSLOConfig: &apimodelsv2.ServiceLevelObjectives{
+				SpecVersion: "1.0",
+				Filter:      nil,
+				Comparison: &apimodelsv2.SLOComparison{
+					CompareWith:               "several_results",
+					IncludeResultWithScore:    "pass",
+					NumberOfComparisonResults: 2,
+					AggregateFunction:         "avg",
+				},
+				Objectives: []*apimodelsv2.SLO{
+					{
+						SLI: "my-test-metric-1",
+						Pass: []*apimodelsv2.SLOCriteria{
+							{
+								Criteria: []string{"<=15.0"},
+							},
+							{
+								Criteria: []string{"<=+10%"},
+							},
+						},
+						Warning: []*apimodelsv2.SLOCriteria{
+							{
+								Criteria: []string{"<=20.0"},
+							},
+							{
+								Criteria: []string{"<=+15%"},
+							},
+						},
+						Weight: 1,
+						KeySLI: false,
+					},
+					{
+						SLI:    "my-info-metric-1",
+						Weight: 1,
+						KeySLI: false,
+					},
+				},
+				TotalScore: &apimodelsv2.SLOScore{
+					Pass:    "90%",
+					Warning: "75%",
+				},
+			},
+			InKeySLIFailed: KeySLI{
+				Failed: false,
+			},
+			ExpectedEvaluationResult: &keptnv2.EvaluationFinishedEventData{
+				Evaluation: keptnv2.EvaluationDetails{
+					TimeStart: "2019-10-20T07:57:27.152330783Z",
+					TimeEnd:   "2019-10-22T08:57:27.152330783Z",
+					Result:    "pass",
+					Score:     100.0,
+					IndicatorResults: []*keptnv2.SLIEvaluationResult{
+						{
+							Score: 1,
+							Value: &keptnv2.SLIResult{
+								Metric:  "my-test-metric-1",
+								Value:   10.0,
+								Success: true,
+								Message: "",
+							},
+							PassTargets: []*keptnv2.SLITarget{
+								{
+									Criteria: "<=15.0",
+								},
+								{
+									Criteria: "<=+10%",
+								},
+							},
+							WarningTargets: []*keptnv2.SLITarget{
+								{
+									Criteria: "<=20.0",
+								},
+								{
+									Criteria: "<=+15%",
+								},
+							},
+							KeySLI: false,
+							Status: "pass",
+						},
+						{
+							Score: 1,
+							Value: &keptnv2.SLIResult{
+								Metric:  "my-info-metric-1",
+								Value:   10.0,
+								Success: true,
+								Message: "",
+							},
+							PassTargets:    nil,
+							WarningTargets: nil,
+							KeySLI:         false,
+							Status:         "pass",
+						},
+					},
+				},
+				EventData: keptnv2.EventData{
+					Result:  "pass",
+					Status:  "succeeded",
+					Project: "sockshop",
+					Service: "carts",
+					Stage:   "dev",
+				},
+			},
+			ExpectedError: nil,
+		},
 	}
 
 	for _, test := range tests {

--- a/lighthouse-service/main_test.go
+++ b/lighthouse-service/main_test.go
@@ -990,7 +990,7 @@ func Test_NoSLOObjectives(t *testing.T) {
 	require.Equal(t, serviceName, evaluationFinishedPayload.EventData.Service)
 	require.Equal(t, keptnv2.StatusSucceeded, evaluationFinishedPayload.EventData.Status)
 	require.Equal(t, keptnv2.ResultFailed, evaluationFinishedPayload.EventData.Result)
-	require.Equal(t, "lighthouse failed because no SLO objective was provided", evaluationFinishedPayload.EventData.Message)
+	require.Equal(t, "lighthouse failed because SLI failed with message no SLIs were requested", evaluationFinishedPayload.EventData.Message)
 
 	go func() {
 		natsClient.Close()

--- a/lighthouse-service/main_test.go
+++ b/lighthouse-service/main_test.go
@@ -990,7 +990,7 @@ func Test_NoSLOObjectives(t *testing.T) {
 	require.Equal(t, serviceName, evaluationFinishedPayload.EventData.Service)
 	require.Equal(t, keptnv2.StatusSucceeded, evaluationFinishedPayload.EventData.Status)
 	require.Equal(t, keptnv2.ResultFailed, evaluationFinishedPayload.EventData.Result)
-	require.Equal(t, "lighthouse failed because SLI failed with message no SLIs were requested", evaluationFinishedPayload.EventData.Message)
+	require.Equal(t, "lighthouse failed because no SLO objective was provided", evaluationFinishedPayload.EventData.Message)
 
 	go func() {
 		natsClient.Close()

--- a/test/go-tests/test_qualitygate.go
+++ b/test/go-tests/test_qualitygate.go
@@ -439,8 +439,8 @@ func Test_QualityGates(t *testing.T) {
 			Message:       "",
 		},
 		DisplayName:    "",
-		PassTargets:    nil,
-		WarningTargets: nil,
+		PassTargets:    []*keptnv2.SLITarget{},
+		WarningTargets: []*keptnv2.SLITarget{},
 		Status:         "info",
 		KeySLI:         false,
 	}, evaluationFinishedPayload.Evaluation.IndicatorResults[2])
@@ -544,8 +544,8 @@ func Test_QualityGates(t *testing.T) {
 			Message:       "",
 		},
 		DisplayName:    "",
-		PassTargets:    nil,
-		WarningTargets: nil,
+		PassTargets:    []*keptnv2.SLITarget{},
+		WarningTargets: []*keptnv2.SLITarget{},
 		Status:         "info",
 		KeySLI:         false,
 	}, evaluationFinishedPayload.Evaluation.IndicatorResults[2])
@@ -660,8 +660,8 @@ func Test_QualityGates(t *testing.T) {
 			Message:       "",
 		},
 		DisplayName:    "",
-		PassTargets:    nil,
-		WarningTargets: nil,
+		PassTargets:    []*keptnv2.SLITarget{},
+		WarningTargets: []*keptnv2.SLITarget{},
 		Status:         "info",
 		KeySLI:         false,
 	}, evaluationFinishedPayload.Evaluation.IndicatorResults[2])

--- a/test/go-tests/test_qualitygate.go
+++ b/test/go-tests/test_qualitygate.go
@@ -316,8 +316,8 @@ func Test_QualityGates(t *testing.T) {
 			Message:       "",
 		},
 		DisplayName:    "",
-		PassTargets:    nil,
-		WarningTargets: nil,
+		PassTargets:    []*keptnv2.SLITarget{},
+		WarningTargets: []*keptnv2.SLITarget{},
 		Status:         "info",
 		KeySLI:         false,
 	}, evaluationFinishedPayload.Evaluation.IndicatorResults[2])


### PR DESCRIPTION
Signed-off-by: odubajDT <ondrej.dubaj@dynatrace.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- fixes inconsistent behaviour when SLI provider returns warning

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #9494 

https://github.com/keptn/keptn/actions/runs/4121475886

