### PR TITLE
chore: update go.mod and pipeline to use the same Go version of Dockerfile

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ on:
       - 'master'
       - '[0-9]+.[1-9][0-9]*.x'
 env:
-  GO_VERSION: "~1.18"
+  GO_VERSION: "~1.19"
   INSTALLER_FOLDER: "installer/"
   
   BRIDGE_ARTIFACT_PREFIX: "BRIDGE"

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -21,7 +21,7 @@ defaults:
   run:
     shell: bash
 env:
-  GO_VERSION: "~1.18"
+  GO_VERSION: "~1.19"
 jobs:
   build-cli:
     name: Build Keptn CLI

--- a/.github/workflows/build-helm-charts.yml
+++ b/.github/workflows/build-helm-charts.yml
@@ -24,7 +24,7 @@ defaults:
   run:
     shell: bash
 env:
-  GO_VERSION: "~1.18"
+  GO_VERSION: "~1.19"
 jobs:
   helm_charts_build:
     name: Build Helm Charts

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -82,7 +82,7 @@ jobs:
       RUN_AIRGAPPED_TEST: ${{ matrix.RUN_AIRGAPPED_TEST }}
       AIRGAPPED_REGISTRY_URL: "k3d-container-registry.localhost:12345"
       COLLECT_RESOURCE_LIMITS: ${{ matrix.COLLECT_RESOURCE_LIMITS }}
-      GO_VERSION: "~1.18"
+      GO_VERSION: "~1.19"
       TEST_REPORT_FOLDER: test-reports-${{ matrix.CLOUD_PROVIDER}}-${{ matrix.PLATFORM_VERSION }}
       FINAL_TEST_REPORT_FOLDER: test-reports
       FINAL_TEST_REPORT_PATH: test-reports/test-report-final-${{ matrix.CLOUD_PROVIDER}}-${{ matrix.PLATFORM_VERSION }}.log

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   NODE_VERSION: 16
-  GO_VERSION: "~1.18"
+  GO_VERSION: "~1.19"
   KEPTN_BOT_NAME: "Keptn Bot"
   KEPTN_BOT_EMAIL: "keptn-bot <86361500+keptn-bot@users.noreply.github.com>"
   RELEASE_NOTES_FILE: "RELEASE-BODY.md"

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -9,7 +9,7 @@ defaults:
     shell: bash
 
 env:
-  GO_VERSION: "~1.18"
+  GO_VERSION: "~1.19"
 
 jobs:
   prepare-security-scans:

--- a/.github/workflows/test-and-build-docker-images.yml
+++ b/.github/workflows/test-and-build-docker-images.yml
@@ -47,7 +47,7 @@ defaults:
   run:
     shell: bash
 env:
-  GO_VERSION: "~1.18"
+  GO_VERSION: "~1.19"
 jobs:
   test_and_build:
     name: Test and Build

--- a/.github/workflows/zero-downtime-tests.yml
+++ b/.github/workflows/zero-downtime-tests.yml
@@ -50,7 +50,7 @@ jobs:
       PLATFORM_VERSION: ${{ matrix.PLATFORM_VERSION }}
       KUBECONFIG: ${{ matrix.KUBECONFIG }}
       KEPTN_NAMESPACE: "keptn-zd-test-${{ github.run_number }}-${{ github.run_attempt }}"
-      GO_VERSION: "~1.18"
+      GO_VERSION: "~1.19"
       UPGRADE_TO: ${{ inputs.upgradeTo || 'https://charts-dev.keptn.sh/packages/keptn-0.19.0-dev.tgz' }}
     outputs:
       BRANCH: ${{ steps.determine_branch.outputs.BRANCH }}

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/keptn/keptn/api
 
