### PR TITLE
feat(bridge): Add support for NodeJS18 introducing a caching dir on an emptydir volume

### DIFF
--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -55,5 +55,8 @@ USER myuser
 ARG version=develop
 LABEL org.opencontainers.image.version="${version}"
 
+# Fix NodeJS caching on root fs. See https://github.com/keptn/keptn/issues/9581
+ENV npm_config_cache /tmp/
+
 EXPOSE 3000
 CMD ["npm", "start", "--prefix", "./server"]

--- a/installer/manifests/keptn/templates/core.yaml
+++ b/installer/manifests/keptn/templates/core.yaml
@@ -170,6 +170,8 @@ spec:
           resources:
             {{- toYaml .Values.bridge.resources | nindent 12 }}
           volumeMounts:
+            - name: cache
+              mountPath: /tmp
             - name: assets
               mountPath: /usr/src/app/dist/assets/branding
             - name: bridge-oauth
@@ -196,8 +198,10 @@ spec:
           {{- end }}
       serviceAccountName: keptn-default
       volumes:
-        - emptyDir: {}
-          name: assets
+        - name: cache
+          emptyDir: {}
+        - name: assets
+          emptyDir: {}
         - name: bridge-oauth
           secret:
             secretName: bridge-oauth


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
- Adds an emptydir mounted in Bridge under `/tmp` so npm doesn't write on the root FS 


See https://github.com/npm/cli/issues/4996 and https://github.com/nodejs/docker-node/issues/1749


Fixes https://github.com/keptn/keptn/issues/9581