### PR TITLE
fix(installer): Add MongoDB init container iff there is no external connection string

### DIFF
--- a/installer/manifests/keptn/templates/api-service.yaml
+++ b/installer/manifests/keptn/templates/api-service.yaml
@@ -21,7 +21,9 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.apiService.gracePeriod | default 60 }}
       initContainers:
         {{- include "keptn.initContainers.wait-for-nats" . | nindent 8 }}
-        {{- include "keptn.initContainers.wait-for-keptn-mongo" . | nindent 8 }}
+        {{- if not .Values.mongo.external.connectionString }}
+          {{- include "keptn.initContainers.wait-for-keptn-mongo" . | nindent 8 }}
+        {{- end }}
         {{- include "keptn.initContainers.wait-for-mongodb-datastore" . | nindent 8 }}
         {{- include "keptn.initContainers.wait-for-shipyard-controller" . | nindent 8 }}
         {{- include "keptn.initContainers.wait-for-secret-service" . | nindent 8 }}


### PR DESCRIPTION
## This PR

In #9534 we introduced init container for API-service. This PR changes the installer to introduce the init container for MongoDB iff there is not external connection string set. 
