### PR TITLE
test: adapt uniform integration tests to restart echo service after subscription change

### DIFF
--- a/test/go-tests/test_uniform.go
+++ b/test/go-tests/test_uniform.go
@@ -499,8 +499,13 @@ func testUniformIntegration(t *testing.T, configureIntegrationFunc func(), clean
 	_, err = ApiPUTRequest(fmt.Sprintf("/controlPlane/v1/uniform/registration/%s/subscription/%s", fetchedEchoIntegration.ID, fetchedEchoIntegration.Subscriptions[0].ID), fetchedEchoIntegration.Subscriptions[0], 3)
 	require.Nil(t, err)
 
-	// wait some time to make sure the echo service has pulled the updated subscription
-	<-time.After(20 * time.Second) // sorry :(
+	// wait a little bit and restart the echo-service to make sure it has pulled the updated subscription
+	<-time.After(time.Duration(20 * int(time.Second))) // sorry :(
+	err = RestartPod(echoServiceName)
+	require.Nil(t, err)
+
+	err = waitForDeploymentToBeRolledOut(false, echoServiceName, GetKeptnNameSpaceFromEnv())
+	require.Nil(t, err)
 
 	// now, trigger the sequence that matches the filter - now we should get a response from the echo service again
 	filteredStageName := "filtered-stage"

--- a/test/go-tests/test_uniform.go
+++ b/test/go-tests/test_uniform.go
@@ -500,12 +500,13 @@ func testUniformIntegration(t *testing.T, configureIntegrationFunc func(), clean
 	require.Nil(t, err)
 
 	// wait a little bit and restart the echo-service to make sure it has pulled the updated subscription
-	<-time.After(time.Duration(20 * int(time.Second))) // sorry :(
 	err = RestartPod(echoServiceName)
 	require.Nil(t, err)
 
 	err = waitForDeploymentToBeRolledOut(false, echoServiceName, GetKeptnNameSpaceFromEnv())
 	require.Nil(t, err)
+
+	<-time.After(time.Duration(20 * int(time.Second))) // sorry :(
 
 	// now, trigger the sequence that matches the filter - now we should get a response from the echo service again
 	filteredStageName := "filtered-stage"


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

### Integration test run
<!-- add the description of the PR here -->

https://github.com/keptn/keptn/actions/runs/4554351852
https://github.com/keptn/keptn/actions/runs/4560806610

After adaptation:
https://github.com/keptn/keptn/actions/runs/4561515967

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes: #9598 #9600

