### PR TITLE
fix(installer): add missing NATS init container to API service

### DIFF
--- a/installer/manifests/keptn/templates/api-service.yaml
+++ b/installer/manifests/keptn/templates/api-service.yaml
@@ -21,6 +21,11 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.apiService.gracePeriod | default 60 }}
       initContainers:
         {{- include "keptn.initContainers.wait-for-nats" . | nindent 8 }}
+        {{- include "keptn.initContainers.wait-for-mongodb-datastore" . | nindent 8 }}
+        {{- include "keptn.initContainers.wait-for-keptn-mongo" . | nindent 8 }}
+        {{- include "keptn.initContainers.wait-for-shipyard-controller" . | nindent 8 }}
+        {{- include "keptn.initContainers.wait-for-secret-service" . | nindent 8 }}
+        {{- include "keptn.initContainers.wait-for-resource-service" . | nindent 8 }}
       containers:
         - name: api-service
           image: {{ include "keptn.common.images.image" ( dict "imageRoot" .Values.apiService.image "global" .Values.global.keptn "defaultTag" .Chart.AppVersion) | quote }}

--- a/installer/manifests/keptn/templates/api-service.yaml
+++ b/installer/manifests/keptn/templates/api-service.yaml
@@ -21,8 +21,8 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.apiService.gracePeriod | default 60 }}
       initContainers:
         {{- include "keptn.initContainers.wait-for-nats" . | nindent 8 }}
-        {{- include "keptn.initContainers.wait-for-mongodb-datastore" . | nindent 8 }}
         {{- include "keptn.initContainers.wait-for-keptn-mongo" . | nindent 8 }}
+        {{- include "keptn.initContainers.wait-for-mongodb-datastore" . | nindent 8 }}
         {{- include "keptn.initContainers.wait-for-shipyard-controller" . | nindent 8 }}
         {{- include "keptn.initContainers.wait-for-secret-service" . | nindent 8 }}
         {{- include "keptn.initContainers.wait-for-resource-service" . | nindent 8 }}

--- a/installer/manifests/keptn/templates/api-service.yaml
+++ b/installer/manifests/keptn/templates/api-service.yaml
@@ -19,6 +19,8 @@ spec:
       {{- include "keptn.common.pod-security-context" . | nindent 6 }}
       {{- include "keptn.imagePullSecrets" . | nindent 6 }}
       terminationGracePeriodSeconds: {{ .Values.apiService.gracePeriod | default 60 }}
+      initContainers:
+        {{- include "keptn.initContainers.wait-for-nats" . | nindent 8 }}
       containers:
         - name: api-service
           image: {{ include "keptn.common.images.image" ( dict "imageRoot" .Values.apiService.image "global" .Values.global.keptn "defaultTag" .Chart.AppVersion) | quote }}


### PR DESCRIPTION
### This PR
- adds the missing `wait-for-nats` init container to the API service in the helm chart to set up launch dependencies between NATS and API service correctly

Fixes #9533