### PR TITLE
chore: check for latest version of go before installation

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:
+          check-latest: true
           go-version: ${{ env.GO_VERSION }}
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -98,6 +98,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:
+          check-latest: true
           go-version: ${{ env.GO_VERSION }}
 
       - name: Check out code.

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -64,6 +64,7 @@ jobs:
         if: matrix.tool == 'kubeconform'
         uses: actions/setup-go@v4
         with:
+          check-latest: true
           go-version: ${{ env.GO_VERSION }}
 
       - name: Check out code
@@ -138,6 +139,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v4
       with:
+        check-latest: true
         go-version: ${{ env.GO_VERSION }}
 
     - name: Checkout Code

--- a/.github/workflows/test-and-build-docker-images.yml
+++ b/.github/workflows/test-and-build-docker-images.yml
@@ -64,6 +64,7 @@ jobs:
       with:
         go-version: ${{ env.GO_VERSION }}
         cache: true
+        check-latest: true
         cache-dependency-path: '${{ inputs.working-dir }}go.sum'
 
     - name: Set up gotestsum


### PR DESCRIPTION
In order to fix the security vulnerability https://pkg.go.dev/vuln/GO-2023-1752 we need to use go 1.20.4 instead of 1.20.3, which is currently used by the GH action setting up the Go environment

Security scan: https://github.com/keptn/keptn/actions/runs/4938311643

Fixes: https://github.com/keptn/keptn/issues/9664
