### PR TITLE
fix(installer): fix mongo auth/connectivity in bridge

### DIFF
--- a/installer/manifests/keptn/templates/core.yaml
+++ b/installer/manifests/keptn/templates/core.yaml
@@ -152,7 +152,17 @@ spec:
             - name: TRUST_PROXY
               value: "{{ .Values.bridge.oauth.trustProxy }}"
             - name: MONGODB_HOST
-              value: '{{ .Release.Name }}-{{ .Values.mongo.service.nameOverride }}:{{ .Values.mongo.service.ports.mongodb }}'
+              value: '{{ .Release.Name }}-mongo:{{ .Values.mongo.service.ports.mongodb }}'
+            - name: MONGODB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: mongodb-credentials
+                  key: mongodb-user
+            - name: MONGODB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mongodb-credentials
+                  key: mongodb-passwords
             - name: MONGODB_DATABASE
               value: {{ .Values.mongo.auth.bridgeAuthDatabase | default "openid" }}
             - name: CONFIG_DIR


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
This PR just ensures that the MONGODB_HOST env var in the bridge matches up to what is used elsewhere. Currently if you turn on a feature that requires the bridge to talk to mongo the backend crashes because its env var is incorrectly calculated.

### Related Issues
Fixes #9526

### Follow-up Tasks
Ideally integration tests should exist to cover the oidc/oauth side to prevent this from regressing.