### PR TITLE
fix(installer): MONGODB_HOST should hardcode mongo

### DIFF
--- a/installer/manifests/keptn/templates/core.yaml
+++ b/installer/manifests/keptn/templates/core.yaml
@@ -152,7 +152,7 @@ spec:
             - name: TRUST_PROXY
               value: "{{ .Values.bridge.oauth.trustProxy }}"
             - name: MONGODB_HOST
-              value: '{{ .Release.Name }}-{{ .Values.mongo.service.nameOverride }}:{{ .Values.mongo.service.ports.mongodb }}'
+              value: '{{ .Release.Name }}-mongo:{{ .Values.mongo.service.ports.mongodb }}'
             - name: MONGODB_DATABASE
               value: {{ .Values.mongo.auth.bridgeAuthDatabase | default "openid" }}
             - name: CONFIG_DIR


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

as mentioned in https://github.com/keptn/keptn/pull/9527 we removed the name-override from MongoDB so this should be hardcoded in the MONGODB_HOST env var.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes https://github.com/keptn/keptn/issues/9526#issuecomment-1528084634

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