-go 1.18
+go 1.19
 
 require (
 	github.com/benbjohnson/clock v1.3.0

--- a/approval-service/go.mod
+++ b/approval-service/go.mod
@@ -1,6 +1,6 @@
 module keptn/approval-service
 
-go 1.18
+go 1.19
 
 require (
 	github.com/cloudevents/sdk-go/v2 v2.13.0

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/keptn/keptn/cli
 
-go 1.18
+go 1.19
 
 require (
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -98,7 +98,6 @@ require (
 
 // required as per https://github.com/helm/helm/issues/9354
 replace (
-	github.com/docker/distribution => github.com/docker/distribution v0.0.0-20191216044856-a8371794149d
 	github.com/emicklei/go-restful/v3 => github.com/emicklei/go-restful/v3 v3.10.1
 	golang.org/x/crypto => golang.org/x/crypto v0.4.0
 	golang.org/x/text => golang.org/x/text v0.6.0

--- a/distributor/go.mod
+++ b/distributor/go.mod
@@ -1,6 +1,6 @@
 module github.com/keptn/keptn/distributor
 
-go 1.18
+go 1.19
 
 require (
 	github.com/cloudevents/sdk-go/protocol/nats/v2 v2.12.0

--- a/lighthouse-service/go.mod
+++ b/lighthouse-service/go.mod
@@ -1,6 +1,6 @@
 module github.com/keptn/keptn/lighthouse-service
 
-go 1.18
+go 1.19
 
 require (
 	github.com/cloudevents/sdk-go/v2 v2.13.0

--- a/mongodb-datastore/go.mod
+++ b/mongodb-datastore/go.mod
@@ -1,6 +1,6 @@
 module github.com/keptn/keptn/mongodb-datastore
 
-go 1.18
+go 1.19
 
 require (
 	github.com/go-openapi/errors v0.20.3

--- a/remediation-service/go.mod
+++ b/remediation-service/go.mod
@@ -1,6 +1,6 @@
 module github.com/keptn/keptn/remediation-service
 
-go 1.18
+go 1.19
 
 require (
 	github.com/ghodss/yaml v1.0.0

--- a/resource-service/go.mod
+++ b/resource-service/go.mod
@@ -1,6 +1,6 @@
 module github.com/keptn/keptn/resource-service
 
-go 1.18
+go 1.19
 
 require (
 	github.com/gin-gonic/gin v1.8.2

--- a/secret-service/go.mod
+++ b/secret-service/go.mod
@@ -1,6 +1,6 @@
 module github.com/keptn/keptn/secret-service
 
-go 1.18
+go 1.19
 
 require (
 	github.com/ghodss/yaml v1.0.0

--- a/shipyard-controller/go.mod
+++ b/shipyard-controller/go.mod
@@ -1,6 +1,6 @@
 module github.com/keptn/keptn/shipyard-controller
 
-go 1.18
+go 1.19
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.0

--- a/statistics-service/go.mod
+++ b/statistics-service/go.mod
@@ -1,6 +1,6 @@
 module github.com/keptn/keptn/statistics-service
 
-go 1.18
+go 1.19
 
 require (
 	github.com/gin-gonic/gin v1.8.2

--- a/webhook-service/go.mod
+++ b/webhook-service/go.mod
@@ -1,6 +1,6 @@
 module github.com/keptn/keptn/webhook-service
 
-go 1.18
+go 1.19
 
 require (
 	github.com/keptn/go-utils v0.20.1-0.20230223104941-6b8d8f221081

--- a/webhook-service/lib/template_engine_test.go
+++ b/webhook-service/lib/template_engine_test.go
@@ -45,7 +45,7 @@ func TestTemplateEngine_ParseTemplate(t1 *testing.T) {
 			},
 			want:    "",
 			wantErr: true,
-			errMsg:  "unexpected",
+			errMsg:  "template: :1: bad character U+007D '}'",
 		},
 		{
 			name: "non-existing key",


### PR DESCRIPTION
## This PR

Align Go version to what is used in the Dockerfile


Integration test run: https://github.com/keptn/keptn/actions/runs/4283773729
